### PR TITLE
fix(ci): drop unused import and narrow job types for mypy

### DIFF
--- a/src/dji_metadata_embedder/ui/server.py
+++ b/src/dji_metadata_embedder/ui/server.py
@@ -244,6 +244,7 @@ def create_app(token: str) -> "Flask":
         job = registry().get(job_id)
         if job is None:
             abort(404)
+        assert job is not None
         return jsonify(job.to_json())
 
     @app.route("/api/jobs/<job_id>/cancel", methods=["POST"])
@@ -253,6 +254,7 @@ def create_app(token: str) -> "Flask":
         job = registry().get(job_id)
         if job is None:
             abort(404)
+        assert job is not None
         job.request_cancel()
         return jsonify(job.to_json())
 
@@ -263,6 +265,7 @@ def create_app(token: str) -> "Flask":
         job = registry().get(job_id)
         if job is None:
             abort(404)
+        assert job is not None
         start = int(request.args.get("from", 0))
 
         def _stream():

--- a/tests/test_ui_server.py
+++ b/tests/test_ui_server.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 flask = pytest.importorskip("flask")


### PR DESCRIPTION
## Summary

Follow-up to #171, which was merged before CI caught two lint/type failures. This restores green CI on `master`:

- Remove unused `import json` from `tests/test_ui_server.py` (ruff `F401`).
- Add `assert job is not None` after `abort(404)` in the three `/api/jobs/<id>` routes so mypy can narrow `registry().get(job_id)` (union-attr).

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy src/dji_metadata_embedder` — `Success: no issues found in 19 source files`
- [x] `pytest tests/test_ui_server.py -q` — 14/14 passing
- [ ] CI matrix (Windows + Linux, Python 3.10–3.12) — expected to go green on this PR

https://claude.ai/code/session_017t9RAzhXsApzoarhSzcVg9