### PR TITLE
Add winget dependency manifests

### DIFF
--- a/.github/winget/exiftool.yaml
+++ b/.github/winget/exiftool.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: CallMarcus.DJI-Embed.ExifTool
+PackageVersion: 0.0.0
+PackageName: DJI Embedder ExifTool Bundle
+Publisher: CallMarcus
+License: MIT
+LicenseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/LICENSE
+ShortDescription: Reference manifest for ExifTool.
+PackageDependencies:
+  - PackageIdentifier: PhilHarvey.ExifTool
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/.github/winget/ffmpeg.yaml
+++ b/.github/winget/ffmpeg.yaml
@@ -1,0 +1,11 @@
+PackageIdentifier: CallMarcus.DJI-Embed.FFmpeg
+PackageVersion: 0.0.0
+PackageName: DJI Embedder FFmpeg Bundle
+Publisher: CallMarcus
+License: MIT
+LicenseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/LICENSE
+ShortDescription: Reference manifest for FFmpeg.
+PackageDependencies:
+  - PackageIdentifier: Gyan.FFmpeg
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/.github/winget/python.yaml
+++ b/.github/winget/python.yaml
@@ -1,0 +1,12 @@
+PackageIdentifier: CallMarcus.DJI-Embed.Python
+PackageVersion: 0.0.0
+PackageName: DJI Embedder Python Runtime
+Publisher: CallMarcus
+License: MIT
+LicenseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/LICENSE
+ShortDescription: Reference manifest for Python runtime.
+PackageDependencies:
+  - PackageIdentifier: Python.Python.3
+    MinimumVersion: 3.10
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -29,3 +29,9 @@ jobs:
           $tag = "v$version"
           $url = "https://github.com/${{ github.repository }}/releases/download/$tag/dji-embed.exe"
           wingetcreate update CallMarcus.DJI-Embed -v $version -u $url -t $env:WINGET_TOKEN -m .github/winget/installer.yaml --submit
+          $pyUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/python.zip"
+          wingetcreate update CallMarcus.DJI-Embed.Python -v $version -u $pyUrl -t $env:WINGET_TOKEN -m .github/winget/python.yaml --submit
+          $ffUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/ffmpeg.zip"
+          wingetcreate update CallMarcus.DJI-Embed.FFmpeg -v $version -u $ffUrl -t $env:WINGET_TOKEN -m .github/winget/ffmpeg.yaml --submit
+          $exUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/exiftool.zip"
+          wingetcreate update CallMarcus.DJI-Embed.ExifTool -v $version -u $exUrl -t $env:WINGET_TOKEN -m .github/winget/exiftool.yaml --submit

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,15 @@ winget install -e --id CallMarcus.DJI-Embed
 ```
 *Note: some corporate PCs block the Microsoft Store, which also disables `winget`. Contact your IT department if the installer fails.*
 
+### Incremental install
+If you prefer to install each component separately, run:
+```powershell
+winget install -e --id Python.Python.3
+winget install -e --id Gyan.FFmpeg
+winget install -e --id PhilHarvey.ExifTool
+pip install dji-metadata-embedder
+```
+
 
 ## Via `pip`
 


### PR DESCRIPTION
## Summary
- publish incremental winget manifests for Python, FFmpeg and ExifTool
- submit those manifests from the `publish-winget` workflow
- document the incremental winget install option

## Testing
- `ruff check .`
- `mypy`
- `pytest`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_687807561ee4832c9b4a3f46eaf61066