### PR TITLE
Update winget workflow to fill SHA

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -41,16 +41,43 @@ jobs:
         with:
           files: dist/dji-embed.exe
         env:
-          GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}  # Use WINGET_PAT for release creation
+          # Use WINGET_PAT for release creation
+          GITHUB_TOKEN: ${{ secrets.WINGET_PAT }}
 
-  publish-winget:
-    runs-on: windows-latest
+  winget-submission:
     needs: build-windows-exe
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Download executable
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-executable
+          path: dist
+
+      - name: Calculate SHA256
+        id: sha256
+        run: |
+          $hash = Get-FileHash -Path "dist\dji-embed.exe" -Algorithm SHA256
+          echo "hash=$($hash.Hash)" >> $env:GITHUB_OUTPUT
+
+      - name: Update manifests
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          $sha256 = "${{ steps.sha256.outputs.hash }}"
+          $date = Get-Date -Format "yyyy-MM-dd"
+
+          # Update installer manifest
+          $installer = Get-Content `
+            ".github/winget-manifests/installer.yaml" -Raw
+          $installer = $installer -replace '{{ VERSION }}', $version
+          $installer = $installer -replace '{{ SHA256 }}', $sha256
+          $installer = $installer -replace '{{ RELEASE_DATE }}', $date
+          $installer | Set-Content "manifests/installer.yaml"
       - name: Install wingetcreate
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- rename `publish-winget` job to `winget-submission`
- download the built executable and calculate its SHA
- fill the version, hash and release date in the installer manifest
- ensure YAML linting passes

## Testing
- `yamllint --strict .github/workflows/winget-submission.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7b321654832c877d841b67d0b2b7