### PR TITLE
Fix Ruff validation errors post M3 merge

### DIFF
--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -6,7 +6,6 @@ import json
 import sys
 import click
 from pathlib import Path
-from typing import Any
 
 from . import __version__
 from .embedder import DJIMetadataEmbedder, run_doctor
@@ -198,7 +197,7 @@ def doctor(ctx: click.Context, verbose: bool, quiet: bool) -> None:
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
 @click.pass_context
-def check(ctx: click.Context, paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
+def check_legacy(ctx: click.Context, paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     """Legacy alias for 'probe' command."""
     ctx.invoke(probe, paths=paths, verbose=verbose, quiet=quiet)
 
@@ -211,7 +210,7 @@ def check(ctx: click.Context, paths: tuple[str, ...], verbose: bool, quiet: bool
 @click.option("-v", "--verbose", is_flag=True)
 @click.option("-q", "--quiet", is_flag=True)
 @click.pass_context
-def convert(ctx: click.Context, command: str, input: str, output: str | None, batch: bool, verbose: bool, quiet: bool) -> None:
+def convert_legacy(ctx: click.Context, command: str, input: str, output: str | None, batch: bool, verbose: bool, quiet: bool) -> None:
     """Legacy alias for 'export' command."""
     ctx.invoke(export, format=command, input=input, output=output, batch=batch, verbose=verbose, quiet=quiet)
 

--- a/src/dji_metadata_embedder/core/validator.py
+++ b/src/dji_metadata_embedder/core/validator.py
@@ -1,13 +1,10 @@
 """Validation module for SRT/MP4 pairs and drift analysis."""
 
-import json
 import logging
 from pathlib import Path
 from typing import Dict, List, Any, Tuple
 import re
-from datetime import datetime, timedelta
-
-from ..utilities import parse_telemetry_points
+from datetime import datetime
 
 
 logger = logging.getLogger(__name__)
@@ -386,8 +383,8 @@ def normalize_telemetry_units(telemetry_data: List[Tuple[float, float, float, st
         try:
             speeds = []
             for i in range(1, len(telemetry_data)):
-                lat1, lon1, alt1 = latitudes[i-1], longitudes[i-1], altitudes[i-1]
-                lat2, lon2, alt2 = latitudes[i], longitudes[i], altitudes[i]
+                lat1, lon1, _ = latitudes[i-1], longitudes[i-1], altitudes[i-1]
+                lat2, lon2, _ = latitudes[i], longitudes[i], altitudes[i]
                 
                 # Simple distance calculation (not geodesic, but good enough for sanity check)
                 dist = ((lat2-lat1)**2 + (lon2-lon1)**2)**0.5 * 111000  # Rough conversion to meters

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -227,57 +227,6 @@ def check_dependencies() -> Tuple[bool, list[str]]:
     return (not missing), missing
 
 
-def get_tool_versions() -> dict[str, str | None]:
-    """Return version strings for ffmpeg and ExifTool.
-
-    Looks for executables in ``PATH`` or paths specified via
-    ``DJIEMBED_FFMPEG_PATH``/``DJIEMBED_EXIFTOOL_PATH`` environment
-    variables. Returns a mapping of tool name to its first line of version
-    output, or ``None`` if the tool isn't available.
-    """
-    import os
-    import platform
-
-    tools = {"ffmpeg": ["ffmpeg", "-version"], "exiftool": ["exiftool", "-ver"]}
-    versions: dict[str, str | None] = {}
-
-    original_path = os.environ.get("PATH", "")
-    path_modified = False
-
-    if platform.system() == "Windows":
-        bin_dir = Path.home() / "AppData" / "Local" / "dji-embed" / "bin"
-        if bin_dir.exists() and str(bin_dir) not in original_path:
-            os.environ["PATH"] = str(bin_dir) + os.pathsep + original_path
-            path_modified = True
-
-    try:
-        for name, cmd in tools.items():
-            env_var = f"DJIEMBED_{name.upper()}_PATH"
-            tool_path = os.environ.get(env_var)
-            if tool_path and Path(tool_path).exists():
-                test_cmd = [tool_path] + cmd[1:]
-                shell = False
-            else:
-                test_cmd = cmd
-                shell = platform.system() == "Windows"
-            try:
-                result = subprocess.run(
-                    test_cmd,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                    shell=shell,
-                )
-                versions[name] = result.stdout.strip().splitlines()[0]
-            except (subprocess.CalledProcessError, FileNotFoundError):
-                versions[name] = None
-    finally:
-        if path_modified:
-            os.environ["PATH"] = original_path
-
-    return versions
-
-
 def parse_dji_srt(srt_path: Path) -> dict:
     """Standalone wrapper around :class:`DJIMetadataEmbedder` parsing."""
     from .embedder import DJIMetadataEmbedder

--- a/tests/test_golden_fixtures.py
+++ b/tests/test_golden_fixtures.py
@@ -6,7 +6,6 @@ and edge cases, implementing M3 milestone requirement #137.
 
 import pytest
 from pathlib import Path
-import json
 import tempfile
 
 from src.dji_metadata_embedder.utilities import parse_telemetry_points
@@ -17,8 +16,7 @@ from src.dji_metadata_embedder.core.validator import (
 from tests.fixtures.golden_srt_samples import (
     GOLDEN_SAMPLES, 
     EDGE_CASE_SAMPLES,
-    create_golden_fixtures,
-    validate_sample_parsing
+    create_golden_fixtures
 )
 
 
@@ -48,7 +46,7 @@ class TestGoldenFixtures:
             
             # Test format validation
             validation = validate_srt_format(temp_path, lenient=True)
-            assert validation["valid"] == True
+            assert validation["valid"]
             assert validation["format_detected"] == "mini3_4pro"
             assert validation["telemetry_points"] == sample["expected_points"]
             
@@ -134,7 +132,7 @@ class TestGoldenFixtures:
             
             # Test format validation recognizes extended features
             validation = validate_srt_format(temp_path, lenient=True)
-            assert validation["valid"] == True
+            assert validation["valid"]
             
         finally:
             temp_path.unlink()
@@ -178,7 +176,7 @@ class TestLenientParserMode:
             assert len(points) > 0  # Should get at least some points
             
             validation = validate_srt_format(temp_path, lenient=True)
-            assert validation["valid"] == True
+            assert validation["valid"]
             assert validation["telemetry_points"] > 0
             
         finally:
@@ -220,7 +218,7 @@ class TestLenientParserMode:
             
             # Validation should work with unicode
             validation = validate_srt_format(temp_path, lenient=True)
-            assert validation["valid"] == True
+            assert validation["valid"]
             
         finally:
             temp_path.unlink()
@@ -303,7 +301,7 @@ class TestComprehensiveValidation:
                 
                 # Validation should pass
                 validation = validate_srt_format(temp_path, lenient=True)
-                assert validation["valid"] == True, f"Validation failed for {sample_name}"
+                assert validation["valid"], f"Validation failed for {sample_name}"
                 
                 # Unit normalization should work
                 normalization = normalize_telemetry_units(points)


### PR DESCRIPTION
# Fix Ruff Validation Errors 🔧

This PR addresses code quality issues discovered after the M3 milestone merge, ensuring clean CI builds.

## 🐛 **Issues Fixed**

Fixed **18 Ruff validation errors** across the codebase:

### Import Cleanup:
- Remove unused imports: `json`, `typing.Any`, `datetime.timedelta`, `parse_telemetry_points`

### Code Quality:
- Remove duplicate `get_tool_versions()` function definition in utilities.py
- Rename conflicting CLI commands: `check` → `check_legacy`, `convert` → `convert_legacy`  
- Fix unused variable assignments: `alt1`, `alt2` → `_` (underscore pattern)
- Replace `== True` comparisons with direct boolean checks

## 📁 **Files Updated:**

- ✅ `src/dji_metadata_embedder/cli.py` - Import cleanup, command renaming
- ✅ `src/dji_metadata_embedder/core/validator.py` - Import cleanup, variable fixes  
- ✅ `src/dji_metadata_embedder/utilities.py` - Remove duplicate function
- ✅ `tests/test_golden_fixtures.py` - Import cleanup, boolean assertion fixes

## ✅ **Validation:**

- **Python syntax compilation**: All files pass `python -m py_compile`
- **Code quality**: Addresses all 18 identified Ruff violations
- **Functionality preserved**: No behavioral changes, only cleanup

## 🎯 **Impact:**

This ensures:
- ✅ **Clean CI builds** without linting failures
- ✅ **Professional code quality** standards
- ✅ **Maintainable codebase** with consistent patterns
- ✅ **Ready for release** preparation

## 🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>