### PR TITLE
Add installation and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 A Python tool to embed telemetry data from DJI drone SRT files into MP4 video files. This tool extracts GPS coordinates, altitude, camera settings, and other telemetry data from SRT files and embeds them as metadata in the corresponding video files.
 
 See the [Development Roadmap](docs/development_roadmap.md) for plans to expand this CLI tool into a Windows application with a graphical interface.
+For detailed setup instructions and a quick-start tutorial, see [docs/installation.md](docs/installation.md) and [docs/user_guide.md](docs/user_guide.md).
+Common problems are covered in [docs/troubleshooting.md](docs/troubleshooting.md).
+
 
 ## Features
 
@@ -248,6 +251,7 @@ GPS(59.302335,18.203059,132.860)
 
 ## Troubleshooting
 
+See [docs/troubleshooting.md](docs/troubleshooting.md) for additional tips.
 ### "Python was not found"
 Use `py` instead of `python`:
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,4 +4,7 @@ Welcome to the documentation for **DJI Drone Metadata Embedder**. This project p
 
 Use the guides in this site to embed GPS data in your footage, redact sensitive information and generate GPX tracks.
 
-The [Development Roadmap](development_roadmap.md) outlines the planned phases for turning this tool into a user-friendly Windows application.
+- [Installation](installation.md)
+- [User Guide](user_guide.md)
+- [Troubleshooting](troubleshooting.md)
+- [Development Roadmap](development_roadmap.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,43 @@
+# Installation
+
+Follow these steps to install **DJI Drone Metadata Embedder** and its dependencies.
+
+## Via `pip`
+
+```bash
+pip install dji-drone-metadata-embedder
+```
+
+This installs the `dji-embed` command into your current Python environment. Ensure the Python `Scripts` directory is in your `PATH` so the command is available.
+
+## Via `pipx`
+
+[`pipx`](https://pypa.github.io/pipx/) creates an isolated environment and places the command on your user path. It is a convenient option on Windows.
+
+```bash
+python -m pip install --user pipx
+python -m pipx ensurepath
+pipx install dji-drone-metadata-embedder
+```
+
+Restart your terminal so `dji-embed` is found.
+
+## FFmpeg
+
+The embedder relies on [FFmpeg](https://ffmpeg.org/) for video processing. Install it according to your platform:
+
+- **Windows:** download a build from [gyan.dev](https://www.gyan.dev/ffmpeg/builds/), extract it and add the `bin` folder to your `PATH`.
+- **macOS:** `brew install ffmpeg`
+- **Linux:** use your package manager, e.g. `sudo apt install ffmpeg`
+
+Verify the installation with `ffmpeg -version`.
+
+## ExifTool (optional)
+
+ExifTool is only required when embedding additional metadata. Install it if you plan to use the `--exiftool` option.
+
+- **Windows:** grab the Windows package from [exiftool.org](https://exiftool.org/), rename the executable to `exiftool.exe` and add its folder to `PATH`.
+- **macOS:** `brew install exiftool`
+- **Linux:** `sudo apt install libimage-exiftool-perl`
+
+With these tools installed you are ready to embed metadata into your DJI footage.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,28 @@
+# Troubleshooting
+
+This page lists solutions to common issues encountered when running `dji-embed`.
+
+## "ffmpeg is not recognized"
+
+The program requires FFmpeg to be installed and available on your `PATH`.
+
+- Verify with `ffmpeg -version`.
+- On Windows, download a build from [gyan.dev](https://www.gyan.dev/ffmpeg/builds/) and add its `bin` folder to your `PATH`.
+
+## "exiftool is not recognized"
+
+ExifTool is optional but needed for the `--exiftool` flag.
+
+- Download the package from [exiftool.org](https://exiftool.org/), rename the executable to `exiftool.exe` and add it to your `PATH`.
+
+## "python was not found"
+
+On Windows, the `python` command may not be available. Use `py` instead:
+
+```cmd
+dji-embed /path/to/footage
+```
+
+## Permission errors
+
+If the tool fails to write output files, ensure you have permission to create files in the chosen directory. Try running the command prompt or terminal with elevated rights or choose a different output location.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,33 @@
+# User Guide
+
+This guide shows the basics of processing DJI footage with `dji-embed`.
+
+## Quick start
+
+Process a directory of videos and matching SRT files:
+
+```bash
+dji-embed /path/to/footage
+```
+
+A `processed` folder will be created containing new videos with embedded metadata and telemetry summary files.
+
+## Common options
+
+- `-o DIR` – choose an output directory
+- `--exiftool` – also write metadata via ExifTool (requires ExifTool)
+- `--dat FILE` – merge a DAT flight log with the video
+
+Run `dji-embed --help` to see all available options.
+
+## Converting telemetry
+
+The package also includes a converter for GPX or CSV output:
+
+```bash
+python -m dji_metadata_embedder.telemetry_converter gpx DJI_0001.SRT
+```
+
+Use `csv` instead of `gpx` to create a CSV file.
+
+For detailed how-to guides such as creating Windows bundles or redacting location data, see the files in `docs/how-to`.


### PR DESCRIPTION
## Summary
- document install steps using pip or pipx
- add quick start usage guide and troubleshooting page
- link new pages from docs index
- reference documentation from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c73c4250832ca9f75587df34a1df