### PR TITLE
Add Windows bootstrap smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,3 @@ jobs:
       - name: Build package
         run: python -m build
 
-  windows-bootstrap-smoke-test:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Bootstrap and verify
-        shell: powershell
-        run: |
-          Set-ExecutionPolicy Bypass -Scope Process -Force
-          .\tools\bootstrap.ps1 -Silent -NoLaunch
-          dji-embed --version

--- a/.github/workflows/windows-bootstrap-smoke-test.yml
+++ b/.github/workflows/windows-bootstrap-smoke-test.yml
@@ -1,0 +1,18 @@
+name: Windows Bootstrap Smoke Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  windows-bootstrap-smoke-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bootstrap and verify
+        shell: powershell
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          .\tools\bootstrap.ps1 -Silent -NoLaunch
+          dji-embed --version


### PR DESCRIPTION
## Summary
- run the Windows bootstrap script in its own CI workflow
- trim CI workflow to only run Linux build jobs

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_6877f15a2ae0832c809c39babb5873fd