### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release]][release]
-[![Version](https://img.shields.io/badge/version-1.2.0-blue)][release]
+[![Version](https://img.shields.io/badge/version-1.3.0-blue)][release]
 [![PyPI]][pypi]
 
 A Python tool to embed telemetry data from DJI drone SRT files into MP4 video files.

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,6 +1,6 @@
 """DJI Drone Metadata Embedder."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 # Import check to ensure files were moved correctly
 try:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -188,7 +188,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "1.2.0"
+    $fallbackVersion = "1.3.0"
     
     try{
         LogInfo "Checking for latest version..."

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.2.0
+PackageVersion: 1.3.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -18,7 +18,7 @@ FileExtensions:
 - dat
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.2.0/dji-embed.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.3.0/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
   InstallerSwitches:
     Silent: ""

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.2.0
+PackageVersion: 1.3.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus

--- a/winget/CallMarcus.DJIMetadataEmbedder.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.2.0
+PackageVersion: 1.3.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Bumps the project version to **v1.3.0** across all synced files via `tools/sync_version.py`.

### What's in this release (since v1.2.0)

**feat**
- #190 — M300 legacy-with-unit and P4 RTK compact SRT formats

**fix**
- #193 — preserve all input streams with `-map 0 -map 1` (DJI Neo 2 dropped-streams bug, [discussion #192](https://github.com/CallMarcus/dji-drone-metadata-embedder/discussions/192))
- #186 — exclude archival research dir from mkdocs strict build

**chore / docs**
- #194 — `.gitattributes` to enforce LF line endings
- #191 — archive sample-request post drafts
- #189, #187, #185 — dependency syncs / dev-deps bumps
- #184, #183 — model survey + roadmap docs

## Release procedure (after this PR merges)
```bash
git checkout master && git pull
git tag v1.3.0
git push origin v1.3.0
```
That triggers PyPI release, Windows EXE build (now auto-creates the GitHub release thanks to #177), and the auto-changelog workflow. Winget remains a known-broken manual step ([#175](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/175)).

## Notes
- `tools/sync_version.py --check` passes — all 7 synced files agree on 1.3.0.
- `pytest -q`: 46 passed, 1 skipped (flask not installed; unrelated).
- `CHANGELOG.md`'s `[Unreleased]` block is stale (entries from before v1.2.0 never got moved into a versioned section). Not blocking — the `auto-changelog.yml` workflow runs on tag push and will generate the v1.3.0 section. Worth a separate cleanup pass later.

## Test plan
- [x] `python tools/sync_version.py --check` passes
- [x] `pytest -q` green locally
- [ ] CI green on the matrix
- [ ] Post-merge: tag pushed, PyPI + EXE workflows succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)