### PR TITLE
Add release publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build distribution
+        run: python -m build
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+      - name: Sign artefacts
+        run: |
+          for file in dist/*; do
+            gpg --batch --yes --armor --detach-sign "$file"
+          done
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Attach artefacts to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*
+            dist/*.asc
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for HTML-based SRT logs with extended camera info
 - Pytest test suite for parsing and FFmpeg command generation
 - Optional DAT flight log merging and parser
+- GitHub Action to publish signed wheels to PyPI on semver tags
+- Release documentation in `docs/RELEASE.md`
 
 ### Changed
 - Improved metadata checker output with clearer status icons

--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ If your DJI model uses a different SRT format:
 1. Open an issue with a sample SRT file
 2. Or submit a PR with regex patterns for the new format
 
+## Release
+
+See [docs/RELEASE.md](docs/RELEASE.md) for instructions on publishing a new version.
+
 ## License
 
 MIT License - see LICENSE file for details

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,23 @@
+# Release Process
+
+This project publishes packages to PyPI via GitHub Actions. Pushing a git tag that follows the pattern `vX.Y.Z` triggers the **Release** workflow.
+
+The workflow performs the following steps:
+
+1. Build the wheel and source distribution using `python -m build`.
+2. Import a GPG key from the `GPG_PRIVATE_KEY` repository secret.
+3. Sign all files in `dist/` with `gpg --detach-sign`.
+4. Upload the package to PyPI using the `PYPI_API_TOKEN` secret.
+5. Attach the artefacts and their signatures to the GitHub release page.
+
+## Creating a Release
+
+1. Update `CHANGELOG.md` and the version in `pyproject.toml`.
+2. Commit the changes and create a tag:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Once the tag is pushed, the workflow will publish the signed packages and attach them to the release page automatically.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish signed packages on tag push
- document the release process
- document release instructions in README
- note workflow in CHANGELOG

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`
- `python -m build` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_6876ca36532c832c9bfbb39b8ae08e26