### PR TITLE
Fix wingetcreate update flags

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller
-          winget install --id Microsoft.WingetCreate -e --accept-source-agreements --accept-package-agreements --silent
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
       - name: Build executable
         run: pyinstaller --onefile -n dji-embed dji_metadata_embedder/embedder.py
       - name: Publish via wingetcreate
@@ -27,10 +27,10 @@ jobs:
           $version = (Select-String -Path pyproject.toml -Pattern '^version').Line.Split('=')[1].Trim().Trim('"')
           $tag = "v$version"
           $url = "https://github.com/${{ github.repository }}/releases/download/$tag/dji-embed.exe"
-          wingetcreate update CallMarcus.DJI-Embed -v $version -u $url -t $env:WINGET_TOKEN -m .github/winget/installer.yaml --submit
+          .\wingetcreate.exe update CallMarcus.DJI-Embed -v $version -u $url -t $env:WINGET_TOKEN --submit
           $pyUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/python.zip"
-          wingetcreate update CallMarcus.DJI-Embed.Python -v $version -u $pyUrl -t $env:WINGET_TOKEN -m .github/winget/python.yaml --submit
+          .\wingetcreate.exe update CallMarcus.DJI-Embed.Python -v $version -u $pyUrl -t $env:WINGET_TOKEN --submit
           $ffUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/ffmpeg.zip"
-          wingetcreate update CallMarcus.DJI-Embed.FFmpeg -v $version -u $ffUrl -t $env:WINGET_TOKEN -m .github/winget/ffmpeg.yaml --submit
+          .\wingetcreate.exe update CallMarcus.DJI-Embed.FFmpeg -v $version -u $ffUrl -t $env:WINGET_TOKEN --submit
           $exUrl = "https://github.com/${{ github.repository }}/releases/download/$tag/exiftool.zip"
-          wingetcreate update CallMarcus.DJI-Embed.ExifTool -v $version -u $exUrl -t $env:WINGET_TOKEN -m .github/winget/exiftool.yaml --submit
+          .\wingetcreate.exe update CallMarcus.DJI-Embed.ExifTool -v $version -u $exUrl -t $env:WINGET_TOKEN --submit

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller
-          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
       - name: Build executable
         run: pyinstaller --onefile -n dji-embed dji_metadata_embedder/embedder.py
       - name: Publish via wingetcreate


### PR DESCRIPTION
## Summary
- update publish workflow to drop deprecated `-m` flag when calling wingetcreate

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_6878ccb16288832cbad39aef3c54f247