### PR TITLE
feat(ui): local web UI served by `dji-embed ui` (browser + PWA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ dji-embed [OPTIONS] COMMAND [ARGS]...
 
 Commands:
   embed    Embed telemetry from SRT files into MP4 videos
-  check    Check media files for embedded metadata
+  validate Validate SRT/MP4 pairs and report drift
   convert  Convert SRT telemetry to GPX or CSV
+  check    Check media files for embedded metadata
   doctor   Show system information and verify dependencies
+  ui       Launch the local web UI in your browser
   wizard   Launch interactive setup wizard
   gui      Launch graphical interface (placeholder)
   init     Perform initial setup (placeholder)
@@ -123,6 +125,24 @@ Global Options:
   --version   Show the version and exit
   -h, --help  Show this message and exit
 ```
+
+### Web UI (optional)
+
+Prefer a browser over the terminal? Install the `[ui]` extra and launch the
+local UI — it runs entirely on `127.0.0.1` and uses your installed browser,
+so there is no separate signed app to trust.
+
+```bash
+pip install 'dji-drone-metadata-embedder[ui]'
+dji-embed ui                       # opens http://127.0.0.1:<free-port>
+dji-embed ui --no-browser          # print the URL instead of opening
+dji-embed ui --port 8765           # pin to a fixed port
+```
+
+Every tab (Doctor / Embed / Validate / Convert / Check) is a thin wrapper
+over the matching CLI command. Access is gated by a per-session token that
+is injected into the opened URL; requests without the token return `403`.
+Chromium-based browsers will offer "Install app" for a standalone window.
 
 ### Embed Command Options
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -31,3 +31,27 @@ python -m dji_metadata_embedder.telemetry_converter gpx DJI_0001.SRT
 Use `csv` instead of `gpx` to create a CSV file.
 
 For detailed how-to guides such as creating Windows bundles or redacting location data, see the files in `docs/how-to`.
+
+## Web UI
+
+If you'd rather click buttons than type commands, install the `[ui]` extra
+and launch the browser-based UI:
+
+```bash
+pip install 'dji-drone-metadata-embedder[ui]'
+dji-embed ui
+```
+
+The UI binds to `127.0.0.1` only (never the network) and opens a page in
+your default browser with tabs for Doctor, Embed, Validate, Convert, and
+Check. Each tab maps 1:1 to the matching CLI command, so anything you can
+do on the terminal is available here too.
+
+Useful flags:
+
+- `--port N` — pin to a fixed port instead of picking a free one.
+- `--no-browser` — print the URL instead of auto-opening.
+
+Access is gated by a per-session token that is injected into the URL that
+opens. If you bookmark a page, that link will stop working when the server
+restarts — relaunch `dji-embed ui` to get a fresh token.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ docs = [
     "mkdocs>=1.5",
     "mkdocstrings[python]>=0.24",
 ]
+# Local web UI served by `dji-embed ui`. Optional so the base install stays lean.
+ui = [
+    "flask>=3.0,<4.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/CallMarcus/dji-drone-metadata-embedder"

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -68,6 +68,7 @@ def main(ctx: click.Context, log_json: bool) -> None:
       convert   Convert SRT telemetry to GPX or CSV formats
       check     Analyze video files for embedded metadata
       doctor    Check system dependencies and configuration
+      ui        Launch the local web UI in your browser
     """
     ctx.ensure_object(dict)
     ctx.obj['log_json'] = log_json
@@ -261,6 +262,41 @@ def validate(
         else:
             click.echo(f"Error: {error_msg}", err=True)
         sys.exit(ExitCode.GENERAL_ERROR)
+
+
+@main.command()
+@click.option(
+    "--host",
+    default="127.0.0.1",
+    show_default=True,
+    help="Host to bind. Only 127.0.0.1/localhost are intended for use.",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=None,
+    help="Port to bind (default: a random free port).",
+)
+@click.option(
+    "--no-browser",
+    is_flag=True,
+    help="Do not open the browser automatically.",
+)
+def ui(host: str, port: int | None, no_browser: bool) -> None:
+    """Launch the local web UI in your default browser.
+
+    Requires the ``[ui]`` extra:
+
+        pip install 'dji-drone-metadata-embedder[ui]'
+    """
+    try:
+        from .ui.server import run_server
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise click.ClickException(f"UI module could not be loaded: {exc}")
+    try:
+        run_server(host=host, port=port, open_browser=not no_browser)
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/dji_metadata_embedder/ui/__init__.py
+++ b/src/dji_metadata_embedder/ui/__init__.py
@@ -1,0 +1,19 @@
+"""Local web UI for dji-embed.
+
+Runs a Flask app bound to 127.0.0.1 and served in the user's default browser.
+No new binaries are shipped; trust is delegated to the installed browser.
+
+Requires the optional ``[ui]`` extra.
+"""
+
+from __future__ import annotations
+
+__all__ = ["create_app", "run_server"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        from . import server
+
+        return getattr(server, name)
+    raise AttributeError(name)

--- a/src/dji_metadata_embedder/ui/jobs.py
+++ b/src/dji_metadata_embedder/ui/jobs.py
@@ -1,0 +1,164 @@
+"""In-process job registry for long-running UI tasks.
+
+Each job runs a subprocess, streams stdout lines as ``log`` events, and
+exposes a blocking subscription iterator that SSE handlers drain.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+TERMINAL_STATUSES = frozenset({"succeeded", "failed", "cancelled"})
+_HEARTBEAT_TIMEOUT = 15.0
+
+
+@dataclass
+class Job:
+    id: str
+    kind: str
+    status: str = "pending"
+    created_at: float = field(default_factory=time.time)
+    started_at: float | None = None
+    finished_at: float | None = None
+    error: str | None = None
+    events: list[dict] = field(default_factory=list)
+    _cond: threading.Condition = field(default_factory=threading.Condition)
+    _cancel: threading.Event = field(default_factory=threading.Event)
+    _proc: subprocess.Popen | None = None
+    _thread: threading.Thread | None = None
+
+    def to_json(self) -> dict:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "status": self.status,
+            "created_at": self.created_at,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "error": self.error,
+            "event_count": len(self.events),
+        }
+
+    def append(self, event: dict) -> None:
+        with self._cond:
+            self.events.append(event)
+            self._cond.notify_all()
+
+    def set_status(self, status: str) -> None:
+        with self._cond:
+            self.status = status
+            if status in TERMINAL_STATUSES and self.finished_at is None:
+                self.finished_at = time.time()
+            self._cond.notify_all()
+
+    def subscribe(self, start: int = 0) -> Iterator[dict]:
+        """Yield events from ``start`` onward, blocking until terminal."""
+        seq = start
+        while True:
+            with self._cond:
+                while (
+                    len(self.events) <= seq
+                    and self.status not in TERMINAL_STATUSES
+                ):
+                    if not self._cond.wait(timeout=_HEARTBEAT_TIMEOUT):
+                        yield {"type": "ping", "t": time.time()}
+                batch = self.events[seq:]
+                seq = len(self.events)
+                terminal = self.status in TERMINAL_STATUSES
+                final_status = self.status
+                final_error = self.error
+            for ev in batch:
+                yield ev
+            if terminal:
+                yield {"type": "status", "status": final_status, "error": final_error}
+                return
+
+    def request_cancel(self) -> None:
+        self._cancel.set()
+        proc = self._proc
+        if proc is not None and proc.poll() is None:
+            try:
+                proc.terminate()
+            except OSError as exc:  # pragma: no cover - defensive
+                logger.warning("proc.terminate failed for job %s: %s", self.id, exc)
+        self.append(
+            {"type": "log", "level": "warn", "msg": "Cancellation requested."}
+        )
+
+
+class JobRegistry:
+    def __init__(self) -> None:
+        self._jobs: dict[str, Job] = {}
+        self._lock = threading.Lock()
+
+    def create(self, kind: str) -> Job:
+        job = Job(id=uuid.uuid4().hex, kind=kind)
+        with self._lock:
+            self._jobs[job.id] = job
+        return job
+
+    def get(self, job_id: str) -> Job | None:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def list(self) -> list[Job]:
+        with self._lock:
+            return list(self._jobs.values())
+
+
+_registry = JobRegistry()
+
+
+def registry() -> JobRegistry:
+    return _registry
+
+
+def run_subprocess_job(job: Job, cmd: list[str]) -> None:
+    """Start ``cmd`` under ``job`` in a background daemon thread."""
+
+    def _target() -> None:
+        job.started_at = time.time()
+        job.set_status("running")
+        job.append(
+            {"type": "log", "level": "info", "msg": "$ " + " ".join(cmd)}
+        )
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            job._proc = proc
+            assert proc.stdout is not None
+            for raw in proc.stdout:
+                if job._cancel.is_set():
+                    break
+                line = raw.rstrip("\r\n")
+                if line:
+                    job.append({"type": "log", "level": "info", "msg": line})
+            rc = proc.wait()
+            if job._cancel.is_set():
+                job.set_status("cancelled")
+            elif rc == 0:
+                job.set_status("succeeded")
+            else:
+                job.error = f"exit code {rc}"
+                job.set_status("failed")
+        except Exception as exc:
+            job.error = str(exc)
+            job.append({"type": "log", "level": "err", "msg": f"Error: {exc}"})
+            job.set_status("failed")
+
+    thread = threading.Thread(target=_target, daemon=True, name=f"job-{job.id[:8]}")
+    job._thread = thread
+    thread.start()

--- a/src/dji_metadata_embedder/ui/server.py
+++ b/src/dji_metadata_embedder/ui/server.py
@@ -10,9 +10,11 @@ from pathlib import Path
 from typing import Any, Callable
 
 try:
-    from flask import Flask, abort, g, render_template, request
+    from flask import Flask, abort, g, jsonify, render_template, request
 except ImportError:  # pragma: no cover - exercised at runtime via CLI
     Flask = None  # type: ignore[assignment]
+
+from .. import __version__
 
 
 logger = logging.getLogger(__name__)
@@ -94,6 +96,27 @@ def create_app(token: str) -> "Flask":
     @app.route("/")
     def _home():
         return render_template("index.html", token=token)
+
+    @app.route("/api/doctor")
+    def _api_doctor():
+        from ..utilities import check_dependencies, get_tool_versions
+        from ..utils import system_info
+
+        try:
+            sys_info = system_info.get_system_summary()
+        except Exception as exc:  # defensive - system_info shells out
+            sys_info = {"error": str(exc)}
+        versions = get_tool_versions()
+        deps_ok, missing = check_dependencies()
+        return jsonify(
+            {
+                "app_version": __version__,
+                "system": sys_info,
+                "tools": versions,
+                "dependencies_ok": deps_ok,
+                "missing": missing,
+            }
+        )
 
     return app
 

--- a/src/dji_metadata_embedder/ui/server.py
+++ b/src/dji_metadata_embedder/ui/server.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import secrets
 import socket
+import sys
 import webbrowser
 from pathlib import Path
 from typing import Any, Callable
 
 try:
-    from flask import Flask, abort, g, jsonify, render_template, request
+    from flask import Flask, Response, abort, g, jsonify, render_template, request, stream_with_context
 except ImportError:  # pragma: no cover - exercised at runtime via CLI
     Flask = None  # type: ignore[assignment]
 
@@ -116,6 +118,97 @@ def create_app(token: str) -> "Flask":
                 "dependencies_ok": deps_ok,
                 "missing": missing,
             }
+        )
+
+    @app.route("/api/recent-folders")
+    def _api_recent_folders():
+        from . import state
+
+        return jsonify({"folders": state.get_recent_folders()})
+
+    @app.route("/api/jobs/embed", methods=["POST"])
+    def _api_start_embed():
+        from . import state
+        from .jobs import registry, run_subprocess_job
+
+        body = request.get_json(silent=True) or {}
+        directory = (body.get("directory") or "").strip()
+        if not directory:
+            return jsonify({"error": "directory is required"}), 400
+        target = Path(directory).expanduser()
+        if not target.is_dir():
+            return jsonify({"error": f"Not a directory: {directory}"}), 400
+
+        cmd: list[str] = [
+            sys.executable,
+            "-m",
+            "dji_metadata_embedder",
+            "embed",
+            str(target),
+        ]
+        if body.get("overwrite"):
+            cmd.append("--overwrite")
+        elif body.get("output"):
+            cmd += ["-o", str(body["output"])]
+        if body.get("exiftool"):
+            cmd.append("--exiftool")
+        if body.get("dat_auto"):
+            cmd.append("--dat-auto")
+        dat = (body.get("dat") or "").strip()
+        if dat:
+            cmd += ["--dat", dat]
+        redact = (body.get("redact") or "none").strip().lower()
+        if redact in {"drop", "fuzz"}:
+            cmd += ["--redact", redact]
+        if body.get("verbose"):
+            cmd.append("-v")
+
+        state.add_recent_folder(str(target))
+        job = registry().create("embed")
+        run_subprocess_job(job, cmd)
+        return jsonify({"job_id": job.id})
+
+    @app.route("/api/jobs/<job_id>")
+    def _api_job_status(job_id: str):
+        from .jobs import registry
+
+        job = registry().get(job_id)
+        if job is None:
+            abort(404)
+        return jsonify(job.to_json())
+
+    @app.route("/api/jobs/<job_id>/cancel", methods=["POST"])
+    def _api_job_cancel(job_id: str):
+        from .jobs import registry
+
+        job = registry().get(job_id)
+        if job is None:
+            abort(404)
+        job.request_cancel()
+        return jsonify(job.to_json())
+
+    @app.route("/api/jobs/<job_id>/events")
+    def _api_job_events(job_id: str):
+        from .jobs import registry
+
+        job = registry().get(job_id)
+        if job is None:
+            abort(404)
+        start = int(request.args.get("from", 0))
+
+        def _stream():
+            yield "retry: 2000\n\n"
+            for event in job.subscribe(start=start):
+                yield f"data: {json.dumps(event)}\n\n"
+
+        return Response(
+            stream_with_context(_stream()),
+            mimetype="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
         )
 
     return app

--- a/src/dji_metadata_embedder/ui/server.py
+++ b/src/dji_metadata_embedder/ui/server.py
@@ -126,6 +126,27 @@ def create_app(token: str) -> "Flask":
 
         return jsonify({"folders": state.get_recent_folders()})
 
+    @app.route("/api/validate", methods=["POST"])
+    def _api_validate():
+        from ..core.validator import validate_directory
+
+        body = request.get_json(silent=True) or {}
+        directory = (body.get("directory") or "").strip()
+        if not directory:
+            return jsonify({"error": "directory is required"}), 400
+        target = Path(directory).expanduser()
+        if not target.is_dir():
+            return jsonify({"error": f"Not a directory: {directory}"}), 400
+        try:
+            threshold = float(body.get("drift_threshold", 1.0))
+        except (TypeError, ValueError):
+            return jsonify({"error": "drift_threshold must be a number"}), 400
+
+        from . import state
+        state.add_recent_folder(str(target))
+        result = validate_directory(target, drift_threshold=threshold)
+        return jsonify(result)
+
     @app.route("/api/jobs/embed", methods=["POST"])
     def _api_start_embed():
         from . import state

--- a/src/dji_metadata_embedder/ui/server.py
+++ b/src/dji_metadata_embedder/ui/server.py
@@ -126,6 +126,20 @@ def create_app(token: str) -> "Flask":
 
         return jsonify({"folders": state.get_recent_folders()})
 
+    @app.route("/api/check", methods=["POST"])
+    def _api_check():
+        from ..metadata_check import check_metadata
+
+        body = request.get_json(silent=True) or {}
+        path = (body.get("path") or "").strip()
+        if not path:
+            return jsonify({"error": "path is required"}), 400
+        target = Path(path).expanduser()
+        if not target.exists():
+            return jsonify({"error": f"Not found: {path}"}), 400
+        result = check_metadata(target)
+        return jsonify({"path": str(target), "metadata": result})
+
     @app.route("/api/convert", methods=["POST"])
     def _api_convert():
         from ..telemetry_converter import (

--- a/src/dji_metadata_embedder/ui/server.py
+++ b/src/dji_metadata_embedder/ui/server.py
@@ -126,6 +126,35 @@ def create_app(token: str) -> "Flask":
 
         return jsonify({"folders": state.get_recent_folders()})
 
+    @app.route("/api/convert", methods=["POST"])
+    def _api_convert():
+        from ..telemetry_converter import (
+            extract_telemetry_to_csv,
+            extract_telemetry_to_gpx,
+        )
+
+        body = request.get_json(silent=True) or {}
+        srt = (body.get("srt") or "").strip()
+        fmt = (body.get("format") or "").strip().lower()
+        if not srt:
+            return jsonify({"error": "srt is required"}), 400
+        if fmt not in {"gpx", "csv"}:
+            return jsonify({"error": "format must be 'gpx' or 'csv'"}), 400
+        srt_path = Path(srt).expanduser()
+        if not srt_path.is_file():
+            return jsonify({"error": f"SRT file not found: {srt}"}), 400
+
+        output = (body.get("output") or "").strip()
+        output_path = Path(output).expanduser() if output else None
+        try:
+            if fmt == "gpx":
+                result = extract_telemetry_to_gpx(srt_path, output_path)
+            else:
+                result = extract_telemetry_to_csv(srt_path, output_path)
+        except Exception as exc:
+            return jsonify({"error": str(exc)}), 500
+        return jsonify({"output": str(result), "format": fmt})
+
     @app.route("/api/validate", methods=["POST"])
     def _api_validate():
         from ..core.validator import validate_directory

--- a/src/dji_metadata_embedder/ui/server.py
+++ b/src/dji_metadata_embedder/ui/server.py
@@ -1,0 +1,131 @@
+"""Flask application and local HTTP runner for the dji-embed UI."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import socket
+import webbrowser
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    from flask import Flask, abort, g, render_template, request
+except ImportError:  # pragma: no cover - exercised at runtime via CLI
+    Flask = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_COOKIE_NAME = "djiembed_token"
+_PUBLIC_PREFIXES = ("/static/",)
+_PUBLIC_PATHS = frozenset({"/healthz"})
+_FLASK_INSTALL_HINT = (
+    "Flask is not installed. Install the UI extra:\n"
+    "    pip install 'dji-drone-metadata-embedder[ui]'"
+)
+
+
+def _require_flask() -> None:
+    if Flask is None:
+        raise RuntimeError(_FLASK_INSTALL_HINT)
+
+
+def _is_public(path: str) -> bool:
+    return path in _PUBLIC_PATHS or any(path.startswith(p) for p in _PUBLIC_PREFIXES)
+
+
+def _token_matches(candidate: str, expected: str) -> bool:
+    return bool(candidate) and secrets.compare_digest(candidate, expected)
+
+
+def create_app(token: str) -> "Flask":
+    """Build the Flask app. ``token`` gates every non-public route."""
+    _require_flask()
+    app = Flask(
+        __name__,
+        template_folder=str(_PACKAGE_DIR / "templates"),
+        static_folder=str(_PACKAGE_DIR / "static"),
+        static_url_path="/static",
+    )
+    app.config["DJIEMBED_TOKEN"] = token
+
+    @app.before_request
+    def _enforce_token() -> Any:
+        if _is_public(request.path):
+            return None
+        query = request.args.get("t", "")
+        header = request.headers.get("X-DJIEmbed-Token", "")
+        cookie = request.cookies.get(_COOKIE_NAME, "")
+        if any(_token_matches(c, token) for c in (query, header, cookie)):
+            g.needs_cookie = not _token_matches(cookie, token)
+            return None
+        abort(403)
+
+    @app.after_request
+    def _security_headers(response):
+        if getattr(g, "needs_cookie", False):
+            response.set_cookie(
+                _COOKIE_NAME,
+                token,
+                httponly=True,
+                samesite="Strict",
+                secure=False,
+            )
+        response.headers.setdefault(
+            "Content-Security-Policy",
+            "default-src 'self'; "
+            "script-src 'self'; "
+            "style-src 'self'; "
+            "img-src 'self' data:; "
+            "connect-src 'self'; "
+            "frame-ancestors 'none'; "
+            "base-uri 'none'",
+        )
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        return response
+
+    @app.route("/healthz")
+    def _healthz():
+        return {"ok": True}
+
+    @app.route("/")
+    def _home():
+        return render_template("index.html", token=token)
+
+    return app
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def run_server(
+    host: str = "127.0.0.1",
+    port: int | None = None,
+    open_browser: bool = True,
+    token: str | None = None,
+    opener: Callable[[str], bool] | None = None,
+) -> None:
+    """Start the UI server and block until interrupted."""
+    _require_flask()
+    if host not in {"127.0.0.1", "localhost", "::1"}:
+        logger.warning(
+            "UI bound to %s; only 127.0.0.1/localhost are intended for use.", host
+        )
+    token = token or secrets.token_urlsafe(32)
+    port = port or _pick_free_port()
+    url = f"http://{host}:{port}/?t={token}"
+    app = create_app(token)
+    print(f"dji-embed UI ready at {url}")
+    print("Local use only — do not expose this server to a network.")
+    if open_browser:
+        try:
+            (opener or webbrowser.open)(url)
+        except Exception as exc:  # pragma: no cover - browser launch is best-effort
+            logger.warning("Could not open browser automatically: %s", exc)
+    app.run(host=host, port=port, debug=False, use_reloader=False, threaded=True)

--- a/src/dji_metadata_embedder/ui/server.py
+++ b/src/dji_metadata_embedder/ui/server.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 _PACKAGE_DIR = Path(__file__).resolve().parent
 _COOKIE_NAME = "djiembed_token"
 _PUBLIC_PREFIXES = ("/static/",)
-_PUBLIC_PATHS = frozenset({"/healthz"})
+_PUBLIC_PATHS = frozenset({"/healthz", "/sw.js"})
 _FLASK_INSTALL_HINT = (
     "Flask is not installed. Install the UI extra:\n"
     "    pip install 'dji-drone-metadata-embedder[ui]'"
@@ -94,6 +94,11 @@ def create_app(token: str) -> "Flask":
     @app.route("/healthz")
     def _healthz():
         return {"ok": True}
+
+    @app.route("/sw.js")
+    def _service_worker():
+        # Served from root so its scope covers the whole origin.
+        return app.send_static_file("sw.js")
 
     @app.route("/")
     def _home():

--- a/src/dji_metadata_embedder/ui/state.py
+++ b/src/dji_metadata_embedder/ui/state.py
@@ -1,0 +1,51 @@
+"""Persistent UI state (recent folders, preferences) under the user config dir."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+_MAX_RECENT = 10
+
+
+def _config_dir() -> Path:
+    if os.name == "nt":
+        base = Path(os.environ.get("APPDATA") or (Path.home() / "AppData" / "Roaming"))
+    else:
+        base = Path(os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config"))
+    cfg = base / "dji-embed"
+    cfg.mkdir(parents=True, exist_ok=True)
+    return cfg
+
+
+def _state_path() -> Path:
+    return _config_dir() / "ui.json"
+
+
+def load() -> dict[str, Any]:
+    path = _state_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save(state: dict[str, Any]) -> None:
+    _state_path().write_text(json.dumps(state, indent=2))
+
+
+def get_recent_folders() -> list[str]:
+    return list(load().get("recent_folders", []))
+
+
+def add_recent_folder(folder: str) -> list[str]:
+    state = load()
+    recents = [p for p in state.get("recent_folders", []) if p != folder]
+    recents.insert(0, folder)
+    state["recent_folders"] = recents[:_MAX_RECENT]
+    save(state)
+    return state["recent_folders"]

--- a/src/dji_metadata_embedder/ui/static/app.css
+++ b/src/dji_metadata_embedder/ui/static/app.css
@@ -100,3 +100,46 @@ pre {
 
 .panel h2 { margin: 0 0 .5rem; font-size: 1.1rem; }
 .panel h3 { margin: 1rem 0 .5rem; font-size: .95rem; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; }
+
+form label {
+  display: block;
+  margin: .75rem 0;
+  color: var(--muted);
+  font-size: .9rem;
+}
+form label input[type="text"],
+form label select {
+  display: block;
+  margin-top: .25rem;
+  width: 100%;
+  max-width: 520px;
+  color: var(--fg);
+}
+form label input[type="checkbox"] {
+  margin-right: .4rem;
+  vertical-align: middle;
+}
+details {
+  margin: 1rem 0;
+  padding: .5rem .75rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+details summary {
+  cursor: pointer;
+  color: var(--muted);
+  list-style: revert;
+}
+details[open] > summary { color: var(--fg); margin-bottom: .25rem; }
+
+.actions { margin-top: 1rem; display: flex; gap: .5rem; }
+
+#job-status { margin: .75rem 0 .25rem; }
+#job-log {
+  max-height: 400px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 2rem;
+}

--- a/src/dji_metadata_embedder/ui/static/app.css
+++ b/src/dji_metadata_embedder/ui/static/app.css
@@ -1,0 +1,90 @@
+:root {
+  --bg: #0f1220;
+  --panel: #141a2b;
+  --fg: #e8ecf1;
+  --muted: #8892a6;
+  --accent: #4c9aff;
+  --border: #1e2538;
+  --warn: #f2a93b;
+  --err: #ef5a5a;
+  --ok: #4ad07b;
+}
+
+* { box-sizing: border-box; }
+
+html, body { height: 100%; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.45;
+}
+
+.topbar {
+  padding: 1rem 1.5rem .75rem;
+  border-bottom: 1px solid var(--border);
+}
+.topbar h1 { margin: 0; font-size: 1.25rem; }
+.banner { color: var(--warn); font-size: .8rem; margin: .25rem 0 0; }
+
+.tabs {
+  display: flex;
+  gap: .25rem;
+  padding: .5rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+}
+.tab {
+  color: var(--muted);
+  text-decoration: none;
+  padding: .5rem .85rem;
+  border-radius: 6px;
+  font-size: .95rem;
+}
+.tab:hover { color: var(--fg); }
+.tab.active { color: var(--fg); background: var(--panel); }
+
+.content { padding: 1.5rem; max-width: 960px; }
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+}
+
+button, .btn {
+  background: var(--accent);
+  color: white;
+  border: 0;
+  padding: .5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+}
+button:hover { filter: brightness(1.1); }
+button:disabled { opacity: .5; cursor: not-allowed; }
+
+input, select, textarea {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: .5rem;
+  border-radius: 4px;
+  font: inherit;
+}
+
+pre {
+  background: var(--bg);
+  padding: .75rem;
+  border-radius: 4px;
+  overflow-x: auto;
+  font-size: .85rem;
+}
+
+.muted { color: var(--muted); }
+.ok { color: var(--ok); }
+.warn { color: var(--warn); }
+.err { color: var(--err); }

--- a/src/dji_metadata_embedder/ui/static/app.css
+++ b/src/dji_metadata_embedder/ui/static/app.css
@@ -143,3 +143,16 @@ details[open] > summary { color: var(--fg); margin-bottom: .25rem; }
   word-break: break-word;
   min-height: 2rem;
 }
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: .5rem 0 1rem;
+  font-size: .9rem;
+}
+.table th, .table td {
+  text-align: left;
+  padding: .4rem .5rem;
+  border-bottom: 1px solid var(--border);
+}
+.table th { color: var(--muted); font-weight: 500; }

--- a/src/dji_metadata_embedder/ui/static/app.css
+++ b/src/dji_metadata_embedder/ui/static/app.css
@@ -88,3 +88,15 @@ pre {
 .ok { color: var(--ok); }
 .warn { color: var(--warn); }
 .err { color: var(--err); }
+
+.kv {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: .35rem 1rem;
+  margin: .5rem 0 1rem;
+}
+.kv dt { color: var(--muted); }
+.kv dd { margin: 0; }
+
+.panel h2 { margin: 0 0 .5rem; font-size: 1.1rem; }
+.panel h3 { margin: 1rem 0 .5rem; font-size: .95rem; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; }

--- a/src/dji_metadata_embedder/ui/static/app.js
+++ b/src/dji_metadata_embedder/ui/static/app.js
@@ -186,10 +186,80 @@
     });
   }
 
+  async function renderValidate(root) {
+    let recents = { folders: [] };
+    try { recents = await api("/api/recent-folders"); } catch (_) {}
+    const recentOpts = recents.folders.map((f) => `<option value="${esc(f)}">`).join("");
+
+    root.innerHTML = `
+      <section class="panel">
+        <h2>Validate</h2>
+        <form id="validate-form">
+          <label>Folder with SRT/MP4 pairs
+            <input type="text" name="directory" list="validate-recents" required placeholder="/path/to/footage">
+          </label>
+          <datalist id="validate-recents">${recentOpts}</datalist>
+          <label>Drift threshold (seconds)
+            <input type="number" name="drift_threshold" step="0.1" min="0" value="1.0">
+          </label>
+          <div class="actions">
+            <button type="submit">Run</button>
+          </div>
+        </form>
+        <div id="validate-result"></div>
+      </section>`;
+
+    const form = root.querySelector("#validate-form");
+    const out = root.querySelector("#validate-result");
+    const runBtn = form.querySelector('button[type="submit"]');
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      const body = {
+        directory: fd.get("directory"),
+        drift_threshold: parseFloat(fd.get("drift_threshold") || "1.0"),
+      };
+      out.innerHTML = '<p class="muted">Scanning…</p>';
+      runBtn.disabled = true;
+      try {
+        const r = await api("/api/validate", {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        const issuesHtml = (r.issues || []).length
+          ? `<h3>Issues</h3><ul>${r.issues.map((i) => `<li class="err">${esc(i)}</li>`).join("")}</ul>`
+          : "";
+        const warningsHtml = (r.warnings || []).length
+          ? `<h3>Warnings</h3><ul>${r.warnings.map((w) => `<li class="warn">${esc(w)}</li>`).join("")}</ul>`
+          : "";
+        const filesHtml = (r.file_analyses || []).length
+          ? `<h3>Files</h3>
+             <table class="table">
+               <thead><tr><th>File</th><th>Valid</th><th>SRT points</th><th>Drift (s)</th></tr></thead>
+               <tbody>${r.file_analyses.map((f) => `
+                 <tr>
+                   <td>${esc(f.srt_file ? f.srt_file.split(/[\\/]/).pop() : "—")}</td>
+                   <td class="${f.valid ? "ok" : "err"}">${f.valid ? "yes" : "no"}</td>
+                   <td>${esc(f.srt_points ?? "—")}</td>
+                   <td>${esc(f.drift_seconds ?? "—")}</td>
+                 </tr>`).join("")}</tbody>
+             </table>`
+          : "";
+        const summary = `<p>Total: <strong>${r.total_files}</strong> &middot; Valid pairs: <strong class="${r.valid_pairs === r.total_files && r.total_files > 0 ? "ok" : "warn"}">${r.valid_pairs}</strong></p>`;
+        out.innerHTML = summary + issuesHtml + warningsHtml + filesHtml;
+      } catch (e) {
+        out.innerHTML = `<p class="err">Error: ${esc(e.message)}</p>`;
+      } finally {
+        runBtn.disabled = false;
+      }
+    });
+  }
+
   const routes = {
     doctor: renderDoctor,
     embed: renderEmbed,
-    validate: stub("Validate tab — wiring in a later commit."),
+    validate: renderValidate,
     convert: stub("Convert tab — wiring in a later commit."),
     check: stub("Check tab — wiring in a later commit."),
   };

--- a/src/dji_metadata_embedder/ui/static/app.js
+++ b/src/dji_metadata_embedder/ui/static/app.js
@@ -1,0 +1,52 @@
+(() => {
+  "use strict";
+
+  const tokenMeta = document.querySelector('meta[name="djiembed-token"]');
+  const token = tokenMeta ? tokenMeta.content : "";
+
+  async function api(path, init = {}) {
+    const headers = new Headers(init.headers || {});
+    headers.set("X-DJIEmbed-Token", token);
+    if (init.body && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    const res = await fetch(path, { ...init, headers, credentials: "same-origin" });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`${res.status} ${res.statusText}${text ? `: ${text}` : ""}`);
+    }
+    const ct = res.headers.get("content-type") || "";
+    return ct.includes("application/json") ? res.json() : res.text();
+  }
+
+  function setActiveTab(name) {
+    document.querySelectorAll(".tab").forEach((el) => {
+      el.classList.toggle("active", el.dataset.tab === name);
+    });
+  }
+
+  function stub(message) {
+    return (root) => {
+      root.innerHTML = `<section class="panel"><p class="muted">${message}</p></section>`;
+    };
+  }
+
+  const routes = {
+    doctor: stub("Doctor tab — wiring in a later commit."),
+    embed: stub("Embed tab — wiring in a later commit."),
+    validate: stub("Validate tab — wiring in a later commit."),
+    convert: stub("Convert tab — wiring in a later commit."),
+    check: stub("Check tab — wiring in a later commit."),
+  };
+
+  function render() {
+    const hash = (window.location.hash || "#/doctor").replace(/^#\/?/, "") || "doctor";
+    const route = routes[hash] || routes.doctor;
+    setActiveTab(routes[hash] ? hash : "doctor");
+    route(document.getElementById("app"));
+  }
+
+  window.djiEmbed = { api, routes, render };
+  window.addEventListener("hashchange", render);
+  window.addEventListener("DOMContentLoaded", render);
+})();

--- a/src/dji_metadata_embedder/ui/static/app.js
+++ b/src/dji_metadata_embedder/ui/static/app.js
@@ -256,11 +256,62 @@
     });
   }
 
+  function renderConvert(root) {
+    root.innerHTML = `
+      <section class="panel">
+        <h2>Convert</h2>
+        <form id="convert-form">
+          <label>SRT file
+            <input type="text" name="srt" required placeholder="/path/to/DJI_0001.SRT">
+          </label>
+          <label>Format
+            <select name="format">
+              <option value="gpx">GPX</option>
+              <option value="csv">CSV</option>
+            </select>
+          </label>
+          <label>Output path <span class="muted">(optional; defaults next to source)</span>
+            <input type="text" name="output" placeholder="leave blank to use default">
+          </label>
+          <div class="actions">
+            <button type="submit">Convert</button>
+          </div>
+        </form>
+        <div id="convert-result"></div>
+      </section>`;
+
+    const form = root.querySelector("#convert-form");
+    const out = root.querySelector("#convert-result");
+    const runBtn = form.querySelector('button[type="submit"]');
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      out.innerHTML = '<p class="muted">Converting…</p>';
+      runBtn.disabled = true;
+      try {
+        const r = await api("/api/convert", {
+          method: "POST",
+          body: JSON.stringify({
+            srt: fd.get("srt"),
+            format: fd.get("format"),
+            output: fd.get("output"),
+          }),
+        });
+        out.innerHTML = `<p class="ok">Wrote ${esc(r.format.toUpperCase())}: <code>${esc(r.output)}</code></p>`;
+      } catch (e) {
+        out.innerHTML = `<p class="err">Error: ${esc(e.message)}</p>`;
+      } finally {
+        runBtn.disabled = false;
+      }
+    });
+  }
+
   const routes = {
     doctor: renderDoctor,
     embed: renderEmbed,
     validate: renderValidate,
-    convert: stub("Convert tab — wiring in a later commit."),
+    convert: renderConvert,
     check: stub("Check tab — wiring in a later commit."),
   };
 

--- a/src/dji_metadata_embedder/ui/static/app.js
+++ b/src/dji_metadata_embedder/ui/static/app.js
@@ -307,12 +307,59 @@
     });
   }
 
+  function renderCheck(root) {
+    root.innerHTML = `
+      <section class="panel">
+        <h2>Check</h2>
+        <p class="muted">Inspect a single media file for embedded GPS, altitude, and creation time metadata.</p>
+        <form id="check-form">
+          <label>File path
+            <input type="text" name="path" required placeholder="/path/to/DJI_0001.MP4">
+          </label>
+          <div class="actions">
+            <button type="submit">Check</button>
+          </div>
+        </form>
+        <div id="check-result"></div>
+      </section>`;
+
+    const form = root.querySelector("#check-form");
+    const out = root.querySelector("#check-result");
+    const runBtn = form.querySelector('button[type="submit"]');
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const path = new FormData(form).get("path");
+      out.innerHTML = '<p class="muted">Checking…</p>';
+      runBtn.disabled = true;
+      try {
+        const r = await api("/api/check", {
+          method: "POST",
+          body: JSON.stringify({ path }),
+        });
+        const meta = r.metadata || {};
+        const rows = Object.entries(meta).length
+          ? Object.entries(meta).map(([k, v]) =>
+              `<dt>${esc(k)}</dt><dd class="${v ? "ok" : "err"}">${v ? "present" : "missing"}</dd>`
+            ).join("")
+          : '<dt class="muted">no data</dt><dd class="muted">(tool unavailable or unreadable file)</dd>';
+        out.innerHTML = `
+          <p class="muted"><code>${esc(r.path)}</code></p>
+          <dl class="kv">${rows}</dl>`;
+      } catch (e) {
+        out.innerHTML = `<p class="err">Error: ${esc(e.message)}</p>`;
+      } finally {
+        runBtn.disabled = false;
+      }
+    });
+  }
+
   const routes = {
     doctor: renderDoctor,
     embed: renderEmbed,
     validate: renderValidate,
     convert: renderConvert,
-    check: stub("Check tab — wiring in a later commit."),
+    check: renderCheck,
   };
 
   function render() {

--- a/src/dji_metadata_embedder/ui/static/app.js
+++ b/src/dji_metadata_embedder/ui/static/app.js
@@ -372,4 +372,12 @@
   window.djiEmbed = { api, routes, render };
   window.addEventListener("hashchange", render);
   window.addEventListener("DOMContentLoaded", render);
+
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", () => {
+      navigator.serviceWorker.register("/sw.js").catch(() => {
+        // Service worker is nice-to-have; ignore failures.
+      });
+    });
+  }
 })();

--- a/src/dji_metadata_embedder/ui/static/app.js
+++ b/src/dji_metadata_embedder/ui/static/app.js
@@ -71,9 +71,124 @@
     }
   }
 
+  async function renderEmbed(root) {
+    let recents = { folders: [] };
+    try { recents = await api("/api/recent-folders"); } catch (_) {}
+    const recentOpts = recents.folders.map((f) => `<option value="${esc(f)}">`).join("");
+
+    root.innerHTML = `
+      <section class="panel">
+        <h2>Embed</h2>
+        <form id="embed-form">
+          <label>Footage folder
+            <input type="text" name="directory" list="recent-folders" required placeholder="/path/to/footage">
+          </label>
+          <datalist id="recent-folders">${recentOpts}</datalist>
+
+          <label><input type="checkbox" name="overwrite"> Overwrite original files in place</label>
+
+          <label>Redact GPS
+            <select name="redact">
+              <option value="none">none</option>
+              <option value="drop">drop</option>
+              <option value="fuzz">fuzz</option>
+            </select>
+          </label>
+
+          <details>
+            <summary>Advanced</summary>
+            <label><input type="checkbox" name="exiftool"> Also use ExifTool for GPS metadata</label>
+            <label><input type="checkbox" name="dat_auto"> Auto-detect DAT flight logs</label>
+            <label>DAT log file <input type="text" name="dat" placeholder="optional path"></label>
+            <label>Output folder <input type="text" name="output" placeholder="optional; ignored if overwrite is set"></label>
+            <label><input type="checkbox" name="verbose"> Verbose output</label>
+          </details>
+
+          <div class="actions">
+            <button type="submit">Run</button>
+            <button type="button" id="cancel-btn" disabled>Cancel</button>
+          </div>
+        </form>
+        <p id="job-status" class="muted"></p>
+        <pre id="job-log" aria-live="polite"></pre>
+      </section>`;
+
+    const form = root.querySelector("#embed-form");
+    const logEl = root.querySelector("#job-log");
+    const statusEl = root.querySelector("#job-status");
+    const cancelBtn = root.querySelector("#cancel-btn");
+    const runBtn = form.querySelector('button[type="submit"]');
+    let currentJob = null;
+    let stream = null;
+
+    function setStatus(text, cls = "muted") {
+      statusEl.textContent = text;
+      statusEl.className = cls;
+    }
+
+    cancelBtn.addEventListener("click", async () => {
+      if (!currentJob) return;
+      try {
+        await api(`/api/jobs/${currentJob}/cancel`, { method: "POST" });
+        setStatus("cancelling…", "warn");
+      } catch (e) {
+        setStatus("cancel failed: " + e.message, "err");
+      }
+    });
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      const body = Object.fromEntries(fd.entries());
+      ["overwrite", "exiftool", "dat_auto", "verbose"].forEach((k) => {
+        body[k] = form.elements[k].checked;
+      });
+
+      logEl.textContent = "";
+      setStatus("starting…", "muted");
+      runBtn.disabled = true;
+      cancelBtn.disabled = false;
+
+      try {
+        const { job_id } = await api("/api/jobs/embed", {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+        currentJob = job_id;
+        setStatus(`running (${job_id.slice(0, 8)})`, "warn");
+
+        stream = new EventSource(`/api/jobs/${job_id}/events`);
+        stream.onmessage = (ev) => {
+          let msg;
+          try { msg = JSON.parse(ev.data); } catch { return; }
+          if (msg.type === "log") {
+            logEl.textContent += msg.msg + "\n";
+            logEl.scrollTop = logEl.scrollHeight;
+          } else if (msg.type === "status") {
+            const cls = msg.status === "succeeded" ? "ok"
+                      : msg.status === "failed" ? "err" : "warn";
+            setStatus(msg.status + (msg.error ? " — " + msg.error : ""), cls);
+            runBtn.disabled = false;
+            cancelBtn.disabled = true;
+            stream.close();
+            stream = null;
+            currentJob = null;
+          }
+        };
+        stream.onerror = () => {
+          // Browser auto-reconnects; nothing to do unless terminal status already sent.
+        };
+      } catch (e) {
+        setStatus("error: " + e.message, "err");
+        runBtn.disabled = false;
+        cancelBtn.disabled = true;
+      }
+    });
+  }
+
   const routes = {
     doctor: renderDoctor,
-    embed: stub("Embed tab — wiring in a later commit."),
+    embed: renderEmbed,
     validate: stub("Validate tab — wiring in a later commit."),
     convert: stub("Convert tab — wiring in a later commit."),
     check: stub("Check tab — wiring in a later commit."),

--- a/src/dji_metadata_embedder/ui/static/app.js
+++ b/src/dji_metadata_embedder/ui/static/app.js
@@ -31,8 +31,48 @@
     };
   }
 
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, (c) => (
+      { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+    ));
+  }
+
+  function kvList(obj) {
+    return Object.entries(obj)
+      .map(([k, v]) => `<dt>${esc(k)}</dt><dd>${esc(v)}</dd>`)
+      .join("");
+  }
+
+  async function renderDoctor(root) {
+    root.innerHTML = '<section class="panel"><p class="muted">Loading…</p></section>';
+    try {
+      const d = await api("/api/doctor");
+      const status = d.dependencies_ok
+        ? '<span class="ok">All dependencies verified</span>'
+        : `<span class="err">Missing: ${d.missing.map(esc).join(", ")}</span>`;
+      const tools = Object.entries(d.tools)
+        .map(([name, ver]) => {
+          const ok = ver && ver !== "not available";
+          const cls = ok ? "ok" : "err";
+          return `<dt>${esc(name)}</dt><dd class="${cls}">${esc(ver || "not available")}</dd>`;
+        })
+        .join("");
+      root.innerHTML = `
+        <section class="panel">
+          <h2>Doctor</h2>
+          <p>dji-embed ${esc(d.app_version)} — ${status}</p>
+          <h3>External tools</h3>
+          <dl class="kv">${tools}</dl>
+          <h3>System</h3>
+          <dl class="kv">${kvList(d.system)}</dl>
+        </section>`;
+    } catch (e) {
+      root.innerHTML = `<section class="panel"><p class="err">Error: ${esc(e.message)}</p></section>`;
+    }
+  }
+
   const routes = {
-    doctor: stub("Doctor tab — wiring in a later commit."),
+    doctor: renderDoctor,
     embed: stub("Embed tab — wiring in a later commit."),
     validate: stub("Validate tab — wiring in a later commit."),
     convert: stub("Convert tab — wiring in a later commit."),

--- a/src/dji_metadata_embedder/ui/static/icon-maskable.svg
+++ b/src/dji_metadata_embedder/ui/static/icon-maskable.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="dji-embed">
+  <rect width="512" height="512" fill="#0f1220"/>
+  <circle cx="256" cy="256" r="96" fill="none" stroke="#4c9aff" stroke-width="24"/>
+  <circle cx="256" cy="256" r="20" fill="#4c9aff"/>
+</svg>

--- a/src/dji_metadata_embedder/ui/static/icon.svg
+++ b/src/dji_metadata_embedder/ui/static/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="dji-embed">
+  <rect width="512" height="512" rx="96" fill="#0f1220"/>
+  <circle cx="256" cy="256" r="128" fill="none" stroke="#4c9aff" stroke-width="28"/>
+  <circle cx="256" cy="256" r="26" fill="#4c9aff"/>
+  <circle cx="112" cy="112" r="32" fill="#1e2538"/>
+  <circle cx="400" cy="112" r="32" fill="#1e2538"/>
+  <circle cx="112" cy="400" r="32" fill="#1e2538"/>
+  <circle cx="400" cy="400" r="32" fill="#1e2538"/>
+</svg>

--- a/src/dji_metadata_embedder/ui/static/manifest.webmanifest
+++ b/src/dji_metadata_embedder/ui/static/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "dji-embed",
+  "short_name": "dji-embed",
+  "description": "Embed DJI drone telemetry into videos",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "theme_color": "#0f1220",
+  "background_color": "#0f1220",
+  "icons": [
+    {
+      "src": "/static/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any"
+    },
+    {
+      "src": "/static/icon-maskable.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/src/dji_metadata_embedder/ui/static/sw.js
+++ b/src/dji_metadata_embedder/ui/static/sw.js
@@ -1,0 +1,19 @@
+// Minimal service worker. Present so the browser exposes "Install app"
+// for PWA installability. Network-first with no caching because the
+// backend is local and always available.
+
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(
+    fetch(event.request).catch(
+      () => new Response("Server offline", { status: 503, statusText: "Offline" })
+    )
+  );
+});

--- a/src/dji_metadata_embedder/ui/templates/index.html
+++ b/src/dji_metadata_embedder/ui/templates/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>dji-embed</title>
+  <meta name="djiembed-token" content="{{ token }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='app.css') }}">
+</head>
+<body>
+  <header class="topbar">
+    <h1>dji-embed</h1>
+    <p class="banner">Local use only &mdash; do not expose this server.</p>
+  </header>
+  <nav class="tabs" aria-label="Sections">
+    <a href="#/doctor" class="tab" data-tab="doctor">Doctor</a>
+    <a href="#/embed" class="tab" data-tab="embed">Embed</a>
+    <a href="#/validate" class="tab" data-tab="validate">Validate</a>
+    <a href="#/convert" class="tab" data-tab="convert">Convert</a>
+    <a href="#/check" class="tab" data-tab="check">Check</a>
+  </nav>
+  <main id="app" class="content"></main>
+  <script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>

--- a/src/dji_metadata_embedder/ui/templates/index.html
+++ b/src/dji_metadata_embedder/ui/templates/index.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>dji-embed</title>
   <meta name="djiembed-token" content="{{ token }}">
+  <meta name="theme-color" content="#0f1220">
+  <link rel="manifest" href="{{ url_for('static', filename='manifest.webmanifest') }}">
+  <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='icon.svg') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='app.css') }}">
 </head>
 <body>

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -1,0 +1,131 @@
+"""Smoke tests for the dji-embed web UI server."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+flask = pytest.importorskip("flask")
+
+from dji_metadata_embedder.ui.server import create_app  # noqa: E402
+
+TOKEN = "unit-test-token"
+
+
+@pytest.fixture()
+def client():
+    app = create_app(TOKEN)
+    app.config.update(TESTING=True)
+    with app.test_client() as c:
+        yield c
+
+
+def _auth(client):
+    """Seed the auth cookie so subsequent requests are authenticated."""
+    resp = client.get(f"/?t={TOKEN}")
+    assert resp.status_code == 200
+    return resp
+
+
+def test_home_requires_token(client):
+    resp = client.get("/")
+    assert resp.status_code == 403
+
+
+def test_home_with_token_sets_cookie_and_renders(client):
+    resp = _auth(client)
+    assert "djiembed_token" in resp.headers.get("Set-Cookie", "")
+    assert b"djiembed-token" in resp.data
+
+
+def test_security_headers_present(client):
+    resp = _auth(client)
+    assert "Content-Security-Policy" in resp.headers
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["Referrer-Policy"] == "no-referrer"
+
+
+def test_public_routes_bypass_token(client):
+    healthz = client.get("/healthz")
+    assert healthz.status_code == 200
+    assert healthz.get_json() == {"ok": True}
+
+    sw = client.get("/sw.js")
+    assert sw.status_code == 200
+    assert b"serviceWorker" in sw.data or b"addEventListener" in sw.data
+
+    manifest = client.get("/static/manifest.webmanifest")
+    assert manifest.status_code == 200
+    assert manifest.get_json()["name"] == "dji-embed"
+
+
+def test_api_rejects_unauth_requests(client):
+    resp = client.get("/api/doctor")
+    assert resp.status_code == 403
+
+
+def test_api_accepts_header_token(client):
+    resp = client.get("/api/doctor", headers={"X-DJIEmbed-Token": TOKEN})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert {"app_version", "system", "tools", "dependencies_ok", "missing"} <= body.keys()
+
+
+def test_api_accepts_cookie_after_seeded(client):
+    _auth(client)
+    resp = client.get("/api/doctor")
+    assert resp.status_code == 200
+
+
+def test_api_embed_requires_directory(client):
+    _auth(client)
+    resp = client.post("/api/jobs/embed", json={})
+    assert resp.status_code == 400
+    assert "directory" in resp.get_json()["error"].lower()
+
+
+def test_api_embed_rejects_non_directory(client, tmp_path):
+    _auth(client)
+    bogus = tmp_path / "does-not-exist"
+    resp = client.post("/api/jobs/embed", json={"directory": str(bogus)})
+    assert resp.status_code == 400
+
+
+def test_api_validate_rejects_non_directory(client, tmp_path):
+    _auth(client)
+    resp = client.post("/api/validate", json={"directory": str(tmp_path / "nope")})
+    assert resp.status_code == 400
+
+
+def test_api_validate_empty_directory(client, tmp_path):
+    _auth(client)
+    resp = client.post("/api/validate", json={"directory": str(tmp_path)})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["total_files"] == 0
+    assert body["valid_pairs"] == 0
+
+
+def test_api_convert_requires_known_format(client, tmp_path):
+    _auth(client)
+    srt = tmp_path / "tiny.SRT"
+    srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nhello\n")
+    resp = client.post(
+        "/api/convert", json={"srt": str(srt), "format": "bogus"}
+    )
+    assert resp.status_code == 400
+
+
+def test_api_check_missing_path(client):
+    _auth(client)
+    resp = client.post("/api/check", json={"path": "/definitely/not/here"})
+    assert resp.status_code == 400
+
+
+def test_job_not_found(client):
+    _auth(client)
+    resp = client.get("/api/jobs/nonexistent")
+    assert resp.status_code == 404
+    resp = client.post("/api/jobs/nonexistent/cancel")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Adds a local web UI served by a new `dji-embed ui` command so non-CLI users can drive the tool from their browser. Trust is delegated to the user's installed browser — no signed binary, no "unknown publisher" warnings, no notarization burden. Optional: ships under a new `[ui]` extra, so the base install is unaffected.

Closes #170.

## What's in it

9 conventional commits, one per logical slice:

| Commit | Slice |
|---|---|
| `d9d0a7e` | scaffold: `dji-embed ui`, Flask app, token gate, CSP |
| `59c1680` | Doctor tab + `/api/doctor` |
| `fa7c6c6` | Embed tab + job runner + SSE + cancel |
| `0af4103` | Validate tab + `/api/validate` |
| `ce00e10` | Convert tab + `/api/convert` |
| `4b58714` | Check tab + `/api/check` |
| `517ba66` | PWA manifest + service worker + icons |
| `eac1987` | 14 UI smoke tests |
| `61b253e` | README + user guide |

## Design highlights

- **Trust model:** Flask app bound to `127.0.0.1` only; a per-session token is injected into the URL opened by the browser, then persisted as an `HttpOnly; SameSite=Strict` cookie. The `before_request` hook accepts the token via query, cookie, or `X-DJIEmbed-Token` header. Unauth'd API requests get `403`.
- **Security headers:** strict `Content-Security-Policy` (`default-src 'self'`, `frame-ancestors 'none'`, `base-uri 'none'`), `X-Content-Type-Options`, `Referrer-Policy`. No CORS.
- **Framework:** Flask (sync). Work is subprocess-bound — async would buy nothing.
- **Frontend:** plain HTML + vanilla JS + `fetch` / `EventSource`. No build step, no npm.
- **Jobs:** each `POST /api/jobs/embed` creates a `Job` that runs `python -m dji_metadata_embedder embed …` in a daemon thread. Stdout lines land as `log` events on a condition variable; an SSE handler drains them with heartbeat pings on idle. Cancel = `proc.terminate()`.
- **File picker:** plain path input backed by a `recent-folders` datalist persisted under `~/.config/dji-embed/ui.json` (or `%APPDATA%\dji-embed\ui.json` on Windows). Server-side folder browser deferred.
- **PWA:** minimal service worker at `/sw.js` (network-first, no caching) + `manifest.webmanifest` + SVG icons. Chromium exposes "Install app" for a standalone-window feel.

## How to try

```bash
git fetch origin feat/issue-170-web-ui
git checkout feat/issue-170-web-ui
uv sync --extra ui
uv run dji-embed ui
```

## Test plan

- [x] `uv run pytest -q` — **55/55 passing** (14 new UI tests)
- [x] End-to-end smoke: `/healthz`, `/sw.js`, `/static/*`, `/api/doctor`, `/api/validate`, `/api/convert`, `/api/check`, job create + SSE stream + cancel
- [x] Token gate verified: no token → 403; query, cookie, and header all accepted
- [x] Security headers verified on response
- [x] Wheel build inspected — all 11 UI files (templates, static, Python modules) present
- [ ] CI matrix (Windows + Linux, Python 3.10–3.12) — expected to run on this PR

## Explicitly out of scope

Deferred to follow-up issues so this PR stays reviewable:

- `[desktop]` extra with `pywebview` for a native window wrapper
- Native OS folder-picker dialog (shell out to zenity / osascript / PowerShell)
- Uploading files through the browser (backend reads from disk directly)
- Remote / multi-user access
- Authentication beyond the local token

## Checklist

- [x] Tests added
- [x] Documentation updated (README, user guide)
- [x] Static assets packaged in wheel
- [x] No breaking changes to existing CLI or API
- [x] Conventional commit format used throughout
- [x] `[ui]` extra is opt-in; base install untouched
