### PR TITLE
Release v1.0.6

### DIFF
--- a/.github/winget/CallMarcus.DJI-Embed.locale.en-US.yaml
+++ b/.github/winget/CallMarcus.DJI-Embed.locale.en-US.yaml
@@ -1,6 +1,6 @@
 ---
 PackageIdentifier: CallMarcus.DJI-Embed
-PackageVersion: 1.0.5
+PackageVersion: 1.0.6
 PackageLocale: en-US
 PackageName: DJI Drone Metadata Embedder
 Publisher: CallMarcus

--- a/.github/winget/CallMarcus.DJI-Embed.yaml
+++ b/.github/winget/CallMarcus.DJI-Embed.yaml
@@ -1,6 +1,6 @@
 ---
 PackageIdentifier: CallMarcus.DJI-Embed
-PackageVersion: 1.0.5
+PackageVersion: 1.0.6
 PackageName: DJI Drone Metadata Embedder
 Publisher: CallMarcus
 Moniker: dji-embed

--- a/.github/winget/installer.yaml
+++ b/.github/winget/installer.yaml
@@ -1,6 +1,6 @@
 ---
 PackageIdentifier: CallMarcus.DJI-Embed
-PackageVersion: 1.0.5
+PackageVersion: 1.0.6
 PackageName: DJI Drone Metadata Embedder
 Publisher: CallMarcus
 License: MIT
@@ -11,7 +11,7 @@ ShortDescription: >-
 Installers:
   - Architecture: x64
     InstallerUrl: >-
-      https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.0.5/dji-embed.exe
+      https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.0.6/dji-embed.exe
     InstallerSha256: '{{SHA256}}'
     InstallerType: exe
 ManifestType: installer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > being stabilised. Expect ongoing changes and potential breakage as bugs are
 > fixed and the build process is improved.
 
+## [1.0.6] - 2025-07-23
+
+### Fixed
+- ExifTool extraction now copies bundled libraries correctly
+- `dji-embed embed` processes all videos instead of stopping early
+
 ## [1.0.5] - 2025-07-22
 
 ### Fixed

--- a/FIX_SUMMARY.md
+++ b/FIX_SUMMARY.md
@@ -1,4 +1,4 @@
-# DJI Metadata Embedder - Fix Summary (v1.0.5)
+# DJI Metadata Embedder - Fix Summary (v1.0.6)
 
 ## Issue Fixed
 The bootstrap script was failing because it tried to install version `1.0.4-test1` which is not a valid Python package version format (PEP 440 doesn't allow hyphens).
@@ -24,7 +24,7 @@ Run the release script:
 
 This will:
 - Delete the problematic v1.0.4-test1 tag
-- Create a proper v1.0.5 tag
+ - Create a proper v1.0.6 tag
 - Push it to GitHub to trigger release workflows
 
 ### 3. Monitor GitHub Actions
@@ -57,7 +57,7 @@ The updated script now:
 
 After creating the release:
 - [ ] Bootstrap script installs successfully
-- [ ] `dji-embed --version` shows 1.0.5
+- [ ] `dji-embed --version` shows 1.0.6
 - [ ] FFmpeg and ExifTool are downloaded
 - [ ] Basic video processing works
 - [ ] Winget package updates (may take 24-48 hours)

--- a/create_github_release.ps1
+++ b/create_github_release.ps1
@@ -1,5 +1,5 @@
-# Create GitHub Release for v1.0.5
-Write-Host "Creating GitHub Release for v1.0.5..." -ForegroundColor Green
+# Create GitHub Release for v1.0.6
+Write-Host "Creating GitHub Release for v1.0.6..." -ForegroundColor Green
 
 # Check if GitHub CLI is installed
 $ghInstalled = Get-Command gh -ErrorAction SilentlyContinue
@@ -36,7 +36,7 @@ iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedd
 
 **PyPI:**
 ``````bash
-pip install dji-drone-metadata-embedder==1.0.5
+pip install dji-drone-metadata-embedder==1.0.6
 ``````
 
 **Docker:**
@@ -49,19 +49,19 @@ docker pull callmarcus/dji-embed:latest
 - [User Guide](https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/docs/user_guide.md)
 - [Troubleshooting](https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/docs/troubleshooting.md)
 
-**Full Changelog**: https://github.com/CallMarcus/dji-drone-metadata-embedder/compare/v1.0.4...v1.0.5
+**Full Changelog**: https://github.com/CallMarcus/dji-drone-metadata-embedder/compare/v1.0.5...v1.0.6
 "@
 
 # Create the release using GitHub CLI
 try {
-    gh release create v1.0.5 `
-        --title "v1.0.5 - Bootstrap Script Fixes" `
+    gh release create v1.0.6 `
+        --title "v1.0.6 - Bug Fix Release" `
         --notes $releaseNotes `
         --latest
     
     Write-Host "✅ GitHub Release created successfully!" -ForegroundColor Green
     Write-Host ""
-    Write-Host "View the release at: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v1.0.5" -ForegroundColor Cyan
+    Write-Host "View the release at: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v1.0.6" -ForegroundColor Cyan
 } catch {
     Write-Host "❌ Failed to create release: $_" -ForegroundColor Red
     Write-Host ""

--- a/create_release.ps1
+++ b/create_release.ps1
@@ -1,28 +1,25 @@
-# Quick script to create a proper 1.0.5 release
+# Quick script to create a proper 1.0.6 release
 
-Write-Host "Creating proper 1.0.5 release..." -ForegroundColor Green
+Write-Host "Creating proper 1.0.6 release..." -ForegroundColor Green
 
 # Delete the test tag locally and remotely
 Write-Host "Cleaning up test tag..." -ForegroundColor Cyan
 git tag -d v1.0.4-test1 2>$null
 git push origin :refs/tags/v1.0.4-test1 2>$null
 
-# Create a proper v1.0.5 tag
-Write-Host "Creating v1.0.5 tag..." -ForegroundColor Cyan
+# Create a proper v1.0.6 tag
+Write-Host "Creating v1.0.6 tag..." -ForegroundColor Cyan
 $message = @"
-Release v1.0.5
+Release v1.0.6
 
-- Fixed bootstrap script to handle pre-release versions
-- Pre-release tags now install from GitHub instead of PyPI
-- Better error messages for version format issues
-- Fallback to stable version if pre-release installation fails
-- Support for installing directly from GitHub tags
+- ExifTool extraction copies bundled libraries correctly
+- Embed command processes all videos
 "@
 
-git tag -a v1.0.5 -m $message
+git tag -a v1.0.6 -m $message
 
 # Push the new tag
-Write-Host "Pushing v1.0.5 tag..." -ForegroundColor Cyan
-git push origin v1.0.5
+Write-Host "Pushing v1.0.6 tag..." -ForegroundColor Cyan
+git push origin v1.0.6
 
-Write-Host "Done! Release v1.0.5 created." -ForegroundColor Green
+Write-Host "Done! Release v1.0.6 created." -ForegroundColor Green

--- a/release_v1.0.6.ps1
+++ b/release_v1.0.6.ps1
@@ -1,18 +1,18 @@
-# Complete release process for v1.0.5
-Write-Host "DJI Metadata Embedder v1.0.5 Release Process" -ForegroundColor Green
+# Complete release process for v1.0.6
+Write-Host "DJI Metadata Embedder v1.0.6 Release Process" -ForegroundColor Green
 Write-Host "===========================================" -ForegroundColor Green
 
 # Step 1: Commit the fix summary update
 Write-Host "`nStep 1: Committing final updates..." -ForegroundColor Cyan
 git add FIX_SUMMARY.md
-git commit -m "docs: update fix summary for v1.0.5"
+git commit -m "docs: update fix summary for v1.0.6"
 
 # Step 2: Push all commits
 Write-Host "`nStep 2: Pushing commits to master..." -ForegroundColor Cyan
 git push origin master
 
 # Step 3: Run the release script
-Write-Host "`nStep 3: Creating v1.0.5 release..." -ForegroundColor Cyan
+Write-Host "`nStep 3: Creating v1.0.6 release..." -ForegroundColor Cyan
 .\create_release.ps1
 
 Write-Host "`n✅ Release process complete!" -ForegroundColor Green

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,5 +1,5 @@
 """DJI Drone Metadata Embedder."""
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 # Import check to ensure files were moved correctly
 try:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -188,7 +188,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "1.0.5"
+    $fallbackVersion = "1.0.6"
     
     try{
         LogInfo "Checking for latest version..."


### PR DESCRIPTION
## Summary
- bump version to 1.0.6
- update changelog for 1.0.6
- set fallback version in bootstrap script
- refresh release scripts and winget manifests
- add GitHub release script for v1.0.6

## Testing
- `pip install -e .[dev]`
- `pytest -q`
- `dji-embed --version`
- `python -m build`
- `twine check dist/*`


------
https://chatgpt.com/codex/tasks/task_e_687feacb1f3c832c8cbc24cdc834a8e0