### PR TITLE
feat(embedder): add --container mkv to preserve djmd/dbgi data streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Options:
   --dat PATH                 DAT flight log to merge
   --dat-auto                 Auto-detect DAT logs matching videos
   --redact [none|drop|fuzz]  Redact GPS coordinates (default: none)
+  --container [mp4|mkv]      Output container; 'mkv' preserves DJI djmd/dbgi
+                             data streams (default: mp4)
   -v, --verbose              Verbose output
   -q, --quiet                Suppress progress output
 ```
@@ -242,6 +244,8 @@ Options:
   --dat PATH                 DAT flight log to merge
   --dat-auto                 Auto-detect DAT logs matching videos
   --redact [none|drop|fuzz]  Redact GPS coordinates (default: none)
+  --container [mp4|mkv]      Output container; 'mkv' preserves DJI djmd/dbgi
+                             data streams (default: mp4)
   -v, --verbose              Verbose output
   -q, --quiet                Suppress progress output
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -190,6 +190,24 @@ dji-embed embed /path/to/converted/
 - ❌ **ProRes/DNxHD**: Not supported for metadata embedding
 - ❌ **VP9/AV1**: Not supported
 
+### Preserving DJI Data Streams (`djmd` / `dbgi`)
+
+Newer DJI models (Air 3S, Neo, etc.) embed proprietary timed-metadata streams
+— `djmd` (gyro/IMU/orientation) and `dbgi` (debug info) — inside the source
+MP4. The MP4 muxer cannot tag these streams, so the default embed **drops
+them** (otherwise ffmpeg fails with `Could not find tag for codec none`). The
+video, audio, and telemetry subtitle are unaffected.
+
+To keep those streams byte-for-byte, embed into a Matroska container instead:
+
+```bash
+dji-embed embed /path/to/footage --container mkv
+```
+
+This produces `<name>_metadata.mkv` with every source stream preserved (and an
+`srt` telemetry track). Use the default `mp4` unless a downstream tool needs
+the raw `djmd`/`dbgi` data.
+
 ---
 
 ## 📊 DJI Model-Specific Issues

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -94,6 +94,14 @@ def main(ctx: click.Context, log_json: bool) -> None:
     show_default=True,
     help="Redact GPS coordinates",
 )
+@click.option(
+    "--container",
+    type=click.Choice(["mp4", "mkv"], case_sensitive=False),
+    default="mp4",
+    show_default=True,
+    help="Output container. Use 'mkv' to preserve DJI djmd/dbgi data streams "
+    "(dropped by the mp4 muxer).",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress progress output")
 def embed(
@@ -104,6 +112,7 @@ def embed(
     dat: str | None,
     dat_auto: bool,
     redact: str,
+    container: str,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -121,6 +130,7 @@ def embed(
         dat_path=dat,
         dat_autoscan=dat_auto,
         redact=redact,
+        container=container.lower(),
     )
     embedder.process_directory(use_exiftool=exiftool)
 

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -154,6 +154,7 @@ class DJIMetadataEmbedder:
         redact: str = "none",
         time_offset: float = 0.0,
         resample_strategy: str = "linear",
+        container: str = "mp4",
     ):
         self.directory = Path(directory)
         self.output_dir = (
@@ -167,6 +168,10 @@ class DJIMetadataEmbedder:
         self.redact = redact
         self.time_offset = time_offset
         self.resample_strategy = resample_strategy
+        # Output container. "mp4" (default) drops DJI's untaggable djmd/dbgi
+        # data streams; "mkv" preserves them — Matroska's codec table accepts
+        # the codec=none streams the MP4 muxer rejects (issue #197).
+        self.container = container
 
     def parse_dji_srt(self, srt_path: Path) -> Dict[str, Any]:
         """Parse DJI SRT file and extract telemetry data."""
@@ -411,30 +416,36 @@ class DJIMetadataEmbedder:
                     ffmpeg_cmd = env_ffmpeg
 
             # Build ffmpeg command.
-            # -map 0 -map -0:d -map 1 keeps every video/audio stream from the
-            # source plus the SRT subtitle. Newer DJI models (Air 3S, Neo 2)
-            # also emit proprietary data streams (`djmd` / `dbgi`, gyro and
-            # debug metadata) whose codec the MP4 muxer cannot tag — without
-            # explicitly dropping them the entire mux fails with
-            # "Could not find tag for codec none". We lose those data tracks;
-            # the main video, proxy/LRF MJPEG, audio, and telemetry SRT are
-            # all preserved. Background: GH discussion #192, follow-up to #193.
+            #
+            # MP4 (default): -map 0 -map -0:d -map 1 keeps every video/audio
+            # stream from the source plus the SRT subtitle, but explicitly
+            # drops DJI's proprietary data streams (`djmd` / `dbgi`, gyro and
+            # debug metadata on Air 3S / Neo 2 / etc.). The MP4 muxer cannot
+            # tag their codec, so without the drop the whole mux fails with
+            # "Could not find tag for codec none". Background: GH discussion
+            # #192, follow-up to #193.
+            #
+            # MKV (--container mkv): Matroska's codec table accepts those
+            # streams, so we keep -map 0 (no -0:d) to round-trip djmd/dbgi
+            # byte-for-byte, and use the Matroska-native `srt` subtitle codec
+            # rather than the MP4-only `mov_text` (issue #197).
+            if self.container == "mkv":
+                stream_maps = ["-map", "0", "-map", "1"]
+                subtitle_codec = "srt"
+            else:
+                stream_maps = ["-map", "0", "-map", "-0:d", "-map", "1"]
+                subtitle_codec = "mov_text"
             cmd = [
                 ffmpeg_cmd,
                 "-i",
                 str(video_path),
                 "-i",
                 str(srt_path),
-                "-map",
-                "0",
-                "-map",
-                "-0:d",
-                "-map",
-                "1",
+                *stream_maps,
                 "-c",
                 "copy",
                 "-c:s",
-                "mov_text",
+                subtitle_codec,
                 "-metadata:s:s:0",
                 "language=eng",
                 "-metadata:s:s:0",
@@ -605,8 +616,13 @@ class DJIMetadataEmbedder:
                 if self.overwrite:
                     output_path = video_path
                 else:
+                    # MKV mode rewrites the extension so the preserved
+                    # djmd/dbgi data streams land in a Matroska container.
+                    out_suffix = (
+                        ".mkv" if self.container == "mkv" else video_path.suffix
+                    )
                     output_path = (
-                        self.output_dir / f"{video_path.stem}_metadata{video_path.suffix}"
+                        self.output_dir / f"{video_path.stem}_metadata{out_suffix}"
                     )
                 temp_output_path = output_path.with_name(
                     output_path.stem + _TEMP_SUFFIX + output_path.suffix

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -215,3 +215,40 @@ def test_embed_metadata_ffmpeg_command(tmp_path, monkeypatch):
         str(output),
     ]
     assert called["cmd"] == expected
+
+
+def test_embed_metadata_ffmpeg_mkv_preserves_data_streams(tmp_path, monkeypatch):
+    """MKV container preserves proprietary djmd/dbgi data streams (issue #197).
+
+    The MP4 muxer can't tag DJI's ``codec=none`` data streams, so the default
+    mp4 path drops them with ``-map -0:d``. MKV's codec table round-trips them,
+    so in mkv mode we keep every source stream (no ``-0:d`` exclusion) and use
+    the Matroska-native ``srt`` subtitle codec instead of ``mov_text``.
+    """
+    video = Path(tmp_path / "DJI_0001.mp4")
+    srt = Path(tmp_path / "DJI_0001.srt")
+    video.write_text("dummy")
+    srt.write_text("dummy")
+    output = Path(tmp_path / "out.mkv")
+    telemetry = {"first_gps": None, "max_altitude": None}
+    embedder = DJIMetadataEmbedder(tmp_path, container="mkv")
+    called = {}
+
+    def fake_run(cmd, capture_output=True, text=True):
+        called["cmd"] = cmd
+
+        class Res:
+            returncode = 0
+
+        return Res()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert embedder.embed_metadata_ffmpeg(video, srt, telemetry, output)
+    cmd = called["cmd"]
+    # Data streams must NOT be dropped in mkv mode.
+    assert "-0:d" not in cmd
+    # Only two -map args: source (0) and subtitle (1).
+    assert cmd.count("-map") == 2
+    assert cmd[cmd.index("-map") + 1] == "0"
+    # Matroska-native subtitle codec.
+    assert cmd[cmd.index("-c:s") + 1] == "srt"


### PR DESCRIPTION
Closes #197.

## Problem
The default mp4 mux drops DJI's proprietary timed-metadata streams — `djmd` (gyro/IMU/orientation) and `dbgi` (debug) — because the MP4 muxer can't tag their `codec=none` (it fails with *"Could not find tag for codec none"*). These streams are used by stabilization and flight-analysis tooling.

## Fix
New opt-in `--container mkv`. Matroska's codec table accepts those streams, so in mkv mode the mux keeps every source stream (`-map 0`, no `-0:d`), uses the Matroska-native `srt` subtitle codec instead of `mov_text`, and writes `<name>_metadata.mkv`.

This is route 1 from the issue's analysis ("small, opt-in, real fidelity win"). The default `mp4` path is **unchanged**.

## Changes
- `embedder.py`: `container` param; branch the `-map`/`-c:s` args; `.mkv` output extension.
- `cli.py`: `--container [mp4|mkv]` flag (default mp4).
- Tests: `test_embed_metadata_ffmpeg_mkv_preserves_data_streams` (asserts no `-0:d`, `-c:s srt`); existing mp4 command test guards the default.
- Docs: README option list + troubleshooting "Preserving DJI Data Streams" section.

Full suite: **71 passed, 1 skipped**.

> **Note:** stacked on #209 (base `fix/parser-framecnt-barometer`); GitHub will retarget this to `master` once #209 merges. Review the [diff against the base branch](https://github.com/CallMarcus/dji-drone-metadata-embedder/compare/fix/parser-framecnt-barometer...fix/issue-197-preserve-data-streams) for just the #197 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)