### PR TITLE
feat(parser): capture FrameCnt counter and BAROMETER value

### DIFF
--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -183,6 +183,7 @@ class DJIMetadataEmbedder:
             "flight_duration": None,
             "srt_counts": [],
             "diff_times": [],
+            "barometers": [],
         }
 
         try:
@@ -210,14 +211,20 @@ class DJIMetadataEmbedder:
                     if "<font" in telemetry_line:
                         telemetry_line = re.sub(r"<[^>]+>", "", telemetry_line)
 
-                    # Detect comprehensive format with frame counters
-                    srt_cnt_match = re.search(r"SrtCnt\s*:\s*(\d+)", telemetry_line)
+                    # Detect comprehensive format with frame counters. Older
+                    # firmware labels this ``SrtCnt``; newer firmware (Neo,
+                    # Mini 5 Pro, Avata 360) uses ``FrameCnt``. Accept either
+                    # spelling and store under the existing ``srt_counts`` key
+                    # for backwards compatibility.
+                    counter_match = re.search(
+                        r"(?:Srt|Frame)Cnt\s*:\s*(\d+)", telemetry_line
+                    )
                     diff_time_match = re.search(
                         r"DiffTime\s*:\s*([^\s]+)", telemetry_line
                     )
-                    if srt_cnt_match or diff_time_match:
+                    if counter_match or diff_time_match:
                         telemetry_data.setdefault("srt_counts", []).append(
-                            int(srt_cnt_match.group(1)) if srt_cnt_match else None
+                            int(counter_match.group(1)) if counter_match else None
                         )
                         telemetry_data.setdefault("diff_times", []).append(
                             diff_time_match.group(1) if diff_time_match else None
@@ -266,6 +273,20 @@ class DJIMetadataEmbedder:
                         abs_alt = float(alt_match.group(2))
                         telemetry_data["rel_altitudes"].append(rel_alt)
                         telemetry_data["altitudes"].append(abs_alt)
+
+                    # Extract barometric altitude. Two delimiter variants exist:
+                    # Avata 2 parenthesised ``BAROMETER(91.2)`` and Matrice 300
+                    # colon form ``BAROMETER:0.3M`` (optional trailing unit).
+                    # Barometric height is more reliable than GPS altitude in
+                    # tight / FPV environments.
+                    baro_match = re.search(
+                        r"BAROMETER[(:]\s*([+-]?\d+\.?\d*)[A-Za-z]*\)?",
+                        telemetry_line,
+                    )
+                    if baro_match:
+                        telemetry_data["barometers"].append(
+                            float(baro_match.group(1))
+                        )
 
                     # Extract camera info including extended fields
                     iso_match = re.search(r"\[iso\s*:\s*(\d+)\]", telemetry_line)
@@ -631,6 +652,10 @@ class DJIMetadataEmbedder:
                             "camera_settings": telemetry.get("camera_settings", {}),
                             "dat_records": len(telemetry.get("dat_records", [])),
                         }
+                        # Barometric altitude is only present on some formats
+                        # (Avata 2 / Matrice 300); include it when captured.
+                        if telemetry.get("barometers"):
+                            json_data["barometers"] = telemetry["barometers"]
                         try:
                             with open(json_tmp_path, "w") as f:
                                 json.dump(json_data, f, indent=2)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -97,6 +97,71 @@ F/5.6, SS 400, ISO 100, EV 0, GPS (-58.851745, -34.237922, 15), HOME (-58.847509
     assert t["camera_settings"]["ev"] == "0"
 
 
+def test_parse_framecnt_counter(tmp_path):
+    """Newer firmware (Neo, Mini 5 Pro, Avata 360) emits ``FrameCnt`` rather
+    than ``SrtCnt``; the counter must still be captured (issue #204)."""
+    srt = """1
+00:00:00,000 --> 00:00:00,041
+<font size="28">FrameCnt: 1, DiffTime: 41ms
+2026-05-27 13:10:00.015
+[iso: 200] [latitude: 53.365080] [longitude: 6.460739] [rel_alt: 5.400 abs_alt: -124.744]</font>
+
+2
+00:00:00,041 --> 00:00:00,082
+<font size="28">FrameCnt: 2, DiffTime: 41ms
+2026-05-27 13:10:00.056
+[iso: 200] [latitude: 53.365080] [longitude: 6.460739] [rel_alt: 5.400 abs_alt: -124.744]</font>
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["srt_counts"] == [1, 2]
+
+
+def test_parse_srtcnt_counter_still_works(tmp_path):
+    """Regression: legacy ``SrtCnt`` spelling (Mavic 3, Air 2S) keeps working."""
+    srt = """1
+00:00:00,000 --> 00:00:00,033
+<font size='36'>SrtCnt : 1, DiffTime : 33ms
+2024-01-01 12:00:00,000
+[latitude: 59.1111] [longitude: 18.2222] [rel_alt: 5.0 abs_alt: 105.0]</font>
+
+2
+00:00:00,033 --> 00:00:00,066
+<font size='36'>SrtCnt : 2, DiffTime : 33ms
+2024-01-01 12:00:00,033
+[latitude: 59.1112] [longitude: 18.2223] [rel_alt: 5.1 abs_alt: 105.1]</font>
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["srt_counts"] == [1, 2]
+
+
+def test_parse_barometer_avata2_parenthesised(tmp_path):
+    """Avata 2 parenthesised barometer form: ``BAROMETER(91.2)`` (issue #203)."""
+    srt = """1
+00:00:00,000 --> 00:00:00,033
+GPS(39.906217,116.391305,69.800) BAROMETER(91.2) HOME(39.906206,116.391400)
+
+2
+00:00:00,033 --> 00:00:00,066
+GPS(39.906218,116.391306,69.900) BAROMETER(91.3) HOME(39.906206,116.391400)
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["barometers"] == [91.2, 91.3]
+
+
+def test_parse_barometer_m300_colon_with_unit(tmp_path):
+    """Matrice 300 colon form with trailing unit: ``BAROMETER:0.3M`` (issue #203)."""
+    srt = """1
+00:00:00,000 --> 00:00:00,033
+GPS(36.6146,-6.1120,0.0M) BAROMETER:0.3M
+
+2
+00:00:00,033 --> 00:00:00,066
+GPS(36.6147,-6.1121,0.1M) BAROMETER:0.4M
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["barometers"] == [0.3, 0.4]
+
+
 def test_embed_metadata_ffmpeg_command(tmp_path, monkeypatch):
     video = Path(tmp_path / "DJI_20240101_123456.mp4")
     srt = Path(tmp_path / "test.srt")


### PR DESCRIPTION
Two small, related parser additions surfaced by the v1.4.0 model work.

## Closes #204 — `FrameCnt` counter
The counter regex matched only the legacy `SrtCnt` spelling. Newer firmware (Neo, Mini 5 Pro, Avata 360) emits `FrameCnt:` instead, so the counter was recorded as `None` even though the line was present. The regex now accepts `(?:Srt|Frame)Cnt`, and the value is still stored under `srt_counts` for backwards compatibility.

## Closes #203 — `BAROMETER` value
GPS lines from Avata 2 (`BAROMETER(91.2)`) and Matrice 300 (`BAROMETER:0.3M`) carried a barometric altitude the parser silently dropped. Added a `barometers` field, extraction for both delimiter variants (parenthesised + colon-with-optional-unit), and surfaced it in the telemetry JSON when present. Barometric height is more reliable than GPS altitude in tight/FPV environments.

## Tests (TDD, red-first)
- `test_parse_framecnt_counter` — `FrameCnt` → `srt_counts == [1, 2]`
- `test_parse_srtcnt_counter_still_works` — regression guard for legacy `SrtCnt`
- `test_parse_barometer_avata2_parenthesised` / `test_parse_barometer_m300_colon_with_unit`

Verified on real fixtures: Mini 5 Pro / Avata 360 now yield `srt_counts [1..5]`; Avata 2 yields `barometers [91.2, 91.2]`. Full suite: **70 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)