### PR TITLE
Move docstring above future import

### DIFF
--- a/src/utils/system_info.py
+++ b/src/utils/system_info.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utility functions for gathering basic system information."""
+
+from __future__ import annotations
 
 import os
 import platform


### PR DESCRIPTION
## Summary
- reorder `src/utils/system_info.py` so the module docstring is the first statement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877bcaf706c832cafc765e42332bc50