### PR TITLE
Fix ExifTool extraction

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,15 @@ ExifTool is optional but needed for the `--exiftool` flag.
 
 - Download the package from [exiftool.org](https://exiftool.org/), rename the executable to `exiftool.exe` and add it to your `PATH`.
 
+### "Could not find ...exiftool_files/perl5*.dll"
+
+If ExifTool is installed but fails with a missing `perl5*.dll` message, the
+`exiftool_files` directory was not copied alongside `exiftool.exe`.
+
+- Delete the incomplete installation folder (usually `C:\Users\<user>\AppData\Local\dji-embed\bin`).
+- Re-run the [PowerShell bootstrap](../README.md#easy-windows-install) to extract
+  ExifTool correctly.
+
 ## "python was not found"
 
 On Windows, the `python` command may not be available. Use `py` instead:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -416,6 +416,12 @@ $exifSuccess = Install-Tool "ExifTool" $ExifToolUrl {
     $exeTool = Get-ChildItem $tempDir -Recurse -Filter "exiftool*.exe" | Select-Object -First 1
     if ($exeTool) {
         Copy-Item $exeTool.FullName (Join-Path $binDir "exiftool.exe") -Force
+
+        # Copy the bundled Perl library directory if present
+        $libDir = Join-Path $exeTool.DirectoryName "exiftool_files"
+        if (Test-Path $libDir) {
+            Copy-Item $libDir (Join-Path $binDir "exiftool_files") -Recurse -Force
+        }
     } else {
         throw "ExifTool executable not found in archive"
     }


### PR DESCRIPTION
## Summary
- copy `exiftool_files` folder in bootstrap installer
- document how to resolve `perl5*.dll` errors

## Testing
- `pip install -e .[dev]`
- `pytest -q`
- `dji-embed --version`


------
https://chatgpt.com/codex/tasks/task_e_687fe1bdd424832c8ca0045438ea5d53