### PR TITLE
Update winget workflow with PAT

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -16,5 +16,5 @@ jobs:
         run: pip install wingetcreate
       - name: Submit package
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: wingetcreate update -i .github/winget/installer.yaml --submit --token $env:GITHUB_TOKEN
+          WINGET_PAT: ${{ secrets.WINGET_PAT }}
+        run: wingetcreate submit .github/winget/installer.yaml --token $env:WINGET_PAT

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -21,3 +21,10 @@ git push origin vX.Y.Z
 ```
 
 Once the tag is pushed, the workflow will publish the signed packages and attach them to the release page automatically.
+
+## Winget Submission
+
+Winget manifests are published using the `publish-winget.yml` workflow. This workflow
+requires a Personal Access Token with permission to submit packages to the
+Microsoft Store. Add this token to the repository secrets as `WINGET_PAT` before
+running the workflow.


### PR DESCRIPTION
## Summary
- use `wingetcreate submit` in publish-winget workflow
- expect a `WINGET_PAT` secret instead of `GITHUB_TOKEN`
- document the new PAT requirement in `docs/RELEASE.md`

## Testing
- `pip install -e .[dev]`
- `pytest -q`
- `dji-embed --version`


------
https://chatgpt.com/codex/tasks/task_e_687ce23f1d14832cb1d1b467ea23f6df