### PR TITLE
Improve dependency lookup with PATH fallback

### DIFF
--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -473,7 +473,10 @@ def check_dependencies():
 
 def run_doctor() -> None:
     """Print system and dependency information."""
-    manager = DependencyManager(Path("tools"))
+    import os
+
+    bin_dir = Path(os.environ.get("LOCALAPPDATA", Path.home())) / "dji-embed" / "bin"
+    manager = DependencyManager(bin_dir)
     dep_status = manager.verify_dependencies()
     dep_info = manager.get_dependency_info()
     summary = system_info.get_system_summary()

--- a/src/dji_metadata_embedder/utils/dependency_manager.py
+++ b/src/dji_metadata_embedder/utils/dependency_manager.py
@@ -114,6 +114,10 @@ class DependencyManager:
                 if path:
                     candidate = path
                     break
+        if not candidate:
+            found = shutil.which("ffmpeg")
+            if found:
+                candidate = Path(found)
         return candidate
 
     def _find_exiftool_executable(self) -> Optional[Path]:
@@ -124,4 +128,8 @@ class DependencyManager:
                 if path:
                     candidate = path
                     break
+        if not candidate:
+            found = shutil.which("exiftool")
+            if found:
+                candidate = Path(found)
         return candidate


### PR DESCRIPTION
## Summary
- search `self.ffmpeg_dir` and `self.exiftool_dir` first, then fallback to `shutil.which`
- use installer bin path when running `dji-embed doctor`

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d184e2340832cb5f0db4ec16c2812