### PR TITLE
docs(readme): demote winget from install options until published

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,20 @@ Common problems are covered in [docs/troubleshooting.md](docs/troubleshooting.md
 
 ## Easy Windows install
 
-### Option 1: Windows Package Manager (Recommended)
-```powershell
-winget install dji-embed
-```
-
-### Option 2: Bootstrap Script (Includes FFmpeg/ExifTool)
+### Option 1: Bootstrap Script (Includes FFmpeg/ExifTool)
 ```powershell
 iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedder/master/tools/bootstrap.ps1 | iex
 ```
 
-### Option 3: Direct Download
+### Option 2: Direct Download
 Download the ready-to-run **dji-embed.exe** from the [GitHub Releases page](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases).
 
-### Option 4: Python Package
+### Option 3: Python Package
 ```powershell
 pip install dji-drone-metadata-embedder
 ```
+
+> **Windows Package Manager (winget)** — planned, not yet available. The package has not been published to `winget-pkgs` yet; tracking in [#175](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/175).
 
 ## macOS / Linux quick-start
 


### PR DESCRIPTION
## Summary

The README currently advertises `winget install dji-embed` as the **recommended** Windows install, but:

1. The package isn't in `microsoft/winget-pkgs` yet — the command fails for every user.
2. Even once submitted, the id will be `CallMarcus.DJIMetadataEmbedder`, not `dji-embed`.
3. This README is also what renders on PyPI, so the misleading instructions reach a wide audience.

Winget publishing is blocked by several foundational issues tracked in #175; until it ships, the README shouldn't recommend it.

## Changes

- Remove the `winget install dji-embed` block
- Renumber remaining install options (bootstrap / EXE / pip) 1–3
- Add a short note that winget support is planned, linking to #175

## Test plan

- [x] `git diff` reviewed — only `README.md` touched
- [x] Remaining three options are the paths that currently work (bootstrap / direct EXE / pip)
- [x] No other README references to winget remain
