### PR TITLE
Fix bootstrap fallback logic and docs

### DIFF
--- a/.github/winget/installer.yaml
+++ b/.github/winget/installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: CallMarcus.DJI-Embed
-PackageVersion: 0.0.0
+PackageVersion: 1.0.2
 PackageName: DJI Drone Metadata Embedder
 Publisher: CallMarcus
 License: MIT
@@ -7,7 +7,7 @@ LicenseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/maste
 ShortDescription: Embed DJI drone SRT telemetry as metadata in MP4 files.
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v0.0.0/dji-embed.exe
+    InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.0.2/dji-embed.exe
     InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
     InstallerType: exe
 ManifestType: installer

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Answers to frequently asked questions can be found in the [FAQ](docs/faq.md).
 iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedder/master/tools/bootstrap.ps1 | iex
 ```
 
+The script attempts to fetch the latest release. If your network blocks GitHub or PyPI it will fall back to version `1.0.2`. Pass `-Version` to override.
+
 ```powershell
 winget install -e --id CallMarcus.DJI-Embed
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,3 +5,6 @@ Some security tools may flag downloaded executables. Verify the download source 
 
 ## Winget cannot find package
 Winget uses online sources that may be disabled on corporate machines. Ensure your PC has access to the Microsoft Store. If winget still reports "No package found," the package may still be pending publication. Use the manual PowerShell installer instead.
+
+## Bootstrap script fails to determine version
+Some networks block access to GitHub or PyPI. The PowerShell bootstrap script now falls back to version `1.0.2` automatically. Use `-Version` to supply a different release if needed.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,6 +8,8 @@
 iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedder/master/tools/bootstrap.ps1 | iex
 ```
 
+The script fetches the latest version automatically and falls back to `1.0.2` if GitHub or PyPI are unreachable. Use `-Version` to specify a different release.
+
 ```powershell
 winget install -e --id CallMarcus.DJI-Embed
 ```

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -11,14 +11,17 @@ $VerbosePreference = if($Silent){'SilentlyContinue'} else{'Continue'}
 
 function Log($Msg){ if(-not $Silent){ Write-Host "[+] $Msg" } }
 
+$DefaultVersion = '1.0.2'
+
 if(-not $Version){
     try{
-        $Version = (Invoke-RestMethod https://api.github.com/repos/CallMarcus/dji-drone-metadata-embedder/releases/latest).tag_name.TrimStart('v')
+        $Version = (Invoke-RestMethod https://api.github.com/repos/CallMarcus/dji-drone-metadata-embedder/releases/latest -Headers @{ 'User-Agent' = 'bootstrap' }).tag_name.TrimStart('v')
     }catch{
         try{
-            $Version = (Invoke-RestMethod https://pypi.org/pypi/dji-drone-metadata-embedder/json).info.version
+            $Version = (Invoke-RestMethod https://pypi.org/pypi/dji-drone-metadata-embedder/json -UseBasicParsing).info.version
         }catch{
-            throw 'Failed to determine latest version'
+            $Version = $DefaultVersion
+            Log "Falling back to bundled version $DefaultVersion"
         }
     }
 }


### PR DESCRIPTION
## Summary
- improve reliability of `bootstrap.ps1` by falling back to version 1.0.2
- mention fallback behaviour in README and installation docs
- document the new behaviour in the FAQ
- update winget manifest version so sync checks pass

## Testing
- `ruff check .`
- `mypy`
- `pytest`
- `python -m build`
- `python tools/sync_version.py --check`


------
https://chatgpt.com/codex/tasks/task_e_687a5c587608832cb4d81d0855de73fa