### PR TITLE
Release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2025-07-18
+
+### Fixed
+- Release workflow repaired for PyPI publishing
+- Updated bootstrap installer fallback version
+
 ## [1.0.2] - 2025-07-17
 
 ### Added

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,4 +1,4 @@
 ﻿"""DJI Drone Metadata Embedder."""
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 from .cli import main
 __all__ = ["main", "__version__"]

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -1,9 +1,10 @@
 ﻿"""CLI entry point."""
 import sys
 from pathlib import Path
+from . import __version__
 
 def main():
-    print("DJI Metadata Embedder v1.0.2")
+    print(f"DJI Metadata Embedder v{__version__}")
     print("Usage: dji-embed <input_directory>")
     if len(sys.argv) < 2:
         print("Error: Please provide an input directory")

--- a/temp_setup.ps1
+++ b/temp_setup.ps1
@@ -6,7 +6,7 @@ cd C:\Claude\dji-drone-metadata-embedder
 # Create __init__.py
 @'
 """DJI Drone Metadata Embedder."""
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 from .cli import main
 __all__ = ["main", "__version__"]
 '@ | Out-File -FilePath "src\dji_metadata_embedder\__init__.py" -Encoding UTF8
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 def main():
-    print("DJI Metadata Embedder v1.0.2")
+    print("DJI Metadata Embedder v1.0.3")
     print("Usage: dji-embed <input_directory>")
     if len(sys.argv) < 2:
         print("Error: Please provide an input directory")

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -188,7 +188,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "1.0.2"
+    $fallbackVersion = "1.0.3"
     
     try{
         LogInfo "Checking for latest version..."


### PR DESCRIPTION
## Summary
- bump version to 1.0.3
- update bootstrap installer fallback version
- tweak CLI to print version dynamically
- note 1.0.3 changes in CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a90fe2580832c8d14e015be119b8a