### PR TITLE
ci(release): auto-create GitHub release from the EXE workflow

### DIFF
--- a/.github/workflows/release-exe.yml
+++ b/.github/workflows/release-exe.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to build (e.g., 1.1.2)'
+        description: 'Version to build (e.g., 1.2.0)'
         required: true
         type: string
 
@@ -28,6 +28,17 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
+      - name: Determine release version
+        id: meta
+        shell: pwsh
+        run: |
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
+            $ver = '${{ inputs.version }}'
+          } else {
+            $ver = '${{ github.event.workflow_run.head_branch }}'.TrimStart('v')
+          }
+          "version=$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "tag=v$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
@@ -38,14 +49,8 @@ jobs:
       - name: Sync and verify project version
         shell: pwsh
         run: |
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            $tag = '${{ inputs.version }}'
-          } else {
-            $tag = '${{ github.event.workflow_run.head_branch }}'
-            $tag = $tag.TrimStart('v')
-          }
-          uv run python tools/sync_version.py $tag
-          uv run python tools/sync_version.py $tag --check
+          uv run python tools/sync_version.py ${{ steps.meta.outputs.version }}
+          uv run python tools/sync_version.py ${{ steps.meta.outputs.version }} --check
       - name: Install dependencies
         shell: pwsh
         run: uv sync --extra build
@@ -54,15 +59,7 @@ jobs:
         run: uv run python tools/build_exe.py
       - name: Download wheel from PyPI
         shell: pwsh
-        run: |
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            $tag = 'v${{ inputs.version }}'
-            $ver = '${{ inputs.version }}'
-          } else {
-            $tag = '${{ github.event.workflow_run.head_branch }}'
-            $ver = $tag.TrimStart('v')
-          }
-          uv run pip download dji-drone-metadata-embedder==$ver --no-deps -d dist
+        run: uv run pip download dji-drone-metadata-embedder==${{ steps.meta.outputs.version }} --no-deps -d dist
       - name: Generate SHA256SUMS.txt
         shell: pwsh
         run: |
@@ -72,23 +69,16 @@ jobs:
             $hashLines += "$($hash.Hash)  $($_.Name)"
           }
           $hashLines | Out-File -Encoding ascii dist/SHA256SUMS.txt
-      - name: Attach to GitHub Release
-        shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            $tag = 'v${{ inputs.version }}'
-          } else {
-            $tag = '${{ github.event.workflow_run.head_branch }}'
-          }
-          gh release upload $tag dist/* --clobber
+      - name: Create or update GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          files: dist/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true
       - name: Summary
         shell: pwsh
         run: |
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            $tag = 'v${{ inputs.version }}'
-          } else {
-            $tag = '${{ github.event.workflow_run.head_branch }}'
-          }
+          $tag = '${{ steps.meta.outputs.tag }}'
           echo "Windows binaries attached to [release $tag](https://github.com/${{ github.repository }}/releases/tag/$tag)" >> $env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

The release pipeline has had a persistent papercut: `release-exe.yml` ends with `gh release upload $tag dist/*`, which fails if the tagged release does not already exist. Nothing else in the pipeline creates the release entry, so every tag push required a manual "Draft a new release" click in the GitHub UI first — and if the maintainer forgot (as happened for `v1.2.0`), the EXE build went red.

This PR eliminates the manual step.

## Changes

- Replace the `gh release upload` step with [`softprops/action-gh-release@v2`](https://github.com/softprops/action-gh-release), which:
  - creates the release with auto-generated notes if it does not exist,
  - updates the existing release (adding/overwriting the listed files) if it does,
  - is idempotent across re-runs, so a re-dispatch after a flaky build still works.
- Consolidate the four duplicated tag/version extraction blocks into a single `meta` step that exposes `version` and `tag` outputs to the rest of the job.
- Update the `workflow_dispatch` input example from `1.1.2` to `1.2.0`.

## Net effect

Pushing a tag `vX.Y.Z` now produces a fully populated GitHub release — auto-generated notes + `dji-embed.exe` + wheel + `SHA256SUMS.txt` — with no manual step. Re-dispatching the workflow (e.g. after a transient failure) updates the same release idempotently.

## Not in scope

- Winget workflow rewrite — tracked in #175.
- Changing the trigger chain (still `tag push → release-pypi → release-exe`). Works fine; no reason to touch it here.

## Test plan

- [x] YAML parses (workflow lint will run on PR open).
- [ ] Verified on the next real release (or by manually dispatching against an existing tag like `v1.2.0` — will update the existing release in place rather than creating a duplicate).

https://claude.ai/code/session_017t9RAzhXsApzoarhSzcVg9