### PR TITLE
release: attach SHA256 and print toolchain versions (#132)

### DIFF
--- a/.github/workflows/release-exe.yml
+++ b/.github/workflows/release-exe.yml
@@ -33,6 +33,21 @@ jobs:
       - name: Build EXE
         shell: pwsh
         run: python tools/build_exe.py
+      - name: Download wheel from PyPI
+        shell: pwsh
+        run: |
+          $tag = '${{ github.event.workflow_run.head_branch }}'
+          $ver = $tag.TrimStart('v')
+          pip download dji-drone-metadata-embedder==$ver --no-deps -d dist
+      - name: Generate SHA256SUMS.txt
+        shell: pwsh
+        run: |
+          $hashLines = @()
+          Get-ChildItem dist -File | ForEach-Object {
+            $hash = Get-FileHash $_.FullName -Algorithm SHA256
+            $hashLines += "$($hash.Hash)  $($_.Name)"
+          }
+          $hashLines | Out-File -Encoding ascii dist/SHA256SUMS.txt
       - name: Attach to GitHub Release
         shell: pwsh
         env:

--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ GPS(59.302335,18.203059,132.860)
 ## Troubleshooting
 
 See [docs/troubleshooting.md](docs/troubleshooting.md) for additional tips.
+
+### Check tool versions
+Display the application, FFmpeg and ExifTool versions:
+```bash
+dji-embed --version
+```
 ### "Python was not found"
 Use `py` instead of `python`:
 ```bash

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,6 +9,7 @@ The workflow performs the following steps:
 3. Sign all files in `dist/` with `gpg --detach-sign`.
 4. Upload the package to PyPI via the Trusted Publishers flow (OIDC).
 5. Attach the artefacts and their signatures to the GitHub release page.
+6. Generate `SHA256SUMS.txt` for the wheel and Windows executable and upload it with the release assets.
 
 ## Creating a Release
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -12,11 +12,34 @@ from .telemetry_converter import (
     extract_telemetry_to_gpx,
     extract_telemetry_to_csv,
 )
-from .utilities import check_dependencies, setup_logging
+from .utilities import check_dependencies, setup_logging, get_tool_versions
+
+
+def _print_version(ctx: click.Context, param: click.Parameter, value: bool) -> None:
+    """Print application and toolchain versions."""
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(f"dji-embed {__version__}")
+    versions = get_tool_versions()
+    for name in ("ffmpeg", "exiftool"):
+        ver = versions.get(name)
+        if ver:
+            line = ver if ver.lower().startswith(name) else f"{name} {ver}"
+        else:
+            line = f"{name} not found"
+        click.echo(line)
+    ctx.exit()
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
-@click.version_option(__version__, prog_name="dji-embed")
+@click.option(
+    "--version",
+    is_flag=True,
+    expose_value=False,
+    is_eager=True,
+    callback=_print_version,
+    help="Show version and exit",
+)
 def main() -> None:
     """DJI Metadata Embedder command line interface."""
     pass

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -109,19 +109,19 @@ def check_dependencies() -> Tuple[bool, list[str]]:
     # Add dji-embed bin directory to PATH temporarily (Windows only)
     original_path = os.environ.get("PATH", "")
     path_modified = False
-    
+
     if platform.system() == "Windows":
         bin_dir = Path.home() / "AppData" / "Local" / "dji-embed" / "bin"
         if bin_dir.exists() and str(bin_dir) not in original_path:
             os.environ["PATH"] = str(bin_dir) + os.pathsep + original_path
             path_modified = True
-    
+
     try:
         for name, cmd in tools.items():
             # Check environment variables first (set by bootstrap script)
             env_var = f"DJIEMBED_{name.upper()}_PATH"
             tool_path = os.environ.get(env_var)
-            
+
             if tool_path and Path(tool_path).exists():
                 # Use the explicit path from environment variable
                 test_cmd = [tool_path] + cmd[1:]
@@ -130,12 +130,16 @@ def check_dependencies() -> Tuple[bool, list[str]]:
                     continue  # Tool found, skip to next
                 except (subprocess.CalledProcessError, FileNotFoundError):
                     pass  # Fall through to normal check
-            
+
             # Normal check
             try:
                 # Use shell=True on Windows to find executables in PATH
-                subprocess.run(cmd, capture_output=True, check=True, 
-                              shell=(platform.system() == "Windows"))
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    check=True,
+                    shell=(platform.system() == "Windows"),
+                )
             except (subprocess.CalledProcessError, FileNotFoundError):
                 missing.append(name)
     finally:
@@ -144,6 +148,57 @@ def check_dependencies() -> Tuple[bool, list[str]]:
             os.environ["PATH"] = original_path
 
     return (not missing), missing
+
+
+def get_tool_versions() -> dict[str, str | None]:
+    """Return version strings for ffmpeg and ExifTool.
+
+    Looks for executables in ``PATH`` or paths specified via
+    ``DJIEMBED_FFMPEG_PATH``/``DJIEMBED_EXIFTOOL_PATH`` environment
+    variables. Returns a mapping of tool name to its first line of version
+    output, or ``None`` if the tool isn't available.
+    """
+    import os
+    import platform
+
+    tools = {"ffmpeg": ["ffmpeg", "-version"], "exiftool": ["exiftool", "-ver"]}
+    versions: dict[str, str | None] = {}
+
+    original_path = os.environ.get("PATH", "")
+    path_modified = False
+
+    if platform.system() == "Windows":
+        bin_dir = Path.home() / "AppData" / "Local" / "dji-embed" / "bin"
+        if bin_dir.exists() and str(bin_dir) not in original_path:
+            os.environ["PATH"] = str(bin_dir) + os.pathsep + original_path
+            path_modified = True
+
+    try:
+        for name, cmd in tools.items():
+            env_var = f"DJIEMBED_{name.upper()}_PATH"
+            tool_path = os.environ.get(env_var)
+            if tool_path and Path(tool_path).exists():
+                test_cmd = [tool_path] + cmd[1:]
+                shell = False
+            else:
+                test_cmd = cmd
+                shell = platform.system() == "Windows"
+            try:
+                result = subprocess.run(
+                    test_cmd,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    shell=shell,
+                )
+                versions[name] = result.stdout.strip().splitlines()[0]
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                versions[name] = None
+    finally:
+        if path_modified:
+            os.environ["PATH"] = original_path
+
+    return versions
 
 
 def parse_dji_srt(srt_path: Path) -> dict:

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,27 @@
+import subprocess
+from click.testing import CliRunner
+
+from dji_metadata_embedder.cli import main
+from dji_metadata_embedder import __version__
+import dji_metadata_embedder.utilities as utils
+
+
+def test_version_shows_tool_versions(monkeypatch):
+    def fake_run(cmd, capture_output, text, check, shell=False):
+        if cmd[0] == "ffmpeg":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="ffmpeg version 6.1\n", stderr=""
+            )
+        if cmd[0] == "exiftool":
+            return subprocess.CompletedProcess(cmd, 0, stdout="12.34\n", stderr="")
+        raise FileNotFoundError
+
+    monkeypatch.setattr(utils.subprocess, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0
+    output = result.output.strip().splitlines()
+    assert output[0] == f"dji-embed {__version__}"
+    assert "ffmpeg version 6.1" in output[1]
+    assert "exiftool 12.34" in output[2]


### PR DESCRIPTION
## Summary
- show FFmpeg and ExifTool versions in `dji-embed --version`
- generate `SHA256SUMS.txt` during exe release and upload wheel
- document version command and checksum step

## Testing
- `pytest -q`
- `dji-embed --version`


------
https://chatgpt.com/codex/tasks/task_e_68977a7234ec832caeb51dc51967261f