### PR TITLE
Add winget packaging workflow

### DIFF
--- a/.github/winget/installer.yaml
+++ b/.github/winget/installer.yaml
@@ -1,0 +1,14 @@
+PackageIdentifier: CallMarcus.DJI-Embed
+PackageVersion: 0.0.0
+PackageName: DJI Drone Metadata Embedder
+Publisher: CallMarcus
+License: MIT
+LicenseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/LICENSE
+ShortDescription: Embed DJI drone SRT telemetry as metadata in MP4 files.
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v0.0.0/dji-embed.exe
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+    InstallerType: exe
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,31 @@
+name: Publish winget package
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          dotnet tool install --global wingetcreate
+          echo "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Build executable
+        run: pyinstaller --onefile -n dji-embed dji_metadata_embedder/embedder.py
+      - name: Publish via wingetcreate
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          $version = (Select-String -Path pyproject.toml -Pattern '^version').Line.Split('=')[1].Trim().Trim('"')
+          $tag = "v$version"
+          $url = "https://github.com/${{ github.repository }}/releases/download/$tag/dji-embed.exe"
+          wingetcreate update CallMarcus.DJI-Embed -v $version -u $url -t $env:WINGET_TOKEN -m .github/winget/installer.yaml --submit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DJI Drone Metadata Embedder
 
+[![Winget](https://img.shields.io/badge/winget-CallMarcus.DJI--Embed-blue?logo=windows)](https://winget.run/pkg/CallMarcus/DJI-Embed) [![GitHub Release](https://img.shields.io/github/v/release/CallMarcus/dji-drone-metadata-embedder?logo=github)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases) [![PyPI](https://img.shields.io/pypi/v/dji-drone-metadata-embedder?logo=pypi)](https://pypi.org/project/dji-drone-metadata-embedder/)
+
 A Python tool to embed telemetry data from DJI drone SRT files into MP4 video files. This tool extracts GPS coordinates, altitude, camera settings, and other telemetry data from SRT files and embeds them as metadata in the corresponding video files.
 
 See the [Development Roadmap](docs/development_roadmap.md) for plans to expand this CLI tool into a Windows application with a graphical interface.


### PR DESCRIPTION
## Summary
- add winget manifest for `CallMarcus.DJI-Embed`
- add workflow to build PyInstaller exe and submit manifest via `wingetcreate`
- advertise `winget`, GitHub Release, and PyPI badges in the README

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f8227e90832c837c432dc2131704