### PR TITLE
feat(geo): standalone HTML flight-path viewer (Phase 2, #221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **GPS Metadata Embedding**: Embed GPS coordinates as standard metadata tags
 - **Subtitle Track Preservation**: Keep telemetry data as subtitle track for overlay viewing
 - **Multiple Format Support**: Handles different DJI SRT telemetry formats
-- **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, or KML formats (see [docs/geospatial.md](docs/geospatial.md))
+- **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, KML, or a standalone HTML map (see [docs/geospatial.md](docs/geospatial.md))
 - **DAT Flight Log Support**: Merge `.DAT` flight logs into metadata
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Progress Bar**: See processing status while videos are being embedded
@@ -289,13 +289,13 @@ Options:
 ```
 
 #### `dji-embed convert` - Export Formats
-Convert SRT telemetry to GPX or CSV formats.
+Convert SRT telemetry to GPX, CSV, GeoJSON, KML, or a standalone HTML map.
 
 ```bash
-dji-embed convert [OPTIONS] {gpx|csv} INPUT
+dji-embed convert [OPTIONS] {gpx|csv|geojson|kml|html} INPUT
 
 Arguments:
-  {gpx|csv}                  Output format (GPX or CSV)
+  {gpx|csv|geojson|kml|html} Output format
   INPUT                      SRT file or directory to convert
 
 Options:
@@ -303,9 +303,19 @@ Options:
   -b, --batch                Batch process directory
   --tz-offset OFFSET         UTC offset for GPX timestamps, e.g. '+05:30' or
                              '-8' ('auto' detects from file mtime; default: auto)
+  --redact [none|drop|fuzz]  GPS redaction for geojson/kml/html (default: none)
   -v, --verbose              Verbose output
   -q, --quiet                Suppress info output
 ```
+
+**HTML map example** — produces a self-contained `flight.html` you can open in any browser:
+
+```bash
+dji-embed convert html DJI_0001.SRT              # -> DJI_0001.html
+dji-embed convert html DJI_0001.SRT -o flight.html
+```
+
+Leaflet and the basemap tiles load from the internet; the flight data itself is embedded, so the file is portable but needs a connection to render the map.
 
 #### `dji-embed doctor` - System Diagnostics
 Show system information and verify all dependencies.

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -37,8 +37,12 @@ This guide helps you choose the right command and approach for your specific use
 |-----------|------------------|-------------|
 | Single SRT file | GPX track | `dji-embed convert gpx /path/to/file.SRT` |
 | Single SRT file | CSV data | `dji-embed convert csv /path/to/file.SRT` |
+| Single SRT file | GeoJSON | `dji-embed convert geojson /path/to/file.SRT` |
+| Single SRT file | KML (Google Earth) | `dji-embed convert kml /path/to/file.SRT` |
+| Single SRT file | Standalone HTML map | `dji-embed convert html /path/to/file.SRT` |
 | Directory of SRT files | Multiple GPX files | `dji-embed convert gpx /path/to/srt/dir --batch` |
 | Directory of SRT files | Multiple CSV files | `dji-embed convert csv /path/to/srt/dir --batch` |
+| Directory of SRT files | Multiple HTML maps | `dji-embed convert html /path/to/srt/dir --batch` |
 | Custom output filename | Specific output file | `dji-embed convert gpx input.SRT -o custom.gpx` |
 
 ### For Analysis and Validation

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -24,9 +24,32 @@ dji-embed convert kml DJI_0001.SRT              # -> DJI_0001.kml
 A `LineString` placemark with absolute altitude — double-click to open the
 flight path in Google Earth.
 
+## Standalone HTML map
+
+```bash
+dji-embed convert html DJI_0001.SRT              # -> DJI_0001.html
+dji-embed convert html DJI_0001.SRT -o flight.html
+```
+
+Produces a single self-contained file that opens in any browser. The flight path
+is drawn as a Leaflet/OpenStreetMap map, colored by altitude (blue = low,
+red = high), with start/end markers and clickable points that show index,
+altitude, and timestamp.
+
+> **Network note:** Leaflet and the basemap tiles load from the internet; the
+> flight data itself is embedded, so the file is portable but needs a connection
+> to render the map.
+
+`--redact` works the same as for GeoJSON/KML:
+
+```bash
+dji-embed convert html DJI_0001.SRT --redact drop   # empty track, no coords
+dji-embed convert html DJI_0001.SRT --redact fuzz   # ~100 m coarsened coords
+```
+
 ## Privacy
 
-Both formats honour `--redact`:
+All three geo formats honour `--redact`:
 
 ```bash
 dji-embed convert geojson DJI_0001.SRT --redact drop   # empty track, no coords

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -62,4 +62,5 @@ Pre-GPS-lock `(0, 0)` frames are always excluded.
 
 ```bash
 dji-embed convert geojson ./footage --batch     # all *.SRT in the folder
+dji-embed convert html ./footage --batch        # one .html map per *.SRT
 ```

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -191,7 +191,11 @@ def convert(
     verbose: bool,
     quiet: bool,
 ) -> None:
-    """Convert SRT telemetry to GPX, CSV, GeoJSON, KML, or a standalone HTML map."""
+    """Convert SRT telemetry to GPX, CSV, GeoJSON, KML, or a standalone HTML map.
+
+    The html format embeds the flight data but loads Leaflet and the map tiles
+    from the internet, so the produced file needs a connection to render.
+    """
     setup_logging(verbose, quiet)
 
     try:

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -15,7 +15,7 @@ from .telemetry_converter import (
     extract_telemetry_to_csv,
     parse_utc_offset,
 )
-from .geo import convert_to_geojson, convert_to_kml
+from .geo import convert_to_geojson, convert_to_kml, convert_to_html
 from .utilities import check_dependencies, setup_logging, get_tool_versions
 
 
@@ -156,7 +156,9 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
 @main.command()
 @click.argument(
     "command",
-    type=click.Choice(["gpx", "csv", "geojson", "kml"], case_sensitive=False),
+    type=click.Choice(
+        ["gpx", "csv", "geojson", "kml", "html"], case_sensitive=False
+    ),
 )
 @click.argument("input", type=click.Path(exists=True))
 @click.option("-o", "--output", type=click.Path())
@@ -174,7 +176,7 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     type=click.Choice(["none", "drop", "fuzz"], case_sensitive=False),
     default="none",
     show_default=True,
-    help="GPS redaction for geojson/kml: drop removes the track, "
+    help="GPS redaction for geojson/kml/html: drop removes the track, "
     "fuzz coarsens to ~100 m.",
 )
 @click.option("-v", "--verbose", is_flag=True)
@@ -189,7 +191,7 @@ def convert(
     verbose: bool,
     quiet: bool,
 ) -> None:
-    """Convert SRT telemetry to GPX, CSV, GeoJSON, or KML."""
+    """Convert SRT telemetry to GPX, CSV, GeoJSON, KML, or a standalone HTML map."""
     setup_logging(verbose, quiet)
 
     try:
@@ -208,8 +210,10 @@ def convert(
             extract_telemetry_to_csv(srt, out)
         elif command == "geojson":
             convert_to_geojson(srt, out, redact=redact)
-        else:
+        elif command == "kml":
             convert_to_kml(srt, out, redact=redact)
+        else:  # html
+            convert_to_html(srt, out, redact=redact)
 
     if batch:
         for srt in src.glob("*.SRT"):

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -1,6 +1,7 @@
-"""Geospatial track model and exporters (GeoJSON, KML)."""
+"""Geospatial track model and exporters (GeoJSON, KML, HTML)."""
 
 from .geojson import convert_to_geojson, track_to_geojson
+from .html_viewer import convert_to_html, track_to_html
 from .kml import convert_to_kml, track_to_kml
 from .track import Track, TrackPoint, build_track
 
@@ -12,4 +13,6 @@ __all__ = [
     "convert_to_geojson",
     "track_to_kml",
     "convert_to_kml",
+    "track_to_html",
+    "convert_to_html",
 ]

--- a/src/dji_metadata_embedder/geo/html_viewer.py
+++ b/src/dji_metadata_embedder/geo/html_viewer.py
@@ -1,0 +1,157 @@
+"""Render a :class:`Track` as a standalone, self-contained HTML map.
+
+The document embeds the same GeoJSON that :func:`track_to_geojson` produces
+inside a ``<script type="application/json">`` block and ships a small vanilla
+Leaflet app that draws the path colored by altitude. Leaflet and the
+OpenStreetMap basemap tiles load from the network; the flight data itself is
+embedded, so the file is portable but not fully offline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from .geojson import track_to_geojson
+from .track import Track, build_track
+
+logger = logging.getLogger(__name__)
+
+# Pinned Leaflet release + Subresource Integrity hashes (see Task 1 Step 0).
+_LEAFLET_VERSION = "1.9.4"
+_LEAFLET_CSS_SRI = "sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+_LEAFLET_JS_SRI = "sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+
+_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Flight path — {title}</title>
+<!-- Leaflet + OpenStreetMap tiles load from the network; flight data is
+     embedded below, so this file is portable but not fully offline. -->
+<link rel="stylesheet"
+      href="https://unpkg.com/leaflet@{leaflet}/dist/leaflet.css"
+      integrity="{css_sri}" crossorigin="" />
+<style>
+  html, body {{ height: 100%; margin: 0; }}
+  #map {{ height: 100%; }}
+  .legend {{ background: #fff; padding: 6px 8px; font: 12px/1.4 sans-serif;
+             box-shadow: 0 0 6px rgba(0,0,0,0.3); border-radius: 4px; }}
+  .legend i {{ display: inline-block; width: 12px; height: 12px;
+               margin-right: 4px; vertical-align: middle; }}
+  .notice {{ position: absolute; top: 10px; left: 50%;
+             transform: translateX(-50%); z-index: 1000; background: #fff;
+             padding: 6px 10px; border-radius: 4px; font: 13px sans-serif;
+             box-shadow: 0 0 6px rgba(0,0,0,0.3); }}
+</style>
+</head>
+<body>
+<div id="map"></div>
+<script type="application/json" id="flight-data">
+{data}
+</script>
+<script src="https://unpkg.com/leaflet@{leaflet}/dist/leaflet.js"
+        integrity="{js_sri}" crossorigin=""></script>
+<script>
+{app_js}
+</script>
+</body>
+</html>
+"""
+
+_APP_JS = """
+const data = JSON.parse(document.getElementById('flight-data').textContent);
+const map = L.map('map');
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+const features = data.features || [];
+const line = features.find(f => f.geometry && f.geometry.type === 'LineString');
+const points = features.filter(f => f.geometry && f.geometry.type === 'Point');
+
+function altColor(alt, lo, hi) {
+  const t = hi > lo ? (alt - lo) / (hi - lo) : 0;   // 0 (low) .. 1 (high)
+  const hue = 240 * (1 - t);                        // 240=blue -> 0=red
+  return `hsl(${hue}, 90%, 45%)`;
+}
+
+if (line) {
+  const coords = line.geometry.coordinates;          // [lon, lat, alt]
+  const alts = coords.map(c => c[2]);
+  const lo = Math.min(...alts), hi = Math.max(...alts);
+  const latlngs = coords.map(c => [c[1], c[0]]);
+  for (let i = 0; i < coords.length - 1; i++) {
+    const mid = (coords[i][2] + coords[i + 1][2]) / 2;
+    L.polyline([latlngs[i], latlngs[i + 1]],
+               { color: altColor(mid, lo, hi), weight: 4 }).addTo(map);
+  }
+  map.fitBounds(L.latLngBounds(latlngs).pad(0.1));
+  L.circleMarker(latlngs[0], { color: '#2e7d32', radius: 7 })
+    .bindPopup('Start').addTo(map);
+  L.circleMarker(latlngs[latlngs.length - 1], { color: '#c62828', radius: 7 })
+    .bindPopup('End').addTo(map);
+
+  const legend = L.control({ position: 'bottomright' });
+  legend.onAdd = function () {
+    const div = L.DomUtil.create('div', 'legend');
+    div.innerHTML =
+      '<b>Altitude</b><br>' +
+      `<i style="background:${altColor(hi, lo, hi)}"></i>${hi.toFixed(0)} m<br>` +
+      `<i style="background:${altColor(lo, lo, hi)}"></i>${lo.toFixed(0)} m`;
+    return div;
+  };
+  legend.addTo(map);
+} else if (points.length) {
+  const c = points[0].geometry.coordinates;
+  map.setView([c[1], c[0]], 16);
+} else {
+  map.setView([0, 0], 2);
+  const note = L.DomUtil.create('div', 'notice', document.body);
+  note.textContent = 'No GPS track in this clip.';
+}
+
+for (const f of points) {
+  const c = f.geometry.coordinates;                  // [lon, lat, alt]
+  const p = f.properties || {};
+  L.circleMarker([c[1], c[0]], { radius: 3, color: '#1565c0' })
+    .bindPopup(
+      `#${p.index}<br>alt: ${p.abs_alt} m<br>${p.timestamp}`
+    ).addTo(map);
+}
+"""
+
+
+def track_to_html(track: Track) -> str:
+    """Return a complete self-contained HTML document for *track*."""
+    geojson = track_to_geojson(track)
+    # Escape "<" so a value containing "</script>" cannot break out of the
+    # embedded data block. json.dumps already escapes nothing HTML-specific.
+    data = json.dumps(geojson, indent=2).replace("<", "\\u003c")
+    return _TEMPLATE.format(
+        title=track.name,
+        leaflet=_LEAFLET_VERSION,
+        css_sri=_LEAFLET_CSS_SRI,
+        js_sri=_LEAFLET_JS_SRI,
+        data=data,
+        app_js=_APP_JS,
+    )
+
+
+def write_html(track: Track, output_path: Path) -> Path:
+    """Write *track* as an HTML map to *output_path* and return it."""
+    output_path.write_text(track_to_html(track), encoding="utf-8")
+    logger.info("HTML viewer created: %s", output_path)
+    return output_path
+
+
+def convert_to_html(
+    srt_file: Path | str, output_file: Path | str | None = None, redact: str = "none"
+) -> Path:
+    """Convert a DJI SRT file to a standalone HTML map. Defaults to ``<srt>.html``."""
+    srt_path = Path(srt_file)
+    output_path = Path(output_file) if output_file else srt_path.with_suffix(".html")
+    return write_html(build_track(srt_path, redact=redact), output_path)

--- a/src/dji_metadata_embedder/geo/html_viewer.py
+++ b/src/dji_metadata_embedder/geo/html_viewer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+from html import escape
 from pathlib import Path
 
 from .geojson import track_to_geojson
@@ -128,11 +129,12 @@ for (const f of points) {
 def track_to_html(track: Track) -> str:
     """Return a complete self-contained HTML document for *track*."""
     geojson = track_to_geojson(track)
-    # Escape "<" so a value containing "</script>" cannot break out of the
-    # embedded data block. json.dumps already escapes nothing HTML-specific.
+    # Escape "<" to "<" (a JSON Unicode escape) so JSON.parse round-trips
+    # it back to "<" while no literal "</script>" can break out of the data
+    # block.
     data = json.dumps(geojson, indent=2).replace("<", "\\u003c")
     return _TEMPLATE.format(
-        title=track.name,
+        title=escape(track.name),
         leaflet=_LEAFLET_VERSION,
         css_sri=_LEAFLET_CSS_SRI,
         js_sri=_LEAFLET_JS_SRI,

--- a/tests/test_cli_convert_geo.py
+++ b/tests/test_cli_convert_geo.py
@@ -26,6 +26,26 @@ def test_convert_kml_cli(tmp_path):
     assert "<kml" in out.read_text()
 
 
+def test_convert_html_cli(tmp_path):
+    out = tmp_path / "clip.html"
+    runner = CliRunner()
+    result = runner.invoke(main, ["convert", "html", str(CLIP), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    text = out.read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in text
+    assert "leaflet@1.9.4" in text
+
+
+def test_convert_html_redact_drop_still_valid(tmp_path):
+    out = tmp_path / "clip.html"
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["convert", "html", str(CLIP), "-o", str(out), "--redact", "drop"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "<!DOCTYPE html>" in out.read_text(encoding="utf-8")
+
+
 def test_convert_geojson_redact_drop_empties_track(tmp_path):
     out = tmp_path / "clip.geojson"
     runner = CliRunner()

--- a/tests/test_geo_html.py
+++ b/tests/test_geo_html.py
@@ -43,10 +43,27 @@ def test_html_is_self_contained_document():
 
 def test_html_escapes_script_close_in_data():
     # No literal "</script>" may appear inside the embedded JSON, or it would
-    # break out of the data block. The serializer escapes "<" to "<".
+    # break out of the data block. The serializer escapes "<" to "<" (a JSON
+    # Unicode escape) so JSON.parse round-trips it back to "<".
     html = track_to_html(build_track(CLIP))
     data_block = _DATA_RE.search(html).group(1)
     assert "</script>" not in data_block.lower()
+
+
+def test_html_escapes_script_close_when_present_in_data():
+    # Force a "</script>" into the embedded JSON via the track name (which
+    # track_to_geojson emits into the LineString feature's properties.name).
+    # A track with >=2 points produces a LineString.
+    base = build_track(CLIP)
+    track = Track(name="x</script>y", points=base.points)
+    html = track_to_html(track)
+    data_block = _DATA_RE.search(html).group(1)
+    # Raw block (before json.loads) carries the escaped form, never the literal.
+    assert "\\u003c/script>" in data_block
+    assert "</script>" not in data_block
+    # JSON.parse (here json.loads) round-trips it back to the original string.
+    data = json.loads(data_block)
+    assert data["features"][0]["properties"]["name"] == "x</script>y"
 
 
 def test_empty_track_still_renders_valid_document():

--- a/tests/test_geo_html.py
+++ b/tests/test_geo_html.py
@@ -1,0 +1,57 @@
+import json
+import re
+from pathlib import Path
+
+from dji_metadata_embedder.geo.html_viewer import (
+    convert_to_html,
+    track_to_html,
+)
+from dji_metadata_embedder.geo.track import Track, build_track
+
+SAMPLES = Path(__file__).resolve().parents[1] / "samples"
+CLIP = SAMPLES / "air3S" / "clip.SRT"
+
+# Pull the JSON out of <script type="application/json" id="flight-data">...</script>
+_DATA_RE = re.compile(
+    r'<script type="application/json" id="flight-data">(.*?)</script>',
+    re.DOTALL,
+)
+
+
+def _embedded_geojson(html: str) -> dict:
+    match = _DATA_RE.search(html)
+    assert match, "flight-data script block not found"
+    return json.loads(match.group(1))
+
+
+def test_html_embeds_wellformed_geojson():
+    html = track_to_html(build_track(CLIP))
+    data = _embedded_geojson(html)
+    assert data["type"] == "FeatureCollection"
+    points = [f for f in data["features"] if f["geometry"]
+              and f["geometry"]["type"] == "Point"]
+    assert len(points) == 5
+    assert points[0]["properties"]["abs_alt"] == 302.208
+
+
+def test_html_is_self_contained_document():
+    html = track_to_html(build_track(CLIP))
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    assert 'id="map"' in html
+    assert "leaflet@1.9.4" in html  # pinned CDN version
+
+
+def test_html_escapes_script_close_in_data():
+    # No literal "</script>" may appear inside the embedded JSON, or it would
+    # break out of the data block. The serializer escapes "<" to "<".
+    html = track_to_html(build_track(CLIP))
+    data_block = _DATA_RE.search(html).group(1)
+    assert "</script>" not in data_block.lower()
+
+
+def test_empty_track_still_renders_valid_document():
+    html = track_to_html(Track(name="empty", points=[]))
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    data = _embedded_geojson(html)
+    # Null-geometry line feature, no points.
+    assert data["features"][0]["geometry"] is None

--- a/tests/test_geo_html.py
+++ b/tests/test_geo_html.py
@@ -55,3 +55,18 @@ def test_empty_track_still_renders_valid_document():
     data = _embedded_geojson(html)
     # Null-geometry line feature, no points.
     assert data["features"][0]["geometry"] is None
+
+
+def test_convert_to_html_writes_file(tmp_path):
+    out = tmp_path / "clip.html"
+    result = convert_to_html(CLIP, out)
+    assert result == out
+    assert "<!DOCTYPE html>" in out.read_text(encoding="utf-8")
+
+
+def test_convert_to_html_default_output_path(tmp_path):
+    srt = tmp_path / "flight.SRT"
+    srt.write_text(CLIP.read_text(encoding="utf-8"), encoding="utf-8")
+    result = convert_to_html(srt)
+    assert result == srt.with_suffix(".html")
+    assert result.exists()


### PR DESCRIPTION
## Summary

Adds `dji-embed convert html <SRT>` — mapping **Phase 2** from the
[flight-path-mapping design](../blob/master/docs/superpowers/specs/2026-06-04-flight-path-mapping-design.md).
It turns the GeoJSON foundation shipped in v1.6.0 (Phase 1) into something a
non-technical user can actually *see*: a single self-contained `flight.html`
that draws the flight path on a Leaflet / OpenStreetMap basemap.

- New `geo/html_viewer.py` (`track_to_html` / `write_html` / `convert_to_html`)
  reuses the canonical `Track` + `track_to_geojson` — one Track, many renderers.
- The GeoJSON is embedded inline in a `<script type="application/json">` block;
  a small vanilla-JS app draws **altitude-colored** path segments, start/end
  markers, an altitude legend, and clickable per-point popups.
- Leaflet pinned to **1.9.4** with **SRI integrity** hashes (verified live) +
  `crossorigin`. No new Python runtime dependencies (pure stdlib).
- Routed through the existing `--redact drop/fuzz`; degenerate tracks (drop, or
  <2 GPS fixes) still produce a valid, non-throwing document.
- Wired into the `convert` command alongside `gpx/csv/geojson/kml`; batch mode
  is inherited.

### Deliberate scope notes
- **No `speed` in popups** — `TrackPoint` carries no speed field; adding it would
  need a parser change. Popups show index / abs_alt / timestamp. Logged as a
  follow-up.
- **Network tradeoff:** Leaflet + basemap tiles load from the internet (flight
  data is embedded). Documented in `convert --help` and `docs/geospatial.md`.

### Review
Two-stage code review + automated security review applied. Findings fixed in
`63dfc95`: HTML-escape `track.name` in `<title>` (closes an XSS-via-manual-HTML
finding, matching `geo/kml.py`), add the `--help` network caveat, and a real
escape test that actually exercises the `</script>` → `<` path.

## Test Plan
- [x] `uv run --extra dev pytest -q` → **120 passed**, 1 skipped (pre-existing flask skip); +9 new tests
- [x] `uv run ruff check src/ tests/` → clean
- [x] `uv run --extra docs mkdocs build --strict` → clean
- [ ] Manual: open a generated `flight.html` in a browser and confirm the path renders, is altitude-colored, and point popups work

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)