### PR TITLE
Fix docs build by updating nav links

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,7 @@ If ExifTool is installed but fails with a missing `perl5*.dll` message, the
 `exiftool_files` directory was not copied alongside `exiftool.exe`.
 
 - Delete the incomplete installation folder (usually `C:\Users\<user>\AppData\Local\dji-embed\bin`).
-- Re-run the [PowerShell bootstrap](../README.md#easy-windows-install) to extract
+- Re-run the [PowerShell bootstrap](installation.md#easy-windows-install) to extract
   ExifTool correctly.
 
 ## "python was not found"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,11 @@ repo_url: https://github.com/example/dji-drone-metadata-embedder
 site_dir: site
 nav:
   - Home: index.md
+  - Installation: installation.md
+  - User Guide: user_guide.md
+  - FAQ: faq.md
+  - Troubleshooting: troubleshooting.md
+  - Validation Tests: validation_tests.md
   - Development Roadmap: development_roadmap.md
   - How-to Guides:
       - Embed GPS: how-to/embed-gps.md


### PR DESCRIPTION
## Summary
- include installation, user guide and other docs in MkDocs nav
- fix troubleshooting link to installation page

## Testing
- `pip install -e .[dev]`
- `pip install -r docs/requirements.txt`
- `pre-commit run --files mkdocs.yml docs/troubleshooting.md`
- `mkdocs build --strict`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fef446750832cb964fbcdfef27ac8