### PR TITLE
ci(winget): stop firing the winget workflow automatically

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -1,14 +1,16 @@
 ---
 name: Submit to winget
 
+# NOTE: This workflow is currently non-functional — see issue tracker.
+# The automatic trigger on "Build Windows EXE" completion has been
+# removed so it stops firing (and going red) on every release. It can
+# still be invoked manually via workflow_dispatch once the underlying
+# issues are fixed.
 on:
-  workflow_run:
-    workflows: ["Build Windows EXE"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to submit to winget (e.g., 1.1.2)'
+        description: 'Version to submit to winget (e.g., 1.2.0)'
         required: true
         type: string
 
@@ -17,7 +19,7 @@ permissions:
 
 jobs:
   submit:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The winget release workflow has never produced a successful submission and paints every release red. Drop its automatic trigger so it only runs on manual `workflow_dispatch`. File kept in place — #175 tracks the proper rewrite.

## What changes

`.github/workflows/release-winget.yml`:
- Remove the `workflow_run` trigger on "Build Windows EXE" completion.
- Tighten the job guard to `github.event_name == 'workflow_dispatch'` only.
- Add a comment at the top explaining why it's disabled and pointing at the tracking issue.

No code / tests / manifests touched.

## Why not just delete it

Keeping the file means #175 can rewrite it in place without reconstructing history, and the `workflow_dispatch` path remains available for ad-hoc testing while the fix is developed.

Closes #(nothing) — tracked separately in #175.

https://claude.ai/code/session_017t9RAzhXsApzoarhSzcVg9