### PR TITLE
Add note for using `py` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ sudo apt install libimage-exiftool-perl
 
 ## Usage
 
+If the command `python` is not recognized, use `py` instead.
+
 ### Basic Usage
 
 Process a single directory:

--- a/docs/METADATA_CHECKER.md
+++ b/docs/METADATA_CHECKER.md
@@ -10,6 +10,8 @@ and `exiftool` for EXIF data when available.
 python src/metadata_check.py FILE [FILE ...]
 python src/metadata_check.py DIRECTORY
 ```
+If the command `python` is not recognized, use `py` instead.
+
 
 You can provide one or more files or directories. When a directory is given all
 common DJI media types (`*.MP4`, `*.MOV`, `*.JPG`) are scanned.


### PR DESCRIPTION
## Summary
- clarify that `py` may be needed if `python` is not recognized
- mention this both in README and metadata checker docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876aa3b0dd4832cab6c938ab8ba5865