### PR TITLE
fix(changelog): skip the tag being published when finding the previous one

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -128,22 +128,36 @@ def get_commits_since_tag(since_tag: Optional[str] = None) -> List[Dict]:
     return commits
 
 
-def get_latest_release_tag() -> Optional[str]:
-    """Get the latest release tag."""
+def get_latest_release_tag(exclude: Optional[str] = None) -> Optional[str]:
+    """Get the latest release tag, optionally skipping a specific version.
+
+    When the workflow runs after a tag push, the tag we just published is the
+    "latest" — but for changelog generation we want commits since the *previous*
+    tag. Pass the version being published as ``exclude`` (with or without the
+    ``v`` prefix) and that tag will be skipped during the search.
+    """
     try:
         # Get all tags sorted by version
         output = run_git_command(["tag", "--list", "--sort=-version:refname"])
         tags = output.split('\n')
-        
+
         # Find first tag that looks like a version (v1.2.3 or 1.2.3)
         version_pattern = r'^v?\d+\.\d+\.\d+'
+        excluded: set = set()
+        if exclude:
+            bare = exclude.lstrip("v")
+            excluded = {bare, f"v{bare}"}
+
         for tag in tags:
-            if re.match(version_pattern, tag.strip()):
-                return tag.strip()
+            tag = tag.strip()
+            if not tag or tag in excluded:
+                continue
+            if re.match(version_pattern, tag):
+                return tag
 
     except Exception:
         pass
-    
+
     return None
 
 
@@ -303,7 +317,9 @@ def main():
     # Determine commit range
     since_tag = args.since
     if not since_tag and version != "Unreleased":
-        since_tag = get_latest_release_tag()
+        # Skip the tag we're about to publish — we want commits since the
+        # *previous* release, not zero commits since ourselves.
+        since_tag = get_latest_release_tag(exclude=version)
     
     print(f"🔍 Generating changelog for {version}...")
     if since_tag:

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -1,0 +1,76 @@
+"""Tests for scripts/generate_changelog.py.
+
+The historical bug this guards against: on a tag push event the workflow
+calls the script with ``--version 1.3.1`` *after* v1.3.1 has been pushed,
+so ``get_latest_release_tag()`` was returning v1.3.1 itself and the script
+found zero commits "since v1.3.1". Tags between v1.1.2 and v1.3.0 silently
+produced empty changelogs as a result. The fix accepts an ``exclude`` arg
+so callers can ask for the latest tag *other than* the one being published.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import List
+
+
+def _load_module():
+    path = Path(__file__).resolve().parent.parent / "scripts" / "generate_changelog.py"
+    spec = importlib.util.spec_from_file_location("generate_changelog", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _patch_tags(monkeypatch, module, tags: List[str]) -> None:
+    """Replace run_git_command so the tag list lookup returns *tags*."""
+    def fake(args):
+        # `tag --list --sort=-version:refname` — return the canned list.
+        if args[:2] == ["tag", "--list"]:
+            return "\n".join(tags)
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(module, "run_git_command", fake)
+
+
+class TestGetLatestReleaseTag:
+    def test_returns_newest_tag_when_no_exclude(self, monkeypatch):
+        module = _load_module()
+        _patch_tags(monkeypatch, module, ["v1.3.1", "v1.3.0", "v1.2.0", "v1.1.2"])
+        assert module.get_latest_release_tag() == "v1.3.1"
+
+    def test_skips_excluded_v_prefixed_tag(self, monkeypatch):
+        """When publishing v1.3.1, asking for the previous tag must return v1.3.0."""
+        module = _load_module()
+        _patch_tags(monkeypatch, module, ["v1.3.1", "v1.3.0", "v1.2.0", "v1.1.2"])
+        assert module.get_latest_release_tag(exclude="v1.3.1") == "v1.3.0"
+
+    def test_skips_excluded_bare_version(self, monkeypatch):
+        """Workflows pass the version without the v prefix; both forms must match."""
+        module = _load_module()
+        _patch_tags(monkeypatch, module, ["v1.3.1", "v1.3.0"])
+        assert module.get_latest_release_tag(exclude="1.3.1") == "v1.3.0"
+
+    def test_skips_excluded_when_repo_uses_bare_tags(self, monkeypatch):
+        """A tag named ``1.3.1`` (no leading v) is excluded just the same."""
+        module = _load_module()
+        _patch_tags(monkeypatch, module, ["1.3.1", "1.3.0"])
+        assert module.get_latest_release_tag(exclude="1.3.1") == "1.3.0"
+
+    def test_ignores_non_version_tags(self, monkeypatch):
+        module = _load_module()
+        _patch_tags(monkeypatch, module, ["release-candidate", "v1.3.1", "v1.3.0"])
+        assert module.get_latest_release_tag(exclude="1.3.1") == "v1.3.0"
+
+    def test_returns_none_when_only_excluded_tag_exists(self, monkeypatch):
+        """First-ever release: nothing earlier to compare against."""
+        module = _load_module()
+        _patch_tags(monkeypatch, module, ["v1.3.1"])
+        assert module.get_latest_release_tag(exclude="1.3.1") is None
+
+    def test_returns_none_when_no_tags(self, monkeypatch):
+        module = _load_module()
+        _patch_tags(monkeypatch, module, [""])
+        assert module.get_latest_release_tag() is None


### PR DESCRIPTION
## Summary
The auto-changelog workflow has been silently broken since v1.1.2. On a tag push, GitHub Actions runs `generate_changelog.py --version 1.3.1` *after* v1.3.1 has been pushed, so `get_latest_release_tag()` returned v1.3.1 itself, the script computed "commits since v1.3.1" (zero), and exited clean without ever writing a CHANGELOG section. The historical missing sections were backfilled in #200; this PR fixes the script so the next release actually populates.

## Fix
- `get_latest_release_tag()` now takes an optional `exclude` argument. Matches both bare (`1.3.1`) and `v`-prefixed (`v1.3.1`) forms so it works regardless of how the workflow passes the version.
- `main()` passes the `--version` value as `exclude` so the lookup skips the tag we're publishing and returns the *previous* one.

## Verification
End-to-end dry run against the current state, with v1.3.1 already tagged:

```
$ python scripts/generate_changelog.py --version 1.3.1 --dry-run
🔍 Generating changelog for 1.3.1...
📅 Commits since: v1.3.0
📝 Found 4 conventional commits
...
```

Resolves to v1.3.0 (the actual previous tag), not v1.3.1. Generates the expected section.

## Tests
New `tests/test_generate_changelog.py` with 7 cases:
- newest tag returned when no `exclude` (regression guard)
- `v1.3.1` excluded when passed as `v1.3.1`
- `v1.3.1` excluded when passed as bare `1.3.1`
- bare-tag repos (`1.3.1`) excluded correctly
- non-version tags (`release-candidate`) ignored
- returns `None` when only the excluded tag exists (first-release case)
- returns `None` when no tags exist at all

## Test plan
- [x] New tests pass — 7/7
- [x] `pytest -q` — 55 passed (was 48), 1 skipped (flask, unrelated)
- [x] End-to-end dry-run against the live repo state produces the expected section
- [ ] Real verification will happen on the *next* release tag push — the auto-changelog workflow should generate and commit a section for the first time since v1.1.2

## Related
- #200 — historical CHANGELOG backfill (already merged or pending)
- The workflow itself (`.github/workflows/auto-changelog.yml`) is unchanged; the bug is purely in the script it invokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)