### PR TITLE
chore(release): bump version to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release]][release]
-[![Version](https://img.shields.io/badge/version-1.3.1-blue)][release]
+[![Version](https://img.shields.io/badge/version-1.4.0-blue)][release]
 [![PyPI]][pypi]
 
 A Python tool to embed telemetry data from DJI drone SRT files into MP4 video files.

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,6 +1,6 @@
 """DJI Drone Metadata Embedder."""
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 
 # Import check to ensure files were moved correctly
 try:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -188,7 +188,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "1.3.1"
+    $fallbackVersion = "1.4.0"
     
     try{
         LogInfo "Checking for latest version..."

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.3.1
+PackageVersion: 1.4.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -18,7 +18,7 @@ FileExtensions:
 - dat
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.3.1/dji-embed.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.4.0/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
   InstallerSwitches:
     Silent: ""

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.3.1
+PackageVersion: 1.4.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus

--- a/winget/CallMarcus.DJIMetadataEmbedder.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.3.1
+PackageVersion: 1.4.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Prepares the **v1.4.0** release. Pushing the `v1.4.0` tag after this merges triggers the automated PyPI publish (plus Windows EXE, winget submission, and auto-changelog) per `docs/RELEASE.md`.

Version synced across all targets via `tools/sync_version.py 1.4.0`:
- `src/dji_metadata_embedder/__init__.py` (Hatch dynamic-version source of truth)
- `README.md` badge
- `dji-embed.spec`
- `tools/bootstrap.ps1` fallback
- `winget/*.yaml` manifests

`python tools/sync_version.py --check` passes; full test suite green (66 passed, 1 skipped).

## Notable changes since v1.3.1
- **feat:** Avata 360 + Mini 5 Pro support, incl. decimal-aperture parsing fix and `.OSV`/`.LRF` video discovery (#207)
- **fix:** changelog generation skips the tag being published (#201)

## Release steps after merge
1. Tag `v1.4.0` on `master` and push → triggers `release-pypi.yml`.
2. Monitor the workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)