### PR TITLE
docs: refresh roadmap, housekeeping, and record CI baseline

### DIFF
--- a/HOUSEKEEPING.md
+++ b/HOUSEKEEPING.md
@@ -1,294 +1,117 @@
 # Repository Housekeeping Recommendations
 
-**Generated:** 2025-08-15
-**Current State:** 132 remote branches, production-ready codebase
+**Last refreshed:** 2026-04-19
+**Current state:** v1.2.0, production-ready, ~13 remote branches (13 at the
+time of writing), root directory already slim
 
 ---
 
-## 🎯 Executive Summary
+## Context
 
-This repository is production-ready but has accumulated **132 stale remote branches** and several development-only scripts in the root directory. Recommended cleanup will:
+This file started life in August 2025 as a cleanup plan for what was then a
+132-branch repository with several ad-hoc release scripts at the root. Most
+of that cleanup has already happened:
 
-- **Reduce clutter** by removing 125+ merged feature branches
-- **Improve clarity** by moving development scripts to appropriate locations
-- **Maintain functionality** by preserving all user-facing scripts and both test suites
+- **Branch count** is down from 132 to ~13 remote branches (`master`, active
+  `feat/*`, `fix/*`, `chore/*`, plus Dependabot and Claude session branches).
+- **Ad-hoc root scripts** (`create_github_release.ps1`, `create_release.ps1`,
+  `create_release.sh`, `get-exe-info.ps1`, `create-issues.ps1`,
+  `test-exe.ps1`) have all been removed. The only scripts still at the root
+  are the three user-facing convenience wrappers below.
+- **Cleanup scripts** `scripts/delete-stale-branches.sh` and
+  `scripts/delete-stale-branches.ps1` are still available when branches
+  accumulate again.
 
----
-
-## 📊 Current Status Analysis
-
-### Branch Inventory
-- **Total remote branches:** 132
-- **Current working branch:** `claude/review-repo-docs-015rE98NQRiYfUYiwJuxgCpG`
-- **Stale branch patterns:**
-  - `codex/*` - 80+ branches from AI agent development
-  - `feat/*`, `fix/*`, `ci/*`, `docs/*` - Feature branches (merged)
-  - `3l1c1y-codex/*` - Additional AI agent work
-  - Various one-off development branches
-
-### File Organization
-```
-Root Directory Issues:
-✅ KEEP: process_drone_footage.bat/sh (user convenience)
-✅ KEEP: run_diagnostic.bat (user convenience)
-⚠️ MOVE/REMOVE: create-issues.ps1 (dev helper)
-⚠️ MOVE/REMOVE: create_github_release.ps1 (ad-hoc v1.0.7 release)
-⚠️ MOVE/REMOVE: create_release.ps1/sh (ad-hoc release scripts)
-⚠️ MOVE/REMOVE: get-exe-info.ps1 (dev/testing)
-⚠️ DUPLICATE: test-exe.ps1 (exists in tools/)
-```
-
-### Test Directories (Both Legitimate)
-- **tests/** - Unit tests (pytest suite) - 14 test files
-- **validation_tests/** - Integration/E2E tests - 6 comprehensive test modules
-- **scripts/** - Development utilities (sample generation, changelog, etc.)
+This document is kept as a living reference for the ongoing "keep it tidy"
+work rather than as a one-shot cleanup plan.
 
 ---
 
-## 🧹 Cleanup Plan
+## Current layout
 
-### Phase 1: Branch Cleanup (High Impact)
+### Root scripts (all user-facing – keep)
 
-#### Recommended Actions:
+| File | Purpose |
+|------|---------|
+| `process_drone_footage.bat` | Windows double-click wrapper around `dji-embed embed` |
+| `process_drone_footage.sh` | macOS/Linux shell wrapper around `dji-embed embed` |
+| `run_diagnostic.bat` | Windows shortcut for `tools/diagnostic_script.py` |
 
-**1.1 Identify Protected Branches**
-```bash
-# Keep these branches:
-- master (default)
-- Any active development branches
-- Any branches with open PRs
-```
+If you add another script, put it in `scripts/` (developer tooling) or
+`tools/` (release/packaging tooling) unless it is intended to be invoked by
+end users.
 
-**1.2 Delete Merged Feature Branches**
-Most branches with these prefixes are safe to delete:
-- `codex/*` - Merged AI agent work
-- `feat/*` - Merged features
-- `fix/*` - Merged bug fixes
-- `ci/*` - Merged CI improvements
-- `docs/*` - Merged documentation
-- `3l1c1y-codex/*` - Merged AI work
+### Test directories (both needed)
 
-**Automated Scripts Available:**
-We've created comprehensive cleanup scripts in `scripts/`:
-- `scripts/delete-stale-branches.sh` (Bash)
-- `scripts/delete-stale-branches.ps1` (PowerShell)
+- `tests/` – fast, focused pytest suite (16 files, 55 tests at last count).
+- `validation_tests/` – integration / E2E runners that need FFmpeg, ExifTool
+  and real media to exercise fully. See `docs/ci_baseline.md` for expected
+  pass/fail in minimal environments.
 
-Both scripts support dry-run mode and detailed progress reporting.
+### Tools directory
 
-**Important Note - GitHub UI Required:**
-Due to repository permissions, branch deletion must be done through GitHub's web interface:
+All of these are actively referenced by CI or documentation — do not remove
+without checking `.github/workflows/` and the relevant docs first:
 
-1. Go to: `https://github.com/CallMarcus/dji-drone-metadata-embedder/branches/stale`
-2. Review stale branches (filtered by last commit date)
-3. Delete branches matching these patterns:
-   - `codex/*` (~117 branches)
-   - `3l1c1y-codex/*` (1 branch)
-   - `ci-*`, `docs-*` (merged CI/docs branches)
-   - Other merged feature branches
-
-**Alternative - GitHub CLI:**
-```bash
-# If you have admin access
-gh api repos/CallMarcus/dji-drone-metadata-embedder/git/refs/heads/codex/add-* --method DELETE
-
-# Or use the scripts for local testing:
-bash scripts/delete-stale-branches.sh  # Dry-run
-```
+- `tools/bootstrap.ps1` – Windows one-click installer.
+- `tools/sync_version.py` – single-source version sync across package,
+  bootstrap, spec, and winget manifests.
+- `tools/build_exe.py` – PyInstaller build wrapper.
+- `tools/diagnostic_script.py` – user-facing diagnostics (`run_diagnostic.bat`).
+- `tools/test_exe.py` – post-build smoke checks for the EXE.
+- `tools/cleanup_and_restructure.ps1` – retained as a historical cleanup
+  helper; review before use.
 
 ---
 
-### Phase 2: Root Directory Cleanup (Medium Impact)
+## Ongoing housekeeping practice
 
-#### 2.1 Scripts to Remove
-These are one-off development helpers no longer needed:
+### Branch hygiene
 
-```bash
-# Remove ad-hoc release scripts (replaced by CI workflows)
-rm create_github_release.ps1
-rm create_release.ps1
-rm create_release.sh
+- Enable "Automatically delete head branches" in the GitHub repo settings so
+  merged feature branches disappear on their own.
+- When a long-lived branch goes cold, run
+  `bash scripts/delete-stale-branches.sh` (or the `.ps1` equivalent) in
+  dry-run mode first and then actually delete.
+- Keep branch names aligned with the convention in `CLAUDE.md` §4: `feat/`,
+  `fix/`, `docs/`, `ci/`, `chore/`, `claude/<session-id>`.
 
-# Remove development helpers
-rm get-exe-info.ps1
-```
+### Root directory
 
-#### 2.2 Scripts to Relocate
-Move to `scripts/` or `tools/` directory:
+- User-facing wrappers only at the root. Anything else belongs under
+  `scripts/` or `tools/`.
+- Ad-hoc release scripts are not needed — `release-pypi.yml`,
+  `release-exe.yml`, and `release-winget.yml` own those flows.
 
-```bash
-# Move to scripts/ (if keeping for reference)
-mv create-issues.ps1 scripts/create-issues.ps1
+### Documentation hygiene
 
-# Or remove if CI handles this now
-rm create-issues.ps1
-```
+- Update `docs/development_roadmap.md` whenever a milestone ships or the
+  direction of travel changes.
+- Update `docs/ci_baseline.md` when you add tests or change dependencies so
+  contributors know what "green" looks like today.
+- Update `CHANGELOG.md` via the auto-changelog workflow — see
+  `docs/CHANGELOG_AUTOMATION.md`. Avoid hand-editing historical sections.
 
-#### 2.3 Duplicate Files
-```bash
-# test-exe.ps1 exists in root AND tools/
-# Keep tools/test_exe.py (Python version)
-rm test-exe.ps1  # Remove root version
-```
+### Repeat-cleanup checklist
 
----
+When the repository drifts again, re-run this short list:
 
-### Phase 3: Documentation Updates (Low Impact)
-
-#### 3.1 Update .gitignore
-Already comprehensive! Minor addition:
-
-```gitignore
-# At end of file, add:
-# Development scripts (kept for reference but gitignored in future)
-scripts/create-issues.ps1
-scripts/adhoc-*.ps1
-```
-
-#### 3.2 Update CONTRIBUTING.md
-Add branch naming guidance:
-
-```markdown
-### Branch Naming Convention
-- Feature: `feat/issue-123-description`
-- Bug fix: `fix/issue-123-description`
-- CI: `ci/improvement-description`
-- Docs: `docs/improvement-description`
-- AI agents: `claude/session-id` or `codex/description`
-
-**Note:** Feature branches are deleted after merge to keep repository clean.
-```
+1. `git fetch --all --prune` and skim `git branch -r` for branches that are
+   merged or older than ~3 months.
+2. `ls` the repo root — anything new that is not user-facing should move
+   into `scripts/` or `tools/` or be deleted.
+3. `uv run ruff check src/ tests/` and `uv run pytest -q` to confirm the
+   baseline from `docs/ci_baseline.md` still holds.
+4. If you ran the validation suite, update the "Last verified" date on
+   `docs/ci_baseline.md`.
 
 ---
 
-## 📋 Execution Checklist
+## Historical notes
 
-### Before Starting
-- [ ] Backup current branch state
-- [ ] Verify no open PRs on branches to be deleted
-- [ ] Notify collaborators of cleanup
-
-### Branch Cleanup
-- [ ] Create and test deletion script with dry-run
-- [ ] Delete `codex/*` branches (80+ branches)
-- [ ] Delete `3l1c1y-codex/*` branches
-- [ ] Delete merged `feat/*`, `fix/*`, `ci/*`, `docs/*` branches
-- [ ] Verify protected branches remain intact
-- [ ] Run `git fetch --prune` to clean local refs
-
-### File Cleanup
-- [ ] Remove ad-hoc release scripts (3 files)
-- [ ] Remove development helpers (2 files)
-- [ ] Remove duplicate test-exe.ps1
-- [ ] Verify user convenience scripts still work
-
-### Documentation
-- [ ] Update .gitignore if needed
-- [ ] Update CONTRIBUTING.md with branch policy
-- [ ] Add note to README about clean branch policy
-- [ ] Commit and push changes
-
-### Verification
-- [ ] Run test suite: `pytest -q`
-- [ ] Run validation tests: `py validation_tests/run_all_tests.py`
-- [ ] Verify CI workflows still function
-- [ ] Check that user scripts still work
-
----
-
-## 🎯 Expected Results
-
-### Before Cleanup
-- **Remote branches:** 132
-- **Root scripts:** 9 files (.ps1, .sh, .bat)
-- **Git repo size:** 13MB
-
-### After Cleanup
-- **Remote branches:** ~5-7 (master + active work)
-- **Root scripts:** 2-3 (user-facing only)
-- **Git repo size:** 12-13MB (branches are refs, minimal space savings)
-- **Clarity:** Significantly improved
-- **Maintenance:** Easier to navigate
-
----
-
-## ⚠️ Risks & Mitigation
-
-### Risk: Deleting Active Branches
-- **Mitigation:** Check for open PRs first
-- **Recovery:** Branches can be restored from reflog within ~90 days
-
-### Risk: Breaking User Workflows
-- **Mitigation:** Only remove development scripts, keep user-facing ones
-- **Recovery:** Scripts are in git history
-
-### Risk: CI Pipeline Issues
-- **Mitigation:** Test CI after file removals
-- **Recovery:** Revert commit if issues found
-
----
-
-## 🚀 Quick Start Commands
-
-### Safe Dry-Run Analysis
-```bash
-# See what would be deleted (codex branches)
-git branch -r | grep 'origin/codex/' | wc -l
-git branch -r | grep 'origin/codex/' | head -20
-
-# Check for open PRs
-gh pr list --state open --json headRefName
-```
-
-### Conservative Cleanup (Recommended First Step)
-```bash
-# Delete only obviously stale AI agent branches
-git fetch --all --prune
-git push origin --delete $(git branch -r | grep 'origin/codex/add-' | sed 's/origin\///' | head -10)
-
-# Verify no issues, then continue with more
-```
-
----
-
-## 📝 Notes
-
-1. **Test directories are BOTH needed:**
-   - `tests/` = Unit tests (fast, focused)
-   - `validation_tests/` = Integration tests (comprehensive, E2E)
-
-2. **Tools directory is well-organized:**
-   - bootstrap.ps1 (user installer)
-   - sync_version.py (release tooling)
-   - build_exe.py (packaging)
-   - All are actively used
-
-3. **CI workflows are comprehensive:**
-   - All in `.github/workflows/`
-   - No need for root-level release scripts
-
-4. **.gitignore is already excellent:**
-   - Comprehensive coverage
-   - Only minor additions suggested
-
----
-
-## 🤝 Recommendations for Future
-
-1. **Establish branch deletion policy:**
-   - Delete feature branches within 1 week of merge
-   - Use GitHub branch protection rules
-   - Enable "Automatically delete head branches" in repo settings
-
-2. **Use branch naming conventions:**
-   - Follow conventional naming in agents.md
-   - Include issue numbers in branch names
-   - Use descriptive but concise names
-
-3. **Keep root directory clean:**
-   - User-facing scripts only in root
-   - Development scripts in `scripts/` or `tools/`
-   - Ad-hoc scripts should be temporary and removed after use
-
----
-
-**End of Report**
+The original Phase 1 / Phase 2 / Phase 3 cleanup plan (deleting 125+ merged
+branches, removing six ad-hoc PowerShell scripts, adding `.gitignore`
+entries for development helpers) was executed between August 2025 and early
+2026. It is no longer a live plan — the information has been distilled into
+the practices above. If you need the full original text, it is available in
+this file's git history.

--- a/docs/ci_baseline.md
+++ b/docs/ci_baseline.md
@@ -59,6 +59,32 @@ matches the PR gate. Run the validation suite before cutting a release or
 whenever you change parsing / FFmpeg command assembly; otherwise the unit
 tests and golden fixtures are sufficient for day-to-day development.
 
+## Pending: first Dependabot run (2026-04-19)
+
+Dependabot's first run opened two grouped PRs that will shift the numbers
+above once merged. Re-run the commands in this file and update the recorded
+versions when either lands:
+
+- **[#180](https://github.com/CallMarcus/dji-drone-metadata-embedder/pull/180)
+  — `actions` group (8 updates).** `actions/checkout 4→6`,
+  `actions/setup-python 5→6`, `astral-sh/setup-uv 5→7`,
+  `peter-evans/create-pull-request 6→8`, `actions/upload-pages-artifact 3→5`,
+  `actions/configure-pages 4→6`, `actions/deploy-pages 4→5`,
+  `softprops/action-gh-release 2→3`. No local effect, but the CI matrix in
+  `.github/workflows/ci.yml` needs to go green on the new versions.
+- **[#181](https://github.com/CallMarcus/dji-drone-metadata-embedder/pull/181)
+  — `development-deps` group (9 updates).** `pytest 8.3.2→9.0.3`,
+  `pytest-cov 5.0.0→7.1.0`, `coverage 7.6.0→7.13.5`, `black 24.4.2→26.3.1`,
+  **`ruff 0.4.6→0.15.11`**, `mypy 1.8.0→1.20.1`, `build 1.2.1→1.4.3`,
+  `hatchling 1.25.0→1.29.0`, `twine 5.1.1→6.2.0`. The ruff jump is the
+  biggest risk — the 0.5–0.15 series enabled several new default rules, so
+  "ruff clean" on `master` is not guaranteed to hold on this branch. Run
+  `uv sync --extra dev` + `uv run ruff check src/ tests/` on the branch
+  before merging and fix any new lint findings in the same PR.
+  _Verified locally 2026-04-19: on the Dependabot branch
+  `uv run ruff check src/ tests/` is clean and `uv run pytest -q` reports
+  55 passed (41 passed + 14 UI tests when `--extra ui` is installed)._
+
 ## Updating this baseline
 
 Bump the "Last verified" date and adjust the pass counts whenever you add

--- a/docs/ci_baseline.md
+++ b/docs/ci_baseline.md
@@ -1,0 +1,67 @@
+# CI Baseline – Known Good Expectations
+
+_Last verified: 2026-04-19 on Linux with Python 3.11.15 and `uv` 0.8.17._
+
+The project's roadmap expects contributors to run validation before adding new
+work. This page records the "known good" pass/fail baseline so you can tell a
+real regression from a pre-existing environmental gap.
+
+## How to reproduce
+
+```bash
+uv sync --extra dev --extra ui
+uv run ruff check src/ tests/
+uv run pytest -q
+uv run python validation_tests/run_all_tests.py   # requires FFmpeg + samples
+```
+
+## Baseline results
+
+| Suite | Command | Expected result |
+|-------|---------|-----------------|
+| Lint | `uv run ruff check src/ tests/` | `All checks passed!` |
+| Unit tests | `uv run pytest -q` | **55 passed** (fast, < 5 s) |
+| CLI smoke | `uv run dji-embed --version` | Prints version plus availability of FFmpeg/ExifTool |
+| Validation – Installation & Dependencies | `validation_tests/test_installation_and_dependencies.py` | Passes only when FFmpeg + ExifTool are on `PATH`. FFmpeg/ExifTool missing ⇒ expected failure outside release CI |
+| Validation – SRT Parsing | `validation_tests/test_srt_parsing.py` | Passes against the bundled `samples/` fixtures |
+| Validation – Video Processing / Advanced / E2E | remaining scripts in `validation_tests/` | Require both FFmpeg and real MP4 media; they are **expected to fail** in minimal environments that only ship the small public SRT samples |
+
+## Environmental gaps that look like failures
+
+The validation suite was originally written for Windows developer machines
+with FFmpeg, ExifTool, and private MP4 fixtures installed. In a clean clone
+(or in containerised CI without those dependencies) you should expect:
+
+- `ffmpeg not available` and `exiftool not available` in `dji-embed doctor`
+  and `--version` output.
+- `validation_tests/run_all_tests.py` reporting **1/5 suites passing** (only
+  the `Error Handling` subset of the End-to-End integration runner green),
+  because the other suites bail out on missing binaries or missing `.MP4`
+  inputs.
+
+None of these are regressions. Treat them as blocking only when you are
+testing a build that is supposed to ship FFmpeg (e.g. the PyInstaller
+artifact or the Docker image).
+
+## What CI actually enforces today
+
+GitHub Actions workflows in `.github/workflows/`:
+
+- `ci.yml` – runs `ruff` + `pytest` on Windows and Linux across Python
+  3.10–3.12. This is the authoritative gate for PRs.
+- `release-pypi.yml`, `release-exe.yml`, `release-winget.yml` – triggered on
+  `vX.Y.Z` tags. These stages install FFmpeg/ExifTool as needed.
+- `auto-changelog.yml` – updates `CHANGELOG.md` from Conventional Commits.
+- `docs.yml` – builds the MkDocs site.
+
+If `uv run pytest -q` is green and `uv run ruff check` is clean, your branch
+matches the PR gate. Run the validation suite before cutting a release or
+whenever you change parsing / FFmpeg command assembly; otherwise the unit
+tests and golden fixtures are sufficient for day-to-day development.
+
+## Updating this baseline
+
+Bump the "Last verified" date and adjust the pass counts whenever you add
+tests or change dependencies. Keep the expectations terse – this file exists
+so a new contributor can tell at a glance whether their local failures are
+real bugs or pre-existing environmental gaps.

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -74,17 +74,24 @@ from pre-existing environmental gaps.
 
 ## Future direction
 
-- **Additional DJI model coverage.** Mavic 3 Classic, Mavic 3 Pro, and
-  Inspire 3 variants as sample files become available. Follow the "Adding
-  Support for New DJI Models" checklist in `CLAUDE.md`.
+- **Additional DJI model coverage.** Tracked in
+  [#182](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/182):
+  survey Mini 5 Pro, Air 3S, Mavic 4 Pro, Neo, Avata 3, Mini 4K, Inspire 3,
+  Matrice 4 / M30 / M350 RTK, and FPV v2 for SRT documentation and sample
+  availability, then spin off per-model parser issues following the "Adding
+  Support for New DJI Models" checklist in `CLAUDE.md` §7.
 - **Richer web UI.** Incremental improvements to the Flask UI
   (`src/dji_metadata_embedder/ui/`) – nicer job progress, downloadable
   per-job artefacts, and richer previews – instead of new GUI frameworks.
 - **Performance work on large batches.** Candidates include parallel
   per-clip embedding and streaming SRT parsing for long flights.
-- **Optional winget re-enablement** once the signed EXE pipeline has a few
-  more green release cycles behind it. The manifests in `winget/` and the
-  disabled workflow in `release-winget.yml` remain in place.
+- **Winget re-enablement.** Blocked on
+  [#175](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/175):
+  `CallMarcus.DJIMetadataEmbedder` needs a manual first-publisher submission
+  to `microsoft/winget-pkgs`, after which `release-winget.yml` should be
+  rewritten on top of `winget-releaser` and the three hand-maintained
+  manifests in `winget/` retired. The workflow currently fires only on
+  manual dispatch.
 
 ## Explicitly out of scope
 

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -1,46 +1,110 @@
 # Development Roadmap
 
-This roadmap tracks the planned evolution of **DJI Drone Metadata Embedder** from a command-line tool into a fully packaged Windows application. The phases and tasks are summarised below. Refer to `agents.md` for the detailed instructions used by automated coding assistants.
+_Last updated: 2026-04-19 · Current version: **v1.2.0** · Status: **Production Ready**_
 
-## Phase 1 – Foundation & Setup
-- **Project structure setup** – create GUI, core and utils packages with placeholder modules.
-- **Dependency download manager** – manage FFmpeg and ExifTool downloads.
-- **System information utility** – detect Windows version, Python installation and system details.
+This roadmap tracks the evolution of **DJI Drone Metadata Embedder**. The
+original Phase 1–6 plan (standalone Windows GUI, dependency bootstrap,
+packaging, release automation) is complete. This document now focuses on
+what's been shipped and the remaining, forward-looking work.
 
-## Phase 2 – GUI Development
-- **Main window framework** using `tkinter`.
-- **File selection, progress bar and status logger components**.
+Before starting new work, run the baseline checks documented in
+[`ci_baseline.md`](ci_baseline.md) so you can distinguish real regressions
+from pre-existing environmental gaps.
 
-## Phase 3 – Core Processing
-- **Video processing core** that integrates the existing embedding logic.
-- **Input validation utilities**.
+## Shipped
 
-## Phase 4 – Build System
-- **PyInstaller build script** for producing a standalone executable.
-- **Windows installer** scripted via NSIS.
+### Packaging & distribution
+- Single-source versioning driven by `src/dji_metadata_embedder/__init__.py`
+  and `tools/sync_version.py`.
+- Tag-driven releases for PyPI, the Windows EXE, and winget (the winget
+  workflow is currently parked and fires only on manual dispatch).
+- PyInstaller spec (`dji-embed.spec`) and build script (`tools/build_exe.py`).
+- PowerShell bootstrap installer (`tools/bootstrap.ps1`) for Windows users.
+- `uv`-managed dependency set with a hash-verified `uv.lock`.
 
-## Phase 5 – Testing & Quality
-- **Automated test suite** covering core functions and GUI behaviour.
-- **Sample data generator** for development and testing.
+### CLI & processing
+- Professional subcommand CLI (`dji-embed embed|validate|convert|check|doctor|ui`).
+- Core embedding pipeline (`core/processor.py`) and SRT/MP4 drift validator
+  (`core/validator.py`).
+- Parsers for Mini 3/4 Pro, Air 3, Avata 2, and Mavic 3 Enterprise SRT
+  formats, with golden fixtures in `samples/` and `tests/fixtures/`.
+- Lenient parser mode with structured warnings, unit normalisation, and
+  sanity checks for altitude/speed.
+- CLI options for time offsets, resample strategy, GPS redaction (drop /
+  fuzz), and machine-readable JSON logs (`--log-json`).
+- Telemetry export to JSON, GPX, and CSV.
+- DAT flight-log parsing and per-frame embedding helpers.
 
-## Phase 6 – Distribution
-- **GitHub Actions CI/CD** workflow for releases.
-- **User documentation** including installation and troubleshooting guides.
+### UI
+- Local web UI shipped as an optional extra (`pip install
+  'dji-drone-metadata-embedder[ui]'`) and launched via `dji-embed ui`.
+  Implemented in `src/dji_metadata_embedder/ui/` (Flask + templates + static
+  assets + background job runner).
+- Legacy `gui/` Tk skeleton remains as a placeholder but is **not** the
+  direction of travel; the web UI is the supported interactive surface.
 
-### Packaging & Installer Tasks
-Winget packaging has been removed for now. Future releases may revisit this.
-## AI Agents Integration
+### Testing & CI
+- Unit test suite (`tests/`, 55 tests) covering parsing, embedding, DAT,
+  redaction, sync, UI server, and CLI smoke.
+- End-to-end validation suite (`validation_tests/`) for release verification
+  when FFmpeg/ExifTool and real media are available.
+- GitHub Actions CI matrix for Windows + Linux on Python 3.10–3.12
+  (`.github/workflows/ci.yml`).
+- Auto-changelog workflow from Conventional Commits
+  (`auto-changelog.yml`, see `docs/CHANGELOG_AUTOMATION.md`).
+- MkDocs documentation site built and deployed via `docs.yml`.
 
-- **Document AI usage in `agents.md`** – explain where automated helpers fit into the tooling.
-- **Use agents for automated testing** – offload routine CI checks to scripted agents.
+### Documentation
+- User-facing: `README.md`, `docs/installation.md`, `docs/user_guide.md`,
+  `docs/decision-table.md`, `docs/recipes.md`, `docs/troubleshooting.md`.
+- Technical: `docs/SRT_FORMATS.md`, `docs/api.md`,
+  `docs/external-tool-versions.md`, `docs/requirements-lock-policy.md`,
+  `docs/validation_tests.md`.
+- Contributor: `CONTRIBUTING.md`, `CLAUDE.md`, `docs/RELEASE.md`,
+  `docs/CHANGELOG_AUTOMATION.md`, and this roadmap.
 
-## Current Progress
-- The repository currently contains the original CLI implementation.
-- A basic `dependency_manager.py` exists but other Phase 1 modules are missing.
-- `tools/bootstrap.ps1` and its CI smoke test are implemented.
-- No GUI has been created yet.
+## In progress / near-term
 
-The project aims to deliver a one-click Windows application with comprehensive documentation and automated builds.
+- **Keep the baseline honest.** When you touch parsing, FFmpeg command
+  assembly, or the UI, re-run `uv run pytest -q` and — if you have the
+  binaries — `validation_tests/run_all_tests.py`, then update
+  `docs/ci_baseline.md` if expectations change.
+- **Housekeeping follow-ups.** See `HOUSEKEEPING.md` for the current
+  recommendations (branch hygiene, root-level scripts, `.gitignore`).
 
-### Next Steps
-- Run validation tests on all features before adding new ones.
+## Future direction
+
+- **Additional DJI model coverage.** Mavic 3 Classic, Mavic 3 Pro, and
+  Inspire 3 variants as sample files become available. Follow the "Adding
+  Support for New DJI Models" checklist in `CLAUDE.md`.
+- **Richer web UI.** Incremental improvements to the Flask UI
+  (`src/dji_metadata_embedder/ui/`) – nicer job progress, downloadable
+  per-job artefacts, and richer previews – instead of new GUI frameworks.
+- **Performance work on large batches.** Candidates include parallel
+  per-clip embedding and streaming SRT parsing for long flights.
+- **Optional winget re-enablement** once the signed EXE pipeline has a few
+  more green release cycles behind it. The manifests in `winget/` and the
+  disabled workflow in `release-winget.yml` remain in place.
+
+## Explicitly out of scope
+
+- **Standalone Tk/Win32 GUI.** The experiment in `gui/` is superseded by the
+  packaged Flask UI; no further Tk work is planned. The folder stays until a
+  cleanup pass removes the skeleton.
+- **Winget-first install story.** Winget is demoted in the README until the
+  manifests ship on a cadence that matches PyPI and the EXE release.
+- **Re-encoding pipelines.** The project's contract is "no re-encode"; any
+  feature that forces transcoding needs an RFC first.
+
+## Milestone history
+
+- **M1 – Stabilise & Version Cohesion** (Aug 2025) – single-source versioning,
+  tag-driven release flow.
+- **M2 – CI/Build Reliability** (Aug 2025) – Windows + Linux matrix, CLI
+  smoke tests, locked dependency set.
+- **M3 – Parser Hardening & CLI UX** (Aug 2025) – golden fixtures, lenient
+  parser, professional subcommand CLI, validate command, JSON logging.
+- **M4 – Docs, Samples & Release Hygiene** (Aug 2025) – decision table,
+  recipes, troubleshooting expansion, auto-changelog.
+- **v1.2 – UI & release polish** (2026) – Flask-based `dji-embed ui`, winget
+  workflow parked, README install order reshuffled, Dependabot enabled.


### PR DESCRIPTION
## Summary

Docs-only refresh to bring three stale documents in line with the v1.2.0 reality and the first Dependabot run.

- **`docs/development_roadmap.md`** — rewritten around what has actually shipped (subcommand CLI, Flask-based `dji-embed ui`, release automation) with only forward-looking work listed. Cross-references [#182](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/182) (survey new DJI models: Mini 5 Pro, Air 3S, Mavic 4 Pro, Neo, Avata 3, Mini 4K, Inspire 3, Matrice 4 / M30 / M350 RTK, FPV v2) and [#175](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/175) (winget workflow rewrite + manual first-publisher blocker) so the "future direction" items are traceable.
- **`docs/ci_baseline.md`** (new) — records the known-good local baseline: `ruff` clean, `pytest -q` = 55 passed, and documents the environmental gaps (missing FFmpeg/ExifTool ⇒ expected `validation_tests/run_all_tests.py` failures, not regressions). Includes a "Pending: first Dependabot run" section covering [#180](https://github.com/CallMarcus/dji-drone-metadata-embedder/pull/180) (actions group) and [#181](https://github.com/CallMarcus/dji-drone-metadata-embedder/pull/181) (dev-deps group), flagging `ruff 0.4.6→0.15.11` as the biggest risk. Verified locally that #181 is green (ruff clean, 55/55 pytest).
- **`HOUSEKEEPING.md`** — rewritten as a living hygiene guide. The original 132-branch / ad-hoc-script cleanup plan has already been executed (root is down to the three user-facing wrappers, ~13 remote branches), so this now documents the current layout and the repeat-cleanup practice instead of a one-shot plan.

## Test plan

- [x] `uv run ruff check src/ tests/` on this branch — clean
- [x] `uv run pytest -q` on this branch — 55 passed
- [x] Fetched `dependabot/pip/development-deps-d87f79602e` (#181) into a worktree, ran the same two commands with the bumped pins — ruff clean, 55/55 pytest (41 non-UI + 14 UI when `--extra ui` is installed)
- [ ] Manual review of the three touched files on GitHub to confirm rendering

Docs-only, no runtime code changed.

https://claude.ai/code/session_01Dmor2sB9ZHs75hDqvpek7S