### PR TITLE
chore(release): prepare v1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release]][release]
-[![Version](https://img.shields.io/badge/version-1.3.0-blue)][release]
+[![Version](https://img.shields.io/badge/version-1.3.1-blue)][release]
 [![PyPI]][pypi]
 
 A Python tool to embed telemetry data from DJI drone SRT files into MP4 video files.

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,6 +1,6 @@
 """DJI Drone Metadata Embedder."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 # Import check to ensure files were moved correctly
 try:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -188,7 +188,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "1.3.0"
+    $fallbackVersion = "1.3.1"
     
     try{
         LogInfo "Checking for latest version..."

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.3.0
+PackageVersion: 1.3.1
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -18,7 +18,7 @@ FileExtensions:
 - dat
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.3.0/dji-embed.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.3.1/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
   InstallerSwitches:
     Silent: ""

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.3.0
+PackageVersion: 1.3.1
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus

--- a/winget/CallMarcus.DJIMetadataEmbedder.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.3.0
+PackageVersion: 1.3.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
Bumps the project version to **v1.3.1** via `tools/sync_version.py`. Regression-fix release for v1.3.0.

### What's in this release (since v1.3.0)

**fix**
- #198 — skip untaggable DJI data streams (`djmd` / `dbgi`) and switch to ffprobe duration-based validation. v1.3.0's `-map 0 -map 1` turned silent stream-dropping into outright ffmpeg failure on real Air 3S / Neo 2 footage; this restores function for those models. End-to-end verified against 4K HEVC clips contributed by a community user.

**tracking**
- #197 — follow-up issue for preserving `djmd` / `dbgi` (MKV-output, direct MP4-box editing, or companion-files routes). Not in v1.3.1.

## Release procedure (after this PR merges)
```bash
git checkout master && git pull
git tag v1.3.1
git push origin v1.3.1
```
Triggers PyPI release and Windows EXE build (auto-creates the GitHub release via #177). Winget remains the known-broken manual step ([#175](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/175)).

## Notes
- `tools/sync_version.py --check` passes — all 7 synced files agree on 1.3.1.
- `pytest -q`: 48 passed, 1 skipped (flask unrelated).
- `CHANGELOG.md`'s `[Unreleased]` block is still stale from before v1.2.0; auto-changelog will write a v1.3.1 section regardless. Worth a separate cleanup pass.

## Test plan
- [x] `python tools/sync_version.py --check` passes
- [x] `pytest -q` green locally
- [ ] CI green on the matrix
- [ ] Post-merge: tag pushed, PyPI + EXE workflows succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)