### PR TITLE
Add per-frame GPS embedding support

### DIFF
--- a/dji_metadata_embedder/__init__.py
+++ b/dji_metadata_embedder/__init__.py
@@ -1,3 +1,8 @@
 from .embedder import DJIMetadataEmbedder
+from .per_frame_embedder import embed_flight_path, extract_frame_locations
 
-__all__ = ["DJIMetadataEmbedder"]
+__all__ = [
+    "DJIMetadataEmbedder",
+    "embed_flight_path",
+    "extract_frame_locations",
+]

--- a/dji_metadata_embedder/per_frame_embedder.py
+++ b/dji_metadata_embedder/per_frame_embedder.py
@@ -1,0 +1,51 @@
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+from .utilities import parse_telemetry_points, iso6709
+
+
+def embed_flight_path_ffmpeg(video: Path, points: List[Tuple[float, float, float, str]], output: Path) -> bool:
+    """Embed per-frame GPS points using FFmpeg. Returns True on success."""
+    cmd = [
+        "ffmpeg",
+        "-i",
+        str(video),
+        "-c",
+        "copy",
+        "-movflags",
+        "use_metadata_tags",
+    ]
+    for i, (lat, lon, alt, _ts) in enumerate(points):
+        tag = iso6709(lat, lon, alt)
+        cmd.extend(["-metadata", f"location.{i}.ISO6709={tag}"])
+    cmd.extend([str(output)])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode == 0
+
+
+def embed_flight_path(video: Path, srt: Path, output: Path) -> bool:
+    points = parse_telemetry_points(srt)
+    return embed_flight_path_ffmpeg(video, points, output)
+
+
+def extract_frame_locations(path: Path) -> List[str]:
+    """Return list of ISO6709 strings extracted via ffprobe frame tags."""
+    cmd = [
+        "ffprobe",
+        "-v",
+        "0",
+        "-show_entries",
+        "frame_tags",
+        str(path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        return []
+    tags = []
+    for line in result.stdout.splitlines():
+        if line.startswith("TAG:location.") and "ISO6709" in line:
+            _, val = line.split("=", 1)
+            tags.append(val)
+    return tags

--- a/dji_metadata_embedder/utilities.py
+++ b/dji_metadata_embedder/utilities.py
@@ -1,0 +1,37 @@
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+def iso6709(lat: float, lon: float, alt: float = 0.0) -> str:
+    """Return an ISO 6709 location string for QuickTime metadata."""
+    return f"{lat:+08.4f}{lon:+09.4f}{alt:+07.1f}/"
+
+def parse_telemetry_points(srt_path: Path) -> List[Tuple[float, float, float, str]]:
+    """Parse an SRT file into a list of (lat, lon, alt, timestamp)."""
+    content = srt_path.read_text(encoding="utf-8")
+    blocks = content.strip().split("\n\n")
+    points: List[Tuple[float, float, float, str]] = []
+    for block in blocks:
+        lines = block.strip().split("\n")
+        if len(lines) < 3:
+            continue
+        ts_line = lines[1]
+        ts_match = re.search(r"(\d{2}:\d{2}:\d{2},\d{3})", ts_line)
+        timestamp = ts_match.group(1) if ts_match else ""
+        tele_line = " ".join(lines[2:])
+        if "<font" in tele_line:
+            tele_line = re.sub(r"<[^>]+>", "", tele_line)
+        lat_match = re.search(r"\[latitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
+        lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
+        alt_match = re.search(r"abs_alt:\s*([+-]?\d+\.?\d*)\]", tele_line)
+        if not (lat_match and lon_match):
+            gps = re.search(r"GPS\(([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*)\)", tele_line)
+            if gps:
+                lat_match, lon_match = gps, gps
+                alt_match = gps
+        if lat_match and lon_match:
+            lat = float(lat_match.group(1))
+            lon = float(lon_match.group(2) if len(lon_match.groups()) > 1 else lon_match.group(1))
+            alt = float(alt_match.group(3) if alt_match and len(alt_match.groups()) > 1 else (alt_match.group(1) if alt_match else 0.0))
+            points.append((lat, lon, alt, timestamp))
+    return points

--- a/tests/test_per_frame_embedder.py
+++ b/tests/test_per_frame_embedder.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import subprocess
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dji_metadata_embedder import embed_flight_path, extract_frame_locations
+
+
+def test_per_frame_embedder(monkeypatch, tmp_path):
+    video = tmp_path / "video.mp4"
+    srt = tmp_path / "flight.srt"
+    output = tmp_path / "out.mp4"
+    video.write_text("dummy")
+    srt.write_text(
+        """1
+00:00:00,000 --> 00:00:00,033
+[latitude: 59.1] [longitude: 18.2] [rel_alt: 1.0 abs_alt: 2.0]
+
+2
+00:00:00,033 --> 00:00:00,066
+[latitude: 59.2] [longitude: 18.3] [rel_alt: 2.0 abs_alt: 3.0]
+"""
+    )
+
+    calls = []
+
+    def fake_run(cmd, capture_output=True, text=True):
+        calls.append(cmd)
+        class Res:
+            returncode = 0
+            stdout = "\n".join([
+                "TAG:location.0.ISO6709=+59.1000+018.2000+0002.0/",
+                "TAG:location.1.ISO6709=+59.2000+018.3000+0003.0/",
+            ]) if cmd[0] == "ffprobe" else ""
+        return Res()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert embed_flight_path(video, srt, output)
+    tags = extract_frame_locations(output)
+    assert tags == [
+        "+59.1000+018.2000+0002.0/",
+        "+59.2000+018.3000+0003.0/",
+    ]
+    assert calls[0][0] == "ffmpeg"
+    assert calls[1][0] == "ffprobe"
+


### PR DESCRIPTION
## Summary
- support parsing telemetry points into ISO 6709 strings
- add utilities for per-frame GPS embedding with ffmpeg
- expose new APIs from package
- test that per-frame tags are written and read

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876bb1ae378832cabd80e90c345d773