### PR TITLE
feat(gpx): UTC timestamps with timezone auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ Extract GPS track to GPX:
 dji-embed convert gpx DJI_0001.SRT
 ```
 
+GPX timestamps are written in UTC. DJI SRT times are local with no timezone, so
+the offset is auto-detected from the file's modification time. Override it when
+the mtime is unreliable (e.g. copied files):
+```bash
+dji-embed convert gpx DJI_0001.SRT --tz-offset +05:30
+```
+
 Export telemetry to CSV:
 ```bash
 dji-embed convert csv DJI_0001.SRT -o telemetry.csv
@@ -273,6 +280,8 @@ Arguments:
 Options:
   -o, --output PATH          Output file path
   -b, --batch                Batch process directory
+  --tz-offset OFFSET         UTC offset for GPX timestamps, e.g. '+05:30' or
+                             '-8' ('auto' detects from file mtime; default: auto)
   -v, --verbose              Verbose output
   -q, --quiet                Suppress info output
 ```

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -13,6 +13,7 @@ from .metadata_check import check_metadata
 from .telemetry_converter import (
     extract_telemetry_to_gpx,
     extract_telemetry_to_csv,
+    parse_utc_offset,
 )
 from .utilities import check_dependencies, setup_logging, get_tool_versions
 
@@ -146,6 +147,14 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
 @click.argument("input", type=click.Path(exists=True))
 @click.option("-o", "--output", type=click.Path())
 @click.option("-b", "--batch", is_flag=True, help="Batch process directory")
+@click.option(
+    "--tz-offset",
+    default="auto",
+    show_default=True,
+    metavar="OFFSET",
+    help="UTC offset for GPX timestamps, e.g. '+05:30' or '-8'. "
+    "'auto' detects it from the SRT file mtime.",
+)
 @click.option("-v", "--verbose", is_flag=True)
 @click.option("-q", "--quiet", is_flag=True)
 def convert(
@@ -153,11 +162,17 @@ def convert(
     input: str,
     output: str | None,
     batch: bool,
+    tz_offset: str,
     verbose: bool,
     quiet: bool,
 ) -> None:
     """Convert SRT telemetry to GPX or CSV."""
     setup_logging(verbose, quiet)
+
+    try:
+        offset = parse_utc_offset(tz_offset)
+    except ValueError as e:
+        raise click.BadParameter(str(e), param_hint="--tz-offset")
 
     src = Path(input)
     if batch and not src.is_dir():
@@ -166,12 +181,12 @@ def convert(
     if batch:
         for srt in src.glob("*.SRT"):
             if command == "gpx":
-                extract_telemetry_to_gpx(srt, None)
+                extract_telemetry_to_gpx(srt, None, tz_offset=offset)
             else:
                 extract_telemetry_to_csv(srt, None)
     else:
         if command == "gpx":
-            extract_telemetry_to_gpx(src, output)
+            extract_telemetry_to_gpx(src, output, tz_offset=offset)
         else:
             extract_telemetry_to_csv(src, output)
 

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -7,7 +7,7 @@ provided for convenience.
 """
 
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import re
 import logging
 
@@ -16,12 +16,94 @@ from .utilities import setup_logging
 
 logger = logging.getLogger(__name__)
 
+# Seconds in a quarter hour — the granularity real-world UTC offsets use
+# (whole hours plus the :30 and :45 zones like India and Nepal).
+_QUARTER_HOUR = 15 * 60
+
+# DJI SRT blocks carry an absolute wall-clock datetime on their own line, with
+# the milliseconds separated by either a comma (older firmware) or a dot
+# (newer firmware): "2024-01-15 14:30:22,123" / "2026-05-27 13:14:22.911".
+_ABS_DATETIME_RE = re.compile(
+    r"(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})[.,](\d{3})"
+)
+
+
+def _parse_srt_datetime(text: str) -> datetime | None:
+    """Return the absolute wall-clock datetime in *text*, or None if absent."""
+    m = _ABS_DATETIME_RE.search(text)
+    if not m:
+        return None
+    year, month, day, hour, minute, second, millis = (int(g) for g in m.groups())
+    return datetime(year, month, day, hour, minute, second, millis * 1000)
+
+
+def parse_utc_offset(value: str | None) -> timedelta | None:
+    """Parse a CLI UTC-offset string into a :class:`timedelta`.
+
+    Returns ``None`` (meaning "auto-detect") for ``None``, an empty string, or
+    ``"auto"``. Otherwise accepts a signed ``HH`` or ``HH:MM`` form such as
+    ``"+05:30"``, ``"5:45"`` or ``"-8"``. Raises :class:`ValueError` on any
+    other input.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if value == "" or value.lower() == "auto":
+        return None
+    m = re.fullmatch(r"([+-]?)(\d{1,2})(?::(\d{2}))?", value)
+    if not m:
+        raise ValueError(f"Invalid UTC offset: {value!r}")
+    sign = -1 if m.group(1) == "-" else 1
+    hours = int(m.group(2))
+    minutes = int(m.group(3) or 0)
+    return sign * timedelta(hours=hours, minutes=minutes)
+
+
+def estimate_utc_offset(
+    first_local: datetime,
+    last_local: datetime,
+    file_mtime_utc: datetime,
+) -> timedelta:
+    """Estimate the UTC offset of naive DJI SRT timestamps.
+
+    DJI SRT wall-clock timestamps are local with no timezone, while the source
+    file's mtime is UTC. We don't know whether the mtime marks the start or the
+    end of the recording, so both hypotheses are tested: for each anchor the
+    raw offset ``anchor - file_mtime_utc`` is rounded to the nearest quarter
+    hour (covering offsets such as UTC+5:30 and UTC+5:45), and the residual
+    distance from that boundary is kept. The hypothesis with the smaller
+    residual wins, since a genuine offset lands cleanly on a quarter hour.
+
+    All three datetimes must be naive (``file_mtime_utc`` expressed in UTC).
+
+    Re-implemented from the heuristic described in GPStitch
+    (https://github.com/Romancha/GPStitch, GPLv3) — idea only, no code copied.
+    """
+    best_offset = timedelta(0)
+    best_residual: float | None = None
+    for anchor in (first_local, last_local):
+        raw = (anchor - file_mtime_utc).total_seconds()
+        rounded = round(raw / _QUARTER_HOUR) * _QUARTER_HOUR
+        residual = abs(raw - rounded)
+        if best_residual is None or residual < best_residual:
+            best_residual = residual
+            best_offset = timedelta(seconds=rounded)
+    return best_offset
+
 
 def extract_telemetry_to_gpx(
-    srt_file: Path | str, output_file: Path | str | None = None
+    srt_file: Path | str,
+    output_file: Path | str | None = None,
+    tz_offset: timedelta | None = None,
 ) -> Path:
-    """
-    Extract GPS telemetry from DJI SRT file and create GPX file.
+    """Extract GPS telemetry from a DJI SRT file and create a GPX file.
+
+    DJI SRT timestamps are local wall-clock time with no timezone. When a block
+    carries an absolute datetime, its ``<time>`` is emitted as proper UTC
+    ISO 8601. The local-to-UTC offset is taken from *tz_offset* when given,
+    otherwise auto-detected from the SRT file's mtime (see
+    :func:`estimate_utc_offset`). Formats without an absolute datetime fall back
+    to the raw subtitle cue timestamp, as before.
     """
     srt_path = Path(srt_file)
     output_path = Path(output_file) if output_file else srt_path.with_suffix(".gpx")
@@ -55,9 +137,39 @@ def extract_telemetry_to_gpx(
                     "lat": float(lat_match.group(1)),
                     "lon": float(lon_match.group(1)),
                     "ele": float(alt_match.group(1)) if alt_match else 0,
+                    # Raw subtitle cue time (fallback for formats without an
+                    # absolute datetime).
                     "time": timestamp_match.group(1) if timestamp_match else None,
+                    # Absolute wall-clock datetime, when present.
+                    "datetime": _parse_srt_datetime(telemetry_line),
                 }
                 gps_points.append(point)
+
+    # Resolve the local→UTC offset for points that carry an absolute datetime.
+    abs_times = [p["datetime"] for p in gps_points if p["datetime"] is not None]
+    offset: timedelta | None = None
+    if abs_times:
+        if tz_offset is not None:
+            offset = tz_offset
+        else:
+            mtime_utc = datetime.fromtimestamp(
+                srt_path.stat().st_mtime, tz=timezone.utc
+            ).replace(tzinfo=None)
+            offset = estimate_utc_offset(abs_times[0], abs_times[-1], mtime_utc)
+
+    def _point_time(point: dict) -> str | None:
+        """Return the GPX <time> string for a point (UTC if datetime known)."""
+        if point["datetime"] is not None and offset is not None:
+            utc = point["datetime"] - offset
+            return utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return point["time"]
+
+    # The metadata <time> is the first point's UTC time when known, otherwise
+    # the current time (legacy behaviour for datetime-less formats).
+    if abs_times and offset is not None:
+        metadata_time = (abs_times[0] - offset).strftime("%Y-%m-%dT%H:%M:%SZ")
+    else:
+        metadata_time = datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Write GPX file
     gpx_header = """<?xml version="1.0" encoding="UTF-8"?>
@@ -73,7 +185,7 @@ def extract_telemetry_to_gpx(
     <name>DJI Flight Path</name>
     <trkseg>
 """.format(
-        Path(srt_file).stem, datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+        Path(srt_file).stem, metadata_time
     )
 
     gpx_footer = """    </trkseg>
@@ -85,8 +197,9 @@ def extract_telemetry_to_gpx(
         for point in gps_points:
             f.write(f'        <trkpt lat="{point["lat"]}" lon="{point["lon"]}">\n')
             f.write(f'            <ele>{point["ele"]}</ele>\n')
-            if point["time"]:
-                f.write(f'            <time>{point["time"]}</time>\n')
+            time_str = _point_time(point)
+            if time_str:
+                f.write(f'            <time>{time_str}</time>\n')
             f.write("        </trkpt>\n")
         f.write(gpx_footer)
 

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -8,6 +8,7 @@ provided for convenience.
 
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
+from typing import Any
 import re
 import logging
 
@@ -108,7 +109,7 @@ def extract_telemetry_to_gpx(
     srt_path = Path(srt_file)
     output_path = Path(output_file) if output_file else srt_path.with_suffix(".gpx")
 
-    gps_points = []
+    gps_points: list[dict[str, Any]] = []
 
     with open(srt_path, "r", encoding="utf-8") as f:
         content = f.read()

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -9,7 +9,7 @@ from dji_metadata_embedder.utilities import parse_telemetry_points
 
 SAMPLE_HASHES = {
     "mini4pro": "b5b0f199f2dd1c10a0ed42e4964e25a122cbb54288a4eeee6f8e279a3cce05b7",
-    "air3": "16befdcc4e09b4690f61748324a4a7d79d4e933b6d3aaa4e9b1cb568500cae90",
+    "air3": "4141978a30b0f956b6a22ebbafa030aaf05c3ac6a7a1cde59577d045104d03fd",
     "avata2": "44e78c14cc62527a3152350ba060bcfc7c7a3d7a458bdb6013ba0b8d55a7e7f9",
 }
 
@@ -47,15 +47,22 @@ def run_sample(name: str, tmp_path, monkeypatch):
 
     gpx_path = tmp_path / f"{name}.gpx"
 
-    class FixedDT:
-        @staticmethod
-        def now():
-            from datetime import datetime
+    # Subclass datetime so the parser can still construct instances while
+    # now() stays fixed (formats without an absolute datetime fall back to
+    # now() for the GPX metadata <time>).
+    from datetime import datetime, timedelta
 
+    class FixedDT(datetime):
+        @classmethod
+        def now(cls, *args, **kwargs):
             return datetime(2020, 1, 1)
 
     monkeypatch.setattr(telemetry_converter, "datetime", FixedDT)
-    telemetry_converter.extract_telemetry_to_gpx(srt, gpx_path)
+    # Pin the tz offset so GPX output for datetime-bearing formats (air3) is
+    # deterministic rather than dependent on the fixture file's mtime.
+    telemetry_converter.extract_telemetry_to_gpx(
+        srt, gpx_path, tz_offset=timedelta(0)
+    )
     digest = hashlib.sha256(gpx_path.read_bytes()).hexdigest()
     assert digest == SAMPLE_HASHES[name]
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,132 @@
+"""Tests for SRT timezone auto-detection (issue #202).
+
+DJI SRT wall-clock timestamps are local with no timezone; the file mtime is
+UTC. ``estimate_utc_offset`` recovers the local offset by testing both
+"mtime = recording start" and "mtime = recording end" hypotheses and keeping
+whichever lands closest to a quarter-hour boundary.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dji_metadata_embedder.telemetry_converter import (
+    estimate_utc_offset,
+    extract_telemetry_to_gpx,
+    parse_utc_offset,
+)
+
+_HTML_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,033\n"
+    "<font size='36'>SrtCnt : 1, DiffTime : 33ms\n"
+    "2024-01-01 12:00:00,000\n"
+    "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n\n"
+    "2\n00:00:00,033 --> 00:00:00,066\n"
+    "<font size='36'>SrtCnt : 2, DiffTime : 33ms\n"
+    "2024-01-01 12:00:33,000\n"
+    "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n"
+)
+
+
+def test_whole_hour_offset_mtime_is_recording_end():
+    """UTC+2, file written at recording end."""
+    first = datetime(2024, 6, 1, 14, 0, 0)
+    last = datetime(2024, 6, 1, 14, 10, 0)
+    mtime_utc = datetime(2024, 6, 1, 12, 10, 0)  # last - 2h
+    assert estimate_utc_offset(first, last, mtime_utc) == timedelta(hours=2)
+
+
+def test_india_half_hour_offset_mtime_is_recording_start():
+    """UTC+5:30 (India), file written at recording start."""
+    first = datetime(2024, 6, 1, 10, 0, 0)
+    last = datetime(2024, 6, 1, 10, 5, 0)
+    mtime_utc = datetime(2024, 6, 1, 4, 30, 0)  # first - 5:30
+    assert estimate_utc_offset(first, last, mtime_utc) == timedelta(hours=5, minutes=30)
+
+
+def test_nepal_quarter_hour_offset_mtime_is_recording_end():
+    """UTC+5:45 (Nepal), file written at recording end."""
+    first = datetime(2024, 6, 1, 12, 0, 0)
+    last = datetime(2024, 6, 1, 12, 20, 0)
+    mtime_utc = datetime(2024, 6, 1, 6, 35, 0)  # last - 5:45
+    assert estimate_utc_offset(first, last, mtime_utc) == timedelta(hours=5, minutes=45)
+
+
+def test_negative_offset_us_pacific():
+    """UTC-8 (US Pacific), file written at recording start."""
+    first = datetime(2024, 6, 1, 9, 0, 0)
+    last = datetime(2024, 6, 1, 9, 30, 0)
+    mtime_utc = datetime(2024, 6, 1, 17, 0, 0)  # first + 8h
+    assert estimate_utc_offset(first, last, mtime_utc) == timedelta(hours=-8)
+
+
+def test_rounds_noisy_offset_to_nearest_quarter_hour():
+    """A few seconds of mtime jitter must still resolve to a clean offset."""
+    first = datetime(2024, 6, 1, 14, 0, 3)
+    last = datetime(2024, 6, 1, 14, 10, 0)
+    mtime_utc = datetime(2024, 6, 1, 12, 10, 0)  # last - ~2h, first off by 3s
+    assert estimate_utc_offset(first, last, mtime_utc) == timedelta(hours=2)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("auto", None),
+        ("", None),
+        (None, None),
+        ("+05:30", timedelta(hours=5, minutes=30)),
+        ("5:45", timedelta(hours=5, minutes=45)),
+        ("-8", timedelta(hours=-8)),
+        ("-5:30", timedelta(hours=-5, minutes=-30)),
+        ("+0", timedelta(0)),
+    ],
+)
+def test_parse_utc_offset(value, expected):
+    assert parse_utc_offset(value) == expected
+
+
+def test_parse_utc_offset_rejects_garbage():
+    with pytest.raises(ValueError):
+        parse_utc_offset("nonsense")
+
+
+def test_gpx_uses_utc_time_with_explicit_offset(tmp_path):
+    """An explicit tz offset converts local SRT time to UTC in the GPX."""
+    srt = tmp_path / "clip.SRT"
+    srt.write_text(_HTML_SRT)
+    out = tmp_path / "clip.gpx"
+    extract_telemetry_to_gpx(srt, out, tz_offset=timedelta(hours=2))
+    text = out.read_text()
+    # Local 12:00:00 at UTC+2 -> 10:00:00Z.
+    assert "<time>2024-01-01T10:00:00Z</time>" in text
+    assert "<time>2024-01-01T10:00:33Z</time>" in text
+    # Metadata <time> is the first point's UTC, not datetime.now().
+    assert "<time>2024-01-01T10:00:00Z</time>" in text.split("<trk>")[0]
+
+
+def test_gpx_autodetects_offset_from_mtime(tmp_path):
+    """With no explicit offset, the offset is recovered from the file mtime."""
+    srt = tmp_path / "clip.SRT"
+    srt.write_text(_HTML_SRT)
+    # mtime = recording end in UTC for a UTC+2 local clock: 12:00:33 - 2h.
+    mtime = datetime(2024, 1, 1, 10, 0, 33, tzinfo=timezone.utc).timestamp()
+    os.utime(srt, (mtime, mtime))
+    out = tmp_path / "clip.gpx"
+    extract_telemetry_to_gpx(srt, out)
+    text = out.read_text()
+    assert "<time>2024-01-01T10:00:00Z</time>" in text
+
+
+def test_gpx_falls_back_when_no_absolute_datetime(tmp_path):
+    """Formats without a wall-clock datetime keep the cue timestamp (no crash)."""
+    srt = tmp_path / "clip.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]\n"
+    )
+    out = tmp_path / "clip.gpx"
+    extract_telemetry_to_gpx(srt, out)
+    text = out.read_text()
+    assert "<trkpt" in text
+    assert "00:00:00,000" in text


### PR DESCRIPTION
Implements the **timezone auto-detection** idea from #202 (the half that needs no external samples). The `djmd`-protobuf idea in that issue stays open — it needs an Osmo Action sample, and its GPLv3 reference requires clean-room work.

## Problem
DJI SRT timestamps are local wall-clock with no timezone. The old GPX export wrote each point's *subtitle cue* time (`00:00:00,000` — not valid ISO 8601) and a `datetime.now()` metadata `<time>`. Anyone correlating the GPX with external GPS/weather/satellite data saw garbage time.

## Fix
- **`estimate_utc_offset(first, last, mtime_utc)`** — clean-room heuristic: the file mtime is UTC, so test both "mtime = recording start" and "mtime = recording end", round each candidate to the nearest **quarter hour** (covers UTC+5:30 / +5:45), and keep whichever lands closest to a clean boundary. Pure function, fully unit-tested.
- **`extract_telemetry_to_gpx`** now parses each block's absolute datetime and emits `<time>` as real UTC ISO 8601 (`local − offset`, `…Z`). Formats with no absolute datetime keep the prior fallback behaviour.
- **`parse_utc_offset` + `convert --tz-offset`** — override auto-detection (e.g. `+05:30`, `-8`) when the mtime is unreliable (copied files). Default `auto`.

## Attribution
Heuristic idea credited to [GPStitch](https://github.com/Romancha/GPStitch) (GPLv3) in a code comment — re-implemented from the description, no code copied (project is MIT).

## Tests (TDD, red-first)
- `tests/test_timezone.py`: offset estimation across +2 / +5:30 / +5:45 / −8 / jitter; `parse_utc_offset` cases incl. signed `HH:MM` and invalid input; GPX integration (explicit offset, mtime auto-detect, datetime-less fallback).
- `tests/test_samples.py`: air3 golden GPX hash updated (now real UTC); offset pinned via `tz_offset` for determinism; `FixedDT` made a `datetime` subclass.

Full suite: **83 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)