### PR TITLE
chore: sync pre-commit hook pins with dev-deps group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 ---
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.6
+    rev: v0.15.11
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.3.1
     hooks:
       - id: black
         language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.20.1
     hooks:
       - id: mypy
         additional_dependencies: [click>=8.0.0, rich>=10.0.0]


### PR DESCRIPTION
## Summary
- Bump `.pre-commit-config.yaml` revs for `ruff-pre-commit`, `psf/black`, and `mirrors-mypy` to match the versions pinned in `pyproject.toml` `[dev]` after Dependabot PRs #180 and #181.
- Keeps local `pre-commit run` aligned with what CI installs via `uv sync --extra dev`, avoiding formatter/lint drift between contributors and CI.

| Hook | Old rev | New rev |
| --- | --- | --- |
| astral-sh/ruff-pre-commit | v0.4.6 | v0.15.11 |
| psf/black | 24.4.2 | 26.3.1 |
| pre-commit/mirrors-mypy | v1.8.0 | v1.20.1 |

Dependabot only watches the pip ecosystem, so the pre-commit pins drifted from `pyproject.toml` after #181 merged. CI itself wasn't broken (it doesn't invoke pre-commit), but contributors running `pre-commit run` locally would have hit older formatter/lint behavior than CI.

## Test plan
- [ ] `pre-commit run --all-files` succeeds on the new revs.
- [ ] CI green on this PR (sanity check that nothing else regressed).

---
_Generated by [Claude Code](https://claude.ai/code/session_018sVGY3B8eZH1xHmC8qbee5)_