### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install ruff mypy pytest build
+      - name: Ruff
+        run: ruff .
+      - name: Mypy
+        run: mypy
+      - name: Pytest
+        run: pytest
+      - name: Build package
+        run: python -m build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow using Ubuntu 22.04
- run ruff, mypy, pytest and package build across Python 3.10‑3.12

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`
- `python -m build` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_6876c91c5400832c85e08e154171f952