### PR TITLE
feat(samples): formalize DJI Neo 2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ output/
 *.lrf
 *.SRT
 *.srt
+# Raw SRT dumps shared by contributors (e.g. ``*.SRT.txt``) — keep large
+# originals out of the repo; only trimmed ``clip.SRT`` fixtures are committed.
+*.SRT.txt
+*.srt.txt
 *.gpx
 *.GPX
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **DJI Mini 5 Pro** - HTML-style bracket format with decimal aperture (`[fnum: 1.8]`)
 - **DJI Air 3** - HTML-style format with extended telemetry data
 - **DJI Avata 360** - HTML-style bracket format with stabilization (`pp_*`) fields; footage ships as `.OSV` (360 video) + `.LRF` proxy
+- **DJI Neo 2** - HTML-style bracket format with stabilization (`pp_*`) fields; MP4 also carries embedded `djmd`/`dbgi` data streams
 - **DJI Avata 2** - Legacy GPS format `GPS(lat,lon,alt)` with BAROMETER data
 - **DJI Mavic 3 Enterprise** - Extended format with RTK precision data
 - **DJI Matrice 300 (legacy-with-unit)** - `GPS(lat,lon,alt M)` with `BAROMETER:` colon notation

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -95,7 +95,7 @@ Used by: DJI Mavic 3, DJI Air 2S
 
 ### Format 3b: Modern HTML Bracket (FrameCnt + decimal units)
 
-Used by: DJI Mini 5 Pro, DJI Avata 360
+Used by: DJI Mini 5 Pro, DJI Avata 360, DJI Neo 2
 
 Current models keep the HTML-wrapped bracket structure of Format 3 but change
 two things: the counter is `FrameCnt` (not `SrtCnt`), and the aperture and
@@ -199,6 +199,7 @@ if new_format_match:
 | DJI Air 2S | Format 3 | Comprehensive with HTML tags |
 | DJI Mini 5 Pro | Format 3b | FrameCnt + decimal fnum/focal_len |
 | DJI Avata 360 | Format 3b | FrameCnt + decimal units; `.OSV`/`.LRF` video, `pp_*` stabilization fields |
+| DJI Neo 2 | Format 3b | FrameCnt + decimal units; `pp_*` stabilization fields; MP4 carries `djmd`/`dbgi` streams |
 | DJI Mavic Pro | Format 2 | GPS function format |
 | DJI Phantom 4 | Format 2 | GPS function format |
 | DJI Matrice 300 RTK | Format 2b | Legacy-with-unit (`0.0M` altitude) |

--- a/samples/neo2/clip.SRT
+++ b/samples/neo2/clip.SRT
@@ -1,0 +1,29 @@
+1
+00:00:00,000 --> 00:00:00,033
+<font size="28">FrameCnt: 1, DiffTime: 33ms
+2026-05-15 08:24:18.623
+[iso: 400] [shutter: 1/640.0] [fnum: 2.2] [ev: 0] [ct: 5631] [color_md: default] [ae_meter_md: 0] [latitude: 45.607181] [longitude: 13.753860] [rel_alt: 0.000 abs_alt: 113.900] [vsync: 1602] [eis: normal] [shift x: 0.00, y: 0.00] [pp_vsync:1602] [pp_timestamp:0] [pp_target:0.996, -0.004, -0.053, -0.075] [pp_current:0.996, -0.004, -0.053, -0.076] [pp_limit_ratio:1.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>
+
+2
+00:00:00,033 --> 00:00:00,066
+<font size="28">FrameCnt: 2, DiffTime: 33ms
+2026-05-15 08:24:18.657
+[iso: 400] [shutter: 1/640.0] [fnum: 2.2] [ev: 0] [ct: 5631] [color_md: default] [ae_meter_md: 0] [latitude: 45.607181] [longitude: 13.753859] [rel_alt: 0.000 abs_alt: 113.900] [vsync: 1603] [eis: normal] [shift x: 0.00, y: 0.00] [pp_vsync:1603] [pp_timestamp:0] [pp_target:0.996, -0.004, -0.053, -0.075] [pp_current:0.996, -0.004, -0.053, -0.076] [pp_limit_ratio:1.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>
+
+3
+00:00:00,066 --> 00:00:00,099
+<font size="28">FrameCnt: 3, DiffTime: 33ms
+2026-05-15 08:24:18.690
+[iso: 400] [shutter: 1/640.0] [fnum: 2.2] [ev: 0] [ct: 5631] [color_md: default] [ae_meter_md: 0] [latitude: 45.607181] [longitude: 13.753859] [rel_alt: 0.000 abs_alt: 113.900] [vsync: 1604] [eis: normal] [shift x: 0.00, y: 0.00] [pp_vsync:1604] [pp_timestamp:0] [pp_target:0.996, -0.004, -0.053, -0.075] [pp_current:0.995, -0.004, -0.053, -0.079] [pp_limit_ratio:1.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>
+
+4
+00:00:00,099 --> 00:00:00,133
+<font size="28">FrameCnt: 4, DiffTime: 34ms
+2026-05-15 08:24:18.723
+[iso: 400] [shutter: 1/640.0] [fnum: 2.2] [ev: 0] [ct: 5631] [color_md: default] [ae_meter_md: 0] [latitude: 45.607181] [longitude: 13.753859] [rel_alt: 0.000 abs_alt: 113.900] [vsync: 1605] [eis: normal] [shift x: 0.00, y: 0.00] [pp_vsync:1605] [pp_timestamp:0] [pp_target:0.996, -0.004, -0.053, -0.075] [pp_current:0.995, -0.004, -0.053, -0.081] [pp_limit_ratio:1.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>
+
+5
+00:00:00,133 --> 00:00:00,166
+<font size="28">FrameCnt: 5, DiffTime: 33ms
+2026-05-15 08:24:18.757
+[iso: 400] [shutter: 1/640.0] [fnum: 2.2] [ev: 0] [ct: 5631] [color_md: default] [ae_meter_md: 0] [latitude: 45.607181] [longitude: 13.753859] [rel_alt: 0.100 abs_alt: 114.000] [vsync: 1606] [eis: normal] [shift x: 0.00, y: 0.00] [pp_vsync:1606] [pp_timestamp:0] [pp_target:0.996, -0.004, -0.053, -0.075] [pp_current:0.995, -0.004, -0.053, -0.081] [pp_limit_ratio:1.0000] [pp_over_image_border:0] [pp_warp_status:0] [pp_imu_td:0]</font>

--- a/tests/test_new_model_samples.py
+++ b/tests/test_new_model_samples.py
@@ -1,10 +1,11 @@
-"""Golden-fixture tests for the Avata 360 and Mini 5 Pro sample submissions.
+"""Golden-fixture tests for recent DJI model submissions.
 
-Both models emit the HTML-wrapped bracket telemetry format. These tests pin
+Avata 360, Mini 5 Pro, and Neo 2 all emit the HTML-wrapped bracket telemetry
+format (FrameCnt + decimal aperture, ``html_extended`` family). These tests pin
 the parser, telemetry-point extraction, and format detection against the
 trimmed ``clip.SRT`` fixtures shipped under ``samples/``. They also lock the
-decimal-aperture fix (``[fnum: 1.9]``) on real data — see
-``test_parsing.test_parse_bracket_decimal_fnum`` for the focused regression.
+decimal-aperture and FrameCnt fixes on real data — see ``test_parsing`` for the
+focused regressions.
 """
 
 from pathlib import Path
@@ -17,31 +18,40 @@ from dji_metadata_embedder.utilities import parse_telemetry_points
 
 SAMPLES = Path(__file__).resolve().parents[1] / "samples"
 
+# Models with on-disk golden clip.SRT fixtures.
+MODELS = ["Avata360", "Mini5PRO", "neo2"]
+
 
 @pytest.mark.parametrize(
-    "model, first_gps, abs_alt, fnum, focal_len",
+    "model, first_gps, abs_alt, fnum, focal_len, color_md",
     [
-        ("Avata360", (53.365080, 6.460739), -124.744, "1.9", "28.00"),
-        ("Mini5PRO", (53.365108, 6.460719), -122.769, "1.8", "24.00"),
+        # focal_len is None when the model's SRT omits the field (Neo 2).
+        ("Avata360", (53.365080, 6.460739), -124.744, "1.9", "28.00", "dlog_m"),
+        ("Mini5PRO", (53.365108, 6.460719), -122.769, "1.8", "24.00", "dlog_m"),
+        ("neo2", (45.607181, 13.753860), 114.0, "2.2", None, "default"),
     ],
 )
 def test_new_model_clip_parses(
-    tmp_path, model, first_gps, abs_alt, fnum, focal_len
+    tmp_path, model, first_gps, abs_alt, fnum, focal_len, color_md
 ):
     srt = SAMPLES / model / "clip.SRT"
-    embedder = DJIMetadataEmbedder(tmp_path)
-    t = embedder.parse_dji_srt(srt)
+    t = DJIMetadataEmbedder(tmp_path).parse_dji_srt(srt)
 
     assert len(t["gps_coords"]) == 5
     assert t["first_gps"] == first_gps
     assert t["max_altitude"] == abs_alt
-    # Decimal aperture must survive parsing (was dropped before the fix).
+    # Decimal aperture must survive parsing (was dropped before v1.4.0).
     assert t["camera_settings"]["fnum"] == fnum
-    assert t["camera_settings"]["focal_len"] == focal_len
-    assert t["camera_settings"]["color_md"] == "dlog_m"
+    assert t["camera_settings"]["color_md"] == color_md
+    # FrameCnt counter must be captured, not recorded as None (issue #204).
+    assert t["srt_counts"] == [1, 2, 3, 4, 5]
+    if focal_len is None:
+        assert "focal_len" not in t["camera_settings"]
+    else:
+        assert t["camera_settings"]["focal_len"] == focal_len
 
 
-@pytest.mark.parametrize("model", ["Avata360", "Mini5PRO"])
+@pytest.mark.parametrize("model", MODELS)
 def test_new_model_telemetry_points(model):
     srt = SAMPLES / model / "clip.SRT"
     points = parse_telemetry_points(srt)
@@ -50,7 +60,7 @@ def test_new_model_telemetry_points(model):
     assert all(len(p) == 4 for p in points)
 
 
-@pytest.mark.parametrize("model", ["Avata360", "Mini5PRO"])
+@pytest.mark.parametrize("model", MODELS)
 def test_new_model_format_detected_html_extended(model):
     srt = SAMPLES / model / "clip.SRT"
     validation = validate_srt_format(srt, lenient=True)


### PR DESCRIPTION
Makes **DJI Neo 2** a first-class supported model.

The Neo 2 sidecar `.SRT` uses the same HTML bracket *Format 3b* family as Avata 360 (FrameCnt, decimal aperture, `pp_*` stabilization fields), so it already parsed correctly as of v1.5.0 — verified against a real 3,010-frame clip (GPS, altitude, ISO/shutter/aperture, FrameCnt counter, validates as `html_extended`). This PR just formalizes it with a fixture, tests, and docs.

## Changes
- `samples/neo2/clip.SRT` — trimmed 5-frame golden fixture.
- `tests/test_new_model_samples.py` — generalized to cover Neo 2 alongside Avata 360 / Mini 5 Pro. Neo 2 differs: no `focal_len`, `color_md: default` (vs `dlog_m`), so the parametrize flexes on those.
- `README.md` + `docs/SRT_FORMATS.md` — Neo 2 added to supported models / Format 3b / mappings table; notes the MP4 also carries `djmd`/`dbgi` data streams.
- `.gitignore` — ignore raw `*.SRT.txt` contributor dumps (only trimmed `clip.SRT` fixtures are committed).

No parser changes — characterization tests locking existing behaviour. Full suite: **91 passed, 1 skipped**.

> Note: this covers Neo 2 **SRT telemetry**. The embedded `djmd`/`dbgi` MP4 streams remain out of scope (preserved via `--container mkv` from #197; parsing tracked in #206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)