### PR TITLE
Fix winget workflow validation

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Validate manifest
         shell: pwsh
         run: |
-          .\wingetcreate.exe validate `
+          winget validate `
             .github/winget-manifests/CallMarcus.DJIMetadataEmbedder.yaml
 
       - name: Submit package

--- a/agents.md
+++ b/agents.md
@@ -16,12 +16,14 @@
 -   yamllint --strict passes  
     *Done when*: CI still green **and** git diff shows readable YAML.
 
-**T0.B · Verify Winget workflow**  
+**T0.B · Verify Winget workflow**
 *Files*: .github/workflows/publish-winget.yml
 *Checklist*:
 
 -   Ensure on: workflow_dispatch so it can be run manually
--   Run the job once; artefact = valid manifest in manifests/  
+-   Run the job once; artefact = valid manifest in manifests/
+-   Use `winget validate` prior to submission (replaces deprecated
+    `wingetcreate validate`)
     *Done when*: First successful run appears in the Actions tab.
 
 ### 0.2 · Re-format YAML files

--- a/prepare-submission-v1.0.6.ps1
+++ b/prepare-submission-v1.0.6.ps1
@@ -24,12 +24,12 @@ if (Test-Path $sourceDir) {
     exit 1
 }
 
-# Validate with wingetcreate if available
-if (Get-Command wingetcreate -ErrorAction SilentlyContinue) {
+# Validate with winget if available
+if (Get-Command winget -ErrorAction SilentlyContinue) {
     Write-Host "`nValidating manifests..." -ForegroundColor Yellow
-    wingetcreate validate $packageDir
+    winget validate $packageDir
 } else {
-    Write-Host "`n⚠️  Install wingetcreate for validation: winget install wingetcreate" -ForegroundColor Yellow
+    Write-Host "`n⚠️  Install winget for validation" -ForegroundColor Yellow
 }
 
 Write-Host "`n✅ Submission files ready in: $submitDir" -ForegroundColor Green

--- a/tools/prepare-winget-submission.ps1
+++ b/tools/prepare-winget-submission.ps1
@@ -49,10 +49,10 @@ Write-Host "3. Copy the contents of $submitDir\manifests to your fork"
 Write-Host "4. Create a PR with title: 'New package: CallMarcus.DJIMetadataEmbedder version $Version'"
 Write-Host "`nManifests are ready in: $submitDir" -ForegroundColor Green
 
-# Optional: Validate with wingetcreate
-if (Get-Command wingetcreate -ErrorAction SilentlyContinue) {
+# Optional: Validate manifests with winget
+if (Get-Command winget -ErrorAction SilentlyContinue) {
     Write-Host "`nValidating manifests..." -ForegroundColor Cyan
-    wingetcreate validate $packageDir
+    winget validate $packageDir
 } else {
-    Write-Host "`nTip: Install wingetcreate for validation: winget install wingetcreate" -ForegroundColor Gray
+    Write-Host "`nTip: Install winget for validation" -ForegroundColor Gray
 }


### PR DESCRIPTION
## Summary
- switch validation step to use `winget validate`
- update helper scripts for winget validation
- refresh agents instructions about the new command

## Testing
- `pytest -q`
- `dji-embed --version`
- `yamllint .github/workflows/publish-winget.yml`


------
https://chatgpt.com/codex/tasks/task_e_688136c13590832ca5aac4c979ee1698