### PR TITLE
Fix: GitHub Actions artifacts v3 → v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,14 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
+        retention-days: 7
+        if-no-files-found: warn
+        compression-level: 6
+        overwrite: false
 
   publish-to-pypi:
     name: >-
@@ -51,7 +55,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
## 🔧 Fix: GitHub Actions Artifacts v3 → v4 Migration

### Problem
- GitHub Actions artifact v3 actions are deprecated

### Solution
- Updated upload/download steps in `release.yml` to use v4
- Added retention and compression settings

### Benefits
- Faster artifact handling and better defaults

### Testing
- `pytest` passed
- YAML syntax validated
- No remaining `@v3` references


------
https://chatgpt.com/codex/tasks/task_e_687a87373ac0832cb1c0ecad83e11b7c