### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Normalize line endings repo-wide.
+#
+# `text=auto` lets git detect text vs binary; `eol=lf` ensures every text
+# file is stored with LF in the index and checked out with LF on every
+# platform. Without this, Windows clones can introduce CRLF working-tree
+# changes that show up as spurious diffs on every modified file.
+
+* text=auto eol=lf
+
+# Windows shell scripts must keep CRLF — cmd.exe/PowerShell can misbehave
+# with LF-only line endings.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# DJI flight log binaries — never normalize.
+*.DAT binary
+*.dat binary


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` with `* text=auto eol=lf` so every text file is stored with LF in the index and checked out with LF on all platforms.
- Carves out `*.bat`, `*.cmd`, `*.ps1` as `eol=crlf` (Windows shells can misbehave with LF-only).
- Marks `*.DAT` / `*.dat` as `binary` so git never touches DJI flight log fixtures.
- Prevents Windows clones from re-introducing CRLF working-tree drift that recently surfaced as ~120 spurious "modified" files across the repo.

## Verification
- `git check-attr -a` confirms the rules resolve as expected for `.py`, `.SRT`, `.bat`, `.ps1`, `.sh`.
- `git add --renormalize .` against current HEAD produces **no changes** — every committed text file already has LF, so this PR is a guard against future drift rather than a content migration. No diff churn for reviewers.

## Impact on contributors
Windows contributors with a pre-existing CRLF working tree will see those files re-normalize themselves on the next `git checkout` / `git pull` after this lands. No action required — just a one-time visible refresh.

## Test plan
- [x] `git check-attr -a` spot-check on representative files (Python, SRT, BAT, PS1, SH)
- [x] `git add --renormalize .` produces no staged changes against HEAD
- [ ] CI green on Linux + Windows matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)