### PR TITLE
ci: split tag-driven releases (PyPI / EXE / winget) (#131)

### DIFF
--- a/.github/workflows/release-exe.yml
+++ b/.github/workflows/release-exe.yml
@@ -1,0 +1,47 @@
+---
+name: Build Windows EXE
+
+on:
+  workflow_run:
+    workflows: ["Release to PyPI"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Verify tag matches project version
+        shell: pwsh
+        run: |
+          $tag = '${{ github.event.workflow_run.head_branch }}'
+          $tag = $tag.TrimStart('v')
+          python tools/sync_version.py $tag --check
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r requirements-build.txt
+      - name: Build EXE
+        shell: pwsh
+        run: python tools/build_exe.py
+      - name: Attach to GitHub Release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag = '${{ github.event.workflow_run.head_branch }}'
+          gh release upload $tag dist/* --clobber
+      - name: Summary
+        shell: pwsh
+        run: |
+          $tag = '${{ github.event.workflow_run.head_branch }}'
+          echo "Windows binaries attached to [release $tag](https://github.com/${{ github.repository }}/releases/tag/$tag)" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,10 +1,7 @@
 ---
-name: Build and Publish to PyPI
+name: Release to PyPI
 
-on:  # yamllint disable-line rule:truthy
-  release:
-    types:
-      - published
+on:
   push:
     tags:
       - 'v*'
@@ -24,8 +21,7 @@ jobs:
           python-version: '3.x'
       - name: Verify tag matches project version
         run: |
-          TAG="${GITHUB_REF##*/}"
-          TAG="${TAG#v}"
+          TAG="${GITHUB_REF_NAME#v}"
           python tools/sync_version.py "$TAG" --check
       - name: Install dependencies
         run: |
@@ -38,3 +34,7 @@ jobs:
         with:
           print-auth-token: false
           skip-existing: true
+      - name: Summary
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "Published [dji-drone-metadata-embedder $TAG](https://pypi.org/project/dji-drone-metadata-embedder/$TAG/)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -1,0 +1,46 @@
+---
+name: Submit to winget
+
+on:
+  workflow_run:
+    workflows: ["Build Windows EXE"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Verify tag matches project version
+        shell: pwsh
+        run: |
+          $tag = '${{ github.event.workflow_run.head_branch }}'
+          $tag = $tag.TrimStart('v')
+          python tools/sync_version.py $tag --check
+      - name: Install wingetcreate
+        shell: pwsh
+        run: dotnet tool install --global wingetcreate
+      - name: Submit manifest
+        id: winget
+        shell: pwsh
+        env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          $tag = '${{ github.event.workflow_run.head_branch }}'
+          $version = $tag.TrimStart('v')
+          $url = "https://github.com/${{ github.repository }}/releases/download/$tag/"
+          $output = wingetcreate update --submit --version $version --urls "$url" --token $env:WINGET_GITHUB_TOKEN
+          $pr = ($output | Select-String 'https://github.com/[^ ]+').Matches.Value
+          if (-not $pr) { $pr = 'https://github.com/microsoft/winget-pkgs/pulls' }
+          "pr_url=$pr" >> $env:GITHUB_OUTPUT
+      - name: Summary
+        shell: pwsh
+        run: |
+          echo "Winget PR: ${{ steps.winget.outputs.pr_url }}" >> $env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- separate release workflow into PyPI, Windows EXE and winget submissions
- each job checks version sync and publishes a summary link to its artefacts

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`
- `dji-embed --help`
- `dji-embed --version`


------
https://chatgpt.com/codex/tasks/task_e_689770198c1c832cbc1b6ee37a2368cb