### PR TITLE
Fix winget publish manifest path

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,3 +1,4 @@
+---
 name: Publish winget package
 
 "on":
@@ -23,10 +24,15 @@ jobs:
           Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest `
             -OutFile wingetcreate.exe
 
+      - name: Validate manifest
+        shell: pwsh
+        run: |
+          .\wingetcreate.exe validate .github/winget/CallMarcus.DJI-Embed.yaml
+
       - name: Submit package
         shell: pwsh
         env:
           WINGET_PAT: ${{ secrets.WINGET_PAT }}
         run: |
-          .\wingetcreate.exe submit .github/winget/installer.yaml `
+          .\wingetcreate.exe submit .github/winget/CallMarcus.DJI-Embed.yaml `
             --token $env:WINGET_PAT


### PR DESCRIPTION
## Summary
- update publish-winget workflow with manifest validation and correct manifest path

## Testing
- `ruff check .` *(fails: `.utils.dependency_manager.DependencyManager` imported but unused)*
- `mypy`
- `pytest`
- `dji-embed --version`


------
https://chatgpt.com/codex/tasks/task_e_687d4f996f68832c8bab9041b14ff1dc