### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      production-deps:
+        dependency-type: "production"
+      development-deps:
+        dependency-type: "development"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to keep pinned Action versions and Python dependencies fresh automatically.

## Configuration choices

- **Schedule: monthly, Mondays.** You asked for biweekly; Dependabot only supports `daily` / `weekly` / `monthly`, so monthly is the closest low-noise option. Security updates bypass this schedule and are opened immediately regardless.
- **Two ecosystems:**
  - `github-actions` — keeps `actions/checkout`, `astral-sh/setup-uv`, `softprops/action-gh-release`, etc. up to date
  - `pip` — reads `pyproject.toml`; `uv.lock` gets regenerated on the next `uv sync` / CI run
- **Grouped PRs** — one PR for all GitHub Actions bumps, one PR each for production vs development Python deps, rather than one PR per package
- **Labels:** `dependencies` plus a topic label (`ci` or `python`) so you can filter the queue
- **Commit prefixes** aligned with the conventional-commit policy in `CLAUDE.md` (`ci:` for Actions, `chore:` for pip)
- **Open PR cap:** 5 per ecosystem

## Test plan

- [x] `.github/dependabot.yml` validates against Dependabot v2 schema
- [ ] After merge: verify Dependabot picks up the config (Insights → Dependency graph → Dependabot)
- [ ] First run should land on the next Monday
