### PR TITLE
Fix build and docs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,5 +18,4 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          setup_commands:
-            - import sys, os; sys.path.insert(0, os.path.abspath('.'))
+          paths: ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Embed DJI drone SRT telemetry as metadata in MP4 files"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [{name = "DJI Drone Tools"}]
-license = {file = "LICENSE"}
+license = "MIT"
 dependencies = [
     "ffmpeg-python>=0.2",
     "rich>=13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
 [project.scripts]
 dji-embed = "dji_metadata_embedder.embedder:main"
 
+[tool.setuptools.packages.find]
+include = ["dji_metadata_embedder"]
+
 [tool.black]
 line-length = 88
 


### PR DESCRIPTION
## Summary
- restrict setuptools package discovery to the main package
- update MkDocs config for mkdocstrings

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`
- `python -m build`
- `mkdocs build --strict`


------
https://chatgpt.com/codex/tasks/task_e_6876ffe5cce8832ca86448effc96c40b