### PR TITLE
build: tools: add sync_version.py to propagate version (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release]][release]
+[![Version](https://img.shields.io/badge/version-1.0.7-blue)][release]
 [![PyPI]][pypi]
 
 A Python tool to embed telemetry data from DJI drone SRT files into MP4 video files.

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-
+__version__ = "1.0.7"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -1,0 +1,65 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    path = Path(__file__).resolve().parent.parent / "tools" / "sync_version.py"
+    spec = importlib.util.spec_from_file_location("sync_version", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+def _write_project(root: Path, version: str) -> None:
+    (root / "src/pkg").mkdir(parents=True)
+    (root / "tools").mkdir()
+    (root / "winget").mkdir()
+
+    (root / "pyproject.toml").write_text(
+        """
+[tool.hatch.version]
+path = "src/pkg/__init__.py"
+""".strip()
+    )
+
+    (root / "src/pkg/__init__.py").write_text(f'__version__ = "{version}"\n')
+    (root / "README.md").write_text(
+        f'[![Version](https://img.shields.io/badge/version-{version}-blue)][release]\n'
+    )
+    (root / "tools/bootstrap.ps1").write_text(
+        f'$fallbackVersion = "{version}"\n'
+    )
+    (root / "dji-embed.spec").write_text(f'__version__ = "{version}"\n')
+    (root / "winget/manifest.yaml").write_text(f'PackageVersion: {version}\n')
+
+
+def test_sync_and_check(tmp_path: Path):
+    sync_version = _load_module()
+    _write_project(tmp_path, "0.1.0")
+
+    sync_version.main(["1.2.3"], project_root=tmp_path)
+
+    # All files should now contain the new version
+    for rel in [
+        "src/pkg/__init__.py",
+        "README.md",
+        "tools/bootstrap.ps1",
+        "dji-embed.spec",
+        "winget/manifest.yaml",
+    ]:
+        assert "1.2.3" in (tmp_path / rel).read_text()
+
+    # Check mode should pass
+    sync_version.main(["--check"], project_root=tmp_path)
+
+    # Introduce drift and ensure check fails
+    (tmp_path / "README.md").write_text(
+        '[![Version](https://img.shields.io/badge/version-0.0.1-blue)][release]\n'
+    )
+    with pytest.raises(SystemExit) as exc:
+        sync_version.main(["--check"], project_root=tmp_path)
+    assert exc.value.code == 1
+

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -1,0 +1,189 @@
+"""Synchronize project version across multiple files.
+
+This helper keeps the version defined in ``pyproject.toml`` (via
+``[tool.hatch.version]``) in sync with other project files such as the
+README badge, bootstrap script, PyInstaller spec and optional winget
+manifests.
+
+Usage::
+
+    python tools/sync_version.py 1.2.3       # update files to 1.2.3
+    python tools/sync_version.py --check     # verify files are in sync
+
+``--check`` exits with code 1 if any target file contains a different
+version.  The script is intentionally dependency light and uses only the
+standard library.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:  # Python >=3.11
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# mapping of target files to (regex, replacement template)
+TARGET_PATTERNS: dict[Path, tuple[str, str]] = {
+    Path("README.md"): (
+        r"https://img.shields.io/badge/version-(?P<ver>\d+\.\d+\.\d+)-blue",
+        "https://img.shields.io/badge/version-{version}-blue",
+    ),
+    Path("tools/bootstrap.ps1"): (
+        r"\$fallbackVersion\s*=\s*\"(?P<ver>\d+\.\d+\.\d+)\"",
+        "$fallbackVersion = \"{version}\"",
+    ),
+    Path("dji-embed.spec"): (
+        r"__version__\s*=\s*\"(?P<ver>\d+\.\d+\.\d+)\"",
+        "__version__ = \"{version}\"",
+    ),
+}
+
+
+VERSION_RE = re.compile(r"__version__\s*=\s*\"(?P<ver>\d+\.\d+\.\d+)\"")
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+
+
+def _read_toml(path: Path) -> dict:
+    with path.open("rb") as fh:  # tomllib requires binary mode
+        return tomllib.load(fh)
+
+
+def _version_file(root: Path) -> Path:
+    """Return the path to the version file defined in pyproject.toml."""
+
+    data = _read_toml(root / "pyproject.toml")
+    try:
+        rel_path = data["tool"]["hatch"]["version"]["path"]
+    except KeyError as exc:  # pragma: no cover - malformed config
+        raise KeyError("Version path not found in pyproject.toml") from exc
+    return (root / rel_path).resolve()
+
+
+def _replace_in_file(path: Path, pattern: str, replacement: str) -> bool:
+    """Replace ``pattern`` with ``replacement`` in ``path``.
+
+    Returns ``True`` if a substitution was made.
+    """
+
+    text = path.read_text(encoding="utf-8")
+    new_text, count = re.subn(pattern, replacement, text)
+    if count:
+        path.write_text(new_text, encoding="utf-8")
+        return True
+    return False
+
+
+def _update_targets(version: str, root: Path) -> None:
+    """Update all known target files to ``version``."""
+
+    # update version file
+    _replace_in_file(_version_file(root), VERSION_RE.pattern, f'__version__ = "{version}"')
+
+    for rel_path, (pattern, template) in TARGET_PATTERNS.items():
+        path = root / rel_path
+        if path.exists():
+            _replace_in_file(path, pattern, template.format(version=version))
+
+    # winget manifests (optional)
+    winget_dir = root / "winget"
+    if winget_dir.exists():
+        for manifest in winget_dir.rglob("*.yml"):
+            _replace_in_file(manifest, r"(?m)^PackageVersion:\s*(?P<ver>\d+\.\d+\.\d+)", f"PackageVersion: {version}")
+        for manifest in winget_dir.rglob("*.yaml"):
+            _replace_in_file(manifest, r"(?m)^PackageVersion:\s*(?P<ver>\d+\.\d+\.\d+)", f"PackageVersion: {version}")
+
+
+def _check_targets(version: str, root: Path) -> bool:
+    """Return ``True`` if all target files contain ``version``."""
+
+    mismatches: list[Path] = []
+
+    # version file
+    vf = _version_file(root)
+    vf_text = vf.read_text(encoding="utf-8")
+    match = VERSION_RE.search(vf_text)
+    if not match or match.group("ver") != version:
+        mismatches.append(vf)
+
+    # other targets
+    for rel_path, (pattern, _) in TARGET_PATTERNS.items():
+        path = root / rel_path
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        match = re.search(pattern, text)
+        if not match or match.group("ver") != version:
+            mismatches.append(path)
+
+    winget_dir = root / "winget"
+    if winget_dir.exists():
+        manifest_files = list(winget_dir.rglob("*.yml")) + list(winget_dir.rglob("*.yaml"))
+        for manifest in manifest_files:
+            text = manifest.read_text(encoding="utf-8")
+            match = re.search(r"(?m)^PackageVersion:\s*(?P<ver>\d+\.\d+\.\d+)", text)
+            if not match or match.group("ver") != version:
+                mismatches.append(manifest)
+
+    if mismatches:
+        print("Version drift detected in:", file=sys.stderr)
+        for path in mismatches:
+            print(f" - {path}", file=sys.stderr)
+        return False
+    return True
+
+
+def _current_version(root: Path) -> str:
+    """Extract current version from the version file."""
+
+    vf = _version_file(root)
+    text = vf.read_text(encoding="utf-8")
+    match = VERSION_RE.search(text)
+    if not match:
+        raise RuntimeError("Version string not found in version file")
+    return match.group("ver")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def main(argv: list[str] | None = None, project_root: Path | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Synchronize project version")
+    parser.add_argument("version", nargs="?", help="Version to apply")
+    parser.add_argument(
+        "--check", action="store_true", help="Only verify that versions match"
+    )
+    args = parser.parse_args(argv)
+
+    root = project_root or PROJECT_ROOT
+
+    if args.check:
+        version = args.version or _current_version(root)
+        ok = _check_targets(version, root)
+        if not ok:
+            raise SystemExit(1)
+        return
+
+    if not args.version:
+        parser.error("version argument required when not using --check")
+
+    _update_targets(args.version, root)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+


### PR DESCRIPTION
## Summary
- add `sync_version.py` to keep README badge, bootstrap script, PyInstaller spec and winget manifests aligned with project version
- expose version in `dji-embed.spec` and README badge for script to update
- test version propagation and drift checking

## Testing
- `ruff check tools/sync_version.py tests/test_sync_version.py`
- `mypy src`
- `pytest -q`
- `python tools/sync_version.py --check`
- `dji-embed --help`
- `dji-embed --version`


------
https://chatgpt.com/codex/tasks/task_e_689769003d5c832c8603f67f02e1436a