### PR TITLE
Include src modules in wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with mapping services
 - Flight path visualization
 
+## [1.0.1] - 2025-07-16
+
+### Fixed
+- Packaging now includes the `src` package so the CLI works when installed from a wheel
+
 ## [1.0.0] - 2025-07-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dji-drone-metadata-embedder"
-version = "1.0.0"
+version = "1.0.1"
 description = "Embed DJI drone SRT telemetry as metadata in MP4 files"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -20,7 +20,7 @@ dependencies = [
 dji-embed = "dji_metadata_embedder.embedder:main"
 
 [tool.setuptools.packages.find]
-include = ["dji_metadata_embedder"]
+include = ["dji_metadata_embedder", "src*"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- add `src` package to the setuptools discovery list
- bump version to 1.0.1
- document packaging fix in the changelog

## Testing
- `python -m build --wheel`
- `pip install --force-reinstall dist/*.whl`
- `dji-embed --help`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780a976ab0832ca7e6f90754ebb939