### PR TITLE
feat(geo): CoT (Cursor-on-Target) export (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,12 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release]][release]
-[![Version](https://img.shields.io/badge/version-1.7.0-blue)][release]
+[![Version](https://img.shields.io/badge/version-1.8.0-blue)][release]
 [![PyPI]][pypi]
 
 A Python tool to embed telemetry data from DJI drone SRT files into MP4 video files.
 This tool extracts GPS coordinates, altitude, camera settings and other telemetry data from SRT files and embeds
 them as metadata in the corresponding video files.
-
-> **Production Ready** ✅
-> 
-> All major milestones (M1-M4) completed! The tool features comprehensive documentation, 
-> professional CLI, automated testing, and supports major DJI drone models.
-> Future releases focus on new model support and community enhancements.
 
 See the [Development Roadmap](docs/development_roadmap.md) for plans to expand this CLI tool into a Windows
 application with a graphical interface.
@@ -132,7 +126,7 @@ dji-embed [OPTIONS] COMMAND [ARGS]...
 Commands:
   embed    Embed telemetry from SRT files into MP4 videos
   validate Validate SRT/MP4 pairs and report drift
-  convert  Convert SRT telemetry to GPX or CSV
+  convert  Convert SRT telemetry to GPX, CSV, GeoJSON, KML, HTML, or CoT
   check    Check media files for embedded metadata
   doctor   Show system information and verify dependencies
   ui       Launch the local web UI in your browser
@@ -291,21 +285,23 @@ Options:
 ```
 
 #### `dji-embed convert` - Export Formats
-Convert SRT telemetry to GPX, CSV, GeoJSON, KML, or a standalone HTML map.
+Convert SRT telemetry to GPX, CSV, GeoJSON, KML, CoT, or a standalone HTML map.
 
 ```bash
-dji-embed convert [OPTIONS] {gpx|csv|geojson|kml|html} INPUT
+dji-embed convert [OPTIONS] {gpx|csv|geojson|kml|html|cot} INPUT
 
 Arguments:
-  {gpx|csv|geojson|kml|html} Output format
+  {gpx|csv|geojson|kml|html|cot} Output format
   INPUT                      SRT file or directory to convert
 
 Options:
   -o, --output PATH          Output file path
   -b, --batch                Batch process directory
-  --tz-offset OFFSET         UTC offset for GPX timestamps, e.g. '+05:30' or
+  --tz-offset OFFSET         UTC offset for GPX/CoT timestamps, e.g. '+05:30' or
                              '-8' ('auto' detects from file mtime; default: auto)
-  --redact [none|drop|fuzz]  GPS redaction for geojson/kml/html (default: none)
+  --redact [none|drop|fuzz]  GPS redaction for geojson/kml/html/cot (default: none)
+  --interval FLOAT           cot only: seconds between sampled points (default: 1.0)
+  --cot-type CODE            cot only: CoT type/affiliation code (default: a-n-A)
   -v, --verbose              Verbose output
   -q, --quiet                Suppress info output
 ```
@@ -315,6 +311,13 @@ Options:
 ```bash
 dji-embed convert html DJI_0001.SRT              # -> DJI_0001.html
 dji-embed convert html DJI_0001.SRT -o flight.html
+```
+
+**CoT (Cursor-on-Target) example** — for ATAK/TAK; see [docs/fmv-interop.md](docs/fmv-interop.md):
+
+```bash
+dji-embed convert cot DJI_0001.SRT                       # -> DJI_0001.cot.xml
+dji-embed convert cot DJI_0001.SRT --interval 2 --cot-type a-u-A
 ```
 
 Leaflet and the basemap tiles load from the internet; the flight data itself is embedded, so the file is portable but needs a connection to render the map.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **Subtitle Track Preservation**: Keep telemetry data as subtitle track for overlay viewing
 - **Multiple Format Support**: Handles different DJI SRT telemetry formats
 - **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, KML, or a standalone HTML map (see [docs/geospatial.md](docs/geospatial.md))
+- **CoT Export**: `dji-embed convert cot FLIGHT.SRT` writes Cursor-on-Target XML for ATAK/TAK (route + timed track). See [docs/fmv-interop.md](docs/fmv-interop.md).
 - **Footage verification:** `dji-embed verify-sun clip.SRT` reports the sun's azimuth/elevation over a clip for shadow cross-checking; CSV export gains `datetime_utc` / `sun_azimuth` / `sun_elevation` columns.
 - **DAT Flight Log Support**: Merge `.DAT` flight logs into metadata
 - **Cross-Platform**: Works on Windows, macOS, and Linux

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/docs/fmv-interop.md
+++ b/docs/fmv-interop.md
@@ -1,0 +1,59 @@
+# FMV / GIS interop: Cursor-on-Target (CoT)
+
+`dji-embed` can export a flight as **Cursor-on-Target (CoT)** XML for the
+ATAK/TAK ecosystem — useful for SAR, disaster response, and verification
+workflows. This is export-only; embedding metadata into the video and MISB 0601
+KLV are tracked separately (see "Roadmap" below).
+
+## Usage
+
+```bash
+# Write <name>.cot.xml next to the SRT
+dji-embed convert cot FLIGHT.SRT
+
+# Choose an output path, sample one point per 2 s, set the CoT type
+dji-embed convert cot FLIGHT.SRT -o flight.cot.xml --interval 2 --cot-type a-f-A-M-H-Q
+
+# Redact coordinates (drop removes the track; fuzz coarsens to ~100 m)
+dji-embed convert cot FLIGHT.SRT --redact fuzz
+
+# Override the local->UTC offset (default: auto-detect from file mtime)
+dji-embed convert cot FLIGHT.SRT --tz-offset +02:00
+```
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `--interval` | `1.0` | Seconds between sampled track points (DJI SRT is ~30 blocks/s). |
+| `--cot-type` | `a-n-A` | CoT type/affiliation code. Default is **neutral air**. |
+| `--redact` | `none` | `drop` empties the track; `fuzz` coarsens to ~100 m. |
+| `--tz-offset` | `auto` | Local->UTC offset for timestamps, e.g. `+05:30`, `-8`. |
+
+## What the file contains
+
+A single well-formed XML document with an `<events>` root holding:
+
+- **Timed PLI events** — one `<event>` per sampled point, sharing the UID stem
+  `DJI-<name>-<i>`, with UTC `time`/`start`, a `<point>` (lat/lon/`hae`), and
+  `<detail>` carrying `<contact>`, `<precisionlocation>`, and a derived
+  `<track course=... speed=...>` (great-circle bearing + speed between consecutive
+  sampled points; omitted at the final point).
+- **One route event** (`type="b-m-r"`) whose `<link>` elements trace the path.
+
+## Ingestion notes & caveats
+
+- **The timed PLI track is the primary, standards-clean representation.** The
+  `b-m-r` route is best-effort: full TAK route semantics (control points,
+  `__routeinfo`, `__navcues`) are intentionally not reproduced.
+- **Altitude** is DJI `abs_alt` placed in `hae` (height above ellipsoid). DJI
+  altitude is not strictly WGS-84 ellipsoidal, so treat it as approximate.
+- **`ce`/`le`** (positional error) are set to the CoT "unknown" sentinel
+  `9999999.0`.
+- **Timestamps** are real UTC when the SRT carries an absolute datetime;
+  otherwise they are synthesized from the file mtime plus cue spacing
+  (monotonic, approximate).
+
+## Roadmap
+
+- **MISB 0601 / STANAG 4609 KLV** encoding (and muxing into the MP4) — the
+  larger, fiddly half of issue #217, tracked separately.
+- **Network push** (UDP multicast / TCP to a TAK server) — file export first.

--- a/docs/superpowers/specs/2026-06-13-cot-export-design.md
+++ b/docs/superpowers/specs/2026-06-13-cot-export-design.md
@@ -1,0 +1,232 @@
+# CoT (Cursor-on-Target) export — design
+
+_Date: 2026-06-13 · Issue: #217 (CoT half) · Status: approved, pre-implementation_
+
+## Summary
+
+Add `dji-embed convert cot <SRT>` to export a DJI flight as a **Cursor-on-Target
+(CoT) XML** file for the ATAK/TAK ecosystem. This is the small, self-contained
+half of #217 — **export only, file output only**. The Large/fiddly **MISB 0601
+KLV** half and any **network push** to a TAK server are explicitly out of scope
+and remain follow-ups.
+
+CoT slots into the project's [use-for-good direction](../../../README.md#intended-use--scope):
+SAR, disaster response, and verification tooling (ATAK/TAK, ArcGIS FMV, QGIS) is
+exactly where open conversion helps the good side. The default CoT affiliation is
+**neutral** to match that civilian/verification framing.
+
+## Scope decisions (settled during brainstorming)
+
+| Decision | Choice |
+| --- | --- |
+| Output target | **File only** (`<srt>.cot.xml`). No sockets / network push. |
+| Flight representation | **Both** a route polyline **and** per-point timed PLI events. |
+| Default CoT type | **`a-n-A`** (neutral air), overridable via `--cot-type`. |
+| Track course/speed | **Included** — derived from consecutive points (great-circle bearing + haversine speed). |
+| New runtime deps | **None** (stdlib `xml`/serialization only). |
+
+## Background
+
+`telemetry_converter.py` already extracts per-point lat/lon/alt and resolves real
+UTC time for GPX (issue #202). The `geo/` package already hosts a shared `Track`
+model plus GeoJSON/KML/HTML exporters (issues #215, #221). CoT follows the same
+`convert <fmt>` + `geo/<fmt>.py` exporter pattern.
+
+The one genuinely new problem CoT introduces: **every CoT event legally requires
+a real ISO-8601 UTC timestamp**, but the shared `Track`/`TrackPoint` model today
+carries only the raw SRT *cue* string (e.g. `00:00:01,000`). The UTC-resolution
+machinery lives in `telemetry_converter.py`, which `geo/` **cannot import** —
+`telemetry_converter` already does `from .geo.solar import sun_position`, so a
+`geo → telemetry_converter` import would create a cycle.
+
+## Architecture
+
+### Approach (and rejected alternatives)
+
+**Chosen — extend the `Track` layer with resolved UTC.** Move the UTC helpers down
+into the lower-level `utilities.py` (which `geo/` already imports safely), enrich
+the canonical parse with an aligned absolute datetime, and populate a `utc` field
+on each `TrackPoint`. CoT — and any future exporter — reads `point.utc`. Redaction
+stays centralized in the `Track` layer, preserving the project's "redaction
+enforced once so no exporter can bypass `--redact`" invariant.
+
+- **Rejected B — CoT resolves its own timestamps, Track for coords only.** Re-parse
+  datetimes in the CoT module and zip onto Track points. Fragile: `Track` drops
+  `(0,0)` no-fix frames and can redact/drop points, so a separately-parsed datetime
+  list misaligns; also duplicates parsing.
+- **Rejected C — separate CoT data path, bypass Track.** Violates the deliberate
+  "redaction enforced once at `Track`" invariant; a future redaction change could
+  silently miss CoT.
+
+### 1. `utilities.py` — canonical parse + UTC helpers (cycle-breaking move)
+
+- **New `parse_telemetry_samples(srt_path) -> list[TelemetrySample]`** where
+  `TelemetrySample` is a small dataclass `(lat, lon, alt, cue, dt)`:
+  - Reuses the **existing** regex/extraction logic of `parse_telemetry_points`
+    (bracket format + `GPS(...)` compact + M300 `0.0M` suffix + `is_gps_fix`
+    `(0,0)` filtering) so no format support is lost.
+  - Additionally captures the block's absolute wall-clock datetime (`dt`, or
+    `None` when the format carries none).
+- **`parse_telemetry_points` becomes a thin wrapper** returning the existing
+  4-tuple `(lat, lon, alt, cue)` from `parse_telemetry_samples`. Its signature and
+  behavior are unchanged, so `per_frame_embedder.py` and all existing tests
+  (`test_gps_nofix`, `test_golden_fixtures`, `test_samples`, `test_new_model_samples`)
+  are untouched. A regression test pins this equivalence.
+- **Move** `_parse_srt_datetime`, `parse_utc_offset`, `estimate_utc_offset`,
+  `resolve_utc_offset` from `telemetry_converter.py` into `utilities.py`.
+  `telemetry_converter.py` **re-exports** them (`from .utilities import ...`) so
+  existing imports keep working — notably `tests/test_timezone.py`, which imports
+  `estimate_utc_offset` / `parse_utc_offset` from `telemetry_converter`. This move
+  is what breaks the import cycle; it is in-scope because `Track` legitimately needs
+  UTC resolution and the lower-level home is the correct one.
+
+### 2. `geo/track.py` — UTC on every point
+
+- `TrackPoint` gains **`utc: datetime | None = None`**. The default keeps existing
+  direct constructions in tests valid; geojson/kml/html ignore the field, so their
+  output is unchanged.
+- `build_track(srt, redact="none", tz_offset=None)` gains `tz_offset`:
+  - Parses via `parse_telemetry_samples` (datetimes aligned to kept points by
+    construction).
+  - Resolves the local→UTC offset with `resolve_utc_offset(abs_times, tz_offset,
+    mtime_utc)` — auto-detected from file mtime, or the explicit `--tz-offset`.
+  - Sets each point's `utc`:
+    - When the block has an absolute datetime → `utc = dt - offset`.
+    - When it does not → **synthesized** as `mtime_utc + (cue − first_cue)` so CoT
+      always has monotonic UTC time. Documented as approximate.
+- geojson/kml/html callers keep calling `build_track(srt, redact=redact)` (auto
+  tz); they don't read `utc`.
+
+### 3. `geo/cot.py` — the exporter (mirrors `kml.py`)
+
+Public surface, matching the existing exporter shape:
+
+```python
+def track_to_cot(track: Track, *, cot_type: str = "a-n-A",
+                 interval: float = 1.0, stale_seconds: float = 300.0) -> str: ...
+def write_cot(track: Track, output_path: Path, **kw) -> Path: ...
+def convert_to_cot(srt_file, output_file=None, *, redact="none",
+                   tz_offset=None, interval=1.0, cot_type="a-n-A") -> Path: ...
+```
+
+Exported from `geo/__init__.py` (`convert_to_cot`, `track_to_cot`).
+
+**Downsampling.** SRT carries one block per video frame (~30/s). Both the PLI
+events and the route vertices use a single **sampled** point list: walking the
+track in cue-time order, keep the first point whose cue time is ≥ `interval`
+seconds after the last kept point (default `interval = 1.0`). First and last
+points are always kept.
+
+**Output: one well-formed XML document, `<events>` root** containing:
+
+- **Timed PLI events** — one `<event>` per sampled point:
+  ```xml
+  <event version="2.0" uid="DJI-{stem}-{i}" type="{cot_type}" how="m-g"
+         time="{utc}" start="{utc}" stale="{utc + stale_seconds}">
+    <point lat="{lat}" lon="{lon}" hae="{alt}" ce="9999999.0" le="9999999.0"/>
+    <detail>
+      <contact callsign="{stem}"/>
+      <precisionlocation altsrc="GPS"/>
+      <track course="{course}" speed="{speed}"/>   <!-- when derivable -->
+      <remarks>frame {i}, abs_alt {alt} m</remarks>
+    </detail>
+  </event>
+  ```
+  - `type` defaults to `a-n-A` (neutral air); `--cot-type` overrides verbatim.
+  - `how="m-g"` = machine / GPS-derived.
+  - DJI `abs_alt` → `hae` (height above ellipsoid). DJI altitude is not strictly
+    WGS-84 ellipsoidal; documented caveat in `docs/fmv-interop.md`.
+  - Unknown position error → CoT's `9999999.0` sentinel for `ce`/`le`.
+  - `time`/`start` = the point's UTC; `stale` = `time + stale_seconds`
+    (default 300 s for PLI events). No CLI knob for stale (YAGNI).
+- **One route event** — `type="b-m-r"`, with a `<link>` per sampled vertex
+  carrying `point="lat,lon,hae"`, `<contact callsign="{stem} route"/>`, and a
+  `<remarks>` point count. `stale` set generously (event end + 1 h).
+
+**Course/speed derivation (included).** For each sampled point with a following
+sampled point and `dt > 0` (using the resolved `utc` values):
+
+- `speed` (m/s) = haversine great-circle distance between the two points ÷ `dt`.
+- `course` (deg, `[0, 360)`) = initial great-circle bearing to the next point.
+- The `<track>` element is **omitted** where undefined (the final point, or
+  `dt == 0`). Small `_haversine_m` / `_initial_bearing_deg` helpers live in
+  `geo/cot.py` (its only consumer for now).
+
+**Representation honesty.** The PLI track is the **primary, schema-clean**
+representation (standard, unambiguous CoT events). The `b-m-r` route is
+**best-effort**: full TAK route semantics (control points, `__routeinfo`,
+`__navcues`) are finicky and can't be validated offline without a TAK endpoint.
+`docs/fmv-interop.md` states this plainly and points users to the PLI track as the
+robust path. Tests validate the route at the "well-formed + expected
+elements/attributes present" level, not full TAK semantic round-trip.
+
+### 4. CLI (`cli.py`)
+
+- Add `"cot"` to the `convert` command's `click.Choice`.
+- Two new **shared** options on `convert` (the command already shares options
+  across formats; non-cot formats ignore them, exactly as `--redact` is today
+  documented as geojson/kml/html-only):
+  - `--interval FLOAT` (default `1.0`, help notes "cot only: seconds between
+    sampled points").
+  - `--cot-type TEXT` (default `a-n-A`, help notes "cot only: CoT type/affiliation
+    code").
+- `--redact` and `--tz-offset` already exist on `convert` and flow through.
+- Dispatch: `elif command == "cot": convert_to_cot(srt, out, redact=redact,
+  tz_offset=offset, interval=interval, cot_type=cot_type)`.
+
+## Edge cases
+
+| Input | Output |
+| --- | --- |
+| 0 track points (no GPS fix, or `--redact drop`) | Well-formed empty `<events/>` + a `WARNING` log; exit success. |
+| 1 track point | A single PLI event, **no** route (route needs ≥ 2 vertices, mirroring the geojson LineString ≥ 2 guard). No `<track>` (course/speed undefined). |
+| No absolute datetime in SRT | `utc` synthesized from `mtime + cue` offset; CoT still valid, times approximate (documented). |
+| `--redact fuzz` | Coarsened coordinates arrive via `Track`; CoT emits the fuzzed values. |
+
+## Testing (offline, no new deps — stdlib `xml.etree.ElementTree`)
+
+New `tests/test_geo_cot.py` and additions to `tests/test_cli_convert_geo.py`:
+
+- Fixture SRT → output parses as well-formed XML with `<events>` root.
+- Event count matches expectation for a given `--interval` (downsampling correct).
+- PLI `time`/`start` are ISO-8601 UTC (`...Z`); `stale` > `time`.
+- `point` `lat`/`lon`/`hae` match the (possibly redacted) track values.
+- Default `type` is `a-n-A`; `--cot-type` override is emitted verbatim.
+- Redaction: `fuzz` coarsens emitted coords; `drop` yields empty `<events/>`.
+- A route `<event type="b-m-r">` exists with one `<link>` per sampled vertex.
+- Course/speed: a hand-computed 2-point fixture yields the expected `course`/`speed`
+  within tolerance; endpoint correctly omits `<track>`.
+- Edge cases: 0-point and 1-point inputs (table above).
+- CLI smoke test: `convert cot <fixture>` writes `<stem>.cot.xml`, exit 0.
+- **Regression:** `parse_telemetry_points` returns the identical 4-tuple list
+  before/after the `parse_telemetry_samples` refactor (golden fixtures).
+
+## Documentation
+
+- **New `docs/fmv-interop.md`**: CoT section (what it is, the `convert cot` command,
+  `--interval`/`--cot-type`/`--redact`/`--tz-offset`, TAK ingestion notes, the
+  `hae` altitude caveat, and the route best-effort caveat). A short **KLV stub**
+  section marks the #217 follow-up.
+- **README**: one bullet under the export/geospatial features; link to
+  `docs/fmv-interop.md`.
+- **`convert` help text**: mention `cot` and the two new options.
+
+## Out of scope (follow-ups)
+
+- **MISB 0601 / STANAG 4609 KLV** encoding + muxing — the Large half of #217.
+- **Network push** (UDP multicast / TCP to a TAK server).
+- Unifying `utilities.parse_telemetry_samples` with
+  `telemetry_converter._parse_gps_points` (they differ on `(0,0)` filtering;
+  left as-is to avoid an unrelated refactor / regression risk).
+
+## Acceptance criteria (this slice)
+
+- [ ] `dji-embed convert cot <SRT>` produces a well-formed CoT XML file.
+- [ ] Output contains timed PLI events (downsampled by `--interval`) **and** a
+      route event; PLI events carry UTC time and derived course/speed where defined.
+- [ ] `--cot-type` overrides the default `a-n-A`; `--redact` and `--tz-offset` honored.
+- [ ] Graceful handling of 0-/1-point and datetime-less inputs.
+- [ ] Unit tests (XML structure, counts, UTC, redaction, course/speed) + CLI smoke
+      test, all offline; `parse_telemetry_points` regression test passes.
+- [ ] Docs: `docs/fmv-interop.md` + README bullet + `convert` help text.
+- [ ] No new runtime dependencies.

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,6 +1,6 @@
 """DJI Drone Metadata Embedder."""
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 # Import check to ensure files were moved correctly
 try:

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -177,7 +177,7 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     type=click.Choice(["none", "drop", "fuzz"], case_sensitive=False),
     default="none",
     show_default=True,
-    help="GPS redaction for geojson/kml/html: drop removes the track, "
+    help="GPS redaction for geojson/kml/html/cot: drop removes the track, "
     "fuzz coarsens to ~100 m.",
 )
 @click.option(

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -169,7 +169,7 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     default="auto",
     show_default=True,
     metavar="OFFSET",
-    help="UTC offset for GPX timestamps, e.g. '+05:30' or '-8'. "
+    help="UTC offset for GPX/CoT timestamps, e.g. '+05:30' or '-8'. "
     "'auto' detects it from the SRT file mtime.",
 )
 @click.option(

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -16,7 +16,7 @@ from .telemetry_converter import (
     parse_utc_offset,
     summarize_sun,
 )
-from .geo import convert_to_geojson, convert_to_kml, convert_to_html
+from .geo import convert_to_geojson, convert_to_kml, convert_to_html, convert_to_cot
 from .utilities import check_dependencies, setup_logging, get_tool_versions
 
 
@@ -158,7 +158,7 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
 @click.argument(
     "command",
     type=click.Choice(
-        ["gpx", "csv", "geojson", "kml", "html"], case_sensitive=False
+        ["gpx", "csv", "geojson", "kml", "html", "cot"], case_sensitive=False
     ),
 )
 @click.argument("input", type=click.Path(exists=True))
@@ -180,6 +180,20 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     help="GPS redaction for geojson/kml/html: drop removes the track, "
     "fuzz coarsens to ~100 m.",
 )
+@click.option(
+    "--interval",
+    type=float,
+    default=1.0,
+    show_default=True,
+    help="cot only: seconds between sampled track points.",
+)
+@click.option(
+    "--cot-type",
+    default="a-n-A",
+    show_default=True,
+    metavar="CODE",
+    help="cot only: CoT event type/affiliation code (default neutral air).",
+)
 @click.option("-v", "--verbose", is_flag=True)
 @click.option("-q", "--quiet", is_flag=True)
 def convert(
@@ -189,10 +203,12 @@ def convert(
     batch: bool,
     tz_offset: str,
     redact: str,
+    interval: float,
+    cot_type: str,
     verbose: bool,
     quiet: bool,
 ) -> None:
-    """Convert SRT telemetry to GPX, CSV, GeoJSON, KML, or a standalone HTML map.
+    """Convert SRT telemetry to GPX, CSV, GeoJSON, KML, CoT, or a standalone HTML map.
 
     The html format embeds the flight data but loads Leaflet and the map tiles
     from the internet, so the produced file needs a connection to render.
@@ -217,6 +233,11 @@ def convert(
             convert_to_geojson(srt, out, redact=redact)
         elif command == "kml":
             convert_to_kml(srt, out, redact=redact)
+        elif command == "cot":
+            convert_to_cot(
+                srt, out, redact=redact, tz_offset=offset,
+                interval=interval, cot_type=cot_type,
+            )
         else:  # html
             convert_to_html(srt, out, redact=redact)
 

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -1,5 +1,6 @@
-"""Geospatial track model and exporters (GeoJSON, KML, HTML)."""
+"""Geospatial track model and exporters (GeoJSON, KML, HTML, CoT)."""
 
+from .cot import convert_to_cot, track_to_cot
 from .geojson import convert_to_geojson, track_to_geojson
 from .html_viewer import convert_to_html, track_to_html
 from .kml import convert_to_kml, track_to_kml
@@ -11,6 +12,8 @@ __all__ = [
     "TrackPoint",
     "build_track",
     "sun_position",
+    "track_to_cot",
+    "convert_to_cot",
     "track_to_geojson",
     "convert_to_geojson",
     "track_to_kml",

--- a/src/dji_metadata_embedder/geo/cot.py
+++ b/src/dji_metadata_embedder/geo/cot.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import math
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
@@ -28,6 +28,20 @@ _CE_LE_UNKNOWN = "9999999.0"
 _COT_TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
 # Mean Earth radius (m, IUGG) for the haversine helpers.
 _EARTH_R = 6371008.8
+
+
+def _utc(p: TrackPoint) -> datetime:
+    """Return *p*'s resolved UTC, enforcing the CoT precondition.
+
+    ``build_track`` always populates ``TrackPoint.utc``; this guard turns a
+    hand-built track that skipped it into a clear error instead of a cryptic
+    ``NoneType`` failure (and narrows the type for the serializer)."""
+    if p.utc is None:
+        raise ValueError(
+            "TrackPoint.utc is None; CoT export requires build_track to "
+            "populate it (got a Track built another way)"
+        )
+    return p.utc
 
 
 def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -54,11 +68,11 @@ def _downsample(points: list[TrackPoint], interval: float) -> list[TrackPoint]:
     if not points:
         return []
     kept = [points[0]]
-    last = points[0].utc
+    last = _utc(points[0])
     for p in points[1:-1]:
-        if (p.utc - last).total_seconds() >= interval:
+        if (_utc(p) - last).total_seconds() >= interval:
             kept.append(p)
-            last = p.utc
+            last = _utc(p)
     if len(points) > 1:
         kept.append(points[-1])
     return kept
@@ -87,8 +101,9 @@ def _append_pli_event(
     cot_type: str,
     stale_seconds: float,
 ) -> None:
-    t = p.utc.strftime(_COT_TIME_FMT)
-    stale = (p.utc + timedelta(seconds=stale_seconds)).strftime(_COT_TIME_FMT)
+    p_utc = _utc(p)
+    t = p_utc.strftime(_COT_TIME_FMT)
+    stale = (p_utc + timedelta(seconds=stale_seconds)).strftime(_COT_TIME_FMT)
     ev = ET.SubElement(
         root,
         "event",
@@ -107,7 +122,7 @@ def _append_pli_event(
     ET.SubElement(detail, "contact", {"callsign": name})
     ET.SubElement(detail, "precisionlocation", {"altsrc": "GPS"})
     if nxt is not None:
-        dt = (nxt.utc - p.utc).total_seconds()
+        dt = (_utc(nxt) - p_utc).total_seconds()
         if dt > 0:
             dist = _haversine_m(p.lat, p.lon, nxt.lat, nxt.lon)
             ET.SubElement(
@@ -123,8 +138,8 @@ def _append_pli_event(
 
 def _append_route_event(root: ET.Element, name: str, sampled: list[TrackPoint]) -> None:
     first, last = sampled[0], sampled[-1]
-    t = first.utc.strftime(_COT_TIME_FMT)
-    stale = (last.utc + timedelta(hours=1)).strftime(_COT_TIME_FMT)
+    t = _utc(first).strftime(_COT_TIME_FMT)
+    stale = (_utc(last) + timedelta(hours=1)).strftime(_COT_TIME_FMT)
     ev = ET.SubElement(
         root,
         "event",

--- a/src/dji_metadata_embedder/geo/cot.py
+++ b/src/dji_metadata_embedder/geo/cot.py
@@ -1,0 +1,206 @@
+"""Render a :class:`Track` as Cursor-on-Target (CoT) XML for ATAK/TAK.
+
+Emits one well-formed XML document with an ``<events>`` root holding timed PLI
+position events (the primary, schema-clean representation) plus a best-effort
+``b-m-r`` route polyline. Course/speed are derived from consecutive sampled
+points. See docs/fmv-interop.md for ingestion notes and caveats.
+
+Security note: this module only *writes* XML using stdlib ``xml.etree.ElementTree``
+(ET.Element / ET.SubElement / ET.tostring). It never parses untrusted external XML,
+so the XXE / billion-laughs parser-side vulnerabilities that ``defusedxml`` guards
+against are not applicable here.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import timedelta
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from .track import Track, TrackPoint, build_track
+
+logger = logging.getLogger(__name__)
+
+# CoT sentinel for unknown circular/linear error (90% containment, metres).
+_CE_LE_UNKNOWN = "9999999.0"
+_COT_TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
+# Mean Earth radius (m, IUGG) for the haversine helpers.
+_EARTH_R = 6371008.8
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in metres between two WGS84 points."""
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlmb = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
+    return 2 * _EARTH_R * math.asin(math.sqrt(a))
+
+
+def _initial_bearing_deg(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Initial great-circle bearing (degrees, 0..360) from point 1 to point 2."""
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dl = math.radians(lon2 - lon1)
+    y = math.sin(dl) * math.cos(p2)
+    x = math.cos(p1) * math.sin(p2) - math.sin(p1) * math.cos(p2) * math.cos(dl)
+    return (math.degrees(math.atan2(y, x)) + 360.0) % 360.0
+
+
+def _downsample(points: list[TrackPoint], interval: float) -> list[TrackPoint]:
+    """Keep the first point, then each point at least ``interval`` s after the
+    last kept one (by ``utc``), always keeping the final point."""
+    if not points:
+        return []
+    kept = [points[0]]
+    last = points[0].utc
+    for p in points[1:-1]:
+        if (p.utc - last).total_seconds() >= interval:
+            kept.append(p)
+            last = p.utc
+    if len(points) > 1:
+        kept.append(points[-1])
+    return kept
+
+
+def _add_point(ev: ET.Element, p: TrackPoint) -> None:
+    ET.SubElement(
+        ev,
+        "point",
+        {
+            "lat": f"{p.lat}",
+            "lon": f"{p.lon}",
+            "hae": f"{p.alt}",
+            "ce": _CE_LE_UNKNOWN,
+            "le": _CE_LE_UNKNOWN,
+        },
+    )
+
+
+def _append_pli_event(
+    root: ET.Element,
+    name: str,
+    index: int,
+    p: TrackPoint,
+    nxt: TrackPoint | None,
+    cot_type: str,
+    stale_seconds: float,
+) -> None:
+    t = p.utc.strftime(_COT_TIME_FMT)
+    stale = (p.utc + timedelta(seconds=stale_seconds)).strftime(_COT_TIME_FMT)
+    ev = ET.SubElement(
+        root,
+        "event",
+        {
+            "version": "2.0",
+            "uid": f"DJI-{name}-{index}",
+            "type": cot_type,
+            "how": "m-g",
+            "time": t,
+            "start": t,
+            "stale": stale,
+        },
+    )
+    _add_point(ev, p)
+    detail = ET.SubElement(ev, "detail")
+    ET.SubElement(detail, "contact", {"callsign": name})
+    ET.SubElement(detail, "precisionlocation", {"altsrc": "GPS"})
+    if nxt is not None:
+        dt = (nxt.utc - p.utc).total_seconds()
+        if dt > 0:
+            dist = _haversine_m(p.lat, p.lon, nxt.lat, nxt.lon)
+            ET.SubElement(
+                detail,
+                "track",
+                {
+                    "course": f"{_initial_bearing_deg(p.lat, p.lon, nxt.lat, nxt.lon):.1f}",
+                    "speed": f"{dist / dt:.2f}",
+                },
+            )
+    ET.SubElement(detail, "remarks").text = f"frame {index}, abs_alt {p.alt} m"
+
+
+def _append_route_event(root: ET.Element, name: str, sampled: list[TrackPoint]) -> None:
+    first, last = sampled[0], sampled[-1]
+    t = first.utc.strftime(_COT_TIME_FMT)
+    stale = (last.utc + timedelta(hours=1)).strftime(_COT_TIME_FMT)
+    ev = ET.SubElement(
+        root,
+        "event",
+        {
+            "version": "2.0",
+            "uid": f"DJI-{name}-route",
+            "type": "b-m-r",
+            "how": "m-g",
+            "time": t,
+            "start": t,
+            "stale": stale,
+        },
+    )
+    _add_point(ev, first)
+    detail = ET.SubElement(ev, "detail")
+    for j, p in enumerate(sampled):
+        ET.SubElement(
+            detail,
+            "link",
+            {
+                "uid": f"DJI-{name}-route-{j}",
+                "type": "b-m-p",
+                "point": f"{p.lat},{p.lon},{p.alt}",
+            },
+        )
+    ET.SubElement(detail, "contact", {"callsign": f"{name} route"})
+    ET.SubElement(detail, "remarks").text = f"DJI flight path, {len(sampled)} points"
+
+
+def track_to_cot(
+    track: Track,
+    *,
+    cot_type: str = "a-n-A",
+    interval: float = 1.0,
+    stale_seconds: float = 300.0,
+) -> str:
+    """Return a CoT XML document string for *track*.
+
+    ``interval`` downsamples the per-frame telemetry (seconds between sampled
+    points). ``cot_type`` is the CoT type/affiliation code for the PLI events
+    (default neutral air). Requires each kept point to carry ``utc`` (always set
+    by :func:`build_track`).
+    """
+    sampled = _downsample(track.points, interval)
+    root = ET.Element("events")
+    for i, p in enumerate(sampled):
+        nxt = sampled[i + 1] if i + 1 < len(sampled) else None
+        _append_pli_event(root, track.name, i, p, nxt, cot_type, stale_seconds)
+    if len(sampled) >= 2:
+        _append_route_event(root, track.name, sampled)
+    ET.indent(root)
+    return ET.tostring(root, encoding="unicode", xml_declaration=True) + "\n"
+
+
+def write_cot(track: Track, output_path: Path, **kwargs) -> Path:
+    """Write *track* as CoT XML to *output_path* and return it."""
+    output_path.write_text(track_to_cot(track, **kwargs), encoding="utf-8")
+    logger.info("CoT file created: %s", output_path)
+    return output_path
+
+
+def convert_to_cot(
+    srt_file: Path | str,
+    output_file: Path | str | None = None,
+    *,
+    redact: str = "none",
+    tz_offset: timedelta | None = None,
+    interval: float = 1.0,
+    cot_type: str = "a-n-A",
+) -> Path:
+    """Convert a DJI SRT file to CoT XML. Defaults output to ``<srt>.cot.xml``."""
+    srt_path = Path(srt_file)
+    output_path = (
+        Path(output_file)
+        if output_file
+        else srt_path.with_name(f"{srt_path.stem}.cot.xml")
+    )
+    track = build_track(srt_path, redact=redact, tz_offset=tz_offset)
+    return write_cot(track, output_path, interval=interval, cot_type=cot_type)

--- a/src/dji_metadata_embedder/geo/track.py
+++ b/src/dji_metadata_embedder/geo/track.py
@@ -7,20 +7,24 @@ exact coordinates.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from ..utilities import parse_telemetry_points, redact_coords
+from ..utilities import parse_telemetry_samples, redact_coords, resolve_utc_offset
 
 
 @dataclass
 class TrackPoint:
-    """One GPS-fixed sample: WGS84 lat/lon, absolute altitude (m), raw cue time."""
+    """One GPS-fixed sample: WGS84 lat/lon, absolute altitude (m), raw cue time,
+    and best-effort UTC datetime."""
 
     lat: float
     lon: float
     alt: float
     timestamp: str
+    utc: datetime | None = None
 
 
 @dataclass
@@ -31,33 +35,61 @@ class Track:
     points: list[TrackPoint]
 
 
-def build_track(srt_file: Path | str, redact: str = "none") -> Track:
+def _cue_seconds(cue: str) -> float:
+    """Convert an SRT cue ``HH:MM:SS,mmm`` into total seconds (0.0 if unparseable)."""
+    m = re.match(r"(\d{2}):(\d{2}):(\d{2}),(\d{3})", cue)
+    if not m:
+        return 0.0
+    h, mnt, s, ms = (int(g) for g in m.groups())
+    return h * 3600 + mnt * 60 + s + ms / 1000.0
+
+
+def build_track(
+    srt_file: Path | str,
+    redact: str = "none",
+    tz_offset: timedelta | None = None,
+) -> Track:
     """Build a :class:`Track` from a DJI SRT file.
 
     ``redact`` mirrors the embed pipeline: ``"drop"`` yields an empty track,
     ``"fuzz"`` coarsens coordinates to ~100 m (3 decimals), ``"none"`` keeps
-    them. Pre-GPS-lock ``(0, 0)`` frames are already excluded by
-    :func:`parse_telemetry_points`.
+    them. Each point's ``utc`` is the block's absolute datetime minus the
+    resolved local->UTC offset (``tz_offset`` if given, else auto-detected from
+    the file mtime); when the format carries no absolute datetime, ``utc`` is
+    synthesized as ``mtime + (cue - first_cue)`` so consumers that need a
+    timestamp (e.g. CoT) always have a monotonic one. Pre-GPS-lock ``(0, 0)``
+    frames are already excluded by :func:`parse_telemetry_samples`.
     """
     srt_path = Path(srt_file)
-    raw = parse_telemetry_points(srt_path)
+    samples = parse_telemetry_samples(srt_path)
 
-    coords = redact_coords([(lat, lon) for lat, lon, _, _ in raw], redact)
+    abs_times = [s.dt for s in samples if s.dt is not None]
+    mtime_utc = datetime.fromtimestamp(
+        srt_path.stat().st_mtime, tz=timezone.utc
+    ).replace(tzinfo=None)
+    offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
+    base_cue = _cue_seconds(samples[0].cue) if samples else 0.0
+
+    coords = redact_coords([(s.lat, s.lon) for s in samples], redact)
     if redact == "drop":
         points: list[TrackPoint] = []
     else:
-        # ``redact_coords`` returns coordinates 1:1 for "none"/"fuzz", so the zip
-        # below keeps each point's altitude and timestamp aligned. Guard the
-        # invariant explicitly: a future mode that filters individual points
-        # would otherwise silently truncate the track at the zip.
-        if len(coords) != len(raw):
+        # ``redact_coords`` returns coordinates 1:1 for "none"/"fuzz". Guard the
+        # invariant so a future mode that filters points cannot silently
+        # truncate the track at the zip below.
+        if len(coords) != len(samples):
             raise ValueError(
-                f"redact_coords returned {len(coords)} coords for {len(raw)} "
+                f"redact_coords returned {len(coords)} coords for {len(samples)} "
                 f"points (mode={redact!r}); cannot preserve alt/timestamp alignment"
             )
-        points = [
-            TrackPoint(lat=c[0], lon=c[1], alt=alt, timestamp=ts)
-            for c, (_, _, alt, ts) in zip(coords, raw)
-        ]
+        points = []
+        for c, s in zip(coords, samples):
+            if s.dt is not None and offset is not None:
+                utc = s.dt - offset
+            else:
+                utc = mtime_utc + timedelta(seconds=_cue_seconds(s.cue) - base_cue)
+            points.append(
+                TrackPoint(lat=c[0], lon=c[1], alt=s.alt, timestamp=s.cue, utc=utc)
+            )
 
     return Track(name=srt_path.stem, points=points)

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -14,104 +14,16 @@ import logging
 
 from rich.progress import Progress
 from .utilities import is_gps_fix, setup_logging
+from .utilities import _parse_srt_datetime, resolve_utc_offset
+# Re-exported for backwards compatibility — cli.py and tests/test_timezone.py
+# import these from here:
+from .utilities import parse_utc_offset, estimate_utc_offset  # noqa: F401
 from .geo.solar import sun_position
 
 logger = logging.getLogger(__name__)
 
-# Seconds in a quarter hour — the granularity real-world UTC offsets use
-# (whole hours plus the :30 and :45 zones like India and Nepal).
-_QUARTER_HOUR = 15 * 60
-
 # Peak solar elevation (degrees) below which a clip is flagged "very low sun".
 _VERY_LOW_SUN_DEG = 5
-
-# DJI SRT blocks carry an absolute wall-clock datetime on their own line, with
-# the milliseconds separated by either a comma (older firmware) or a dot
-# (newer firmware): "2024-01-15 14:30:22,123" / "2026-05-27 13:14:22.911".
-_ABS_DATETIME_RE = re.compile(
-    r"(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})[.,](\d{3})"
-)
-
-
-def _parse_srt_datetime(text: str) -> datetime | None:
-    """Return the absolute wall-clock datetime in *text*, or None if absent."""
-    m = _ABS_DATETIME_RE.search(text)
-    if not m:
-        return None
-    year, month, day, hour, minute, second, millis = (int(g) for g in m.groups())
-    return datetime(year, month, day, hour, minute, second, millis * 1000)
-
-
-def parse_utc_offset(value: str | None) -> timedelta | None:
-    """Parse a CLI UTC-offset string into a :class:`timedelta`.
-
-    Returns ``None`` (meaning "auto-detect") for ``None``, an empty string, or
-    ``"auto"``. Otherwise accepts a signed ``HH`` or ``HH:MM`` form such as
-    ``"+05:30"``, ``"5:45"`` or ``"-8"``. Raises :class:`ValueError` on any
-    other input.
-    """
-    if value is None:
-        return None
-    value = value.strip()
-    if value == "" or value.lower() == "auto":
-        return None
-    m = re.fullmatch(r"([+-]?)(\d{1,2})(?::(\d{2}))?", value)
-    if not m:
-        raise ValueError(f"Invalid UTC offset: {value!r}")
-    sign = -1 if m.group(1) == "-" else 1
-    hours = int(m.group(2))
-    minutes = int(m.group(3) or 0)
-    return sign * timedelta(hours=hours, minutes=minutes)
-
-
-def estimate_utc_offset(
-    first_local: datetime,
-    last_local: datetime,
-    file_mtime_utc: datetime,
-) -> timedelta:
-    """Estimate the UTC offset of naive DJI SRT timestamps.
-
-    DJI SRT wall-clock timestamps are local with no timezone, while the source
-    file's mtime is UTC. We don't know whether the mtime marks the start or the
-    end of the recording, so both hypotheses are tested: for each anchor the
-    raw offset ``anchor - file_mtime_utc`` is rounded to the nearest quarter
-    hour (covering offsets such as UTC+5:30 and UTC+5:45), and the residual
-    distance from that boundary is kept. The hypothesis with the smaller
-    residual wins, since a genuine offset lands cleanly on a quarter hour.
-
-    All three datetimes must be naive (``file_mtime_utc`` expressed in UTC).
-
-    Re-implemented from the heuristic described in GPStitch
-    (https://github.com/Romancha/GPStitch, GPLv3) — idea only, no code copied.
-    """
-    best_offset = timedelta(0)
-    best_residual: float | None = None
-    for anchor in (first_local, last_local):
-        raw = (anchor - file_mtime_utc).total_seconds()
-        rounded = round(raw / _QUARTER_HOUR) * _QUARTER_HOUR
-        residual = abs(raw - rounded)
-        if best_residual is None or residual < best_residual:
-            best_residual = residual
-            best_offset = timedelta(seconds=rounded)
-    return best_offset
-
-
-def resolve_utc_offset(
-    abs_datetimes: list[datetime],
-    tz_offset: timedelta | None,
-    file_mtime_utc: datetime,
-) -> timedelta | None:
-    """Resolve the single local->UTC offset for an SRT file.
-
-    Returns ``None`` when the file carries no absolute datetime (callers then
-    fall back to the raw cue time). An explicit *tz_offset* wins; otherwise the
-    offset is auto-detected from the file mtime via :func:`estimate_utc_offset`.
-    """
-    if not abs_datetimes:
-        return None
-    if tz_offset is not None:
-        return tz_offset
-    return estimate_utc_offset(abs_datetimes[0], abs_datetimes[-1], file_mtime_utc)
 
 
 def _parse_gps_points(content: str) -> list[dict[str, Any]]:

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -1,10 +1,116 @@
 import logging
 import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Tuple
 import subprocess
 
 from rich.logging import RichHandler
+
+
+# Seconds in a quarter hour — the granularity real-world UTC offsets use
+# (whole hours plus the :30 and :45 zones like India and Nepal).
+_QUARTER_HOUR = 15 * 60
+
+# DJI SRT blocks carry an absolute wall-clock datetime on their own line, with
+# the milliseconds separated by either a comma (older firmware) or a dot
+# (newer firmware): "2024-01-15 14:30:22,123" / "2026-05-27 13:14:22.911".
+_ABS_DATETIME_RE = re.compile(
+    r"(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})[.,](\d{3})"
+)
+
+
+def _parse_srt_datetime(text: str) -> datetime | None:
+    """Return the absolute wall-clock datetime in *text*, or None if absent."""
+    m = _ABS_DATETIME_RE.search(text)
+    if not m:
+        return None
+    year, month, day, hour, minute, second, millis = (int(g) for g in m.groups())
+    return datetime(year, month, day, hour, minute, second, millis * 1000)
+
+
+def parse_utc_offset(value: str | None) -> timedelta | None:
+    """Parse a CLI UTC-offset string into a :class:`timedelta`.
+
+    Returns ``None`` (meaning "auto-detect") for ``None``, an empty string, or
+    ``"auto"``. Otherwise accepts a signed ``HH`` or ``HH:MM`` form such as
+    ``"+05:30"``, ``"5:45"`` or ``"-8"``. Raises :class:`ValueError` on any
+    other input.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if value == "" or value.lower() == "auto":
+        return None
+    m = re.fullmatch(r"([+-]?)(\d{1,2})(?::(\d{2}))?", value)
+    if not m:
+        raise ValueError(f"Invalid UTC offset: {value!r}")
+    sign = -1 if m.group(1) == "-" else 1
+    hours = int(m.group(2))
+    minutes = int(m.group(3) or 0)
+    return sign * timedelta(hours=hours, minutes=minutes)
+
+
+def estimate_utc_offset(
+    first_local: datetime,
+    last_local: datetime,
+    file_mtime_utc: datetime,
+) -> timedelta:
+    """Estimate the UTC offset of naive DJI SRT timestamps.
+
+    DJI SRT wall-clock timestamps are local with no timezone, while the source
+    file's mtime is UTC. We don't know whether the mtime marks the start or the
+    end of the recording, so both hypotheses are tested: for each anchor the
+    raw offset ``anchor - file_mtime_utc`` is rounded to the nearest quarter
+    hour (covering offsets such as UTC+5:30 and UTC+5:45), and the residual
+    distance from that boundary is kept. The hypothesis with the smaller
+    residual wins, since a genuine offset lands cleanly on a quarter hour.
+
+    All three datetimes must be naive (``file_mtime_utc`` expressed in UTC).
+
+    Re-implemented from the heuristic described in GPStitch
+    (https://github.com/Romancha/GPStitch, GPLv3) — idea only, no code copied.
+    """
+    best_offset = timedelta(0)
+    best_residual: float | None = None
+    for anchor in (first_local, last_local):
+        raw = (anchor - file_mtime_utc).total_seconds()
+        rounded = round(raw / _QUARTER_HOUR) * _QUARTER_HOUR
+        residual = abs(raw - rounded)
+        if best_residual is None or residual < best_residual:
+            best_residual = residual
+            best_offset = timedelta(seconds=rounded)
+    return best_offset
+
+
+def resolve_utc_offset(
+    abs_datetimes: list[datetime],
+    tz_offset: timedelta | None,
+    file_mtime_utc: datetime,
+) -> timedelta | None:
+    """Resolve the single local->UTC offset for an SRT file.
+
+    Returns ``None`` when the file carries no absolute datetime (callers then
+    fall back to the raw cue time). An explicit *tz_offset* wins; otherwise the
+    offset is auto-detected from the file mtime via :func:`estimate_utc_offset`.
+    """
+    if not abs_datetimes:
+        return None
+    if tz_offset is not None:
+        return tz_offset
+    return estimate_utc_offset(abs_datetimes[0], abs_datetimes[-1], file_mtime_utc)
+
+
+@dataclass
+class TelemetrySample:
+    """One GPS-fixed SRT block: position, raw cue time, and absolute datetime."""
+
+    lat: float
+    lon: float
+    alt: float
+    cue: str
+    dt: datetime | None
 
 
 def iso6709(lat: float, lon: float, alt: float = 0.0) -> str:
@@ -23,11 +129,16 @@ def is_gps_fix(lat: float, lon: float) -> bool:
     return not (lat == 0.0 and lon == 0.0)
 
 
-def parse_telemetry_points(srt_path: Path) -> List[Tuple[float, float, float, str]]:
-    """Parse an SRT file into a list of (lat, lon, alt, timestamp)."""
+def parse_telemetry_samples(srt_path: Path) -> List[TelemetrySample]:
+    """Parse an SRT file into :class:`TelemetrySample` records.
+
+    Same GPS extraction as the legacy 4-tuple parser (bracket format, ``GPS(...)``
+    compact form, M300 altitude unit suffix, ``(0,0)`` no-fix filtering) plus the
+    block's absolute wall-clock datetime when present.
+    """
     content = srt_path.read_text(encoding="utf-8")
     blocks = content.strip().split("\n\n")
-    points: List[Tuple[float, float, float, str]] = []
+    samples: List[TelemetrySample] = []
     for block in blocks:
         lines = block.strip().split("\n")
         if len(lines) < 3:
@@ -38,6 +149,7 @@ def parse_telemetry_points(srt_path: Path) -> List[Tuple[float, float, float, st
         tele_line = " ".join(lines[2:])
         if "<font" in tele_line:
             tele_line = re.sub(r"<[^>]+>", "", tele_line)
+        dt = _parse_srt_datetime(tele_line)
         lat_match = re.search(r"\[latitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
         lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
         alt_match = re.search(r"abs_alt:\s*([+-]?\d+\.?\d*)\]", tele_line)
@@ -63,11 +175,19 @@ def parse_telemetry_points(srt_path: Path) -> List[Tuple[float, float, float, st
                 if alt_match and len(alt_match.groups()) > 1
                 else (alt_match.group(1) if alt_match else 0.0)
             )
-            # Skip pre-GPS-lock ``(0, 0)`` no-fix frames so exported tracks
-            # (GPX/CSV/per-frame) do not include Null Island points.
+            # Skip pre-GPS-lock ``(0, 0)`` no-fix frames so exported tracks do
+            # not include Null Island points.
             if is_gps_fix(lat, lon):
-                points.append((lat, lon, alt, timestamp))
-    return points
+                samples.append(TelemetrySample(lat, lon, alt, timestamp, dt))
+    return samples
+
+
+def parse_telemetry_points(srt_path: Path) -> List[Tuple[float, float, float, str]]:
+    """Parse an SRT file into a list of (lat, lon, alt, timestamp).
+
+    Backwards-compatible 4-tuple view over :func:`parse_telemetry_samples`.
+    """
+    return [(s.lat, s.lon, s.alt, s.cue) for s in parse_telemetry_samples(srt_path)]
 
 
 def redact_coords(

--- a/tests/test_cli_convert_geo.py
+++ b/tests/test_cli_convert_geo.py
@@ -1,4 +1,5 @@
 import json
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -59,3 +60,36 @@ def test_convert_geojson_redact_drop_empties_track(tmp_path):
     assert len(data["features"]) == 1
     assert data["features"][0]["geometry"] is None
     assert all(f["geometry"] is None for f in data["features"])
+
+
+def test_convert_cot_cli(tmp_path):
+    out = tmp_path / "clip.cot.xml"
+    runner = CliRunner()
+    result = runner.invoke(main, ["convert", "cot", str(CLIP), "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    root = ET.fromstring(out.read_text(encoding="utf-8"))
+    assert root.tag == "events"
+    assert any(e.get("type") == "a-n-A" for e in root)
+
+
+def test_convert_cot_type_override_cli(tmp_path):
+    out = tmp_path / "clip.cot.xml"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["convert", "cot", str(CLIP), "-o", str(out), "--cot-type", "a-f-A-M-H-Q"],
+    )
+    assert result.exit_code == 0, result.output
+    root = ET.fromstring(out.read_text(encoding="utf-8"))
+    assert any(e.get("type") == "a-f-A-M-H-Q" for e in root)
+
+
+def test_convert_cot_redact_drop_empties_events(tmp_path):
+    out = tmp_path / "clip.cot.xml"
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["convert", "cot", str(CLIP), "-o", str(out), "--redact", "drop"]
+    )
+    assert result.exit_code == 0, result.output
+    root = ET.fromstring(out.read_text(encoding="utf-8"))
+    assert len(root) == 0

--- a/tests/test_geo_cot.py
+++ b/tests/test_geo_cot.py
@@ -1,6 +1,8 @@
 import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
 
+import pytest
+
 from dji_metadata_embedder.geo.track import Track, TrackPoint
 from dji_metadata_embedder.geo.cot import track_to_cot
 
@@ -94,3 +96,11 @@ def test_single_point_has_no_route():
     root = _parse(track_to_cot(track))
     assert len(_pli_events(root)) == 1
     assert _route_events(root) == []
+
+
+def test_track_to_cot_requires_utc():
+    # build_track always sets utc; a hand-built point without it must raise a
+    # clear error rather than fail cryptically deep in serialization.
+    track = Track(name="t", points=[TrackPoint(lat=0.0, lon=0.0, alt=0.0, timestamp="")])
+    with pytest.raises(ValueError, match="utc"):
+        track_to_cot(track)

--- a/tests/test_geo_cot.py
+++ b/tests/test_geo_cot.py
@@ -1,0 +1,96 @@
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta
+
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+from dji_metadata_embedder.geo.cot import track_to_cot
+
+_BASE = datetime(2024, 7, 2, 22, 31, 0)
+
+
+def _pt(lat, lon, alt, sec):
+    return TrackPoint(
+        lat=lat, lon=lon, alt=alt, timestamp="", utc=_BASE + timedelta(seconds=sec)
+    )
+
+
+def _moving_track(n=4, step_sec=0.6):
+    # Each point ~0.001 deg north of the previous -> due-north heading.
+    pts = [_pt(59.30 + i * 0.001, 18.20, 100.0, i * step_sec) for i in range(n)]
+    return Track(name="DJI_0157", points=pts)
+
+
+def _parse(xml_text):
+    return ET.fromstring(xml_text)
+
+
+def _pli_events(root, cot_type="a-n-A"):
+    return [e for e in root if e.get("type") == cot_type]
+
+
+def _route_events(root):
+    return [e for e in root if e.get("type") == "b-m-r"]
+
+
+def test_output_is_well_formed_events_root():
+    root = _parse(track_to_cot(_moving_track()))
+    assert root.tag == "events"
+
+
+def test_interval_downsamples_pli_events():
+    track = _moving_track(n=4, step_sec=0.6)  # utc at 0,0.6,1.2,1.8
+    # interval 0 keeps every point; interval 1.0 keeps first, 1.2, and last.
+    assert len(_pli_events(_parse(track_to_cot(track, interval=0.0)))) == 4
+    assert len(_pli_events(_parse(track_to_cot(track, interval=1.0)))) == 3
+
+
+def test_pli_event_has_utc_time_point_and_stale():
+    ev = _pli_events(_parse(track_to_cot(_moving_track())))[0]
+    assert ev.get("time") == "2024-07-02T22:31:00Z"
+    assert ev.get("start") == ev.get("time")
+    assert ev.get("stale") > ev.get("time")  # lexical compare OK for Z-times
+    pt = ev.find("point")
+    assert pt.get("lat") == "59.3"
+    assert pt.get("hae") == "100.0"
+    assert pt.get("ce") == "9999999.0"
+
+
+def test_default_and_override_cot_type():
+    assert _pli_events(_parse(track_to_cot(_moving_track())))  # default a-n-A present
+    root = _parse(track_to_cot(_moving_track(), cot_type="a-f-A-M-H-Q"))
+    assert _pli_events(root, cot_type="a-f-A-M-H-Q")
+    assert not _pli_events(root, cot_type="a-n-A")
+
+
+def test_course_and_speed_derived_for_moving_track():
+    # Two points 0.001 deg north, 1s apart -> ~111 m/s due north.
+    track = Track(name="t", points=[_pt(0.0, 0.0, 50.0, 0), _pt(0.001, 0.0, 50.0, 1)])
+    ev = _pli_events(_parse(track_to_cot(track, interval=0.0)))[0]
+    trk = ev.find("./detail/track")
+    assert trk is not None
+    assert trk.get("course") == "0.0"
+    assert abs(float(trk.get("speed")) - 111.2) < 1.0
+
+
+def test_last_point_omits_track_detail():
+    track = Track(name="t", points=[_pt(0.0, 0.0, 50.0, 0), _pt(0.001, 0.0, 50.0, 1)])
+    events = _pli_events(_parse(track_to_cot(track, interval=0.0)))
+    assert events[-1].find("./detail/track") is None
+
+
+def test_route_event_links_match_sampled_points():
+    root = _parse(track_to_cot(_moving_track(n=3), interval=0.0))
+    routes = _route_events(root)
+    assert len(routes) == 1
+    assert len(routes[0].findall("./detail/link")) == 3
+
+
+def test_empty_track_yields_no_events():
+    root = _parse(track_to_cot(Track(name="t", points=[])))
+    assert len(root) == 0
+
+
+def test_single_point_has_no_route():
+    track = Track(name="t", points=[_pt(0.0, 0.0, 50.0, 0)])
+    root = _parse(track_to_cot(track))
+    assert len(_pli_events(root)) == 1
+    assert _route_events(root) == []

--- a/tests/test_geo_track.py
+++ b/tests/test_geo_track.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from dji_metadata_embedder.geo.track import build_track
@@ -27,3 +28,30 @@ def test_build_track_redact_fuzz_rounds_coords():
     assert (p.lat, p.lon) == (34.27, -84.176)
     # Altitude and timestamp are preserved, only coordinates are coarsened.
     assert p.alt == 302.208
+
+
+# Bracket format WITHOUT an absolute datetime line, cue times 1s apart.
+NODT_SRT = (
+    "1\n00:00:00,000 --> 00:00:01,000\n"
+    '<font size="28">[latitude: 10.0] [longitude: 20.0] '
+    "[rel_alt: 0.000 abs_alt: 5.0]</font>\n\n"
+    "2\n00:00:01,000 --> 00:00:02,000\n"
+    '<font size="28">[latitude: 11.0] [longitude: 21.0] '
+    "[rel_alt: 0.000 abs_alt: 6.0]</font>\n"
+)
+
+
+def test_build_track_sets_utc_from_explicit_offset():
+    # First block local datetime is 2026-05-17 08:28:30.219; -2h -> 06:28:30.219.
+    track = build_track(CLIP, tz_offset=timedelta(hours=2))
+    assert track.points[0].utc == datetime(2026, 5, 17, 6, 28, 30, 219000)
+
+
+def test_build_track_synthesizes_utc_without_datetime(tmp_path):
+    srt = tmp_path / "nodt.SRT"
+    srt.write_text(NODT_SRT, encoding="utf-8")
+    track = build_track(srt)
+    assert track.points[0].utc is not None
+    # Cue times are 1s apart -> synthesized UTC preserves that spacing.
+    delta = track.points[1].utc - track.points[0].utc
+    assert delta.total_seconds() == 1.0

--- a/tests/test_parse_samples.py
+++ b/tests/test_parse_samples.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from pathlib import Path
+
+from dji_metadata_embedder.utilities import (
+    parse_telemetry_samples,
+    parse_telemetry_points,
+)
+
+SAMPLES = Path(__file__).resolve().parents[1] / "samples"
+CLIP = SAMPLES / "air3S" / "clip.SRT"
+
+# Bracket format WITHOUT an absolute datetime line.
+NODT_SRT = (
+    "1\n00:00:00,000 --> 00:00:01,000\n"
+    '<font size="28">[latitude: 10.0] [longitude: 20.0] '
+    "[rel_alt: 0.000 abs_alt: 5.0]</font>\n\n"
+    "2\n00:00:01,000 --> 00:00:02,000\n"
+    '<font size="28">[latitude: 11.0] [longitude: 21.0] '
+    "[rel_alt: 0.000 abs_alt: 6.0]</font>\n"
+)
+
+
+def test_samples_extract_absolute_datetime():
+    samples = parse_telemetry_samples(CLIP)
+    assert len(samples) == 5
+    s = samples[0]
+    assert (s.lat, s.lon, s.alt) == (34.270373, -84.176160, 302.208)
+    assert s.cue == "00:00:00,000"
+    # clip.SRT carries "2026-05-17 08:28:30.219" on its own line.
+    assert s.dt == datetime(2026, 5, 17, 8, 28, 30, 219000)
+
+
+def test_samples_datetime_none_when_absent(tmp_path):
+    srt = tmp_path / "nodt.SRT"
+    srt.write_text(NODT_SRT, encoding="utf-8")
+    samples = parse_telemetry_samples(srt)
+    assert len(samples) == 2
+    assert all(s.dt is None for s in samples)
+
+
+def test_parse_telemetry_points_is_unchanged_wrapper():
+    # The legacy 4-tuple API must be byte-for-byte the same as before.
+    pts = parse_telemetry_points(CLIP)
+    assert pts == [
+        (34.270373, -84.176160, 302.208, "00:00:00,000"),
+        (34.270373, -84.176160, 302.208, "00:00:00,016"),
+        (34.270373, -84.176160, 302.208, "00:00:00,032"),
+        (34.270373, -84.176160, 302.208, "00:00:00,049"),
+        (34.270373, -84.176160, 302.208, "00:00:00,066"),
+    ]

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -188,7 +188,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "1.7.0"
+    $fallbackVersion = "1.8.0"
     
     try{
         LogInfo "Checking for latest version..."

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.7.0
+PackageVersion: 1.8.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -18,7 +18,7 @@ FileExtensions:
 - dat
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.7.0/dji-embed.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.8.0/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
   InstallerSwitches:
     Silent: ""

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.7.0
+PackageVersion: 1.8.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus

--- a/winget/CallMarcus.DJIMetadataEmbedder.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 1.7.0
+PackageVersion: 1.8.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Adds `dji-embed convert cot <SRT>` — exports a DJI flight as **Cursor-on-Target (CoT)** XML for the ATAK/TAK ecosystem (SAR, disaster response, OSINT/journalistic verification). This is the small, **export-only / file-only** half of #217; MISB 0601 KLV and network push remain follow-ups.

- **New `geo/cot.py` serializer** — one `<events>` doc with timed PLI events (downsampled via `--interval`) carrying UTC time, `point` (lat/lon/`hae`), and derived `<track course/speed>` (great-circle bearing + haversine speed, omitted at the final point), plus a best-effort `b-m-r` route polyline. Default type `a-n-A` (neutral air), overridable with `--cot-type`.
- **UTC on the shared `Track`** — `build_track` now resolves a best-effort `utc` per point (SRT absolute datetime − resolved offset, or synthesized from mtime + cue spacing). To avoid a `geo → telemetry_converter → geo.solar` import cycle, the UTC helpers moved down into `utilities.py` (re-exported from `telemetry_converter` for back-compat). `parse_telemetry_points` is now a thin wrapper over a richer `parse_telemetry_samples`; its 4-tuple output is byte-for-byte unchanged (pinned by a test).
- **CLI** — `cot` choice plus `--interval` (default 1.0) and `--cot-type` (default `a-n-A`); existing `--redact` (drop/fuzz) and `--tz-offset` flow through.
- **Docs** — new `docs/fmv-interop.md` (usage, options, ingestion notes/caveats, KLV roadmap stub); README updated (feature bullet, convert synopsis/options, CoT example) and the stale "Production Ready / M1–M4" blockquote removed.
- **Release prep** — version bumped to **1.8.0** (synced across `__init__.py`, README badge, bootstrap, spec, winget).
- **No new runtime dependencies** (stdlib `xml.etree.ElementTree` only — write-only serializer, so no XXE/defusedxml concern).

Design spec: `docs/superpowers/specs/2026-06-13-cot-export-design.md`.

## Test Plan

- [x] `uv run pytest -q` → 155 passed, 1 skipped (pre-existing flask-absent UI test)
- [x] `uv run ruff check .` → clean
- [x] New unit tests: `tests/test_geo_cot.py` (XML shape, interval downsampling, UTC format, default/override `--cot-type`, derived course/speed, route links, 0-/1-point edge cases), `tests/test_parse_samples.py`, `tests/test_geo_track.py` UTC cases, plus 3 CLI smoke tests in `tests/test_cli_convert_geo.py`
- [x] `parse_telemetry_points` back-compat pinned; `test_timezone` re-export imports still resolve
- [x] Manual E2E on a real ~5.4 min moving flight: 324 PLI events @ `--interval 1`, route links match, 189 distinct headings + realistic 7.4 m/s median speed; `--tz-offset +02:00` yields exact UTC; `--redact fuzz` coarsens coordinates

## Release

Merging this lands the 1.8.0 version bump on `master`; pushing tag **`v1.8.0`** afterward triggers the PyPI / EXE / auto-changelog workflows. Closes #217 (CoT half — KLV/network push tracked as follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)