### PR TITLE
Improve bootstrap reliability and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedd
 winget install -e --id CallMarcus.DJI-Embed
 ```
 
+If winget reports **"No package found"**, the package is still pending publication. Use the PowerShell one-liner above instead.
+
 You can also download a ready-to-run **dji-embed.exe** from the [GitHub Releases page](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases) if `winget` is unavailable.
 
 ### Windows – manual path

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,4 +4,4 @@
 Some security tools may flag downloaded executables. Verify the download source and allow the file if you trust it, or contact your administrator.
 
 ## Winget cannot find package
-Winget uses online sources that may be disabled on corporate machines. Ensure your PC has access to the Microsoft Store or use the manual PowerShell installer instead.
+Winget uses online sources that may be disabled on corporate machines. Ensure your PC has access to the Microsoft Store. If winget still reports "No package found," the package may still be pending publication. Use the manual PowerShell installer instead.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,8 @@ iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedd
 winget install -e --id CallMarcus.DJI-Embed
 ```
 
+If winget cannot locate the package, it may still be awaiting approval. Run the PowerShell one-liner above instead.
+
 ### Windows – manual path
 
 ```powershell

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -5,16 +5,25 @@ param(
     [string]$Version
 )
 
+
 $ErrorActionPreference = 'Stop'
 $VerbosePreference = if($Silent){'SilentlyContinue'} else{'Continue'}
+
+function Log($Msg){ if(-not $Silent){ Write-Host "[+] $Msg" } }
 
 if(-not $Version){
     try{
         $Version = (Invoke-RestMethod https://api.github.com/repos/CallMarcus/dji-drone-metadata-embedder/releases/latest).tag_name.TrimStart('v')
-    }catch{ throw 'Failed to determine latest version' }
+    }catch{
+        try{
+            $Version = (Invoke-RestMethod https://pypi.org/pypi/dji-drone-metadata-embedder/json).info.version
+        }catch{
+            throw 'Failed to determine latest version'
+        }
+    }
 }
 
-function Log($Msg){ if(-not $Silent){ Write-Host "[+] $Msg" } }
+Log "Installing dji-drone-metadata-embedder $Version"
 
 # Elevate if not admin
 $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)


### PR DESCRIPTION
## Summary
- bootstrap.ps1: fall back to PyPI when GitHub releases are absent
- log the package version being installed
- clarify README and docs that winget package might still be pending
- update FAQ entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5912ef7c832cb6373bf6625c4441