### PR TITLE
Add GPS redaction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Options:
   --check           Only check dependencies
   --dat FILE        Merge specified DAT flight log
   --dat-auto        Auto-detect DAT logs matching videos
+  --redact MODE     Redact GPS data (none, drop, fuzz)
 ```
 
 ### Examples

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,25 @@
+from dji_metadata_embedder.utilities import apply_redaction
+
+
+def test_redact_drop():
+    telemetry = {
+        "gps_coords": [(59.123456, 18.654321)],
+        "first_gps": (59.123456, 18.654321),
+        "avg_gps": (59.123456, 18.654321),
+    }
+    apply_redaction(telemetry, "drop")
+    assert telemetry["gps_coords"] == []
+    assert telemetry["first_gps"] is None
+    assert telemetry["avg_gps"] is None
+
+
+def test_redact_fuzz():
+    telemetry = {
+        "gps_coords": [(59.123456, 18.654321)],
+        "first_gps": (59.123456, 18.654321),
+        "avg_gps": (59.123456, 18.654321),
+    }
+    apply_redaction(telemetry, "fuzz")
+    assert telemetry["gps_coords"] == [(59.123, 18.654)]
+    assert telemetry["first_gps"] == (59.123, 18.654)
+    assert telemetry["avg_gps"] == (59.123, 18.654)


### PR DESCRIPTION
## Summary
- allow GPS coordinate redaction with `--redact`
- support `none`, `drop`, and `fuzz` policies
- mention the new option in the README
- test the new redaction utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876bdfbb92c832cb226a0faeecf1019