### PR TITLE
feat(samples): formalize DJI Air 3S support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,13 @@ output/
 !samples/**/clip*.SRT
 !samples/**/clip*.srt
 
+# Contributor scratch dropped into samples/ alongside donated footage —
+# donor notes (following_letter.txt), ffprobe dumps, error logs. These document
+# a submission but are not test fixtures; keep them out of the repo.
+samples/**/following_letter.txt
+samples/**/ffprobe.txt
+samples/**/*error*.txt
+
 # Temporary files
 *.tmp
 *.temp

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **DJI Mini 3/4 Pro** - Square bracket format `[latitude: xx.xxx] [longitude: xx.xxx]`
 - **DJI Mini 5 Pro** - HTML-style bracket format with decimal aperture (`[fnum: 1.8]`)
 - **DJI Air 3** - HTML-style format with extended telemetry data
+- **DJI Air 3S** - HTML-style bracket format with decimal `focal_len` and HLG color mode (`[color_md: hlg]`); MP4 also carries embedded `djmd`/`dbgi` data streams
 - **DJI Avata 360** - HTML-style bracket format with stabilization (`pp_*`) fields; footage ships as `.OSV` (360 video) + `.LRF` proxy
 - **DJI Neo 2** - HTML-style bracket format with stabilization (`pp_*`) fields; MP4 also carries embedded `djmd`/`dbgi` data streams
 - **DJI Avata 2** - Legacy GPS format `GPS(lat,lon,alt)` with BAROMETER data

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -95,7 +95,7 @@ Used by: DJI Mavic 3, DJI Air 2S
 
 ### Format 3b: Modern HTML Bracket (FrameCnt + decimal units)
 
-Used by: DJI Mini 5 Pro, DJI Avata 360, DJI Neo 2
+Used by: DJI Mini 5 Pro, DJI Avata 360, DJI Neo 2, DJI Air 3S
 
 Current models keep the HTML-wrapped bracket structure of Format 3 but change
 two things: the counter is `FrameCnt` (not `SrtCnt`), and the aperture and
@@ -118,6 +118,10 @@ focal length are written as **literal decimals** rather than the legacy
 - Avata 360 footage is delivered as `.OSV` (360 video) plus a `.LRF` low-res
   proxy instead of `.MP4`; both are MP4-family containers and are processed
   like any other video. See [troubleshooting](troubleshooting.md).
+- The Air 3S variant omits the `pp_*` stabilization block but is the first
+  observed fixture to report `color_md: hlg` (HLG color mode, alongside the
+  usual `default`/`dlog_m`). Its MP4 also carries DJI's proprietary
+  `djmd`/`dbgi` data streams, dropped on MP4 mux and round-tripped on MKV.
 - Detected as the `html_extended` format family.
 
 ## Camera Settings Interpretation
@@ -200,6 +204,7 @@ if new_format_match:
 | DJI Mini 5 Pro | Format 3b | FrameCnt + decimal fnum/focal_len |
 | DJI Avata 360 | Format 3b | FrameCnt + decimal units; `.OSV`/`.LRF` video, `pp_*` stabilization fields |
 | DJI Neo 2 | Format 3b | FrameCnt + decimal units; `pp_*` stabilization fields; MP4 carries `djmd`/`dbgi` streams |
+| DJI Air 3S | Format 3b | FrameCnt + decimal units; `color_md: hlg`; MP4 carries `djmd`/`dbgi` streams |
 | DJI Mavic Pro | Format 2 | GPS function format |
 | DJI Phantom 4 | Format 2 | GPS function format |
 | DJI Matrice 300 RTK | Format 2b | Legacy-with-unit (`0.0M` altitude) |

--- a/samples/air3S/clip.SRT
+++ b/samples/air3S/clip.SRT
@@ -1,0 +1,29 @@
+1
+00:00:00,000 --> 00:00:00,016
+<font size="28">FrameCnt: 1, DiffTime: 16ms
+2026-05-17 08:28:30.219
+[iso: 180] [shutter: 1/640.0] [fnum: 1.8] [ev: 0] [color_md: hlg] [focal_len: 24.00] [latitude: 34.270373] [longitude: -84.176160] [rel_alt: 0.000 abs_alt: 302.208] [ct: 5419] </font>
+
+2
+00:00:00,016 --> 00:00:00,032
+<font size="28">FrameCnt: 2, DiffTime: 16ms
+2026-05-17 08:28:30.235
+[iso: 180] [shutter: 1/640.0] [fnum: 1.8] [ev: 0] [color_md: hlg] [focal_len: 24.00] [latitude: 34.270373] [longitude: -84.176160] [rel_alt: 0.000 abs_alt: 302.208] [ct: 5419] </font>
+
+3
+00:00:00,032 --> 00:00:00,049
+<font size="28">FrameCnt: 3, DiffTime: 17ms
+2026-05-17 08:28:30.252
+[iso: 180] [shutter: 1/640.0] [fnum: 1.8] [ev: 0] [color_md: hlg] [focal_len: 24.00] [latitude: 34.270373] [longitude: -84.176160] [rel_alt: 0.000 abs_alt: 302.208] [ct: 5419] </font>
+
+4
+00:00:00,049 --> 00:00:00,066
+<font size="28">FrameCnt: 4, DiffTime: 17ms
+2026-05-17 08:28:30.268
+[iso: 180] [shutter: 1/640.0] [fnum: 1.8] [ev: 0] [color_md: hlg] [focal_len: 24.00] [latitude: 34.270373] [longitude: -84.176160] [rel_alt: 0.000 abs_alt: 302.208] [ct: 5419] </font>
+
+5
+00:00:00,066 --> 00:00:00,082
+<font size="28">FrameCnt: 5, DiffTime: 16ms
+2026-05-17 08:28:30.285
+[iso: 180] [shutter: 1/640.0] [fnum: 1.8] [ev: 0] [color_md: hlg] [focal_len: 24.00] [latitude: 34.270373] [longitude: -84.176160] [rel_alt: 0.000 abs_alt: 302.208] [ct: 5419] </font>

--- a/tests/test_new_model_samples.py
+++ b/tests/test_new_model_samples.py
@@ -1,11 +1,12 @@
 """Golden-fixture tests for recent DJI model submissions.
 
-Avata 360, Mini 5 Pro, and Neo 2 all emit the HTML-wrapped bracket telemetry
-format (FrameCnt + decimal aperture, ``html_extended`` family). These tests pin
-the parser, telemetry-point extraction, and format detection against the
-trimmed ``clip.SRT`` fixtures shipped under ``samples/``. They also lock the
+Avata 360, Mini 5 Pro, Neo 2, and Air 3S all emit the HTML-wrapped bracket
+telemetry format (FrameCnt + decimal aperture, ``html_extended`` family). These
+tests pin the parser, telemetry-point extraction, and format detection against
+the trimmed ``clip.SRT`` fixtures shipped under ``samples/``. They also lock the
 decimal-aperture and FrameCnt fixes on real data — see ``test_parsing`` for the
-focused regressions.
+focused regressions. Air 3S additionally pins ``color_md: hlg``, the first
+fixture to exercise the HLG color mode.
 """
 
 from pathlib import Path
@@ -19,7 +20,7 @@ from dji_metadata_embedder.utilities import parse_telemetry_points
 SAMPLES = Path(__file__).resolve().parents[1] / "samples"
 
 # Models with on-disk golden clip.SRT fixtures.
-MODELS = ["Avata360", "Mini5PRO", "neo2"]
+MODELS = ["Avata360", "Mini5PRO", "neo2", "air3S"]
 
 
 @pytest.mark.parametrize(
@@ -29,6 +30,8 @@ MODELS = ["Avata360", "Mini5PRO", "neo2"]
         ("Avata360", (53.365080, 6.460739), -124.744, "1.9", "28.00", "dlog_m"),
         ("Mini5PRO", (53.365108, 6.460719), -122.769, "1.8", "24.00", "dlog_m"),
         ("neo2", (45.607181, 13.753860), 114.0, "2.2", None, "default"),
+        # Air 3S: first fixture exercising the HLG color mode.
+        ("air3S", (34.270373, -84.176160), 302.208, "1.8", "24.00", "hlg"),
     ],
 )
 def test_new_model_clip_parses(


### PR DESCRIPTION
Makes **DJI Air 3S** first-class, following the Neo 2 pattern (#214).

A contributor donated real Air 3S footage (firmware 01.00.1600, RC-N3). The sidecar SRT is the HTML bracket **Format 3b** family (FrameCnt, decimal `fnum`/`focal_len`) and already parsed correctly as `html_extended` — the parser needed **no changes**. This adds a trimmed golden fixture, golden tests, and docs to lock it in.

Air 3S is the first fixture to exercise `color_md: hlg` (HLG color mode), and its MP4 carries DJI's proprietary `djmd`/`dbgi` data streams like the Neo 2.

## Changes
- `samples/air3S/clip.SRT` — trimmed 5-frame golden fixture (force-added past the `*.SRT` ignore)
- `tests/test_new_model_samples.py` — covers `air3S` alongside Avata 360 / Mini 5 Pro / Neo 2; pins `color_md=hlg` and decimal `focal_len`
- `README.md` + `docs/SRT_FORMATS.md` — list Air 3S (Format 3b "Used by" line, notes, and model-format table)
- `.gitignore` — ignore contributor scratch (`following_letter.txt`, `ffprobe.txt`, `*error*.txt`) dropped alongside donated footage

## Testing
- `pytest -q` → 99 passed, 1 skipped (skip is missing optional `flask`, unrelated)
- New model golden tests (12) all pass

## PR checklist
- [x] Tests added/updated for new functionality
- [x] Documentation updated (README + SRT_FORMATS)
- [x] Sample fixtures tested (parser unchanged; golden assertions added)
- [x] No breaking changes to existing functionality
- [x] Conventional commit format used in PR title

🤖 Generated with [Claude Code](https://claude.com/claude-code)