### PR TITLE
Add pip caching and CLI stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,22 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version:
+          - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Build and Publish to PyPI
 
 on:
   release:
-    types: [published]
+    types:
+      - published
   push:
     tags:
       - 'v*'
@@ -31,3 +32,4 @@ jobs:
         with:
           print-auth-token: false
           skip-existing: true
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,15 @@ repos:
     rev: v0.4.6
     hooks:
       - id: ruff
+
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:
       - id: black
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:
       - id: mypy
         additional_dependencies: []
+

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -24,7 +24,9 @@ def main() -> None:
 
 @main.command()
 @click.argument("directory", type=click.Path(exists=True, file_okay=False))
-@click.option("-o", "--output", type=click.Path(file_okay=False), help="Output directory")
+@click.option(
+    "-o", "--output", type=click.Path(file_okay=False), help="Output directory"
+)
 @click.option("--exiftool", is_flag=True, help="Also use ExifTool for GPS metadata")
 @click.option("--dat", type=click.Path(exists=True), help="DAT flight log to merge")
 @click.option("--dat-auto", is_flag=True, help="Auto-detect DAT logs matching videos")
@@ -52,9 +54,7 @@ def embed(
 
     deps_ok, missing = check_dependencies()
     if not deps_ok:
-        raise click.ClickException(
-            f"Missing dependencies: {', '.join(missing)}"
-        )
+        raise click.ClickException(f"Missing dependencies: {', '.join(missing)}")
 
     embedder = DJIMetadataEmbedder(
         directory,
@@ -122,6 +122,24 @@ def wizard() -> None:
     """Launch interactive setup wizard."""
     run_doctor()
     click.echo("Wizard functionality not yet implemented.")
+
+
+@main.command()
+def doctor() -> None:
+    """Show system information and verify dependencies."""
+    run_doctor()
+
+
+@main.command()
+def gui() -> None:
+    """Launch graphical interface (placeholder)."""
+    click.echo("Not yet implemented")
+
+
+@main.command()
+def init() -> None:
+    """Perform initial setup (placeholder)."""
+    click.echo("Not yet implemented")
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- clean up YAML formatting for workflows and pre-commit config
- cache pip dependencies in CI
- add placeholder CLI commands (doctor, gui, init)

## Testing
- `python -m pip install -e '.[dev]'`
- `ruff check src/dji_metadata_embedder/cli.py`
- `mypy src/dji_metadata_embedder/cli.py`
- `black src/dji_metadata_embedder/cli.py`
- `pytest -q`
- `gh workflow run winget.yml` *(fails: authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_687d42758044832c815eed65e120b51e