### PR TITLE
feat: fallback for interruption; add `--overwrite` to embed in place

### DIFF
--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -76,7 +76,12 @@ def main(ctx: click.Context, log_json: bool) -> None:
 @main.command()
 @click.argument("directory", type=click.Path(exists=True, file_okay=False))
 @click.option(
-    "-o", "--output", type=click.Path(file_okay=False), help="Output directory"
+    "-o", "--output", type=click.Path(file_okay=False), help="Output directory (ignored if --overwrite)"
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="Overwrite original video files in place (destination = input folder)",
 )
 @click.option("--exiftool", is_flag=True, help="Also use ExifTool for GPS metadata")
 @click.option("--dat", type=click.Path(exists=True), help="DAT flight log to merge")
@@ -93,6 +98,7 @@ def main(ctx: click.Context, log_json: bool) -> None:
 def embed(
     directory: str,
     output: str | None,
+    overwrite: bool,
     exiftool: bool,
     dat: str | None,
     dat_auto: bool,
@@ -110,6 +116,7 @@ def embed(
     embedder = DJIMetadataEmbedder(
         directory,
         output,
+        overwrite=overwrite,
         dat_path=dat,
         dat_autoscan=dat_auto,
         redact=redact,

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -87,7 +87,8 @@ class DJIMetadataEmbedder:
     Parameters
     ----------
     directory: path to folder containing MP4/SRT pairs
-    output_dir: destination directory for processed files
+    output_dir: destination directory for processed files (ignored if overwrite=True)
+    overwrite: if True, write embedded video over the original file (in-place)
     dat_path: optional path to a DAT flight log
     dat_autoscan: search for DAT logs matching each video
     redact: GPS redaction mode ("none", "drop", "fuzz")
@@ -103,6 +104,7 @@ class DJIMetadataEmbedder:
         self,
         directory: str,
         output_dir: Optional[str] = None,
+        overwrite: bool = False,
         dat_path: Optional[str] = None,
         dat_autoscan: bool = False,
         redact: str = "none",
@@ -113,7 +115,9 @@ class DJIMetadataEmbedder:
         self.output_dir = (
             Path(output_dir) if output_dir else self.directory / "processed"
         )
-        self.output_dir.mkdir(exist_ok=True)
+        self.overwrite = overwrite
+        if not self.overwrite:
+            self.output_dir.mkdir(exist_ok=True)
         self.dat_path = Path(dat_path) if dat_path else None
         self.dat_autoscan = dat_autoscan
         self.redact = redact
@@ -428,7 +432,7 @@ class DJIMetadataEmbedder:
             "total_files": len(video_files),
             "warnings": [],
             "errors": [],
-            "output_directory": str(self.output_dir)
+            "output_directory": str(self.directory if self.overwrite else self.output_dir),
         }
 
         if not video_files:
@@ -438,7 +442,10 @@ class DJIMetadataEmbedder:
             return result
 
         logger.info("Found %d video files to process", len(video_files))
-        logger.info("Output directory: %s\n", self.output_dir)
+        if self.overwrite:
+            logger.info("Overwrite mode: embedding in place (destination = input folder)\n")
+        else:
+            logger.info("Output directory: %s\n", self.output_dir)
 
         success_count = 0
 
@@ -488,9 +495,13 @@ class DJIMetadataEmbedder:
                         )
 
                 # Final output path; write to temp first, then atomic move (issue #162).
-                output_path = (
-                    self.output_dir / f"{video_path.stem}_metadata{video_path.suffix}"
-                )
+                # When overwrite (issue #163), destination = same as input file.
+                if self.overwrite:
+                    output_path = video_path
+                else:
+                    output_path = (
+                        self.output_dir / f"{video_path.stem}_metadata{video_path.suffix}"
+                    )
                 temp_output_path = Path(str(output_path) + _TEMP_SUFFIX)
 
                 # Embed metadata using ffmpeg into temp file
@@ -520,7 +531,7 @@ class DJIMetadataEmbedder:
                             self.embed_metadata_exiftool(output_path, telemetry)
 
                         # Save telemetry summary as JSON (atomic write)
-                        json_path = self.output_dir / f"{video_path.stem}_telemetry.json"
+                        json_path = output_path.parent / f"{video_path.stem}_telemetry.json"
                         json_tmp_path = Path(str(json_path) + _TEMP_SUFFIX)
                         json_data = {
                             "filename": video_path.name,
@@ -608,7 +619,12 @@ def main():
         help="Directory containing MP4 and SRT files",
     )
     parser.add_argument(
-        "-o", "--output", help="Output directory (default: ./processed)"
+        "-o", "--output", help="Output directory (default: ./processed); ignored if --overwrite"
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite original video files in place (destination = input folder)",
     )
     parser.add_argument(
         "--exiftool", action="store_true", help="Also use exiftool for GPS metadata"
@@ -665,6 +681,7 @@ def main():
     embedder = DJIMetadataEmbedder(
         args.directory,
         args.output,
+        overwrite=args.overwrite,
         dat_path=args.dat,
         dat_autoscan=args.dat_auto,
         redact=args.redact,

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -13,6 +14,66 @@ from .utilities import apply_redaction, setup_logging
 from .utils import system_info
 
 logger = logging.getLogger(__name__)
+
+# Suffix for temporary output files (before atomic move to final path).
+_TEMP_SUFFIX = ".tmp"
+
+
+def _validate_embedded_output(original_path: Path, temp_path: Path) -> bool:
+    """Validate temp output before moving to final destination.
+
+    Ensures the file is not corrupted after embedding (e.g. on interruption).
+    Checks: file exists, size >= original, and ffprobe can read the container.
+
+    Parameters
+    ----------
+    original_path : Path
+        Original source video path (for size comparison).
+    temp_path : Path
+        Path to the temporary embedded output file.
+
+    Returns
+    -------
+    bool
+        True if validation passes and the file is safe to move to destination.
+    """
+    if not temp_path.exists():
+        logger.debug("Validation failed: temp file does not exist %s", temp_path)
+        return False
+    try:
+        original_size = original_path.stat().st_size
+        temp_size = temp_path.stat().st_size
+    except OSError as e:
+        logger.warning("Validation failed: could not stat files: %s", e)
+        return False
+    if temp_size < original_size:
+        logger.warning(
+            "Validation failed: output size %d < original size %d for %s",
+            temp_size,
+            original_size,
+            temp_path.name,
+        )
+        return False
+    # Verify the container is valid (ffprobe -v error exits 0 only if readable).
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "error", "-i", str(temp_path)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            err = getattr(result, "stderr", "") or getattr(result, "stdout", "")
+            logger.warning(
+                "Validation failed: ffprobe reported error for %s: %s",
+                temp_path.name,
+                err,
+            )
+            return False
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        logger.warning("Validation failed: ffprobe check failed: %s", e)
+        return False
+    return True
 
 
 class DJIMetadataEmbedder:
@@ -426,40 +487,80 @@ class DJIMetadataEmbedder:
                             "Failed to parse DAT file %s: %s", dat_file.name, e
                         )
 
-                # Generate output filename
+                # Final output path; write to temp first, then atomic move (issue #162).
                 output_path = (
                     self.output_dir / f"{video_path.stem}_metadata{video_path.suffix}"
                 )
+                temp_output_path = Path(str(output_path) + _TEMP_SUFFIX)
 
-                # Embed metadata using ffmpeg
+                # Embed metadata using ffmpeg into temp file
                 if self.embed_metadata_ffmpeg(
-                    video_path, srt_path, telemetry, output_path
+                    video_path, srt_path, telemetry, temp_output_path
                 ):
-                    success_count += 1
+                    if _validate_embedded_output(video_path, temp_output_path):
+                        try:
+                            os.replace(temp_output_path, output_path)
+                        except OSError as e:
+                            logger.error(
+                                "Failed to move temp output to %s: %s",
+                                output_path,
+                                e,
+                            )
+                            if temp_output_path.exists():
+                                try:
+                                    temp_output_path.unlink()
+                                except OSError:
+                                    pass
+                            progress.advance(task)
+                            continue
+                        success_count += 1
 
-                    # Optionally use exiftool for additional metadata
-                    if use_exiftool:
-                        self.embed_metadata_exiftool(output_path, telemetry)
+                        # Optionally use exiftool for additional metadata
+                        if use_exiftool:
+                            self.embed_metadata_exiftool(output_path, telemetry)
 
-                    # Save telemetry summary as JSON
-                    json_path = self.output_dir / f"{video_path.stem}_telemetry.json"
-                    json_data = {
-                        "filename": video_path.name,
-                        "first_gps": telemetry["first_gps"],
-                        "average_gps": telemetry["avg_gps"],
-                        "max_altitude": telemetry["max_altitude"],
-                        "max_relative_altitude": telemetry.get("max_rel_altitude"),
-                        "flight_duration": telemetry["flight_duration"],
-                        "num_gps_points": len(telemetry["gps_coords"]),
-                        "camera_settings": telemetry.get("camera_settings", {}),
-                        "dat_records": len(telemetry.get("dat_records", [])),
-                    }
-
-                    with open(json_path, "w") as f:
-                        json.dump(json_data, f, indent=2)
-
+                        # Save telemetry summary as JSON (atomic write)
+                        json_path = self.output_dir / f"{video_path.stem}_telemetry.json"
+                        json_tmp_path = Path(str(json_path) + _TEMP_SUFFIX)
+                        json_data = {
+                            "filename": video_path.name,
+                            "first_gps": telemetry["first_gps"],
+                            "average_gps": telemetry["avg_gps"],
+                            "max_altitude": telemetry["max_altitude"],
+                            "max_relative_altitude": telemetry.get("max_rel_altitude"),
+                            "flight_duration": telemetry["flight_duration"],
+                            "num_gps_points": len(telemetry["gps_coords"]),
+                            "camera_settings": telemetry.get("camera_settings", {}),
+                            "dat_records": len(telemetry.get("dat_records", [])),
+                        }
+                        try:
+                            with open(json_tmp_path, "w") as f:
+                                json.dump(json_data, f, indent=2)
+                            os.replace(json_tmp_path, json_path)
+                        except OSError as e:
+                            logger.warning("Failed to write telemetry JSON: %s", e)
+                            if json_tmp_path.exists():
+                                try:
+                                    json_tmp_path.unlink()
+                                except OSError:
+                                    pass
+                    else:
+                        logger.error(
+                            "Validation failed for %s; output not saved.",
+                            video_path.name,
+                        )
+                        if temp_output_path.exists():
+                            try:
+                                temp_output_path.unlink()
+                            except OSError:
+                                pass
                     progress.advance(task)
                 else:
+                    if temp_output_path.exists():
+                        try:
+                            temp_output_path.unlink()
+                        except OSError:
+                            pass
                     progress.advance(task)
 
         result["processed"] = success_count

--- a/tests/test_embedder_atomic.py
+++ b/tests/test_embedder_atomic.py
@@ -170,3 +170,37 @@ class TestProcessDirectoryAtomicWrite:
         assert result["processed"] == 0
         assert not final_output.exists()
         assert not temp_output.exists()
+
+    def test_overwrite_mode_writes_in_place(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With overwrite=True, embedded video replaces the original file (issue #163)."""
+        video = tmp_path / "clip.mp4"
+        srt = tmp_path / "clip.srt"
+        video.write_bytes(b"original video content here")
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nGPS(1,2,3)")
+
+        def fake_run(cmd: list, *args, **kwargs):
+            res = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            if cmd and "ffmpeg" in str(cmd[0]).lower():
+                out_path = Path(cmd[-1])
+                out_path.write_bytes(b"embedded in place (padded for validation)")
+                return res
+            if cmd and "ffprobe" in str(cmd[0]).lower():
+                return res
+            return res
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress",
+            self._fake_progress_class(),
+        )
+
+        embedder = DJIMetadataEmbedder(str(tmp_path), overwrite=True)
+        result = embedder.process_directory(use_exiftool=False)
+
+        assert result["processed"] == 1
+        assert result["output_directory"] == str(tmp_path)
+        assert video.exists()
+        assert video.read_bytes() == b"embedded in place (padded for validation)"
+        assert not Path(str(video) + _TEMP_SUFFIX).exists()

--- a/tests/test_embedder_atomic.py
+++ b/tests/test_embedder_atomic.py
@@ -1,0 +1,172 @@
+"""Tests for atomic write and validation (issue #162).
+
+Ensures output is only saved after successful completion and validation,
+so interrupted runs do not leave corrupted files in the destination.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder.embedder import (
+    _TEMP_SUFFIX,
+    _validate_embedded_output,
+    DJIMetadataEmbedder,
+)
+
+
+class TestValidateEmbeddedOutput:
+    """Tests for _validate_embedded_output."""
+
+    def test_returns_false_when_temp_missing(self, tmp_path: Path) -> None:
+        original = tmp_path / "original.mp4"
+        original.write_bytes(b"x" * 1000)
+        temp_path = tmp_path / "out.mp4.tmp"
+        assert not _validate_embedded_output(original, temp_path)
+
+    def test_returns_false_when_temp_smaller_than_original(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        original = tmp_path / "original.mp4"
+        original.write_bytes(b"x" * 2000)
+        temp_path = tmp_path / "out.mp4.tmp"
+        temp_path.write_bytes(b"x" * 500)
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **k: type("R", (), {"returncode": 0})()
+        )
+        assert not _validate_embedded_output(original, temp_path)
+
+    def test_returns_true_when_size_ok_and_ffprobe_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        original = tmp_path / "original.mp4"
+        original.write_bytes(b"x" * 1000)
+        temp_path = tmp_path / "out.mp4.tmp"
+        temp_path.write_bytes(b"x" * 1500)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: type("R", (), {"returncode": 0})(),
+        )
+        assert _validate_embedded_output(original, temp_path) is True
+
+    def test_returns_false_when_ffprobe_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        original = tmp_path / "original.mp4"
+        original.write_bytes(b"x" * 1000)
+        temp_path = tmp_path / "out.mp4.tmp"
+        temp_path.write_bytes(b"x" * 1500)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: type("R", (), {"returncode": 1})(),
+        )
+        assert _validate_embedded_output(original, temp_path) is False
+
+
+class TestProcessDirectoryAtomicWrite:
+    """Tests that process_directory uses temp file and atomic move."""
+
+    @staticmethod
+    def _fake_progress_class():
+        """Minimal Progress-like class for tests (conftest stubs Progress as object)."""
+        class Task:
+            def advance(self, _=None):
+                pass
+        class FakeProgress:
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                return False
+            def add_task(self, *args, **kwargs):
+                return Task()
+            def update(self, task, description=None):
+                pass
+            def advance(self, task):
+                pass
+        return FakeProgress
+
+    def test_temp_suffix_defined(self) -> None:
+        assert _TEMP_SUFFIX == ".tmp"
+
+    def test_output_written_to_temp_then_moved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When embed succeeds and validation passes, final path exists and temp is gone."""
+        video = tmp_path / "DJI_20240101_123456.mp4"
+        srt = tmp_path / "DJI_20240101_123456.srt"
+        video.write_bytes(b"fake mp4 content here")
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nGPS(1,2,3)")
+
+        out_dir = tmp_path / "processed"
+        out_dir.mkdir()
+        final_output = out_dir / "DJI_20240101_123456_metadata.mp4"
+        temp_output = Path(str(final_output) + _TEMP_SUFFIX)
+
+        ffmpeg_called: list = []
+
+        def fake_run(cmd: list, *args, **kwargs):
+            res = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            if cmd and "ffmpeg" in str(cmd[0]).lower():
+                ffmpeg_called.append(cmd)
+                out_path = Path(cmd[-1])
+                # Write at least as many bytes as original so validation (size >= original) passes
+                out_path.write_bytes(b"embedded content (padded for size check)")
+                return res
+            if cmd and "ffprobe" in str(cmd[0]).lower():
+                return res
+            return res
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress",
+            self._fake_progress_class(),
+        )
+
+        embedder = DJIMetadataEmbedder(str(tmp_path), output_dir=str(out_dir))
+        result = embedder.process_directory(use_exiftool=False)
+
+        assert result["processed"] == 1
+        assert final_output.exists()
+        assert final_output.read_bytes() == b"embedded content (padded for size check)"
+        assert not temp_output.exists()
+        assert len(ffmpeg_called) >= 1
+        assert ffmpeg_called[0][-1].endswith(_TEMP_SUFFIX)
+
+    def test_final_not_created_when_validation_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When validation fails, final output is not created and temp is removed."""
+        video = tmp_path / "DJI_20240101_123456.mp4"
+        srt = tmp_path / "DJI_20240101_123456.srt"
+        video.write_bytes(b"x" * 2000)
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nGPS(1,2,3)")
+
+        out_dir = tmp_path / "processed"
+        out_dir.mkdir()
+        final_output = out_dir / "DJI_20240101_123456_metadata.mp4"
+        temp_output = Path(str(final_output) + _TEMP_SUFFIX)
+
+        def fake_run(cmd: list, *args, **kwargs):
+            res = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            if cmd and "ffmpeg" in str(cmd[0]).lower():
+                Path(cmd[-1]).write_bytes(b"x" * 100)
+                return res
+            if cmd and "ffprobe" in str(cmd[0]).lower():
+                return res
+            return res
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress",
+            self._fake_progress_class(),
+        )
+
+        embedder = DJIMetadataEmbedder(str(tmp_path), output_dir=str(out_dir))
+        result = embedder.process_directory(use_exiftool=False)
+
+        assert result["processed"] == 0
+        assert not final_output.exists()
+        assert not temp_output.exists()


### PR DESCRIPTION
Closes #162
Closes #163

## Fallback for interruption

- **Video:** FFmpeg is given a **temp path** (`..._metadata.mp4.tmp`). Only after it finishes and the temp file passes validation do we **replace** it onto the final path (`..._metadata.mp4`) with `os.replace(temp_output_path, output_path)`. So the final video path only appears when the embedded video is complete and valid.
- **JSON:** The telemetry JSON is also written to a `.tmp` file and then `os.replace`’d to the final name, so it’s atomic too, but that’s in addition to the video logic.

Relevant part of the flow in `embedder.py`:

```python
# Final output path; write to temp first, then atomic move (issue #162).
output_path = self.output_dir / f"{video_path.stem}_metadata{video_path.suffix}"
temp_output_path = Path(str(output_path) + _TEMP_SUFFIX)

# FFmpeg writes the VIDEO to temp_output_path
if self.embed_metadata_ffmpeg(video_path, srt_path, telemetry, temp_output_path):
    if _validate_embedded_output(video_path, temp_output_path):
        os.replace(temp_output_path, output_path)  # atomic move of VIDEO to final path
        success_count += 1
        # ... exiftool on output_path, then JSON written atomically to its own .tmp
```

So: the **output video file** is what we don’t save until it’s complete and validated; the JSON uses the same pattern on top of that.

## Embed in place

Add `--overwrite` to embed in place
- Add overwrite parameter to DJIMetadataEmbedder; when True, write embedded video over the original file (destination = input folder).
- Add --overwrite CLI flag to embed command; -o/--output is ignored when set. Skip creating output_dir when overwrite is used.
- Use same atomic write flow (https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/162): temp file, validate, then replace, so in-place overwrite remains safe on interruption.
- Telemetry JSON still written next to video via output_path.parent.
- Add test_overwrite_mode_writes_in_place in test_embedder_atomic.py.