### PR TITLE
Add batch CSV conversion support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Batch CSV conversion via `telemetry_converter.py csv --batch`
+
 ### Planned
 - Support for more DJI models
 - KML export format

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ Batch convert directory to GPX:
 python src/telemetry_converter.py gpx /path/to/srt/files --batch
 ```
 
+Batch convert directory to CSV:
+```bash
+python src/telemetry_converter.py csv /path/to/srt/files --batch
+```
+
 ## Output
 
 The tool creates a `processed` subdirectory containing:

--- a/src/telemetry_converter.py
+++ b/src/telemetry_converter.py
@@ -100,6 +100,31 @@ def batch_convert_to_gpx(directory):
     
     print(f"\nGPX files saved to: {gpx_dir}")
 
+def batch_convert_to_csv(directory):
+    """
+    Convert all SRT files in a directory to CSV files.
+    """
+    directory = Path(directory)
+    srt_files = list(directory.glob("*.srt")) + list(directory.glob("*.SRT"))
+
+    if not srt_files:
+        print(f"No SRT files found in {directory}")
+        return
+
+    csv_dir = directory / "csv_logs"
+    csv_dir.mkdir(exist_ok=True)
+
+    print(f"Found {len(srt_files)} SRT files to convert")
+
+    for srt_file in srt_files:
+        output_file = csv_dir / f"{srt_file.stem}.csv"
+        try:
+            extract_telemetry_to_csv(srt_file, output_file)
+        except Exception as e:
+            print(f"✗ Error converting {srt_file.name}: {e}")
+
+    print(f"\nCSV files saved to: {csv_dir}")
+
 def extract_telemetry_to_csv(srt_file, output_file=None):
     """
     Extract all telemetry data from DJI SRT file to CSV.
@@ -189,7 +214,7 @@ if __name__ == "__main__":
         if args.command == 'gpx':
             batch_convert_to_gpx(args.input)
         elif args.command == 'csv':
-            print("Batch CSV conversion not implemented yet")
+            batch_convert_to_csv(args.input)
     else:
         if args.command == 'gpx':
             extract_telemetry_to_gpx(args.input, args.output)


### PR DESCRIPTION
## Summary
- add `batch_convert_to_csv` helper
- enable CSV batch mode in telemetry_converter
- document new option
- note update in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68767fdb43fc832c9780fe26b03b2a5a