### PR TITLE
Fix winget publish workflow

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -13,8 +13,8 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install wingetcreate
-        run: pip install wingetcreate
+        run: Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
       - name: Submit package
         env:
           WINGET_PAT: ${{ secrets.WINGET_PAT }}
-        run: wingetcreate submit .github/winget/installer.yaml --token $env:WINGET_PAT
+        run: .\wingetcreate.exe submit .github/winget/installer.yaml --token $env:WINGET_PAT


### PR DESCRIPTION
## Summary
- use the official download URL for `wingetcreate`
- run the downloaded executable when submitting the manifest

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf29216d8832c8d0bf4210915770d