### PR TITLE
Enable PyPI OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,14 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
-  build-and-publish:
+  deploy:
     runs-on: ubuntu-22.04
+    environment: pypi
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -32,7 +37,8 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
+          print-auth-token: false
       - name: Attach artefacts to release
         uses: softprops/action-gh-release@v1
         with:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,7 +7,7 @@ The workflow performs the following steps:
 1. Build the wheel and source distribution using `python -m build`.
 2. Import a GPG key from the `GPG_PRIVATE_KEY` repository secret.
 3. Sign all files in `dist/` with `gpg --detach-sign`.
-4. Upload the package to PyPI using the `PYPI_API_TOKEN` secret.
+4. Upload the package to PyPI via the Trusted Publishers flow (OIDC).
 5. Attach the artefacts and their signatures to the GitHub release page.
 
 ## Creating a Release


### PR DESCRIPTION
## Summary
- publish using GitHub OIDC token
- document the trusted publisher release process

## Testing
- `ruff check .`
- `mypy`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6878096336dc832c8f607d9b5e4eed5a