### PR TITLE
fix(embed): skip untaggable DJI data streams + duration-based validation

### DIFF
--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -19,16 +19,47 @@ logger = logging.getLogger(__name__)
 _TEMP_SUFFIX = ".tmp"
 
 
+def _ffprobe_duration(path: Path) -> Optional[float]:
+    """Return media duration in seconds via ffprobe, or None if unreadable."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "csv=p=0",
+                str(path),
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
 def _validate_embedded_output(original_path: Path, temp_path: Path) -> bool:
     """Validate temp output before moving to final destination.
 
-    Ensures the file is not corrupted after embedding (e.g. on interruption).
-    Checks: file exists, size >= original, and ffprobe can read the container.
+    Confirms the embed completed cleanly by comparing media durations — the
+    output's duration must be within 1 second of the source's. A size check
+    used to live here, but that produced false negatives once we started
+    dropping untaggable data streams from DJI footage (issue surfaced while
+    testing v1.3.0 against real Air 3S clips): the legitimate output was a
+    few percent smaller than the source even though no video frames were
+    lost. Duration is what we actually care about — truncation manifests as
+    a short duration, which this catches; cosmetic size drops do not.
 
     Parameters
     ----------
     original_path : Path
-        Original source video path (for size comparison).
+        Original source video path.
     temp_path : Path
         Path to the temporary embedded output file.
 
@@ -40,39 +71,29 @@ def _validate_embedded_output(original_path: Path, temp_path: Path) -> bool:
     if not temp_path.exists():
         logger.debug("Validation failed: temp file does not exist %s", temp_path)
         return False
-    try:
-        original_size = original_path.stat().st_size
-        temp_size = temp_path.stat().st_size
-    except OSError as e:
-        logger.warning("Validation failed: could not stat files: %s", e)
-        return False
-    if temp_size < original_size:
+
+    out_duration = _ffprobe_duration(temp_path)
+    if out_duration is None:
         logger.warning(
-            "Validation failed: output size %d < original size %d for %s",
-            temp_size,
-            original_size,
-            temp_path.name,
+            "Validation failed: ffprobe could not read output %s", temp_path.name
         )
         return False
-    # Verify the container is valid (ffprobe -v error exits 0 only if readable).
-    try:
-        result = subprocess.run(
-            ["ffprobe", "-v", "error", "-i", str(temp_path)],
-            capture_output=True,
-            text=True,
-            timeout=30,
+
+    src_duration = _ffprobe_duration(original_path)
+    if src_duration is None:
+        # If the source is unreadable we can't compare; trust that the output
+        # was at least readable above.
+        return True
+
+    # 1 second tolerance covers container rounding and the subtitle track's
+    # final-frame extension; anything more is real truncation.
+    if out_duration + 1.0 < src_duration:
+        logger.warning(
+            "Validation failed: output duration %.2fs < source %.2fs for %s",
+            out_duration, src_duration, temp_path.name,
         )
-        if result.returncode != 0:
-            err = getattr(result, "stderr", "") or getattr(result, "stdout", "")
-            logger.warning(
-                "Validation failed: ffprobe reported error for %s: %s",
-                temp_path.name,
-                err,
-            )
-            return False
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        logger.warning("Validation failed: ffprobe check failed: %s", e)
         return False
+
     return True
 
 
@@ -339,12 +360,14 @@ class DJIMetadataEmbedder:
                     ffmpeg_cmd = env_ffmpeg
 
             # Build ffmpeg command.
-            # -map 0 -map 1 forces all streams from the source MP4 plus the SRT
-            # to be carried through. Without explicit -map, ffmpeg picks one
-            # stream per type and silently drops the rest — which loses data
-            # tracks (gyro, GPMF, proxy/LRF) that newer DJI models emit and
-            # makes the output smaller than the original (issue surfaced in
-            # GH discussion #192, DJI Neo 2 footage).
+            # -map 0 -map -0:d -map 1 keeps every video/audio stream from the
+            # source plus the SRT subtitle. Newer DJI models (Air 3S, Neo 2)
+            # also emit proprietary data streams (`djmd` / `dbgi`, gyro and
+            # debug metadata) whose codec the MP4 muxer cannot tag — without
+            # explicitly dropping them the entire mux fails with
+            # "Could not find tag for codec none". We lose those data tracks;
+            # the main video, proxy/LRF MJPEG, audio, and telemetry SRT are
+            # all preserved. Background: GH discussion #192, follow-up to #193.
             cmd = [
                 ffmpeg_cmd,
                 "-i",
@@ -353,6 +376,8 @@ class DJIMetadataEmbedder:
                 str(srt_path),
                 "-map",
                 "0",
+                "-map",
+                "-0:d",
                 "-map",
                 "1",
                 "-c",

--- a/tests/test_embedder_atomic.py
+++ b/tests/test_embedder_atomic.py
@@ -17,7 +17,28 @@ from dji_metadata_embedder.embedder import (
 
 
 class TestValidateEmbeddedOutput:
-    """Tests for _validate_embedded_output."""
+    """Tests for _validate_embedded_output.
+
+    The validator now compares media durations rather than file sizes — the
+    size check produced false negatives once we started dropping untaggable
+    data streams from real DJI footage (see embedder.py for context).
+    """
+
+    @staticmethod
+    def _fake_ffprobe(durations: dict):
+        """Return a subprocess.run replacement that responds to ffprobe duration
+        queries by looking up the input path's stem in *durations*. Anything not
+        in the map returns returncode=1 (simulates unreadable input).
+        """
+        def runner(cmd, *args, **kwargs):
+            target = Path(cmd[-1]).name
+            if target in durations:
+                value = durations[target]
+                if value is None:
+                    return type("R", (), {"returncode": 1, "stdout": "", "stderr": "error"})()
+                return type("R", (), {"returncode": 0, "stdout": f"{value}\n", "stderr": ""})()
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": "unknown"})()
+        return runner
 
     def test_returns_false_when_temp_missing(self, tmp_path: Path) -> None:
         original = tmp_path / "original.mp4"
@@ -25,19 +46,7 @@ class TestValidateEmbeddedOutput:
         temp_path = tmp_path / "out.mp4.tmp"
         assert not _validate_embedded_output(original, temp_path)
 
-    def test_returns_false_when_temp_smaller_than_original(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        original = tmp_path / "original.mp4"
-        original.write_bytes(b"x" * 2000)
-        temp_path = tmp_path / "out.mp4.tmp"
-        temp_path.write_bytes(b"x" * 500)
-        monkeypatch.setattr(
-            subprocess, "run", lambda *a, **k: type("R", (), {"returncode": 0})()
-        )
-        assert not _validate_embedded_output(original, temp_path)
-
-    def test_returns_true_when_size_ok_and_ffprobe_succeeds(
+    def test_returns_true_when_durations_match(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         original = tmp_path / "original.mp4"
@@ -45,13 +54,55 @@ class TestValidateEmbeddedOutput:
         temp_path = tmp_path / "out.mp4.tmp"
         temp_path.write_bytes(b"x" * 1500)
         monkeypatch.setattr(
-            subprocess,
-            "run",
-            lambda *a, **k: type("R", (), {"returncode": 0})(),
+            subprocess, "run",
+            self._fake_ffprobe({"original.mp4": 10.0, "out.mp4.tmp": 10.0}),
         )
         assert _validate_embedded_output(original, temp_path) is True
 
-    def test_returns_false_when_ffprobe_fails(
+    def test_returns_true_when_output_smaller_but_duration_matches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Output may be smaller than source after dropping data streams; that
+        alone must not fail validation."""
+        original = tmp_path / "original.mp4"
+        original.write_bytes(b"x" * 2000)
+        temp_path = tmp_path / "out.mp4.tmp"
+        temp_path.write_bytes(b"x" * 1500)
+        monkeypatch.setattr(
+            subprocess, "run",
+            self._fake_ffprobe({"original.mp4": 53.62, "out.mp4.tmp": 53.62}),
+        )
+        assert _validate_embedded_output(original, temp_path) is True
+
+    def test_returns_false_when_output_duration_short(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Truncated output is what we actually want to catch."""
+        original = tmp_path / "original.mp4"
+        original.write_bytes(b"x" * 1000)
+        temp_path = tmp_path / "out.mp4.tmp"
+        temp_path.write_bytes(b"x" * 1500)
+        monkeypatch.setattr(
+            subprocess, "run",
+            self._fake_ffprobe({"original.mp4": 60.0, "out.mp4.tmp": 5.0}),
+        )
+        assert _validate_embedded_output(original, temp_path) is False
+
+    def test_returns_true_when_output_within_one_second(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sub-second drift (container rounding, subtitle padding) is allowed."""
+        original = tmp_path / "original.mp4"
+        original.write_bytes(b"x" * 1000)
+        temp_path = tmp_path / "out.mp4.tmp"
+        temp_path.write_bytes(b"x" * 1500)
+        monkeypatch.setattr(
+            subprocess, "run",
+            self._fake_ffprobe({"original.mp4": 53.62, "out.mp4.tmp": 53.10}),
+        )
+        assert _validate_embedded_output(original, temp_path) is True
+
+    def test_returns_false_when_output_unreadable(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         original = tmp_path / "original.mp4"
@@ -59,9 +110,8 @@ class TestValidateEmbeddedOutput:
         temp_path = tmp_path / "out.mp4.tmp"
         temp_path.write_bytes(b"x" * 1500)
         monkeypatch.setattr(
-            subprocess,
-            "run",
-            lambda *a, **k: type("R", (), {"returncode": 1})(),
+            subprocess, "run",
+            self._fake_ffprobe({"original.mp4": 10.0, "out.mp4.tmp": None}),
         )
         assert _validate_embedded_output(original, temp_path) is False
 
@@ -110,16 +160,17 @@ class TestProcessDirectoryAtomicWrite:
         ffmpeg_called: list = []
 
         def fake_run(cmd: list, *args, **kwargs):
-            res = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            ok = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
             if cmd and "ffmpeg" in str(cmd[0]).lower():
                 ffmpeg_called.append(cmd)
                 out_path = Path(cmd[-1])
-                # Write at least as many bytes as original so validation (size >= original) passes
-                out_path.write_bytes(b"embedded content (padded for size check)")
-                return res
+                out_path.write_bytes(b"embedded content")
+                return ok
             if cmd and "ffprobe" in str(cmd[0]).lower():
-                return res
-            return res
+                # ffprobe duration query — return matching durations so the
+                # validator's truncation check passes.
+                return type("R", (), {"returncode": 0, "stdout": "10.0\n", "stderr": ""})()
+            return ok
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         monkeypatch.setattr(
@@ -132,7 +183,7 @@ class TestProcessDirectoryAtomicWrite:
 
         assert result["processed"] == 1
         assert final_output.exists()
-        assert final_output.read_bytes() == b"embedded content (padded for size check)"
+        assert final_output.read_bytes() == b"embedded content"
         assert not temp_output.exists()
         assert len(ffmpeg_called) >= 1
         ffmpeg_output_arg = ffmpeg_called[0][-1]
@@ -141,12 +192,13 @@ class TestProcessDirectoryAtomicWrite:
         assert ffmpeg_output_arg.endswith(final_output.suffix)
         assert _TEMP_SUFFIX in Path(ffmpeg_output_arg).name
 
-    def test_ffmpeg_command_maps_all_input_streams(
+    def test_ffmpeg_command_maps_streams_and_drops_data(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """ffmpeg must receive -map 0 -map 1 so extra source streams (gyro,
-        GPMF, proxy tracks emitted by newer DJI models like the Neo 2) are
-        preserved rather than silently dropped (GH discussion #192).
+        """ffmpeg must receive -map 0 -map -0:d -map 1: keep every source
+        video/audio stream and the SRT, but drop proprietary data streams
+        (DJI `djmd` / `dbgi`) that the MP4 muxer cannot tag. See GH discussion
+        #192 and the follow-up in embedder.py for the full context.
         """
         video = tmp_path / "DJI_20240101_123456.mp4"
         srt = tmp_path / "DJI_20240101_123456.srt"
@@ -159,11 +211,14 @@ class TestProcessDirectoryAtomicWrite:
         ffmpeg_called: list = []
 
         def fake_run(cmd: list, *args, **kwargs):
-            res = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            ok = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
             if cmd and "ffmpeg" in str(cmd[0]).lower():
                 ffmpeg_called.append(cmd)
-                Path(cmd[-1]).write_bytes(b"embedded content padded for size check")
-            return res
+                Path(cmd[-1]).write_bytes(b"embedded content")
+                return ok
+            if cmd and "ffprobe" in str(cmd[0]).lower():
+                return type("R", (), {"returncode": 0, "stdout": "10.0\n", "stderr": ""})()
+            return ok
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         monkeypatch.setattr(
@@ -179,12 +234,14 @@ class TestProcessDirectoryAtomicWrite:
         map_indices = [i for i, tok in enumerate(cmd) if tok == "-map"]
         map_targets = [cmd[i + 1] for i in map_indices]
         assert "0" in map_targets, f"expected -map 0 in ffmpeg cmd, got {cmd}"
+        assert "-0:d" in map_targets, f"expected -map -0:d in ffmpeg cmd, got {cmd}"
         assert "1" in map_targets, f"expected -map 1 in ffmpeg cmd, got {cmd}"
 
     def test_final_not_created_when_validation_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When validation fails, final output is not created and temp is removed."""
+        """When ffprobe can't read the embedded output (truncated/corrupt),
+        the final file is not created and the temp file is removed."""
         video = tmp_path / "DJI_20240101_123456.mp4"
         srt = tmp_path / "DJI_20240101_123456.srt"
         video.write_bytes(b"x" * 2000)
@@ -198,13 +255,16 @@ class TestProcessDirectoryAtomicWrite:
         )
 
         def fake_run(cmd: list, *args, **kwargs):
-            res = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
             if cmd and "ffmpeg" in str(cmd[0]).lower():
                 Path(cmd[-1]).write_bytes(b"x" * 100)
-                return res
+                return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
             if cmd and "ffprobe" in str(cmd[0]).lower():
-                return res
-            return res
+                # Output unreadable (simulates truncation/corruption).
+                target = Path(cmd[-1]).name
+                if _TEMP_SUFFIX in target:
+                    return type("R", (), {"returncode": 1, "stdout": "", "stderr": "moov not found"})()
+                return type("R", (), {"returncode": 0, "stdout": "10.0\n", "stderr": ""})()
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         monkeypatch.setattr(
@@ -229,14 +289,14 @@ class TestProcessDirectoryAtomicWrite:
         srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nGPS(1,2,3)")
 
         def fake_run(cmd: list, *args, **kwargs):
-            res = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            ok = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
             if cmd and "ffmpeg" in str(cmd[0]).lower():
                 out_path = Path(cmd[-1])
-                out_path.write_bytes(b"embedded in place (padded for validation)")
-                return res
+                out_path.write_bytes(b"embedded in place")
+                return ok
             if cmd and "ffprobe" in str(cmd[0]).lower():
-                return res
-            return res
+                return type("R", (), {"returncode": 0, "stdout": "10.0\n", "stderr": ""})()
+            return ok
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         monkeypatch.setattr(
@@ -250,7 +310,7 @@ class TestProcessDirectoryAtomicWrite:
         assert result["processed"] == 1
         assert result["output_directory"] == str(tmp_path)
         assert video.exists()
-        assert video.read_bytes() == b"embedded in place (padded for validation)"
+        assert video.read_bytes() == b"embedded in place"
         assert not video.with_name(
             video.stem + _TEMP_SUFFIX + video.suffix
         ).exists()

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -110,6 +110,8 @@ def test_embed_metadata_ffmpeg_command(tmp_path, monkeypatch):
         "-map",
         "0",
         "-map",
+        "-0:d",
+        "-map",
         "1",
         "-c",
         "copy",


### PR DESCRIPTION
## Summary

Follow-up to #193. v1.3.0's `-map 0 -map 1` change preserved everything it was meant to — but for real DJI Air 3S / Neo 2 footage that turned silent stream-dropping into outright ffmpeg failure: the proprietary `djmd` (HAL meta / gyro) and `dbgi` (HAL debug) data streams have valid FOURCC tags in the source but resolve to `codec=none` in ffmpeg, and the MP4 muxer rejects writing them with:

```
Could not find tag for codec none in stream #1, codec not currently supported in container
[out#0/mp4 @ ...] Could not write header (incorrect codec parameters ?): Invalid argument
```

Discovered while testing v1.3.0 end-to-end against real Air 3S clips contributed by a community user.

## Changes

### 1. Drop untaggable data streams
`embedder.py` ffmpeg cmd: `-map 0 -map 1` → `-map 0 -map -0:d -map 1`. Keeps every video/audio stream from the source plus the SRT subtitle; drops `data:*` streams that the MP4 muxer cannot retag. `-copy_unknown` and `-ignore_unknown` were tried first — neither applies to this exact case (they cover *unknown type*, not *known type with unmapped codec*).

### 2. Switch validator from size to duration
`_validate_embedded_output` no longer compares file sizes — the dropped data streams legitimately shrink the output by ~5%, which produced false negatives. Now uses an ffprobe duration comparison (±1 s tolerance). Truncation is what we actually want to catch and it manifests as short duration; a small size reduction does not.

## Verification

Tested end-to-end against real Air 3S MP4s:

| input | src streams | out streams | size ratio | validator |
|---|---|---|---|---|
| 528 MB default profile | hevc / data / data / mjpeg | hevc / mov_text / mjpeg | 93.9% | ✅ pass |
| 476 MB D-Log M | hevc / data / data / mjpeg | hevc / mov_text / mjpeg | 94.9% | ✅ pass |

Main 4K HEVC video, 960×540 MJPEG proxy, and the new telemetry subtitle all preserved. The two `data:none` streams (~5% of bytes) are intentionally dropped.

## Test plan
- [x] `pytest -q` — 48 passed (was 46), 1 skipped (flask unrelated)
- [x] New validator tests cover: duration match, sub-second drift, short-duration rejection, unreadable-output rejection, size shrinkage is not a failure
- [x] `-map -0:d` asserted in the ffmpeg command via both the integration test and the exact-match parser test
- [x] End-to-end run on real Air 3S footage (HEVC + MJPEG + 2x `data:none` + SRT) — fix succeeds, validator passes
- [ ] CI green on Linux + Windows matrix

## What's NOT in this PR

The `djmd` / `dbgi` streams remain unpreserved. That's tracked in #197 with three possible routes (MKV opt-in, direct MP4 box editing, companion files) — needs a separate decision and is a meaningfully larger piece of work.

## Related

- GH discussion #192 — original symptom report (DJI Neo 2)
- #193 — initial `-map 0 -map 1` fix
- #197 — follow-up tracking issue for preserving the dropped data streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)