### PR TITLE
feat(geo): sun-position (shadow) check for footage verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **Subtitle Track Preservation**: Keep telemetry data as subtitle track for overlay viewing
 - **Multiple Format Support**: Handles different DJI SRT telemetry formats
 - **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, KML, or a standalone HTML map (see [docs/geospatial.md](docs/geospatial.md))
+- **Footage verification:** `dji-embed verify-sun clip.SRT` reports the sun's azimuth/elevation over a clip for shadow cross-checking; CSV export gains `datetime_utc` / `sun_azimuth` / `sun_elevation` columns.
 - **DAT Flight Log Support**: Merge `.DAT` flight logs into metadata
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Progress Bar**: See processing status while videos are being embedded

--- a/docs/superpowers/specs/2026-06-13-sun-position-verification-design.md
+++ b/docs/superpowers/specs/2026-06-13-sun-position-verification-design.md
@@ -1,0 +1,175 @@
+# Design: Sun-position (shadow) check for footage verification
+
+_Date: 2026-06-13_
+
+_Issue: [#216](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/216)_
+
+## Context
+
+For each GPS point a DJI clip already gives us `(lat, lon)`. If we also know the
+**absolute UTC time** of that point, we can compute the **sun's azimuth and
+elevation** — and an analyst can then cross-check shadow direction and length in
+the footage against the astronomical sun position. This is a standard
+chronolocation / footage-verification technique, squarely on the project's
+[use-for-good direction](https://github.com/CallMarcus/dji-drone-metadata-embedder#intended-use--scope)
+(open-source verification, journalism, human-rights documentation).
+
+The UTC prerequisite is already met: **#211** added timezone-correct UTC
+timestamps to the telemetry pipeline (`_parse_srt_datetime`, `estimate_utc_offset`,
+and a `convert --tz-offset` override). Without correct UTC, sun angles are
+meaningless, so that work is the foundation this builds on.
+
+### Current state of the code (what this design has to work with)
+
+- `parse_telemetry_points()` (utilities) and the canonical `Track`
+  (`geo/track.py`) carry only `(lat, lon, alt, raw-cue-timestamp)` — **no
+  absolute datetime**.
+- The full UTC-datetime resolution (`_parse_srt_datetime` + `estimate_utc_offset`
+  + `--tz-offset` application) lives **only inside `extract_telemetry_to_gpx`**.
+- `extract_telemetry_to_csv` is a separate block-parser that emits the **raw cue
+  time** (`HH:MM:SS,mmm`), with no date and no UTC.
+
+So the central problem is: sun angles need `(lat, lon, UTC datetime)`, but UTC is
+currently computed in exactly one exporter and not exposed anywhere reusable.
+
+## Goals
+
+- A clean-room solar-position function: `(lat, lon, UTC datetime) → (azimuth,
+  elevation)`, no new runtime dependencies, unit-tested against published
+  reference values.
+- Sun angles surfaced in **CSV export**, alongside the resolved **UTC
+  timestamp** they were computed for (so the cross-check is auditable).
+- A **`dji-embed verify-sun <SRT>`** command giving a human/JSON summary of the
+  sun track over a clip.
+- Graceful handling when UTC can't be resolved (SRT formats without an absolute
+  datetime): no crash, blank/!computed rather than wrong numbers.
+
+## Non-goals (deferred)
+
+- **Sun angles as GeoJSON / GPX extensions.** Natural follow-up, not in this cut.
+- **Pushing absolute datetime into the canonical `Track` / `parse_telemetry_points`.**
+  This is the clean long-term single-source-of-truth (Approach C below) and the
+  base the deferred GeoJSON/GPX extensions should build on — but it touches the
+  Track model, redaction, and every geo exporter, which is more than this issue
+  warrants. Recorded here as the intended future direction.
+- **Any image/CV analysis of the actual shadows in-frame.** We compute the
+  *expected* sun geometry; comparing it to the footage stays a human step.
+
+## Chosen approach: shared UTC resolver + isolated `solar.py`
+
+Considered three ways to get UTC + sun angles to the CSV/`verify-sun` paths:
+
+- **A (chosen) — Extract a shared UTC resolver; add a self-contained solar
+  module.** Pull the datetime-parse + offset-estimate/apply logic out of
+  `extract_telemetry_to_gpx` into a reusable helper (GPX refactored to call it,
+  no behavior change). Add `geo/solar.py`. CSV and `verify-sun` consume both.
+  Removes the "UTC logic only exists in one exporter" smell; each unit is
+  independently testable; small blast radius.
+- **B — Standalone, leave GPX alone.** Duplicate UTC resolution into the
+  CSV/verify-sun path. Less to touch now, but a second copy of the offset logic
+  that will drift. Rejected.
+- **C — Push absolute datetime into the canonical `Track`/`parse_telemetry_points`.**
+  Cleanest long-term and the base for the deferred extensions, but touches the
+  Track model, redaction interaction, and all geo exporters. Larger than "not
+  massive." Deferred (see Non-goals).
+
+## Architecture
+
+```
+                  ┌─ resolve_utc_offset(abs_dts, tz_offset, mtime) ─┐ (extracted
+                  │   (_parse_srt_datetime, estimate_utc_offset)     │  from GPX,
+                  │   → single per-file offset; point_utc = dt-offset│  reused)
+                  └──────────────────────┬───────────────────────────┘
+                                         │  timedelta | None
+        ┌───────────────┬─────────────────┼──────────────────────┐
+        ▼               ▼                                         ▼
+   GPX exporter     CSV exporter ── sun_position(lat,lon,utc) ─► verify-sun
+   (unchanged        (+datetime_utc,      (geo/solar.py)          (summary,
+    behavior)         sun_azimuth,                                 text/json)
+                      sun_elevation)
+```
+
+### 1. `geo/solar.py` — clean-room solar position (no new deps)
+
+- `sun_position(lat: float, lon: float, when_utc: datetime) -> tuple[float, float]`
+  returning `(azimuth_deg, elevation_deg)`.
+  - Azimuth: 0–360°, clockwise from true north.
+  - Elevation: −90…+90° (negative = sun below the horizon).
+- Standard NOAA solar-geometry algorithm: Julian day → solar declination +
+  equation of time → hour angle → altitude/azimuth. Pure stdlib `math`.
+- Accuracy comfortably under ±0.5°, ample for shadow direction/length checks.
+- `when_utc` is treated as UTC (naive-UTC or tz-aware accepted; normalized
+  internally).
+
+### 2. Shared UTC resolver (refactor, no behavior change)
+
+- Extract from `extract_telemetry_to_gpx` a helper that resolves the **single
+  per-file** local→UTC offset (matching today's behavior: `estimate_utc_offset`
+  yields one offset applied to every point), e.g.
+  `resolve_utc_offset(abs_datetimes, tz_offset, file_mtime_utc) -> timedelta | None`,
+  reusing the existing `_parse_srt_datetime` / `estimate_utc_offset`. Each point's
+  UTC is then `point_datetime - offset`. Returns `None` when no absolute datetime
+  is present (the no-UTC case).
+- `extract_telemetry_to_gpx` is rewired to call it and must behave **identically**
+  (guarded by the existing GPX tests).
+
+### 3. CSV export changes
+
+- `extract_telemetry_to_csv(srt_file, output_file=None, tz_offset=None)` gains
+  three trailing columns: `datetime_utc` (ISO 8601), `sun_azimuth`,
+  `sun_elevation`.
+- Per point: if UTC resolves for that clip, fill all three; if not (format with
+  no absolute datetime), leave all three **blank**. Existing columns are
+  unchanged and keep their order.
+- `convert csv` passes through the same `--tz-offset` option the command already
+  exposes (currently only consumed by the `gpx` branch).
+
+### 4. `dji-embed verify-sun <SRT>` command
+
+- Resolves UTC, computes the sun track, prints a summary:
+  - clip UTC start/end,
+  - sun elevation min → max,
+  - azimuth start → end,
+  - flags: **night** (elevation < 0 throughout), **very-low-sun** (peak < 5°),
+    **sun not computable** (no resolvable UTC).
+- Options: `--tz-offset` (default `auto`) and `--format text|json`, mirroring the
+  existing `validate` command.
+- Exit code: non-zero only on real errors (bad file, parse failure). "It was
+  night" / "very low sun" are reported, not error exits.
+
+## Privacy
+
+`verify-sun` and the CSV sun columns operate on coordinates the user already
+holds locally; nothing is sent anywhere. Redaction interaction is out of scope
+here because sun computation lives on the CSV/verify-sun path, not the
+redaction-aware `Track` path. (When the deferred Approach-C work moves datetime
+into `Track`, sun angles will inherit `--redact` for free.)
+
+## Verification
+
+- **`solar.py` unit tests** vs published NOAA reference values: a few known
+  `(lat, lon, UTC) → (az, el)` cases within ~0.5° tolerance, including a
+  southern-hemisphere case and a high-latitude case.
+- **CSV tests:** an SRT fixture *with* absolute datetimes → the three new columns
+  present and within tolerance; a fixture *without* absolute datetimes → the
+  three columns present but blank. Existing CSV columns unchanged.
+- **GPX regression:** existing GPX tests must still pass unchanged after the
+  resolver extraction.
+- **`verify-sun` CLI smoke tests:** text and json output on a sample SRT;
+  graceful path on a no-UTC fixture.
+
+## Docs
+
+- A short **"Footage verification"** section in `README.md` and
+  `docs/user_guide.md`: what the shadow cross-check is, the new CSV columns, and
+  the `verify-sun` command.
+- Note the ±0.5° accuracy and that the tool gives *expected* sun geometry — the
+  comparison to the footage is the analyst's step.
+
+## Issue / roadmap mapping
+
+- Implements the required acceptance criteria of **#216** (solar function +
+  tests, sun angles in CSV, graceful no-UTC handling, docs) plus the issue's
+  optional `verify-sun` summary command.
+- GeoJSON/GPX sun extensions and the `Track`-level datetime refactor (Approach C)
+  are explicitly deferred and noted as the follow-up direction.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -57,6 +57,7 @@ Notes:
 - Accuracy is within ~0.5 deg, ample for shadow direction/length checks.
 - The tool gives the *expected* sun geometry; comparing it to the footage is the analyst's step.
 - SRT formats without an absolute wall-clock datetime can't be resolved to UTC, so the sun columns stay blank and `verify-sun` reports `sun_not_computable`.
+- UTC auto-detection relies on the file's modification time still reflecting the recording; if the file was copied or edited, pass `--tz-offset` explicitly for reliable results.
 
 ## Web UI
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -32,6 +32,32 @@ Use `csv` instead of `gpx` to create a CSV file.
 
 For detailed how-to guides such as creating Windows bundles or redacting location data, see the files in `docs/how-to`.
 
+## Footage verification (sun / shadow check)
+
+For chronolocation and footage verification you can cross-check the **shadows** in a clip against where the sun actually was. Given each GPS point's position and UTC time, `dji-embed` computes the sun's **azimuth** (compass bearing) and **elevation** (height above the horizon).
+
+```bash
+# Summarise the sun track over a clip
+dji-embed verify-sun DJI_0001.SRT
+
+# Force a known UTC offset instead of auto-detecting from the file mtime
+dji-embed verify-sun DJI_0001.SRT --tz-offset +02:00
+
+# Machine-readable summary
+dji-embed verify-sun DJI_0001.SRT --format json
+```
+
+The CSV export also gains `datetime_utc`, `sun_azimuth`, and `sun_elevation` columns:
+
+```bash
+dji-embed convert csv DJI_0001.SRT
+```
+
+Notes:
+- Accuracy is within ~0.5 deg, ample for shadow direction/length checks.
+- The tool gives the *expected* sun geometry; comparing it to the footage is the analyst's step.
+- SRT formats without an absolute wall-clock datetime can't be resolved to UTC, so the sun columns stay blank and `verify-sun` reports `sun_not_computable`.
+
 ## Web UI
 
 If you'd rather click buttons than type commands, install the `[ui]` extra

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -14,6 +14,7 @@ from .telemetry_converter import (
     extract_telemetry_to_gpx,
     extract_telemetry_to_csv,
     parse_utc_offset,
+    summarize_sun,
 )
 from .geo import convert_to_geojson, convert_to_kml, convert_to_html
 from .utilities import check_dependencies, setup_logging, get_tool_versions
@@ -211,7 +212,7 @@ def convert(
         if command == "gpx":
             extract_telemetry_to_gpx(srt, out, tz_offset=offset)
         elif command == "csv":
-            extract_telemetry_to_csv(srt, out)
+            extract_telemetry_to_csv(srt, out, tz_offset=offset)
         elif command == "geojson":
             convert_to_geojson(srt, out, redact=redact)
         elif command == "kml":
@@ -312,6 +313,82 @@ def validate(
         else:
             click.echo(f"Error: {error_msg}", err=True)
         sys.exit(ExitCode.GENERAL_ERROR)
+
+
+@main.command(name="verify-sun")
+@click.argument("srt", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--tz-offset",
+    default="auto",
+    show_default=True,
+    metavar="OFFSET",
+    help="UTC offset for the SRT timestamps, e.g. '+05:30' or '-8'. "
+    "'auto' detects it from the SRT file mtime.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Verbose output")
+@click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
+@click.pass_context
+def verify_sun(
+    ctx: click.Context,
+    srt: str,
+    tz_offset: str,
+    fmt: str,
+    verbose: bool,
+    quiet: bool,
+) -> None:
+    """Summarise the sun's position over a clip for shadow cross-checking.
+
+    Computes solar azimuth/elevation for each GPS point so analysts can compare
+    shadow direction/length in the footage against the astronomical sun.
+    """
+    log_json = ctx.obj.get("log_json", False)
+    setup_logging(verbose, quiet, log_json)
+
+    try:
+        offset = parse_utc_offset(tz_offset)
+    except ValueError as e:
+        raise click.BadParameter(str(e), param_hint="--tz-offset")
+
+    try:
+        summary = summarize_sun(Path(srt), tz_offset=offset)
+    except Exception as e:
+        msg = f"verify-sun failed: {e}"
+        if log_json:
+            click.echo(json.dumps({"error": "verify_sun_failed", "message": msg}))
+        else:
+            click.echo(f"Error: {msg}", err=True)
+        sys.exit(ExitCode.GENERAL_ERROR)
+
+    if fmt == "json" or log_json:
+        click.echo(json.dumps(summary))
+    else:
+        click.echo(f"Sun verification for: {summary['file']}")
+        click.echo(
+            f"GPS points: {summary['points']}  "
+            f"(sun computed: {summary['sun_computed']})"
+        )
+        if summary["sun_computed"]:
+            click.echo(f"UTC span: {summary['utc_start']} -> {summary['utc_end']}")
+            click.echo(
+                f"Sun elevation: {summary['elevation_min']} -> "
+                f"{summary['elevation_max']} deg (min/max)"
+            )
+            click.echo(
+                f"Sun azimuth: {summary['azimuth_start']} -> "
+                f"{summary['azimuth_end']} deg (start/end)"
+            )
+        for flag in summary["flags"]:
+            click.echo(f"  WARNING: {flag}")
+
+    sys.exit(ExitCode.SUCCESS)
 
 
 @main.command()

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -3,12 +3,14 @@
 from .geojson import convert_to_geojson, track_to_geojson
 from .html_viewer import convert_to_html, track_to_html
 from .kml import convert_to_kml, track_to_kml
+from .solar import sun_position
 from .track import Track, TrackPoint, build_track
 
 __all__ = [
     "Track",
     "TrackPoint",
     "build_track",
+    "sun_position",
     "track_to_geojson",
     "convert_to_geojson",
     "track_to_kml",

--- a/src/dji_metadata_embedder/geo/solar.py
+++ b/src/dji_metadata_embedder/geo/solar.py
@@ -1,0 +1,111 @@
+"""Clean-room solar-position helper for footage verification (issue #216).
+
+Computes the sun's azimuth and elevation for a WGS84 position at a UTC instant
+using the standard NOAA solar-geometry algorithm. Pure stdlib ``math`` — no new
+runtime dependencies. Accuracy is comfortably under +/-0.5 degrees away from the
+horizon, ample for cross-checking shadow direction and length in footage.
+
+Implemented clean-room from the public NOAA solar equations; no code copied.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+
+
+def _julian_day(when_utc: datetime) -> float:
+    """Julian Day for a UTC datetime (proleptic Gregorian)."""
+    year, month = when_utc.year, when_utc.month
+    day = when_utc.day + (
+        when_utc.hour
+        + (when_utc.minute + (when_utc.second + when_utc.microsecond / 1e6) / 60) / 60
+    ) / 24
+    if month <= 2:
+        year -= 1
+        month += 12
+    a = year // 100
+    b = 2 - a + a // 4
+    return (
+        int(365.25 * (year + 4716))
+        + int(30.6001 * (month + 1))
+        + day
+        + b
+        - 1524.5
+    )
+
+
+def sun_position(lat: float, lon: float, when_utc: datetime) -> tuple[float, float]:
+    """Return ``(azimuth_deg, elevation_deg)`` of the sun.
+
+    ``lat``/``lon`` are WGS84 degrees (longitude positive east). ``when_utc`` is
+    treated as UTC. Azimuth is 0-360 degrees clockwise from true north; elevation
+    is -90..+90 degrees (negative means the sun is below the horizon). Geometric
+    position (no atmospheric-refraction correction).
+    """
+    jd = _julian_day(when_utc)
+    t = (jd - 2451545.0) / 36525.0  # Julian centuries since J2000.0
+
+    # Geometric mean longitude/anomaly of the sun, and orbital eccentricity.
+    l0 = (280.46646 + t * (36000.76983 + t * 0.0003032)) % 360.0
+    m = 357.52911 + t * (35999.05029 - 0.0001537 * t)
+    e = 0.016708634 - t * (0.000042037 + 0.0000001267 * t)
+    mr = math.radians(m)
+
+    # Sun's equation of centre and apparent ecliptic longitude.
+    c = (
+        math.sin(mr) * (1.914602 - t * (0.004817 + 0.000014 * t))
+        + math.sin(2 * mr) * (0.019993 - 0.000101 * t)
+        + math.sin(3 * mr) * 0.000289
+    )
+    true_long = l0 + c
+    omega = 125.04 - 1934.136 * t
+    lam = true_long - 0.00569 - 0.00478 * math.sin(math.radians(omega))
+
+    # Obliquity of the ecliptic (corrected) and solar declination.
+    obliq0 = 23 + (26 + (21.448 - t * (46.815 + t * (0.00059 - t * 0.001813))) / 60) / 60
+    obliq = obliq0 + 0.00256 * math.cos(math.radians(omega))
+    decl = math.degrees(
+        math.asin(math.sin(math.radians(obliq)) * math.sin(math.radians(lam)))
+    )
+
+    # Equation of time (minutes).
+    y = math.tan(math.radians(obliq / 2)) ** 2
+    l0r = math.radians(l0)
+    eot = 4 * math.degrees(
+        y * math.sin(2 * l0r)
+        - 2 * e * math.sin(mr)
+        + 4 * e * y * math.sin(mr) * math.cos(2 * l0r)
+        - 0.5 * y * y * math.sin(4 * l0r)
+        - 1.25 * e * e * math.sin(2 * mr)
+    )
+
+    # True solar time -> hour angle (degrees).
+    utc_minutes = (
+        when_utc.hour * 60
+        + when_utc.minute
+        + when_utc.second / 60
+        + when_utc.microsecond / 6e7
+    )
+    tst = (utc_minutes + eot + 4 * lon) % 1440.0
+    ha = tst / 4.0 - 180.0
+
+    latr, declr, har = math.radians(lat), math.radians(decl), math.radians(ha)
+    cos_zenith = math.sin(latr) * math.sin(declr) + math.cos(latr) * math.cos(declr) * math.cos(har)
+    cos_zenith = max(-1.0, min(1.0, cos_zenith))
+    zenith = math.acos(cos_zenith)
+    elevation = 90.0 - math.degrees(zenith)
+
+    sin_zenith = math.sin(zenith)
+    if abs(sin_zenith) < 1e-9:
+        # Sun at zenith or nadir: azimuth is undefined; return 0 by convention.
+        azimuth = 0.0
+    else:
+        cos_az = (math.sin(latr) * math.cos(zenith) - math.sin(declr)) / (
+            math.cos(latr) * sin_zenith
+        )
+        cos_az = max(-1.0, min(1.0, cos_az))
+        az = math.degrees(math.acos(cos_az))
+        azimuth = (az + 180.0) % 360.0 if ha > 0 else (540.0 - az) % 360.0
+
+    return azimuth, elevation

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -13,7 +13,7 @@ import re
 import logging
 
 from rich.progress import Progress
-from .utilities import setup_logging
+from .utilities import is_gps_fix, setup_logging
 from .geo.solar import sun_position
 
 logger = logging.getLogger(__name__)
@@ -248,7 +248,7 @@ def summarize_sun(
     track: list[tuple[datetime, float, float]] = []  # (utc, azimuth, elevation)
     if offset is not None:
         for p in points:
-            if p["datetime"] is None:
+            if p["datetime"] is None or not is_gps_fix(p["lat"], p["lon"]):
                 continue
             utc = p["datetime"] - offset
             az, el = sun_position(p["lat"], p["lon"], utc)
@@ -454,6 +454,8 @@ def extract_telemetry_to_csv(
                 continue
             utc = abs_dt - offset
             row["datetime_utc"] = utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if not is_gps_fix(lat_val, lon_val):
+                continue
             az, el = sun_position(lat_val, lon_val, utc)
             row["sun_azimuth"] = f"{az:.3f}"
             row["sun_elevation"] = f"{el:.3f}"

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -341,15 +341,24 @@ def batch_convert_to_csv(directory: Path | str) -> None:
 
 
 def extract_telemetry_to_csv(
-    srt_file: Path | str, output_file: Path | str | None = None
+    srt_file: Path | str,
+    output_file: Path | str | None = None,
+    tz_offset: timedelta | None = None,
 ) -> Path:
-    """
-    Extract all telemetry data from DJI SRT file to CSV.
+    """Extract all telemetry data from a DJI SRT file to CSV.
+
+    When blocks carry an absolute wall-clock datetime, three extra columns are
+    filled: ``datetime_utc`` (ISO 8601; local->UTC via *tz_offset* or mtime
+    auto-detect) and the solar ``sun_azimuth`` / ``sun_elevation`` for that
+    instant and position. Formats without an absolute datetime leave those three
+    columns blank.
     """
     srt_path = Path(srt_file)
     output_path = Path(output_file) if output_file else srt_path.with_suffix(".csv")
 
     rows = []
+    # Per-row solar inputs, index-aligned with ``rows``: (abs_dt, lat, lon).
+    solar_inputs: list[tuple[datetime | None, float | None, float | None]] = []
 
     with open(srt_path, "r", encoding="utf-8") as f:
         content = f.read()
@@ -359,16 +368,13 @@ def extract_telemetry_to_csv(
     for block in blocks:
         lines = block.strip().split("\n")
         if len(lines) >= 3:
-            # Parse timestamp
             timestamp_line = lines[1]
             timestamp_match = re.search(r"(\d{2}:\d{2}:\d{2},\d{3})", timestamp_line)
 
-            # Parse telemetry data
             telemetry_line = " ".join(lines[2:])
             if "<font" in telemetry_line:
                 telemetry_line = re.sub(r"<[^>]+>", "", telemetry_line)
 
-            # Extract all data
             row = {
                 "timestamp": timestamp_match.group(1) if timestamp_match else "",
                 "latitude": "",
@@ -382,14 +388,21 @@ def extract_telemetry_to_csv(
                 "ct": "",
                 "color_md": "",
                 "focal_len": "",
+                "datetime_utc": "",
+                "sun_azimuth": "",
+                "sun_elevation": "",
             }
 
             # GPS coordinates
             lat_match = re.search(r"\[latitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
             lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
+            lat_val: float | None = None
+            lon_val: float | None = None
             if lat_match and lon_match:
                 row["latitude"] = lat_match.group(1)
                 row["longitude"] = lon_match.group(1)
+                lat_val = float(lat_match.group(1))
+                lon_val = float(lon_match.group(1))
 
             # Altitude
             alt_match = re.search(
@@ -425,6 +438,25 @@ def extract_telemetry_to_csv(
                 row["focal_len"] = focal_len_match.group(1)
 
             rows.append(row)
+            solar_inputs.append(
+                (_parse_srt_datetime(telemetry_line), lat_val, lon_val)
+            )
+
+    # Resolve the single local->UTC offset, then fill UTC + solar columns.
+    abs_times = [dt for dt, _, _ in solar_inputs if dt is not None]
+    mtime_utc = datetime.fromtimestamp(
+        srt_path.stat().st_mtime, tz=timezone.utc
+    ).replace(tzinfo=None)
+    offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
+    if offset is not None:
+        for row, (abs_dt, lat_val, lon_val) in zip(rows, solar_inputs):
+            if abs_dt is None or lat_val is None or lon_val is None:
+                continue
+            utc = abs_dt - offset
+            row["datetime_utc"] = utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+            az, el = sun_position(lat_val, lon_val, utc)
+            row["sun_azimuth"] = f"{az:.3f}"
+            row["sun_elevation"] = f"{el:.3f}"
 
     # Write CSV
     import csv

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -92,6 +92,55 @@ def estimate_utc_offset(
     return best_offset
 
 
+def resolve_utc_offset(
+    abs_datetimes: list[datetime],
+    tz_offset: timedelta | None,
+    file_mtime_utc: datetime,
+) -> timedelta | None:
+    """Resolve the single local->UTC offset for an SRT file.
+
+    Returns ``None`` when the file carries no absolute datetime (callers then
+    fall back to the raw cue time). An explicit *tz_offset* wins; otherwise the
+    offset is auto-detected from the file mtime via :func:`estimate_utc_offset`.
+    """
+    if not abs_datetimes:
+        return None
+    if tz_offset is not None:
+        return tz_offset
+    return estimate_utc_offset(abs_datetimes[0], abs_datetimes[-1], file_mtime_utc)
+
+
+def _parse_gps_points(content: str) -> list[dict[str, Any]]:
+    """Parse SRT text into GPS points: lat, lon, ele, cue time, abs datetime.
+
+    Shared by :func:`extract_telemetry_to_gpx` and :func:`summarize_sun` so the
+    GPS/datetime extraction lives in one place.
+    """
+    gps_points: list[dict[str, Any]] = []
+    for block in content.strip().split("\n\n"):
+        lines = block.strip().split("\n")
+        if len(lines) < 3:
+            continue
+        timestamp_match = re.search(r"(\d{2}:\d{2}:\d{2},\d{3})", lines[1])
+        telemetry_line = " ".join(lines[2:])
+        if "<font" in telemetry_line:
+            telemetry_line = re.sub(r"<[^>]+>", "", telemetry_line)
+        lat_match = re.search(r"\[latitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
+        lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
+        alt_match = re.search(r"abs_alt:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
+        if lat_match and lon_match:
+            gps_points.append(
+                {
+                    "lat": float(lat_match.group(1)),
+                    "lon": float(lon_match.group(1)),
+                    "ele": float(alt_match.group(1)) if alt_match else 0,
+                    "time": timestamp_match.group(1) if timestamp_match else None,
+                    "datetime": _parse_srt_datetime(telemetry_line),
+                }
+            )
+    return gps_points
+
+
 def extract_telemetry_to_gpx(
     srt_file: Path | str,
     output_file: Path | str | None = None,
@@ -109,54 +158,17 @@ def extract_telemetry_to_gpx(
     srt_path = Path(srt_file)
     output_path = Path(output_file) if output_file else srt_path.with_suffix(".gpx")
 
-    gps_points: list[dict[str, Any]] = []
-
     with open(srt_path, "r", encoding="utf-8") as f:
         content = f.read()
 
-    blocks = content.strip().split("\n\n")
+    gps_points = _parse_gps_points(content)
 
-    for block in blocks:
-        lines = block.strip().split("\n")
-        if len(lines) >= 3:
-            # Parse timestamp
-            timestamp_line = lines[1]
-            timestamp_match = re.search(r"(\d{2}:\d{2}:\d{2},\d{3})", timestamp_line)
-
-            # Parse telemetry data
-            telemetry_line = " ".join(lines[2:])
-            if "<font" in telemetry_line:
-                telemetry_line = re.sub(r"<[^>]+>", "", telemetry_line)
-
-            # Extract GPS coordinates
-            lat_match = re.search(r"\[latitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
-            lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
-            alt_match = re.search(r"abs_alt:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
-
-            if lat_match and lon_match:
-                point = {
-                    "lat": float(lat_match.group(1)),
-                    "lon": float(lon_match.group(1)),
-                    "ele": float(alt_match.group(1)) if alt_match else 0,
-                    # Raw subtitle cue time (fallback for formats without an
-                    # absolute datetime).
-                    "time": timestamp_match.group(1) if timestamp_match else None,
-                    # Absolute wall-clock datetime, when present.
-                    "datetime": _parse_srt_datetime(telemetry_line),
-                }
-                gps_points.append(point)
-
-    # Resolve the local→UTC offset for points that carry an absolute datetime.
+    # Resolve the local->UTC offset for points that carry an absolute datetime.
     abs_times = [p["datetime"] for p in gps_points if p["datetime"] is not None]
-    offset: timedelta | None = None
-    if abs_times:
-        if tz_offset is not None:
-            offset = tz_offset
-        else:
-            mtime_utc = datetime.fromtimestamp(
-                srt_path.stat().st_mtime, tz=timezone.utc
-            ).replace(tzinfo=None)
-            offset = estimate_utc_offset(abs_times[0], abs_times[-1], mtime_utc)
+    mtime_utc = datetime.fromtimestamp(
+        srt_path.stat().st_mtime, tz=timezone.utc
+    ).replace(tzinfo=None)
+    offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
 
     def _point_time(point: dict) -> str | None:
         """Return the GPX <time> string for a point (UTC if datetime known)."""

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -14,12 +14,16 @@ import logging
 
 from rich.progress import Progress
 from .utilities import setup_logging
+from .geo.solar import sun_position
 
 logger = logging.getLogger(__name__)
 
 # Seconds in a quarter hour — the granularity real-world UTC offsets use
 # (whole hours plus the :30 and :45 zones like India and Nepal).
 _QUARTER_HOUR = 15 * 60
+
+# Peak solar elevation (degrees) below which a clip is flagged "very low sun".
+_VERY_LOW_SUN_DEG = 5
 
 # DJI SRT blocks carry an absolute wall-clock datetime on their own line, with
 # the milliseconds separated by either a comma (older firmware) or a dot
@@ -218,6 +222,66 @@ def extract_telemetry_to_gpx(
 
     logger.info("GPX file created: %s", output_path)
     return output_path
+
+
+def summarize_sun(
+    srt_file: Path | str, tz_offset: timedelta | None = None
+) -> dict[str, Any]:
+    """Summarise the sun's track over a clip for footage verification.
+
+    Resolves each GPS point's UTC time (via *tz_offset* or mtime auto-detect),
+    computes solar azimuth/elevation, and returns aggregate stats plus flags:
+    ``night`` (peak elevation below the horizon), ``very_low_sun`` (peak under
+    5 degrees), or ``sun_not_computable`` (no resolvable UTC time). Angular stats
+    are ``None`` when nothing could be computed.
+    """
+    srt_path = Path(srt_file)
+    content = srt_path.read_text(encoding="utf-8")
+    points = _parse_gps_points(content)
+
+    abs_times = [p["datetime"] for p in points if p["datetime"] is not None]
+    mtime_utc = datetime.fromtimestamp(
+        srt_path.stat().st_mtime, tz=timezone.utc
+    ).replace(tzinfo=None)
+    offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
+
+    track: list[tuple[datetime, float, float]] = []  # (utc, azimuth, elevation)
+    if offset is not None:
+        for p in points:
+            if p["datetime"] is None:
+                continue
+            utc = p["datetime"] - offset
+            az, el = sun_position(p["lat"], p["lon"], utc)
+            track.append((utc, az, el))
+
+    summary: dict[str, Any] = {
+        "file": srt_path.name,
+        "points": len(points),
+        "sun_computed": len(track),
+        "utc_start": None,
+        "utc_end": None,
+        "elevation_min": None,
+        "elevation_max": None,
+        "azimuth_start": None,
+        "azimuth_end": None,
+        "flags": [],
+    }
+    if not track:
+        summary["flags"] = ["sun_not_computable"]
+        return summary
+
+    elevations = [el for _, _, el in track]
+    summary["utc_start"] = track[0][0].strftime("%Y-%m-%dT%H:%M:%SZ")
+    summary["utc_end"] = track[-1][0].strftime("%Y-%m-%dT%H:%M:%SZ")
+    summary["elevation_min"] = round(min(elevations), 3)
+    summary["elevation_max"] = round(max(elevations), 3)
+    summary["azimuth_start"] = round(track[0][1], 3)
+    summary["azimuth_end"] = round(track[-1][1], 3)
+    if summary["elevation_max"] < 0:
+        summary["flags"] = ["night"]
+    elif summary["elevation_max"] < _VERY_LOW_SUN_DEG:
+        summary["flags"] = ["very_low_sun"]
+    return summary
 
 
 def batch_convert_to_gpx(directory: Path | str) -> None:

--- a/tests/test_cli_verify_sun.py
+++ b/tests/test_cli_verify_sun.py
@@ -1,0 +1,43 @@
+"""CLI smoke tests for dji-embed verify-sun (issue #216)."""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from dji_metadata_embedder.cli import main
+
+SAMPLES = Path(__file__).resolve().parents[1] / "samples"
+CLIP = SAMPLES / "air3S" / "clip.SRT"
+
+
+def test_verify_sun_json():
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["verify-sun", str(CLIP), "--tz-offset", "0", "--format", "json", "-q"]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["sun_computed"] > 0
+    assert "flags" in data
+    assert isinstance(data["elevation_max"], float)
+
+
+def test_verify_sun_text():
+    runner = CliRunner()
+    result = runner.invoke(main, ["verify-sun", str(CLIP), "--tz-offset", "0"])
+    assert result.exit_code == 0, result.output
+    assert "Sun elevation" in result.output
+
+
+def test_verify_sun_no_datetime(tmp_path):
+    srt = tmp_path / "nodt.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["verify-sun", str(srt), "--format", "json", "-q"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["flags"] == ["sun_not_computable"]

--- a/tests/test_csv_sun.py
+++ b/tests/test_csv_sun.py
@@ -44,3 +44,26 @@ def test_csv_sun_blank_without_datetime(tmp_path):
     assert rows[0]["sun_azimuth"] == ""
     assert rows[0]["sun_elevation"] == ""
     assert rows[0]["latitude"] == "59.0"
+
+
+def test_csv_sun_blank_for_no_fix_frame(tmp_path):
+    # A (0,0) pre-lock frame keeps datetime_utc (time is valid) but no sun angles.
+    srt = tmp_path / "withnofix.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "<font size='36'>SrtCnt : 1\n2024-01-01 12:00:00,000\n"
+        "[latitude: 0.0] [longitude: 0.0] [rel_alt: 0.0 abs_alt: 0.0]</font>\n\n"
+        "2\n00:00:00,033 --> 00:00:00,066\n"
+        "<font size='36'>SrtCnt : 2\n2024-01-01 12:00:33,000\n"
+        "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n"
+    )
+    out = tmp_path / "withnofix.csv"
+    extract_telemetry_to_csv(srt, out, tz_offset=timedelta(hours=2))
+    rows = _read(out)
+    # Row 0 = (0,0) no-fix: datetime resolved, but sun blank.
+    assert rows[0]["datetime_utc"] == "2024-01-01T10:00:00Z"
+    assert rows[0]["sun_azimuth"] == ""
+    assert rows[0]["sun_elevation"] == ""
+    # Row 1 = real fix: sun computed.
+    assert rows[1]["sun_azimuth"] != ""
+    assert rows[1]["sun_elevation"] != ""

--- a/tests/test_csv_sun.py
+++ b/tests/test_csv_sun.py
@@ -1,0 +1,46 @@
+"""Tests for sun/UTC columns in CSV export (issue #216)."""
+
+import csv
+from datetime import timedelta
+
+from dji_metadata_embedder.telemetry_converter import extract_telemetry_to_csv
+
+_DAY_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,033\n"
+    "<font size='36'>SrtCnt : 1, DiffTime : 33ms\n"
+    "2024-01-01 12:00:00,000\n"
+    "[iso : 100] [latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n"
+)
+
+
+def _read(path):
+    return list(csv.DictReader(path.read_text(encoding="utf-8").splitlines()))
+
+
+def test_csv_has_sun_columns(tmp_path):
+    srt = tmp_path / "clip.SRT"
+    srt.write_text(_DAY_SRT)
+    out = tmp_path / "clip.csv"
+    extract_telemetry_to_csv(srt, out, tz_offset=timedelta(hours=2))
+    rows = _read(out)
+    assert rows[0]["datetime_utc"] == "2024-01-01T10:00:00Z"
+    assert abs(float(rows[0]["sun_azimuth"]) - 168.117) < 0.2
+    assert abs(float(rows[0]["sun_elevation"]) - 7.291) < 0.2
+    # Existing columns intact.
+    assert rows[0]["latitude"] == "59.0"
+    assert rows[0]["iso"] == "100"
+
+
+def test_csv_sun_blank_without_datetime(tmp_path):
+    srt = tmp_path / "nodt.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "[iso : 100] [latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]\n"
+    )
+    out = tmp_path / "nodt.csv"
+    extract_telemetry_to_csv(srt, out)
+    rows = _read(out)
+    assert rows[0]["datetime_utc"] == ""
+    assert rows[0]["sun_azimuth"] == ""
+    assert rows[0]["sun_elevation"] == ""
+    assert rows[0]["latitude"] == "59.0"

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -1,0 +1,38 @@
+"""Tests for the clean-room NOAA solar-position helper (issue #216)."""
+
+# Expected az/el values were cross-checked against the solar-noon physical
+# invariant (az~180, el~90-lat at equinox) — see test_solar_noon_invariant_equinox.
+
+from datetime import datetime
+
+from dji_metadata_embedder.geo.solar import sun_position
+
+
+def _close(a: float, b: float, tol: float) -> bool:
+    return abs(a - b) <= tol
+
+
+def test_sun_position_stockholm_winter():
+    az, el = sun_position(59.0, 18.0, datetime(2024, 1, 1, 10, 0, 0))
+    assert _close(az, 168.117, 0.2)
+    assert _close(el, 7.291, 0.2)
+
+
+def test_sun_position_southern_hemisphere():
+    az, el = sun_position(-33.87, 151.21, datetime(2024, 12, 21, 2, 0, 0))
+    assert _close(az, 351.534, 0.2)
+    assert _close(el, 79.465, 0.2)
+
+
+def test_sun_position_high_latitude():
+    az, el = sun_position(69.65, 18.96, datetime(2024, 6, 21, 10, 0, 0))
+    assert _close(az, 165.427, 0.2)
+    assert _close(el, 43.280, 0.2)
+
+
+def test_solar_noon_invariant_equinox():
+    # Independent physics anchor: at local solar noon on the equinox the sun is
+    # due south (az ~180) and elevation ~ 90 - latitude.
+    az, el = sun_position(40.0, 0.0, datetime(2024, 3, 20, 12, 7, 0))
+    assert _close(az, 180.0, 0.3)
+    assert _close(el, 90.0 - 40.0, 0.5)

--- a/tests/test_sun_summary.py
+++ b/tests/test_sun_summary.py
@@ -64,3 +64,19 @@ def test_summarize_sun_not_computable(tmp_path):
     assert s["sun_computed"] == 0
     assert s["flags"] == ["sun_not_computable"]
     assert s["elevation_max"] is None
+
+
+def test_summarize_sun_skips_no_fix_frames(tmp_path):
+    # First block is a pre-GPS-lock (0,0) frame; only the real fix counts.
+    srt = tmp_path / "withnofix.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "<font size='36'>SrtCnt : 1\n2024-01-01 12:00:00,000\n"
+        "[latitude: 0.0] [longitude: 0.0] [rel_alt: 0.0 abs_alt: 0.0]</font>\n\n"
+        "2\n00:00:00,033 --> 00:00:00,066\n"
+        "<font size='36'>SrtCnt : 2\n2024-01-01 12:00:33,000\n"
+        "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n"
+    )
+    s = summarize_sun(srt, tz_offset=timedelta(hours=2))
+    assert s["points"] == 2          # both GPS-bearing lines parsed
+    assert s["sun_computed"] == 1    # only the genuine fix gets a sun angle

--- a/tests/test_sun_summary.py
+++ b/tests/test_sun_summary.py
@@ -1,0 +1,66 @@
+"""Tests for summarize_sun (issue #216)."""
+
+from datetime import timedelta
+
+from dji_metadata_embedder.telemetry_converter import summarize_sun
+
+_DAY_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,033\n"
+    "<font size='36'>SrtCnt : 1, DiffTime : 33ms\n"
+    "2024-01-01 12:00:00,000\n"
+    "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n\n"
+    "2\n00:00:00,033 --> 00:00:00,066\n"
+    "<font size='36'>SrtCnt : 2, DiffTime : 33ms\n"
+    "2024-01-01 12:00:33,000\n"
+    "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n"
+)
+
+
+def test_summarize_sun_basic(tmp_path):
+    srt = tmp_path / "clip.SRT"
+    srt.write_text(_DAY_SRT)
+    s = summarize_sun(srt, tz_offset=timedelta(hours=2))
+    assert s["points"] == 2
+    assert s["sun_computed"] == 2
+    assert s["utc_start"] == "2024-01-01T10:00:00Z"
+    assert abs(s["azimuth_start"] - 168.117) < 0.2
+    assert abs(s["elevation_max"] - 7.291) < 0.3
+    assert s["flags"] == []  # 7.3 deg: above horizon and above the 5 deg floor
+
+
+def test_summarize_sun_night_flag(tmp_path):
+    srt = tmp_path / "night.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "<font size='36'>SrtCnt : 1\n2024-01-01 00:30:00,000\n"
+        "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n"
+    )
+    s = summarize_sun(srt, tz_offset=timedelta(hours=1))
+    assert s["sun_computed"] == 1
+    assert s["elevation_max"] < 0
+    assert s["flags"] == ["night"]
+
+
+def test_summarize_sun_very_low_sun_flag(tmp_path):
+    srt = tmp_path / "lowsun.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "<font size='36'>SrtCnt : 1\n2024-12-21 12:00:00,000\n"
+        "[latitude: 63.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n"
+    )
+    s = summarize_sun(srt, tz_offset=timedelta(hours=1))
+    assert s["sun_computed"] == 1
+    assert 0 < s["elevation_max"] < 5
+    assert s["flags"] == ["very_low_sun"]
+
+
+def test_summarize_sun_not_computable(tmp_path):
+    srt = tmp_path / "nodt.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]\n"
+    )
+    s = summarize_sun(srt)
+    assert s["sun_computed"] == 0
+    assert s["flags"] == ["sun_not_computable"]
+    assert s["elevation_max"] is None

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -130,3 +130,32 @@ def test_gpx_falls_back_when_no_absolute_datetime(tmp_path):
     text = out.read_text()
     assert "<trkpt" in text
     assert "00:00:00,000" in text
+
+
+def test_resolve_utc_offset_explicit_wins():
+    from dji_metadata_embedder.telemetry_converter import resolve_utc_offset
+
+    off = resolve_utc_offset(
+        [datetime(2024, 1, 1, 12, 0, 0)],
+        timedelta(hours=2),
+        datetime(2024, 1, 1, 9, 0, 0),
+    )
+    assert off == timedelta(hours=2)
+
+
+def test_resolve_utc_offset_none_without_abs_times():
+    from dji_metadata_embedder.telemetry_converter import resolve_utc_offset
+
+    assert resolve_utc_offset([], None, datetime(2024, 1, 1, 9, 0, 0)) is None
+
+
+def test_resolve_utc_offset_autodetects_from_mtime():
+    from dji_metadata_embedder.telemetry_converter import resolve_utc_offset
+
+    # mtime = recording end in UTC for a UTC+2 local clock.
+    off = resolve_utc_offset(
+        [datetime(2024, 1, 1, 12, 0, 0), datetime(2024, 1, 1, 12, 0, 30)],
+        None,
+        datetime(2024, 1, 1, 10, 0, 30),
+    )
+    assert off == timedelta(hours=2)


### PR DESCRIPTION
Closes #216.

## Summary
Adds the ability to cross-check shadows in footage against where the sun actually was — a standard chronolocation / footage-verification technique, on the project's use-for-good direction.

- **`geo/solar.py`** — clean-room NOAA solar-position helper `sun_position(lat, lon, when_utc) -> (azimuth, elevation)`. Pure stdlib `math`, **no new runtime deps**, accuracy well under ±0.5°.
- **Shared UTC resolver** — extracted `resolve_utc_offset` + `_parse_gps_points` out of the GPX exporter (refactored onto them, behavior-preserving) so CSV and the new command reuse one offset-resolution path.
- **CSV export** gains `datetime_utc`, `sun_azimuth`, `sun_elevation` columns (blank when no absolute datetime is resolvable; sun blank for pre-GPS-lock `(0,0)` frames).
- **`dji-embed verify-sun <SRT>`** — text/json summary of the sun track over a clip with `night` / `very_low_sun` / `sun_not_computable` flags; `--tz-offset` (default auto) and `--format`, mirroring `validate`.
- **Docs** — "Footage verification (sun / shadow check)" section in `docs/user_guide.md` + README bullet.

Design spec: `docs/superpowers/specs/2026-06-13-sun-position-verification-design.md`.

Out of scope (deferred): GeoJSON/GPX sun extensions; moving absolute datetime into the canonical `Track` model.

## Test Plan
- [x] `uv run pytest -q` → 138 passed, 1 skipped (pre-existing flask/UI skip)
- [x] `uv run ruff check src/` → clean
- [x] Solar function unit-tested vs reference values + an independent solar-noon physics anchor (S-hemisphere & high-latitude cases included)
- [x] CSV columns: filled-with-datetime, blank-without-datetime, and blank-for-(0,0)-no-fix cases
- [x] `verify-sun` smoke tests: text + json, and `sun_not_computable` path
- [x] GPX regression tests still green after the resolver extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)