### PR TITLE
Fix CLI dependency check invocation

### DIFF
--- a/validation_tests/test_advanced_features.py
+++ b/validation_tests/test_advanced_features.py
@@ -274,7 +274,7 @@ def test_cli_dependency_check():
     try:
         # Test check command with a dummy directory
         with tempfile.TemporaryDirectory() as temp_dir:
-            result = subprocess.run(['dji-embed', '--check', temp_dir], 
+            result = subprocess.run(['dji-embed', 'check', temp_dir],
                                   capture_output=True, text=True, timeout=15)
             
             if result.returncode in [0, 1]:  # 0 = success, 1 = some deps missing


### PR DESCRIPTION
## Summary
- update advanced feature tests to call `dji-embed check`

## Testing
- `python validation_tests/run_all_tests.py` *(fails: Dependencies, External Tools, CLI Command Structure, Full Processing Workflow, Telemetry Export Workflow, CLI Integration)*

------
https://chatgpt.com/codex/tasks/task_e_687e40171690832c88ae7ac4e5a51649