### PR TITLE
fix(embed): place .tmp before extension so ffmpeg picks the muxer

### DIFF
--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -502,7 +502,9 @@ class DJIMetadataEmbedder:
                     output_path = (
                         self.output_dir / f"{video_path.stem}_metadata{video_path.suffix}"
                     )
-                temp_output_path = Path(str(output_path) + _TEMP_SUFFIX)
+                temp_output_path = output_path.with_name(
+                    output_path.stem + _TEMP_SUFFIX + output_path.suffix
+                )
 
                 # Embed metadata using ffmpeg into temp file
                 if self.embed_metadata_ffmpeg(

--- a/tests/test_embedder_atomic.py
+++ b/tests/test_embedder_atomic.py
@@ -103,7 +103,9 @@ class TestProcessDirectoryAtomicWrite:
         out_dir = tmp_path / "processed"
         out_dir.mkdir()
         final_output = out_dir / "DJI_20240101_123456_metadata.mp4"
-        temp_output = Path(str(final_output) + _TEMP_SUFFIX)
+        temp_output = final_output.with_name(
+            final_output.stem + _TEMP_SUFFIX + final_output.suffix
+        )
 
         ffmpeg_called: list = []
 
@@ -133,7 +135,11 @@ class TestProcessDirectoryAtomicWrite:
         assert final_output.read_bytes() == b"embedded content (padded for size check)"
         assert not temp_output.exists()
         assert len(ffmpeg_called) >= 1
-        assert ffmpeg_called[0][-1].endswith(_TEMP_SUFFIX)
+        ffmpeg_output_arg = ffmpeg_called[0][-1]
+        # The temp path must keep the original extension last so ffmpeg can
+        # pick the correct output muxer (issue: a trailing ".tmp" breaks it).
+        assert ffmpeg_output_arg.endswith(final_output.suffix)
+        assert _TEMP_SUFFIX in Path(ffmpeg_output_arg).name
 
     def test_final_not_created_when_validation_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -147,7 +153,9 @@ class TestProcessDirectoryAtomicWrite:
         out_dir = tmp_path / "processed"
         out_dir.mkdir()
         final_output = out_dir / "DJI_20240101_123456_metadata.mp4"
-        temp_output = Path(str(final_output) + _TEMP_SUFFIX)
+        temp_output = final_output.with_name(
+            final_output.stem + _TEMP_SUFFIX + final_output.suffix
+        )
 
         def fake_run(cmd: list, *args, **kwargs):
             res = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
@@ -203,4 +211,6 @@ class TestProcessDirectoryAtomicWrite:
         assert result["output_directory"] == str(tmp_path)
         assert video.exists()
         assert video.read_bytes() == b"embedded in place (padded for validation)"
-        assert not Path(str(video) + _TEMP_SUFFIX).exists()
+        assert not video.with_name(
+            video.stem + _TEMP_SUFFIX + video.suffix
+        ).exists()


### PR DESCRIPTION
## Summary

`dji-embed embed` currently fails on every run. The atomic-write path introduced in #162 builds the temp filename as `output.MP4.tmp`, but FFmpeg selects its output muxer from the filename extension — `.tmp` is not a muxer, so every invocation errors with:

```
Unable to choose an output format for 'DJI_XXXX_metadata.MP4.tmp';
use a standard extension for the filename or specify the format manually.
```

The fix inserts `.tmp` **before** the final extension (`output.tmp.MP4`), keeping the real extension last so ffmpeg picks the correct muxer. `os.replace` still performs the atomic rename, and overwrite-mode (#163) still cleans up.

## Why CI missed this

The atomic-write tests mock `subprocess.run`, so they never exercised real ffmpeg muxer selection. They asserted the mocked ffmpeg command ended with `.tmp`, which is exactly what's broken.

The updated test now asserts the ffmpeg output argument:
1. ends with the **real** video extension (`.mp4`/`.MP4`), and
2. contains `.tmp` somewhere in the filename.

A regression of this bug would fail those assertions.

## Reported from real footage

Discovered while testing the new web UI locally against a folder of DJI Mini 4 Pro clips on Windows 11 with ffmpeg 2025-07-10 from gyan.dev. 0/2 videos processed. Post-fix the muxer selection works.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy src/dji_metadata_embedder` — clean
- [x] `pytest -q` — 55/55 passing (including the updated atomic-write tests)
- [ ] CI matrix (Windows + Linux, Python 3.10–3.12)
- [ ] User re-runs `dji-embed embed C:\TEMP\DroneFootage` after this lands and confirms files are produced

https://claude.ai/code/session_017t9RAzhXsApzoarhSzcVg9