### PR TITLE
Add MkDocs documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r docs/requirements.txt
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-22.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ desktop.ini
 # Test files
 test/
 !tests/
+
+# MkDocs build output
+site/

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,7 @@
+# API Reference
+
+::: dji_metadata_embedder.embedder
+
+::: dji_metadata_embedder.telemetry_converter
+
+::: dji_metadata_embedder.utilities

--- a/docs/how-to/embed-gps.md
+++ b/docs/how-to/embed-gps.md
@@ -1,0 +1,21 @@
+# Embed GPS
+
+This guide shows how to embed GPS data from an SRT file into your DJI video files.
+
+1. Ensure `ffmpeg` is installed and accessible in your `PATH`.
+2. Run the `dji-embed` command pointing at the directory that contains your MP4
+   and SRT files:
+
+```bash
+dji-embed /path/to/videos
+```
+
+3. The processed videos are written to a `processed` directory alongside the
+   originals. Pass `-o` to select a different output folder.
+
+For additional metadata such as EXIF GPS tags, add the `--exiftool` option if
+`exiftool` is installed:
+
+```bash
+dji-embed /path/to/videos --exiftool
+```

--- a/docs/how-to/generate-gpx.md
+++ b/docs/how-to/generate-gpx.md
@@ -1,0 +1,18 @@
+# Generate GPX
+
+The package can convert DJI SRT telemetry files into GPX tracks using the
+`telemetry_converter` module.
+
+Convert a single file:
+
+```bash
+python -m dji_metadata_embedder.telemetry_converter gpx DJI_0001.SRT
+```
+
+Process an entire directory:
+
+```bash
+python -m dji_metadata_embedder.telemetry_converter gpx /path/to/srt --batch
+```
+
+GPX files are saved to a `gpx_tracks` directory in the input folder.

--- a/docs/how-to/strip-serial-number.md
+++ b/docs/how-to/strip-serial-number.md
@@ -1,0 +1,12 @@
+# Strip serial number
+
+Videos recorded on some drones may contain the aircraft serial number in their
+metadata. The embedder itself does not add this information, but you can remove
+existing serial numbers with `exiftool` before publishing your footage.
+
+```bash
+exiftool -DroneSerialNumber= -overwrite_original *.MP4
+```
+
+Run the command in the directory containing the video files. The option
+`-overwrite_original` updates the files in place.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# DJI Drone Metadata Embedder
+
+Welcome to the documentation for **DJI Drone Metadata Embedder**. This project provides tools to embed telemetry from DJI drone SRT files into videos and to convert telemetry to other formats.
+
+Use the guides in this site to embed GPS data in your footage, redact sensitive information and generate GPX tracks.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.5
+mkdocstrings[python]>=0.24

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: DJI Drone Metadata Embedder
+site_description: Embed DJI drone telemetry in video files and convert tracks
+repo_url: https://github.com/example/dji-drone-metadata-embedder
+site_dir: site
+nav:
+  - Home: index.md
+  - How-to Guides:
+      - Embed GPS: how-to/embed-gps.md
+      - Strip serial number: how-to/strip-serial-number.md
+      - Generate GPX: how-to/generate-gpx.md
+  - Reference:
+      - API Reference: api.md
+      - Metadata Checker: METADATA_CHECKER.md
+      - SRT Formats: SRT_FORMATS.md
+      - Release Process: RELEASE.md
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          setup_commands:
+            - import sys, os; sys.path.insert(0, os.path.abspath('.'))


### PR DESCRIPTION
## Summary
- setup MkDocs for the project
- write how-to guides for GPS embedding, GPX generation and stripping serial numbers
- generate API reference using mkdocstrings
- ignore built docs and add workflow to publish docs with GitHub Pages

## Testing
- `ruff check .`
- `mypy`
- `pytest`
- `pip install -r docs/requirements.txt` *(fails: Could not find a version that satisfies the requirement mkdocs>=1.5)*
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876ccce2878832cab5cd8131a114216