### PR TITLE
Improve local tool detection

### DIFF
--- a/src/dji_metadata_embedder/utils/dependency_manager.py
+++ b/src/dji_metadata_embedder/utils/dependency_manager.py
@@ -114,6 +114,13 @@ class DependencyManager:
                 if path:
                     candidate = path
                     break
+        # Look in tools_dir itself when executables are placed directly under bin
+        if not candidate and self.tools_dir.exists():
+            for name in ("ffmpeg.exe", "ffmpeg"):
+                path = self.tools_dir / name
+                if path.exists():
+                    candidate = path
+                    break
         if not candidate:
             found = shutil.which("ffmpeg")
             if found:
@@ -126,6 +133,12 @@ class DependencyManager:
             for name in ("exiftool.exe", "exiftool"):
                 path = next(self.exiftool_dir.rglob(name), None)
                 if path:
+                    candidate = path
+                    break
+        if not candidate and self.tools_dir.exists():
+            for name in ("exiftool.exe", "exiftool"):
+                path = self.tools_dir / name
+                if path.exists():
                     candidate = path
                     break
         if not candidate:


### PR DESCRIPTION
## Summary
- check bin directory for ffmpeg and exiftool
- keep docs about the ffmpeg `-version` flag

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d14c3ae3c832c98484864fa9bc1e4