### PR TITLE
Fix Winget workflow manifest path

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -27,12 +27,14 @@ jobs:
       - name: Validate manifest
         shell: pwsh
         run: |
-          .\wingetcreate.exe validate .github/winget/CallMarcus.DJI-Embed.yaml
+          .\wingetcreate.exe validate `
+            .github/winget-manifests/CallMarcus.DJIMetadataEmbedder.yaml
 
       - name: Submit package
         shell: pwsh
         env:
           WINGET_PAT: ${{ secrets.WINGET_PAT }}
         run: |
-          .\wingetcreate.exe submit .github/winget/CallMarcus.DJI-Embed.yaml `
+          .\wingetcreate.exe submit `
+            .github/winget-manifests/CallMarcus.DJIMetadataEmbedder.yaml `
             --token $env:WINGET_PAT


### PR DESCRIPTION
## Summary
- point winget workflow to the manifest files under `.github/winget-manifests`
- wrap long run commands for yamllint compliance

## Testing
- `yamllint --strict .github/workflows/publish-winget.yml`

------
https://chatgpt.com/codex/tasks/task_e_68812d443774832c9f133c4ba3216a83