### PR TITLE
feat(parser): add Avata 360 + Mini 5 Pro support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,11 @@ output/
 *.mov
 *.avi
 *.AVI
+# DJI 360 video (.OSV) and low-res proxy (.LRF) containers — large binaries
+*.OSV
+*.osv
+*.LRF
+*.lrf
 *.SRT
 *.srt
 *.gpx

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 
 **Fully Tested & Documented** (with sample fixtures):
 - **DJI Mini 3/4 Pro** - Square bracket format `[latitude: xx.xxx] [longitude: xx.xxx]`
+- **DJI Mini 5 Pro** - HTML-style bracket format with decimal aperture (`[fnum: 1.8]`)
 - **DJI Air 3** - HTML-style format with extended telemetry data
+- **DJI Avata 360** - HTML-style bracket format with stabilization (`pp_*`) fields; footage ships as `.OSV` (360 video) + `.LRF` proxy
 - **DJI Avata 2** - Legacy GPS format `GPS(lat,lon,alt)` with BAROMETER data
 - **DJI Mavic 3 Enterprise** - Extended format with RTK precision data
 - **DJI Matrice 300 (legacy-with-unit)** - `GPS(lat,lon,alt M)` with `BAROMETER:` colon notation

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -93,6 +93,33 @@ Used by: DJI Mavic 3, DJI Air 2S
 - `color_md`: Color mode
 - `focal_len`: Focal length × 10 (240 = 24mm)
 
+### Format 3b: Modern HTML Bracket (FrameCnt + decimal units)
+
+Used by: DJI Mini 5 Pro, DJI Avata 360
+
+Current models keep the HTML-wrapped bracket structure of Format 3 but change
+two things: the counter is `FrameCnt` (not `SrtCnt`), and the aperture and
+focal length are written as **literal decimals** rather than the legacy
+×100 / ×10 integer encodings.
+
+```
+<font size="28">FrameCnt: 1, DiffTime: 40ms
+2026-05-27 13:14:22.911
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.8] [ev: -0.7] [color_md: dlog_m] [focal_len: 24.00] [latitude: 53.365108] [longitude: 6.460719] [rel_alt: 6.000 abs_alt: -122.769] [ct: 5263] </font>
+```
+
+**Notes:**
+- `fnum: 1.8` is the literal f-number (f/1.8), not `180`.
+- `focal_len: 24.00` is the literal focal length in mm, not `240`.
+- The Avata 360 variant adds a `FrameId`, a `dzoom_ratio`, gimbal
+  (`gb_yaw`/`gb_pitch`/`gb_roll`), and a block of stabilization /
+  post-processing fields (`eis`, `shift x/y`, `pp_*`). These are ignored by
+  the parser but are valid telemetry-line content.
+- Avata 360 footage is delivered as `.OSV` (360 video) plus a `.LRF` low-res
+  proxy instead of `.MP4`; both are MP4-family containers and are processed
+  like any other video. See [troubleshooting](troubleshooting.md).
+- Detected as the `html_extended` format family.
+
 ## Camera Settings Interpretation
 
 ### ISO Values
@@ -104,18 +131,13 @@ Used by: DJI Mavic 3, DJI Air 2S
 - Long exposure: `2.0` (2 seconds)
 
 ### F-Number (Aperture)
-- Stored as integer × 100
-- Examples:
-  - 170 = f/1.7
-  - 280 = f/2.8
-  - 400 = f/4.0
+- Legacy encoding: integer × 100 (`170` = f/1.7, `280` = f/2.8, `400` = f/4.0)
+- Modern encoding (Format 3b): literal decimal (`1.8` = f/1.8, `1.9` = f/1.9)
+- The parser stores the value verbatim and does not convert between the two.
 
 ### Focal Length
-- Stored as integer × 10
-- Examples:
-  - 240 = 24mm
-  - 350 = 35mm
-  - 500 = 50mm
+- Legacy encoding: integer × 10 (`240` = 24mm, `350` = 35mm, `500` = 50mm)
+- Modern encoding (Format 3b): literal decimal mm (`24.00` = 24mm)
 
 ## GPS Coordinate Formats
 
@@ -175,6 +197,8 @@ if new_format_match:
 | DJI Mini 4 Pro | Format 1 | Bracketed key-value pairs |
 | DJI Mavic 3 | Format 3 | Comprehensive with HTML tags |
 | DJI Air 2S | Format 3 | Comprehensive with HTML tags |
+| DJI Mini 5 Pro | Format 3b | FrameCnt + decimal fnum/focal_len |
+| DJI Avata 360 | Format 3b | FrameCnt + decimal units; `.OSV`/`.LRF` video, `pp_*` stabilization fields |
 | DJI Mavic Pro | Format 2 | GPS function format |
 | DJI Phantom 4 | Format 2 | GPS function format |
 | DJI Matrice 300 RTK | Format 2b | Legacy-with-unit (`0.0M` altitude) |

--- a/docs/superpowers/specs/2026-05-30-avata360-mini5pro-support-design.md
+++ b/docs/superpowers/specs/2026-05-30-avata360-mini5pro-support-design.md
@@ -1,0 +1,89 @@
+# Design: Avata 360 + Mini 5 Pro support
+
+_Date: 2026-05-30_
+
+## Context
+
+Two new model samples arrived via a mavicpilots.com submission:
+
+- `samples/Avata360/` — `.OSV` (360 video), `.LRF` (low-res proxy), `.SRT`. No `.MP4`.
+- `samples/Mini5PRO/` — `.MP4`, `.SRT`.
+
+Both SRTs use the standard HTML-wrapped bracketed format
+(`<font>...[iso:][shutter:][fnum:][latitude:][longitude:][rel_alt: abs_alt:]...`),
+which the parser already supports. Running `DJIMetadataEmbedder.parse_dji_srt`
+against both extracts GPS, altitude, ISO, shutter, EV, color mode, and focal
+length; both validate as the existing `html_extended` format family.
+
+`.OSV` and `.LRF` are ISO BMFF (MP4-family) containers — same
+`ftyp isom/iso2/mp41` brands as a normal DJI `.MP4`, plus extra boxes for 360
+metadata (`covr`, `snal`, `camd`). ffmpeg can read them.
+
+## Goals
+
+Full support for both models: parser fix, video discovery, golden fixtures,
+tests, and docs.
+
+## Non-goals
+
+- Parsing the 360-projection metadata inside `.OSV` boxes.
+- Transcoding or stitching 360 footage.
+- DAT flight-log handling (none provided in the samples).
+
+## Changes
+
+### 1. Decimal `fnum` fix — `embedder.py`
+
+The aperture regex `\[fnum\s*:\s*(\d+)\]` matches integers only, so
+`fnum: 1.9` / `fnum: 1.8` is silently dropped — for these two models and for
+every modern DJI model with a decimal aperture. Change to
+`\[fnum\s*:\s*([+-]?\d+\.?\d*)\]`, matching the existing lat/lon/alt patterns.
+
+Scope check: `utilities.parse_telemetry_points` does not read `fnum`, and
+`core/validator.py` format detection does not depend on it. Single-site fix.
+
+### 2. Video discovery — `.OSV` and `.LRF` — `embedder.py::process_directory`
+
+Current discovery globs `*.mp4` + `*.MP4`. Extend the set to also include
+`*.osv`, `*.OSV`, `*.lrf`, `*.LRF`. Output naming
+(`{stem}_metadata{suffix}`) already preserves arbitrary extensions, so
+Avata 360 yields `..._metadata.OSV` (and `..._metadata.LRF`) with the SRT
+muxed in via the existing `-c copy` path. Mini 5 Pro is a plain `.MP4` and
+needs nothing new.
+
+Note: `.LRF` is a low-res proxy sharing the `.OSV` stem and the same `.SRT`.
+Including it (per user decision) means each Avata clip is processed twice and
+produces both `_metadata.OSV` and `_metadata.LRF` outputs. This is intended.
+
+### 3. `.gitignore` safety
+
+`*.OSV` / `*.LRF` are not currently ignored, so the raw 60–180 MB samples
+could be committed by accident. Add `*.OSV`, `*.osv`, `*.LRF`, `*.lrf`.
+Trimmed `clip.SRT` fixtures are force-added (`git add -f`), the same way the
+existing model fixtures are tracked despite the `*.SRT` ignore rule.
+
+### 4. Golden fixtures + tests
+
+- `samples/Avata360/clip.SRT`, `samples/Mini5PRO/clip.SRT` — trimmed to ~5
+  frames from the real SRTs, following the existing ~7-line `clip.SRT`
+  convention.
+- Add both to `GOLDEN_SAMPLES` in `tests/fixtures/golden_srt_samples.py` with
+  expected point counts and coordinates, including a decimal-`fnum`
+  assertion that locks the bug fix.
+- Add two tests to `tests/test_golden_fixtures.py`; both assert
+  `format_detected == "html_extended"` (they are genuinely that family — no
+  new format vote is required in the validator).
+
+### 5. Docs
+
+- `README.md` "Supported DJI Models" — add **DJI Avata 360** (360 `.OSV`
+  container) and **DJI Mini 5 Pro**.
+- `docs/SRT_FORMATS.md` — document both; note Avata 360's extra
+  `pp_*`/stabilization tokens and the `.OSV`/`.LRF` containers.
+- `docs/troubleshooting.md` — short note on `.OSV` handling and that `.LRF`
+  proxies are also processed.
+
+## Verification
+
+- `uv run pytest -q` (new golden tests pass, existing suite stays green).
+- Parser run against the full real SRTs confirms `fnum` is now captured.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -148,6 +148,19 @@ dji-embed check /drone/footage/
 - Wrong extensions: `.mov`, `.mkv` → Convert to `.mp4`
 - Spaces in names: `DJI 0001.MP4` → `DJI_0001.MP4`
 
+### Avata 360 `.OSV` / `.LRF` Files
+
+DJI Avata 360 footage is delivered as `.OSV` (the 360 video) plus a matching
+`.LRF` low-res proxy instead of `.MP4`. Both are MP4-family containers, so the
+embedder discovers and processes them like any `.mp4`, pairing each with the
+shared `DJI_..._D.SRT`.
+
+- Both the `.OSV` and the `.LRF` are processed, producing
+  `..._metadata.OSV` and `..._metadata.LRF`. If you only want the full-quality
+  360 output, keep the `_metadata.OSV` file and discard the `.LRF` outputs.
+- The 360 projection metadata inside the `.OSV` is preserved by the stream-copy
+  mux but is not parsed by this tool; only the SRT telemetry is read.
+
 ### Codec Compatibility Issues
 
 **Problem:** "Unsupported video codec" or encoding failures

--- a/samples/Avata360/clip.SRT
+++ b/samples/Avata360/clip.SRT
@@ -1,0 +1,29 @@
+1
+00:00:00,000 --> 00:00:00,041
+<font size="28">FrameCnt: 1, DiffTime: 41ms, FrameId: 4787
+2026-05-27 13:10:00.015
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.9] [ev: 0] [ct: 5845] [color_md: dlog_m] [ae_meter_md: 0] [focal_len: 28.00] [dzoom_ratio: 1.00], [latitude: 53.365080] [longitude: 6.460739] [rel_alt: 5.400 abs_alt: -124.744] [gb_yaw: -162.8 gb_pitch: 0.0 gb_roll: 0.0] [vsync: 0] [eis: close] [shift x: 0.00, y: 0.00] [pp_vsync:0] [pp_timestamp:0] [pp_target:0.000, 0.000, 0.000, 0.000] [pp_current:0.000, 0.000, 0.000, 0.000] [pp_limit_ratio:0.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>
+
+2
+00:00:00,041 --> 00:00:00,082
+<font size="28">FrameCnt: 2, DiffTime: 41ms, FrameId: 4788
+2026-05-27 13:10:00.056
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.9] [ev: 0] [ct: 5845] [color_md: dlog_m] [ae_meter_md: 0] [focal_len: 28.00] [dzoom_ratio: 1.00], [latitude: 53.365080] [longitude: 6.460739] [rel_alt: 5.400 abs_alt: -124.744] [gb_yaw: -162.8 gb_pitch: 0.0 gb_roll: 0.0] [vsync: 0] [eis: close] [shift x: 0.00, y: 0.00] [pp_vsync:0] [pp_timestamp:0] [pp_target:0.000, 0.000, 0.000, 0.000] [pp_current:0.000, 0.000, 0.000, 0.000] [pp_limit_ratio:0.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>
+
+3
+00:00:00,082 --> 00:00:00,124
+<font size="28">FrameCnt: 3, DiffTime: 42ms, FrameId: 4789
+2026-05-27 13:10:00.098
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.9] [ev: 0] [ct: 5845] [color_md: dlog_m] [ae_meter_md: 0] [focal_len: 28.00] [dzoom_ratio: 1.00], [latitude: 53.365080] [longitude: 6.460739] [rel_alt: 5.400 abs_alt: -124.744] [gb_yaw: -162.8 gb_pitch: 0.0 gb_roll: 0.0] [vsync: 0] [eis: close] [shift x: 0.00, y: 0.00] [pp_vsync:0] [pp_timestamp:0] [pp_target:0.000, 0.000, 0.000, 0.000] [pp_current:0.000, 0.000, 0.000, 0.000] [pp_limit_ratio:0.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>
+
+4
+00:00:00,124 --> 00:00:00,166
+<font size="28">FrameCnt: 4, DiffTime: 42ms, FrameId: 4790
+2026-05-27 13:10:00.140
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.9] [ev: 0] [ct: 5845] [color_md: dlog_m] [ae_meter_md: 0] [focal_len: 28.00] [dzoom_ratio: 1.00], [latitude: 53.365080] [longitude: 6.460739] [rel_alt: 5.400 abs_alt: -124.744] [gb_yaw: -162.8 gb_pitch: 0.0 gb_roll: 0.0] [vsync: 0] [eis: close] [shift x: 0.00, y: 0.00] [pp_vsync:0] [pp_timestamp:0] [pp_target:0.000, 0.000, 0.000, 0.000] [pp_current:0.000, 0.000, 0.000, 0.000] [pp_limit_ratio:0.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>
+
+5
+00:00:00,166 --> 00:00:00,207
+<font size="28">FrameCnt: 5, DiffTime: 41ms, FrameId: 4791
+2026-05-27 13:10:00.181
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.9] [ev: 0] [ct: 5846] [color_md: dlog_m] [ae_meter_md: 0] [focal_len: 28.00] [dzoom_ratio: 1.00], [latitude: 53.365080] [longitude: 6.460739] [rel_alt: 5.400 abs_alt: -124.744] [gb_yaw: -162.8 gb_pitch: 0.0 gb_roll: 0.0] [vsync: 0] [eis: close] [shift x: 0.00, y: 0.00] [pp_vsync:0] [pp_timestamp:0] [pp_target:0.000, 0.000, 0.000, 0.000] [pp_current:0.000, 0.000, 0.000, 0.000] [pp_limit_ratio:0.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>

--- a/samples/Mini5PRO/clip.SRT
+++ b/samples/Mini5PRO/clip.SRT
@@ -1,0 +1,29 @@
+1
+00:00:00,000 --> 00:00:00,040
+<font size="28">FrameCnt: 1, DiffTime: 40ms
+2026-05-27 13:14:22.911
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.8] [ev: -0.7] [color_md: dlog_m] [focal_len: 24.00] [latitude: 53.365108] [longitude: 6.460719] [rel_alt: 6.000 abs_alt: -122.769] [ct: 5263] </font>
+
+2
+00:00:00,040 --> 00:00:00,080
+<font size="28">FrameCnt: 2, DiffTime: 40ms
+2026-05-27 13:14:22.951
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.8] [ev: -0.7] [color_md: dlog_m] [focal_len: 24.00] [latitude: 53.365108] [longitude: 6.460719] [rel_alt: 6.000 abs_alt: -122.769] [ct: 5262] </font>
+
+3
+00:00:00,080 --> 00:00:00,120
+<font size="28">FrameCnt: 3, DiffTime: 40ms
+2026-05-27 13:14:22.991
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.8] [ev: -0.7] [color_md: dlog_m] [focal_len: 24.00] [latitude: 53.365109] [longitude: 6.460718] [rel_alt: 6.000 abs_alt: -122.769] [ct: 5262] </font>
+
+4
+00:00:00,120 --> 00:00:00,160
+<font size="28">FrameCnt: 4, DiffTime: 40ms
+2026-05-27 13:14:23.031
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.8] [ev: -0.7] [color_md: dlog_m] [focal_len: 24.00] [latitude: 53.365109] [longitude: 6.460718] [rel_alt: 6.000 abs_alt: -122.769] [ct: 5262] </font>
+
+5
+00:00:00,160 --> 00:00:00,200
+<font size="28">FrameCnt: 5, DiffTime: 40ms
+2026-05-27 13:14:23.071
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.8] [ev: -0.7] [color_md: dlog_m] [focal_len: 24.00] [latitude: 53.365109] [longitude: 6.460718] [rel_alt: 6.000 abs_alt: -122.769] [ct: 5262] </font>

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -97,6 +97,29 @@ def _validate_embedded_output(original_path: Path, temp_path: Path) -> bool:
     return True
 
 
+# Video container extensions the embedder can mux a subtitle track into.
+# ``.osv``/``.lrf`` are DJI's 360 video and low-res proxy formats (Avata 360);
+# both are ISO BMFF (MP4-family) containers ffmpeg reads like a normal ``.mp4``.
+# Matching is case-insensitive; cameras emit upper-case extensions while some
+# tools rewrite them lower-case.
+_VIDEO_EXTENSIONS = ("mp4", "osv", "lrf")
+
+
+def discover_video_files(directory: Path) -> list[Path]:
+    """Return the video files in *directory* the embedder can process.
+
+    Globs each supported extension in both cases (``*.mp4`` and ``*.MP4``) so
+    discovery works on case-sensitive file systems too, then returns a sorted,
+    de-duplicated list. On case-insensitive file systems the two globs would
+    otherwise yield the same path twice, hence the set.
+    """
+    matches: set[Path] = set()
+    for ext in _VIDEO_EXTENSIONS:
+        matches.update(directory.glob(f"*.{ext}"))
+        matches.update(directory.glob(f"*.{ext.upper()}"))
+    return sorted(matches)
+
+
 class DJIMetadataEmbedder:
     """Embed DJI telemetry data into video files.
 
@@ -249,7 +272,14 @@ class DJIMetadataEmbedder:
                     shutter_match = re.search(
                         r"\[shutter\s*:\s*([^\]]+)\]", telemetry_line
                     )
-                    fnum_match = re.search(r"\[fnum\s*:\s*(\d+)\]", telemetry_line)
+                    # Aperture is reported two ways: legacy models use an
+                    # f-number*100 integer (``[fnum : 170]`` → f/1.7) while
+                    # current models (Avata 360, Mini 5 Pro, …) emit a literal
+                    # decimal (``[fnum: 1.9]``). Capture both; the value is
+                    # stored verbatim without interpretation.
+                    fnum_match = re.search(
+                        r"\[fnum\s*:\s*([+-]?\d+\.?\d*)\]", telemetry_line
+                    )
                     ev_match = re.search(r"\[ev\s*:\s*([^\]]+)\]", telemetry_line)
                     # P4 RTK compact single-line family uses free-standing
                     # tokens (``F/5.6, SS 400, ISO 100, EV 0``) rather than
@@ -478,11 +508,8 @@ class DJIMetadataEmbedder:
         Returns:
             Dict containing processing results and statistics
         """
-        # Find all MP4 files. On case-insensitive file systems the two globs
-        # may return duplicates, so use a set to deduplicate and then sort
-        video_files = sorted(
-            {*self.directory.glob("*.mp4"), *self.directory.glob("*.MP4")}
-        )
+        # Find all supported video files (.mp4 plus DJI 360 .osv/.lrf).
+        video_files = discover_video_files(self.directory)
 
         # Initialize result structure
         result: Dict[str, Any] = {

--- a/tests/test_new_model_samples.py
+++ b/tests/test_new_model_samples.py
@@ -1,0 +1,59 @@
+"""Golden-fixture tests for the Avata 360 and Mini 5 Pro sample submissions.
+
+Both models emit the HTML-wrapped bracket telemetry format. These tests pin
+the parser, telemetry-point extraction, and format detection against the
+trimmed ``clip.SRT`` fixtures shipped under ``samples/``. They also lock the
+decimal-aperture fix (``[fnum: 1.9]``) on real data — see
+``test_parsing.test_parse_bracket_decimal_fnum`` for the focused regression.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder import DJIMetadataEmbedder
+from dji_metadata_embedder.core.validator import validate_srt_format
+from dji_metadata_embedder.utilities import parse_telemetry_points
+
+SAMPLES = Path(__file__).resolve().parents[1] / "samples"
+
+
+@pytest.mark.parametrize(
+    "model, first_gps, abs_alt, fnum, focal_len",
+    [
+        ("Avata360", (53.365080, 6.460739), -124.744, "1.9", "28.00"),
+        ("Mini5PRO", (53.365108, 6.460719), -122.769, "1.8", "24.00"),
+    ],
+)
+def test_new_model_clip_parses(
+    tmp_path, model, first_gps, abs_alt, fnum, focal_len
+):
+    srt = SAMPLES / model / "clip.SRT"
+    embedder = DJIMetadataEmbedder(tmp_path)
+    t = embedder.parse_dji_srt(srt)
+
+    assert len(t["gps_coords"]) == 5
+    assert t["first_gps"] == first_gps
+    assert t["max_altitude"] == abs_alt
+    # Decimal aperture must survive parsing (was dropped before the fix).
+    assert t["camera_settings"]["fnum"] == fnum
+    assert t["camera_settings"]["focal_len"] == focal_len
+    assert t["camera_settings"]["color_md"] == "dlog_m"
+
+
+@pytest.mark.parametrize("model", ["Avata360", "Mini5PRO"])
+def test_new_model_telemetry_points(model):
+    srt = SAMPLES / model / "clip.SRT"
+    points = parse_telemetry_points(srt)
+    assert len(points) == 5
+    # Each point is (lat, lon, abs_alt, timestamp).
+    assert all(len(p) == 4 for p in points)
+
+
+@pytest.mark.parametrize("model", ["Avata360", "Mini5PRO"])
+def test_new_model_format_detected_html_extended(model):
+    srt = SAMPLES / model / "clip.SRT"
+    validation = validate_srt_format(srt, lenient=True)
+    assert validation["valid"]
+    assert validation["format_detected"] == "html_extended"
+    assert validation["telemetry_points"] == 5

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -66,6 +66,23 @@ GPS(36.6147,-6.1121,0.1M) BAROMETER:0.4M
     assert len(t["gps_coords"]) == 2
 
 
+def test_parse_bracket_decimal_fnum(tmp_path):
+    """Modern DJI bracket format reports a decimal aperture, e.g. ``[fnum: 1.9]``.
+
+    The original regex only matched integers (the legacy f-number*100 encoding,
+    ``[fnum : 170]``), so decimal apertures emitted by current models (Avata
+    360, Mini 5 Pro, and others) were silently dropped.
+    """
+    srt = """1
+00:00:00,000 --> 00:00:00,041
+<font size="28">FrameCnt: 1, DiffTime: 41ms, FrameId: 4787
+2026-05-27 13:10:00.015
+[iso: 200] [shutter: 1/6400.0] [fnum: 1.9] [ev: 0] [ct: 5845] [color_md: dlog_m] [focal_len: 28.00] [latitude: 53.365080] [longitude: 6.460739] [rel_alt: 5.400 abs_alt: -124.744]</font>
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["camera_settings"]["fnum"] == "1.9"
+
+
 def test_parse_p4rtk_compact(tmp_path):
     """P4 RTK compact single-line: free-standing camera tokens + ``GPS (...)``."""
     srt = """1

--- a/tests/test_video_discovery.py
+++ b/tests/test_video_discovery.py
@@ -1,0 +1,47 @@
+"""Tests for video file discovery in the embedder.
+
+Avata 360 footage ships as ``.OSV`` (360 video) plus a ``.LRF`` low-res
+proxy rather than ``.MP4``; both are ISO BMFF (MP4-family) containers that
+ffmpeg can mux a subtitle track into. Discovery must therefore pick them up
+alongside the conventional ``.mp4``/``.MP4`` clips.
+"""
+
+from pathlib import Path
+
+from dji_metadata_embedder.embedder import discover_video_files
+
+
+def _touch(directory: Path, *names: str) -> None:
+    for name in names:
+        (directory / name).write_bytes(b"")
+
+
+def test_discovers_mp4_case_insensitively(tmp_path: Path) -> None:
+    _touch(tmp_path, "a.mp4", "B.MP4")
+    found = {p.name for p in discover_video_files(tmp_path)}
+    assert found == {"a.mp4", "B.MP4"}
+
+
+def test_discovers_osv_and_lrf(tmp_path: Path) -> None:
+    _touch(
+        tmp_path,
+        "clip.OSV",
+        "clip.LRF",
+        "lower.osv",
+        "lower.lrf",
+    )
+    found = {p.name for p in discover_video_files(tmp_path)}
+    assert found == {"clip.OSV", "clip.LRF", "lower.osv", "lower.lrf"}
+
+
+def test_ignores_non_video_companions(tmp_path: Path) -> None:
+    _touch(tmp_path, "clip.OSV", "clip.SRT", "clip.DAT", "notes.txt")
+    found = {p.name for p in discover_video_files(tmp_path)}
+    assert found == {"clip.OSV"}
+
+
+def test_returns_sorted_unique_paths(tmp_path: Path) -> None:
+    _touch(tmp_path, "b.OSV", "a.mp4", "c.LRF")
+    found = discover_video_files(tmp_path)
+    assert found == sorted(found)
+    assert len(found) == len(set(found))


### PR DESCRIPTION
## Summary

Adds full support for two new model samples submitted via mavicpilots.com: **DJI Avata 360** and **DJI Mini 5 Pro**. Both emit the HTML-wrapped bracket telemetry format and now parse, validate as `html_extended`, and embed out of the box.

Design spec: `docs/superpowers/specs/2026-05-30-avata360-mini5pro-support-design.md`

## Changes

- **Decimal aperture fix** (`embedder.py`): the `fnum` regex matched integers only, so modern apertures (`[fnum: 1.9]`) were silently dropped. Widened to accept decimals; the legacy ×100 encoding (`[fnum : 170]`) still matches. Fixes aperture capture for *all* current DJI models, not just these two.
- **Video discovery** (`embedder.py`): extracted `discover_video_files()` and extended it to find `.OSV` (360 video) + `.LRF` proxy alongside `.mp4`/`.MP4`. Both are MP4-family ISO BMFF containers (verified via `ftyp` brands), so the existing `-c copy` subtitle mux handles them.
- **`.gitignore`**: ignore `*.OSV`/`*.LRF` so the 60–180 MB raw samples can't be committed.
- **Golden fixtures**: trimmed 5-frame `clip.SRT` for both models (force-added, matching the existing convention).
- **Docs**: README "Supported Models"; `SRT_FORMATS.md` (new Format 3b + decimal aperture/focal-length encoding notes + mappings table); `troubleshooting.md` note on `.OSV`/`.LRF`.

## Tests

TDD, red-first throughout:
- `test_parsing.py`: decimal-`fnum` regression
- `test_video_discovery.py`: `.OSV`/`.LRF`/`.mp4` discovery behavior
- `test_new_model_samples.py`: both real sample fixtures (parse + `html_extended` detection)

Full suite: **59 passed, 1 skipped** (unrelated missing-`flask` UI test). Verified on the full real SRTs — `fnum` captured (1.9 / 1.8), Avata360 discovers `.OSV`+`.LRF`, Mini5PRO discovers `.MP4`.

## Checklist
- [x] Tests added/updated for new functionality
- [x] Documentation updated (README, SRT_FORMATS, troubleshooting)
- [x] Sample fixtures tested
- [x] No breaking changes (legacy `fnum`/`focal_len` encodings still parse)
- [x] Conventional commit format used in PR title

🤖 Generated with [Claude Code](https://claude.com/claude-code)