### PR TITLE
Fix verbose output in bootstrap script

### DIFF
--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -425,7 +425,7 @@ $ffmpegSuccess = Install-Tool "FFmpeg" "https://www.gyan.dev/ffmpeg/builds/ffmpe
 # Install ExifTool with correct version
 $exifSuccess = Install-Tool "ExifTool" "https://exiftool.org/exiftool-13.32_64.zip" {
     param($zipFile, $tempDir)
-    Expand-Archive $zipFile $tempDir -Force
+    Expand-Archive -Path $zipFile -DestinationPath $tempDir -Force -Verbose:$false
     $exeTool = Get-ChildItem $tempDir -Recurse -Filter "exiftool*.exe" | Select-Object -First 1
     if ($exeTool) {
         Copy-Item $exeTool.FullName (Join-Path $binDir "exiftool.exe") -Force
@@ -461,7 +461,7 @@ try {
     $result = & dji-embed --version 2>&1
     if ($LASTEXITCODE -eq 0) {
         $djiEmbedWorking = $true
-        Log "✓ dji-embed command is working"
+        Log "[OK] dji-embed command is working"
     }
 } catch {}
 
@@ -471,7 +471,7 @@ if (-not $djiEmbedWorking) {
         $result = & $python -m dji_metadata_embedder --version 2>&1
         if ($LASTEXITCODE -eq 0) {
             $djiEmbedWorking = $true
-            Log "✓ dji-embed working via Python module"
+            Log "[OK] dji-embed working via Python module"
         }
     } catch {}
 }
@@ -479,14 +479,14 @@ if (-not $djiEmbedWorking) {
 # Final status report
 Log ""
 Log "=== INSTALLATION SUMMARY ==="
-Log "Python: ✓ Working"
-Log "DJI Metadata Embedder: $(if($djiEmbedWorking){'✓ Working'}else{'⚠ May need PATH refresh'})"
-Log "FFmpeg: $(if($ffmpegSuccess){'✓ Installed'}else{'⚠ Install manually'})"
-Log "ExifTool: $(if($exifSuccess){'✓ Installed'}else{'⚠ Install manually'})"
+Log "Python: [OK] Working"
+Log "DJI Metadata Embedder: $(if($djiEmbedWorking){'[OK] Working'}else{'[WARN] May need PATH refresh'})"
+Log "FFmpeg: $(if($ffmpegSuccess){'[OK] Installed'}else{'[WARN] Install manually'})"
+Log "ExifTool: $(if($exifSuccess){'[OK] Installed'}else{'[WARN] Install manually'})"
 Log ""
 
 if ($djiEmbedWorking) {
-    Log "🎉 Installation completed successfully!"
+    Log "Installation completed successfully!"
     Log ""
     Log "USAGE:"
     Log "  dji-embed /path/to/drone/videos"


### PR DESCRIPTION
## Summary
- suppress verbose output when extracting ExifTool
- use plain text for the final success message

## Testing
- `pip install -e .[dev]`
- `pytest -q`
- `dji-embed --version`


------
https://chatgpt.com/codex/tasks/task_e_687d1a0dd0b4832c9c4180f14a681cbb