### PR TITLE
feat(parser): add M300 legacy-with-unit and P4 RTK compact formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 **Fully Tested & Documented** (with sample fixtures):
 - **DJI Mini 3/4 Pro** - Square bracket format `[latitude: xx.xxx] [longitude: xx.xxx]`
 - **DJI Air 3** - HTML-style format with extended telemetry data
-- **DJI Avata 2** - Legacy GPS format `GPS(lat,lon,alt)` with BAROMETER data  
+- **DJI Avata 2** - Legacy GPS format `GPS(lat,lon,alt)` with BAROMETER data
 - **DJI Mavic 3 Enterprise** - Extended format with RTK precision data
+- **DJI Matrice 300 (legacy-with-unit)** - `GPS(lat,lon,alt M)` with `BAROMETER:` colon notation
+- **DJI Phantom 4 RTK / P4P (compact single-line)** - `F/N, SS N, ISO N, EV N, GPS (lat, lon, alt), HOME (...), D, H, H.S, V.S, F.PRY, G.PRY`
 
 **Community Supported**:
 - DJI Air 2S, Mavic 3, and other models using similar SRT formats

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -37,6 +37,44 @@ HOME(39.906206,116.391400) D=5.2m H=1.5m
 - `D`: Distance from home point
 - `H`: Height above home point
 
+### Format 2b: Legacy-with-Unit (Matrice 300 lineage)
+
+Used by: DJI Matrice 300 RTK and adjacent enterprise models.
+
+```
+GPS(36.6146,-6.1120,0.0M) BAROMETER:0.3M
+```
+
+Identical to Format 2 except the altitude inside the GPS tuple carries a
+unit suffix (`M`) and BAROMETER uses a colon notation rather than
+parentheses. The parser tolerates the suffix via an optional
+`[A-Za-z]*` group on the altitude capture; latitude and longitude are
+extracted as for Format 2.
+
+### Format 2c: P4 RTK Compact Single-Line
+
+Used by: DJI Phantom 4 RTK, Phantom 4 Pro, and likely the Matrice
+350 RTK / Matrice 30 enterprise lineage.
+
+```
+F/5.6, SS 400, ISO 100, EV 0, GPS (-58.851745, -34.237922, 15),
+HOME (-58.847509, -34.232707, -57.98m), D 698.70m, H 85.80m,
+H.S 0.00m/s, V.S 0.00m/s, F.PRY (2.7°, -7.0°, 110.1°),
+G.PRY (-24.4°, 0.0°, 110.4°)
+```
+
+**Fields parsed today:**
+- `GPS (lat, lon, alt)` — note the space before `(` and integer altitude
+- `F/N` → camera fnum (free-standing, not `[fnum:…]`)
+- `SS N` → camera shutter
+- `ISO N` → camera iso
+- `EV N` → camera ev
+
+**Fields recognised but not yet decoded** (open follow-up):
+`HOME (…)`, `D Nm`, `H Nm`, `H.S Nm/s`, `V.S Nm/s`, `F.PRY (p, r, y)`,
+`G.PRY (p, r, y)`. These tokens are documented for future work; the
+parser currently extracts GPS + camera and ignores the rest.
+
 ### Format 3: Comprehensive Format
 
 Used by: DJI Mavic 3, DJI Air 2S
@@ -139,6 +177,8 @@ if new_format_match:
 | DJI Air 2S | Format 3 | Comprehensive with HTML tags |
 | DJI Mavic Pro | Format 2 | GPS function format |
 | DJI Phantom 4 | Format 2 | GPS function format |
+| DJI Matrice 300 RTK | Format 2b | Legacy-with-unit (`0.0M` altitude) |
+| DJI Phantom 4 RTK / P4P | Format 2c | P4 RTK compact single-line |
 | DJI Mavic Air 2 | Format 1 | Bracketed key-value pairs |
 | DJI FPV | Format 1 | May include additional flight data |
 

--- a/src/dji_metadata_embedder/core/validator.py
+++ b/src/dji_metadata_embedder/core/validator.py
@@ -249,7 +249,13 @@ def validate_srt_format(srt_path: Path, lenient: bool = True) -> Dict[str, Any]:
             return validation
         
         telemetry_points = []
-        format_votes = {"mini3_4pro": 0, "html_extended": 0, "legacy_gps": 0}
+        format_votes = {
+            "mini3_4pro": 0,
+            "html_extended": 0,
+            "legacy_gps": 0,
+            "legacy_unit": 0,
+            "p4rtk_compact": 0,
+        }
         
         for i, block in enumerate(blocks):
             lines = block.strip().split("\n")
@@ -280,8 +286,17 @@ def validate_srt_format(srt_path: Path, lenient: bool = True) -> Dict[str, Any]:
                     format_votes["html_extended"] += 1
                 else:
                     format_votes["mini3_4pro"] += 1
-            elif "GPS(" in tele_line:
-                format_votes["legacy_gps"] += 1
+            elif re.search(r"GPS\s*\(", tele_line):
+                # P4 RTK compact single-line family uses ``GPS (...)`` (with
+                # space) plus free-standing ``F/N`` aperture tokens.
+                if " F/" in tele_line or tele_line.lstrip().startswith("F/"):
+                    format_votes["p4rtk_compact"] += 1
+                # Legacy-with-unit (M300 lineage) pins an altitude unit
+                # suffix inside the GPS tuple, e.g. ``GPS(lat,lon,0.0M)``.
+                elif re.search(r"GPS\s*\([^)]*[A-Za-z]\)", tele_line):
+                    format_votes["legacy_unit"] += 1
+                else:
+                    format_votes["legacy_gps"] += 1
             elif lenient:
                 validation["warnings"].append(f"Block {i+1}: Unrecognized telemetry format")
             else:

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -188,10 +188,13 @@ class DJIMetadataEmbedder:
                         r"\[longitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line
                     )
 
-                    # Format 2: GPS(lat,lon,alt)
+                    # Format 2: GPS(lat,lon,alt) — also tolerates a unit
+                    # suffix on altitude (e.g. M300 emits ``GPS(lat,lon,0.0M)``)
+                    # and an optional space between ``GPS`` and ``(`` used by
+                    # the P4 RTK compact single-line family.
                     if not lat_match or not lon_match:
                         gps_match = re.search(
-                            r"GPS\(([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*)\)",
+                            r"GPS\s*\(([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*)[A-Za-z]*\)",
                             telemetry_line,
                         )
                         if gps_match:
@@ -227,6 +230,26 @@ class DJIMetadataEmbedder:
                     )
                     fnum_match = re.search(r"\[fnum\s*:\s*(\d+)\]", telemetry_line)
                     ev_match = re.search(r"\[ev\s*:\s*([^\]]+)\]", telemetry_line)
+                    # P4 RTK compact single-line family uses free-standing
+                    # tokens (``F/5.6, SS 400, ISO 100, EV 0``) rather than
+                    # the bracketed ``[fnum:…]`` syntax. Fall back to those
+                    # when the bracket form did not match.
+                    if not fnum_match:
+                        fnum_match = re.search(
+                            r"(?<![A-Za-z])F/(\d+\.?\d*)", telemetry_line
+                        )
+                    if not shutter_match:
+                        shutter_match = re.search(
+                            r"(?<![A-Za-z])SS\s+(\d+(?:\.\d+)?)", telemetry_line
+                        )
+                    if not iso_match:
+                        iso_match = re.search(
+                            r"(?<![A-Za-z])ISO\s+(\d+)", telemetry_line
+                        )
+                    if not ev_match:
+                        ev_match = re.search(
+                            r"(?<![A-Za-z])EV\s+([+-]?\d+\.?\d*)", telemetry_line
+                        )
                     ct_match = re.search(r"\[ct\s*:\s*([^\]]+)\]", telemetry_line)
                     color_md_match = re.search(
                         r"\[color_md\s*:\s*([^\]]+)\]", telemetry_line

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -31,8 +31,10 @@ def parse_telemetry_points(srt_path: Path) -> List[Tuple[float, float, float, st
         lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
         alt_match = re.search(r"abs_alt:\s*([+-]?\d+\.?\d*)\]", tele_line)
         if not (lat_match and lon_match):
+            # Tolerate optional altitude unit suffix (M300 ``0.0M``) and an
+            # optional space before ``(`` used by the P4 RTK compact format.
             gps = re.search(
-                r"GPS\(([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*)\)",
+                r"GPS\s*\(([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*),\s*([+-]?\d+\.?\d*)[A-Za-z]*\)",
                 tele_line,
             )
             if gps:

--- a/tests/fixtures/golden_srt_samples.py
+++ b/tests/fixtures/golden_srt_samples.py
@@ -109,6 +109,59 @@ GPS(39.906220,116.391308,70.100) BAROMETER(90.9) HOME(39.906206,116.391400)
         }
     },
     
+    "m300_legacy_unit": {
+        "description": "Matrice 300 / legacy-with-unit GPS format (altitude carries a unit suffix)",
+        "format_type": "legacy_unit",
+        "srt_content": """1
+00:00:00,000 --> 00:00:00,033
+GPS(36.6146,-6.1120,0.0M) BAROMETER:0.3M
+
+2
+00:00:00,033 --> 00:00:00,066
+GPS(36.6147,-6.1121,0.1M) BAROMETER:0.4M
+
+3
+00:00:00,066 --> 00:00:00,100
+GPS(36.6148,-6.1122,0.2M) BAROMETER:0.5M
+""",
+        "expected_points": 3,
+        # Altitude inside GPS(...) is currently discarded for legacy formats;
+        # parse_telemetry_points returns 0.0 in the alt slot for this family.
+        "expected_coordinates": [
+            (36.6146, -6.1120, 0.0),
+            (36.6147, -6.1121, 0.1),
+            (36.6148, -6.1122, 0.2),
+        ],
+        "expected_metadata": {
+            "total_duration": 0.1,
+            "frame_rate": 30,
+            "has_unit_suffix": True,
+        }
+    },
+
+    "p4rtk_compact": {
+        "description": "Phantom 4 RTK / P4P compact single-line format (free-standing tokens)",
+        "format_type": "p4rtk_compact",
+        "srt_content": """1
+00:00:00,000 --> 00:00:00,033
+F/5.6, SS 400, ISO 100, EV 0, GPS (-58.851745, -34.237922, 15), HOME (-58.847509, -34.232707, -57.98m), D 698.70m, H 85.80m, H.S 0.00m/s, V.S 0.00m/s, F.PRY (2.7°, -7.0°, 110.1°), G.PRY (-24.4°, 0.0°, 110.4°)
+
+2
+00:00:00,033 --> 00:00:00,066
+F/5.6, SS 400, ISO 100, EV 0, GPS (-58.851746, -34.237923, 16), HOME (-58.847509, -34.232707, -57.98m), D 698.71m, H 85.81m, H.S 0.10m/s, V.S 0.05m/s, F.PRY (2.8°, -7.1°, 110.2°), G.PRY (-24.5°, 0.0°, 110.5°)
+""",
+        "expected_points": 2,
+        "expected_coordinates": [
+            (-58.851745, -34.237922, 0.0),
+            (-58.851746, -34.237923, 0.0),
+        ],
+        "expected_metadata": {
+            "total_duration": 0.066,
+            "frame_rate": 30,
+            "has_camera_settings": True,
+        }
+    },
+
     "mavic3_enterprise": {
         "description": "DJI Mavic 3 Enterprise format with RTK and extended data",
         "format_type": "mavic3_enterprise",

--- a/tests/test_golden_fixtures.py
+++ b/tests/test_golden_fixtures.py
@@ -109,6 +109,54 @@ class TestGoldenFixtures:
         finally:
             temp_path.unlink()
     
+    def test_m300_legacy_unit_format(self):
+        """Test Matrice 300 / legacy-with-unit GPS format (altitude unit suffix)."""
+        sample = GOLDEN_SAMPLES["m300_legacy_unit"]
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+            f.write(sample["srt_content"])
+            temp_path = Path(f.name)
+
+        try:
+            points = parse_telemetry_points(temp_path)
+            assert len(points) == sample["expected_points"]
+
+            for i, (exp_lat, exp_lon, _exp_alt) in enumerate(sample["expected_coordinates"]):
+                lat, lon = points[i][0], points[i][1]
+                assert abs(lat - exp_lat) < 0.0001
+                assert abs(lon - exp_lon) < 0.0001
+
+            validation = validate_srt_format(temp_path, lenient=True)
+            assert validation["valid"]
+            assert validation["format_detected"] == "legacy_unit"
+
+        finally:
+            temp_path.unlink()
+
+    def test_p4rtk_compact_format(self):
+        """Test Phantom 4 RTK / P4P compact single-line format."""
+        sample = GOLDEN_SAMPLES["p4rtk_compact"]
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+            f.write(sample["srt_content"])
+            temp_path = Path(f.name)
+
+        try:
+            points = parse_telemetry_points(temp_path)
+            assert len(points) == sample["expected_points"]
+
+            for i, (exp_lat, exp_lon, _exp_alt) in enumerate(sample["expected_coordinates"]):
+                lat, lon = points[i][0], points[i][1]
+                assert abs(lat - exp_lat) < 0.0001
+                assert abs(lon - exp_lon) < 0.0001
+
+            validation = validate_srt_format(temp_path, lenient=True)
+            assert validation["valid"]
+            assert validation["format_detected"] == "p4rtk_compact"
+
+        finally:
+            temp_path.unlink()
+
     def test_mavic3_enterprise_format(self):
         """Test Mavic 3 Enterprise format with RTK and extended data."""
         sample = GOLDEN_SAMPLES["mavic3_enterprise"]

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -51,6 +51,35 @@ def test_parse_format3(tmp_path):
     assert t["camera_settings"]["shutter"] == "1/1000"
 
 
+def test_parse_m300_legacy_unit(tmp_path):
+    """M300 GPS regex must tolerate altitude unit suffix (``0.0M``)."""
+    srt = """1
+00:00:00,000 --> 00:00:00,033
+GPS(36.6146,-6.1120,0.0M) BAROMETER:0.3M
+
+2
+00:00:00,033 --> 00:00:00,066
+GPS(36.6147,-6.1121,0.1M) BAROMETER:0.4M
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["first_gps"] == (36.6146, -6.1120)
+    assert len(t["gps_coords"]) == 2
+
+
+def test_parse_p4rtk_compact(tmp_path):
+    """P4 RTK compact single-line: free-standing camera tokens + ``GPS (...)``."""
+    srt = """1
+00:00:00,000 --> 00:00:00,033
+F/5.6, SS 400, ISO 100, EV 0, GPS (-58.851745, -34.237922, 15), HOME (-58.847509, -34.232707, -57.98m), D 698.70m, H 85.80m, H.S 0.00m/s, V.S 0.00m/s, F.PRY (2.7°, -7.0°, 110.1°), G.PRY (-24.4°, 0.0°, 110.4°)
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["first_gps"] == (-58.851745, -34.237922)
+    assert t["camera_settings"]["iso"] == "100"
+    assert t["camera_settings"]["shutter"] == "400"
+    assert t["camera_settings"]["fnum"] == "5.6"
+    assert t["camera_settings"]["ev"] == "0"
+
+
 def test_embed_metadata_ffmpeg_command(tmp_path, monkeypatch):
     video = Path(tmp_path / "DJI_20240101_123456.mp4")
     srt = Path(tmp_path / "test.srt")


### PR DESCRIPTION
## Summary

Two new SRT format families flagged as "free wins" by `docs/MODEL_SURVEY.md` (issue #182). Both have real comparator fixtures already available from `JuanIrache/DJI_SRT_Parser`, so no community sample outreach is needed before shipping.

### Format A — Matrice 300 / legacy-with-unit

```
GPS(36.6146,-6.1120,0.0M) BAROMETER:0.3M
```

Trivial fix: the existing GPS regex required `\)` immediately after the third float, so `0.0M` failed to match. Relaxed altitude capture to accept an optional unit suffix `[A-Za-z]*`. Lat/lon now parse; barometer altitude remains unparsed (consistent with Avata 2 behaviour). Survey predicted "fix is trivial" — confirmed, ~1-line regex tweak.

### Format B — Phantom 4 RTK / P4P compact single-line

```
F/5.6, SS 400, ISO 100, EV 0, GPS (-58.851745, -34.237922, 15), HOME (-58.847509, -34.232707, -57.98m), D 698.70m, H 85.80m, H.S 0.00m/s, V.S 0.00m/s, F.PRY (2.7°, -7.0°, 110.1°), G.PRY (-24.4°, 0.0°, 110.4°)
```

- GPS regex now tolerates the space before `(` (same regex tweak handles both A and B).
- Camera fields fall back to free-standing tokens (`F/N`, `SS N`, `ISO N`, `EV N`) when the bracketed `[fnum:…]` form is absent. Used `(?<![A-Za-z])` lookbehinds so e.g. "MISO" doesn't match `ISO`.

**Scope cut (deliberate):** `HOME`, `D`, `H`, `H.S`, `V.S`, `F.PRY`, `G.PRY` tokens are recognised in `docs/SRT_FORMATS.md` but not yet decoded into `telemetry_data`. The data model would need new keys (`home_gps`, `aircraft_attitude`, `gimbal_attitude`, etc.) which is real-API surface and warrants its own PR. Filed mentally as a follow-up; happy to open a tracking issue.

### Format detection

`core/validator.py` `format_votes` now distinguishes three GPS-paren families:
- `legacy_gps` — `GPS(lat,lon,alt)` no suffix (Avata 2)
- `legacy_unit` — `GPS(lat,lon,alt M)` with unit suffix (M300)
- `p4rtk_compact` — `GPS (...)` with space + free-standing `F/N` (P4 RTK lineage)

### Tests

- `tests/test_parsing.py`: two new direct-parser tests covering altitude unit suffix and free-standing camera tokens.
- `tests/fixtures/golden_srt_samples.py` + `tests/test_golden_fixtures.py`: two new golden fixtures and assertions, including format-detection checks.

Local: `uv run pytest -q` → 45 passed; `ruff check` clean; `mypy` clean.

## Test plan
- [ ] CI green (ruff / mypy / pytest 3.10–3.12 / build).
- [ ] Manual spot-check with a real M300 or P4 RTK file once one is in hand (none in this repo today).
- [ ] When community samples for Mini 5 Pro / Air 3S / M350 RTK arrive, repeat survey-based scope analysis before adding more families.

Closes nothing yet; partially addresses the "Next steps" list in `docs/MODEL_SURVEY.md` for issue #182.

---
_Generated by [Claude Code](https://claude.ai/code/session_018sVGY3B8eZH1xHmC8qbee5)_