### PR TITLE
Add v0.3.x release targets

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -12,6 +12,15 @@ This document breaks down the development of the DJI Metadata Embedder into spec
 **Current State**: Working Python package with CLI interface, requires manual dependency installation
 **Target State**: Standalone Windows executable with GUI, includes all dependencies
 
+### Next release targets (v0.3.x)
+
+- 🛠  A1  PyInstaller one‑file binaries (Win / macOS / Linux)
+- 🛠  A2  winget, Scoop, Homebrew, Chocolatey packages
+- 🛠  B1  Embedded FFmpeg + ExifTool with auto‑extract
+- 🛠  B2  `dji‑embed doctor` dependency checker
+- 🛠  C1  Interactive wizard mode (Rich prompts)
+- 🌓  C2  Optional Tauri GUI wrapper
+- 📚  C3  Quick‑start screencast + GIFs
 ---
 
 ## 🎯 Phase 1: Foundation & Setup (Priority: HIGH)


### PR DESCRIPTION
## Summary
- document upcoming features for version 0.3.x in `agents.md`

## Testing
- `pytest -q tests`
- `pytest -q` *(fails: fixture `test_dir` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b6c446ac832cbb721abe7994d6ac