### PR TITLE
Update ffmpeg version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Ensure FFmpeg is in your PATH. Test with:
 ```bash
 ffmpeg -version
 ```
+`ffmpeg` uses a single dash here. Typing `ffmpeg --version` will result in `Unrecognized option '--version'`.
 
 ### No GPS data in JSON
 Check that your SRT files contain GPS coordinates. Open an SRT file to verify the format.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,7 +6,8 @@ This page lists solutions to common issues encountered when running `dji-embed`.
 
 The program requires FFmpeg to be installed and available on your `PATH`.
 
-- Verify with `ffmpeg -version`.
+- Verify with `ffmpeg -version` (single dash).
+- Running `ffmpeg --version` will produce an `Unrecognized option '--version'` error.
 - On Windows, download a build from [gyan.dev](https://www.gyan.dev/ffmpeg/builds/) and add its `bin` folder to your `PATH`.
 
 ## "exiftool is not recognized"


### PR DESCRIPTION
## Summary
- clarify that ffmpeg uses a single dash for the version flag in troubleshooting guide
- mention the same note in README

## Testing
- `pip install -e .[dev]`
- `pytest -q`
- `dji-embed --version`


------
https://chatgpt.com/codex/tasks/task_e_687d192a935c832cbe7666cddaa45bf9