### PR TITLE
Update docs for Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can also download a ready-to-run **dji-embed.exe** from the [GitHub Releases
 winget install -e --id Python.Python.3
 winget install -e --id Gyan.FFmpeg
 winget install -e --id PhilHarvey.ExifTool
-pip install dji-metadata-embedder
+pip install dji-drone-metadata-embedder
 ```
 
 ## macOS / Linux quick-start
@@ -88,7 +88,7 @@ The tool has been tested with:
 
 ## Requirements
 
-- Python 3.6 or higher
+ - Python 3.10 or higher
 - FFmpeg
 - ExifTool (optional, for additional metadata embedding)
 

--- a/docs/how-to/windows-bundle.md
+++ b/docs/how-to/windows-bundle.md
@@ -5,7 +5,7 @@ needing to manage a Python environment manually.
 
 ## Option 1: pipx
 
-1. [Install Python](https://www.python.org/) 3.8 or newer.
+1. [Install Python](https://www.python.org/) 3.10 or newer.
 2. Open **PowerShell** and install `pipx`:
    ```powershell
    python -m pip install --user pipx
@@ -24,7 +24,7 @@ needing to manage a Python environment manually.
 
 ## Option 2: PyInstaller executable
 
-1. Install Python 3.8+ and download [PyInstaller](https://pyinstaller.org/) using
+1. Install Python 3.10+ and download [PyInstaller](https://pyinstaller.org/) using
    PowerShell:
    ```powershell
    pip install pyinstaller

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ If winget cannot locate the package, it may still be awaiting approval. Run the 
 winget install -e --id Python.Python.3
 winget install -e --id Gyan.FFmpeg
 winget install -e --id PhilHarvey.ExifTool
-pip install dji-metadata-embedder
+pip install dji-drone-metadata-embedder
 ```
 
 ## macOS / Linux quick-start

--- a/docs/validation_tests.md
+++ b/docs/validation_tests.md
@@ -14,7 +14,7 @@ py validation_tests\run_all_tests.py
 ## Test Categories
 
 ### 1. Installation & Dependencies (`test_installation_and_dependencies.py`)
-- ✅ Python version compatibility (3.8+)
+ - ✅ Python version compatibility (3.10+)
 - ✅ Package imports work correctly
 - ✅ Python dependencies (rich, ffmpeg-python, piexif)
 - ✅ External tools (FFmpeg, ExifTool)

--- a/process_drone_footage.sh
+++ b/process_drone_footage.sh
@@ -19,7 +19,7 @@ elif command -v python &> /dev/null; then
     PYTHON_CMD=python
 else
     echo "Error: Python is not installed"
-    echo "Please install Python 3.6 or higher"
+    echo "Please install Python 3.10 or higher"
     exit 1
 fi
 

--- a/tools/cleanup_and_restructure.ps1
+++ b/tools/cleanup_and_restructure.ps1
@@ -99,7 +99,7 @@ Write-Host "Missing files created" -ForegroundColor Green
 
 # Step 6: Reinstall in development mode
 Write-Host "`nStep 6: Reinstalling package..." -ForegroundColor Yellow
-& python -m pip uninstall dji-metadata-embedder dji-drone-metadata-embedder -y 2>$null
+& python -m pip uninstall dji-drone-metadata-embedder -y 2>$null
 & python -m pip install -e .
 
 # Step 7: Verify installation

--- a/validation_tests/README.md
+++ b/validation_tests/README.md
@@ -14,7 +14,7 @@ py validation_tests\run_all_tests.py
 ## Test Categories
 
 ### 1. Installation & Dependencies (`test_installation_and_dependencies.py`)
-- ✅ Python version compatibility (3.8+)
+- ✅ Python version compatibility (3.10+)
 - ✅ Package imports work correctly
 - ✅ Python dependencies (rich, ffmpeg-python, piexif)
 - ✅ External tools (FFmpeg, ExifTool)

--- a/validation_tests/run_all_tests.py
+++ b/validation_tests/run_all_tests.py
@@ -87,10 +87,10 @@ def check_prerequisites():
     
     # Check Python version
     version = sys.version_info
-    if version >= (3, 8):
+    if version >= (3, 10):
         print(f"   ✅ Python {version.major}.{version.minor}.{version.micro}")
     else:
-        print(f"   ❌ Python {version.major}.{version.minor}.{version.micro} (need 3.8+)")
+        print(f"   ❌ Python {version.major}.{version.minor}.{version.micro} (need 3.10+)")
         prerequisites_ok = False
     
     # Check if we're in the right directory

--- a/validation_tests/run_tests.bat
+++ b/validation_tests/run_tests.bat
@@ -30,7 +30,7 @@ if %errorlevel% neq 0 (
     py --version >nul 2>&1
     if %errorlevel% neq 0 (
         echo ERROR: Python not found in PATH
-        echo Please install Python 3.8+ and add to PATH
+        echo Please install Python 3.10+ and add to PATH
         pause
         exit /b 1
     ) else (

--- a/validation_tests/test_installation_and_dependencies.py
+++ b/validation_tests/test_installation_and_dependencies.py
@@ -17,8 +17,8 @@ def test_python_version():
     version = sys.version_info
     print(f"   Python {version.major}.{version.minor}.{version.micro}")
     
-    if version < (3, 8):
-        raise RuntimeError("❌ Python 3.8+ required")
+    if version < (3, 10):
+        raise RuntimeError("❌ Python 3.10+ required")
     
     print("   ✅ Python version OK")
     return True


### PR DESCRIPTION
## Summary
- fix manual install instructions
- bump minimum Python requirement to 3.10 in docs and scripts
- remove old package name references
- update validation test scripts accordingly

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fd7640744832c85260e93f42be925