### PR TITLE
feat(geo): camera-footprint polygons for GeoJSON/KML export (#215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **Subtitle Track Preservation**: Keep telemetry data as subtitle track for overlay viewing
 - **Multiple Format Support**: Handles different DJI SRT telemetry formats
 - **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, KML, or a standalone HTML map (see [docs/geospatial.md](docs/geospatial.md))
+- **Camera Footprint Polygons**: `convert geojson/kml … --footprint` adds nadir ground-footprint rectangles to GeoJSON/KML output (gimbal-aware on formats that carry attitude; suppressed under `--redact`). See [docs/geospatial.md](docs/geospatial.md).
 - **CoT Export**: `dji-embed convert cot FLIGHT.SRT` writes Cursor-on-Target XML for ATAK/TAK (route + timed track). See [docs/fmv-interop.md](docs/fmv-interop.md).
 - **Footage verification:** `dji-embed verify-sun clip.SRT` reports the sun's azimuth/elevation over a clip for shadow cross-checking; CSV export gains `datetime_utc` / `sun_azimuth` / `sun_elevation` columns.
 - **DAT Flight Log Support**: Merge `.DAT` flight logs into metadata

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -143,6 +143,21 @@ focal length are written as **literal decimals** rather than the legacy
 - Legacy encoding: integer × 10 (`240` = 24mm, `350` = 35mm, `500` = 50mm)
 - Modern encoding (Format 3b): literal decimal mm (`24.00` = 24mm)
 
+## Camera Footprint Export — Relevant Fields
+
+The `convert geojson/kml --footprint` command uses three SRT fields to project
+ground-footprint polygons. Not all formats carry all three:
+
+| Field | Formats that carry it | Role in footprint export |
+|-------|-----------------------|--------------------------|
+| `rel_alt` | Format 1, Format 3, Format 3b | Height above ground (AGL). Preferred over `abs_alt` subtraction. |
+| `focal_len` | Format 3, Format 3b | 35mm-equivalent focal length. Determines field of view. Written as integer × 10 in Format 3 (`240` = 24 mm) or literal decimal in Format 3b (`24.00` = 24 mm). Overrides the `--model` table when present. |
+| `gb_yaw`, `gb_pitch` | Format 3b — **Avata 360 variant only** | Gimbal yaw rotates the footprint rectangle to match where the lens points; gimbal pitch gates out strongly oblique frames (>~30° off nadir). Other Format 3b models and all earlier formats do not carry these fields — nadir is assumed and heading falls back to course over ground. |
+
+When none of these fields are present (e.g., Format 2 / Format 2b / Format 2c),
+footprints are still generated using `abs_alt` for AGL estimation, the `--model`
+FOV table (or the generic wide fallback), and course-over-ground for orientation.
+
 ## GPS Coordinate Formats
 
 ### Decimal Degrees

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -24,6 +24,97 @@ dji-embed convert kml DJI_0001.SRT              # -> DJI_0001.kml
 A `LineString` placemark with absolute altitude — double-click to open the
 flight path in Google Earth.
 
+## Camera footprints
+
+Add `--footprint` to a `geojson` or `kml` conversion to include camera
+ground-footprint polygons in the output — one rectangle per sampled frame
+showing the area imaged by the lens at that moment.
+
+```bash
+dji-embed convert geojson DJI_0001.SRT --footprint --model air3
+dji-embed convert kml DJI_0001.SRT --footprint --footprint-interval 5
+```
+
+### Sampling interval
+
+`--footprint-interval SECONDS` (default `2.0`) controls how often a footprint
+is sampled. One polygon is emitted per interval, not per frame. Increase the
+interval to keep file sizes manageable on long flights.
+
+### Model and field of view
+
+FOV is derived from the SRT's `focal_len` field (a 35mm-equivalent, present on
+Format 3/3b models) when available. When `focal_len` is absent, a per-model
+native focal length is used instead. Pass `--model <name>` to select the
+correct table entry:
+
+| `--model` value | Equiv. focal length | Typical drone |
+|-----------------|--------------------:|---------------|
+| `air3`          | 24 mm               | DJI Air 3 |
+| `mini4pro`      | 24 mm               | DJI Mini 4 Pro |
+| `avata360`      | 24 mm               | DJI Avata 360 |
+| `avata2`        | 12.7 mm             | DJI Avata 2 |
+
+Omitting `--model` (or using an unrecognised name) falls back to a generic wide
+lens (~84° HFOV). To add a new model, extend `FOV_TABLE` in
+`src/dji_metadata_embedder/geo/footprint.py`.
+
+### Gimbal-aware rotation
+
+The footprint rectangle is oriented to the drone's course over ground by
+default. On the **Avata 360** format, which carries `gb_yaw` in the SRT, the
+real gimbal yaw is used instead, so the footprint follows where the lens
+actually points.
+
+### Oblique frames are skipped
+
+If the SRT carries gimbal pitch (`gb_pitch`) and the camera is more than ~30°
+off nadir, no footprint is drawn for that frame. Full oblique projection is
+deferred future work. When gimbal pitch is absent (most formats), nadir is
+assumed for every frame.
+
+### Privacy — footprints suppressed under `--redact`
+
+Footprint polygons are only emitted when `--redact none` (the default). Under
+`--redact fuzz` or `--redact drop`, no footprints are written — a precise
+polygon would re-sharpen a deliberately coarsened position.
+
+### Output format details
+
+**GeoJSON** — footprints are `Polygon` features alongside the existing track
+`LineString` and `Point` features. Each footprint feature carries:
+
+```json
+{
+  "type": "Feature",
+  "geometry": { "type": "Polygon", "coordinates": [[[lon, lat], ...]] },
+  "properties": {
+    "kind": "footprint",
+    "index": 12,
+    "timestamp": "00:00:24,000",
+    "agl": 28.5,
+    "hfov": 73.7,
+    "vfov": 58.0
+  }
+}
+```
+
+**KML** — footprints are collected in a `<Folder>` named "Camera footprints",
+each as a `clampToGround` polygon.
+
+### Limitations
+
+- **Flat-earth projection.** Footprint size is computed with a plane-earth
+  approximation (equirectangular). Errors grow with altitude and latitude but
+  are negligible at the scales typical drone flights cover.
+- **Nadir assumed when no gimbal data.** Most DJI formats do not carry gimbal
+  attitude in the SRT. When `gb_pitch` is absent the camera is assumed to be
+  pointing straight down. Strongly oblique or FPV flights will produce
+  inaccurate footprints in that case.
+- **No terrain / DEM.** AGL is taken from `rel_alt` in the SRT when present,
+  otherwise estimated as `abs_alt − first-fix abs_alt`. Neither accounts for
+  terrain relief below the drone.
+
 ## Standalone HTML map
 
 ```bash

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -73,6 +73,11 @@ off nadir, no footprint is drawn for that frame. Full oblique projection is
 deferred future work. When gimbal pitch is absent (most formats), nadir is
 assumed for every frame.
 
+The bundled `samples/Avata360/clip.SRT` is a horizon-pointing (gimbal pitch ≈ 0°)
+360 capture — the nadir model intentionally skips every frame and produces no
+footprints. Gimbal yaw is used for footprint rotation only when the camera is
+near-nadir (pitch below the ~30° threshold).
+
 ### Privacy — footprints suppressed under `--redact`
 
 Footprint polygons are only emitted when `--redact none` (the default). Under

--- a/docs/superpowers/specs/2026-06-20-camera-footprint-export-design.md
+++ b/docs/superpowers/specs/2026-06-20-camera-footprint-export-design.md
@@ -1,0 +1,231 @@
+# Design: Camera-footprint polygons for GeoJSON / KML export (#215 follow-up)
+
+_Date: 2026-06-20_
+
+## Context
+
+The track-only half of #215 already shipped (v1.6.0): `dji-embed convert geojson`
+and `convert kml` serialize the flight path as a `LineString` plus per-point
+`Point` features, built from the canonical `geo/track.py` `Track` with redaction
+applied once at the Track layer. See
+`docs/superpowers/specs/2026-06-04-flight-path-mapping-design.md` (Phase 1).
+
+This spec covers the remaining **camera-footprint** checklist on #215: project
+each sampled frame's ground coverage as a polygon and add it to the GeoJSON and
+KML output, for mapping / SAR coverage / OSINT verification / damage assessment
+(the project's [use-for-good direction](https://github.com/CallMarcus/dji-drone-metadata-embedder#intended-use--scope)).
+
+### The hard constraint
+
+A true per-frame ground footprint needs **drone position + height-above-ground
+(AGL) + gimbal pitch/yaw (or heading) + lens FOV**. Inventory of what the
+telemetry actually carries (`docs/SRT_FORMATS.md`, `parse_telemetry_samples`):
+
+- Position + altitude: present in every format.
+- **Gimbal attitude (`gb_yaw`/`gb_pitch`/`gb_roll`): only the Avata 360 SRT
+  variant.** Common models (Mini 3/4 Pro, Air 3, Mavic 3, …) carry no gimbal and
+  no heading in their SRT.
+- FOV: derivable from `focal_len` (present in some formats) + a per-model sensor
+  table, otherwise a per-model / generic default.
+
+So an SRT-only footprint is exact only for Avata 360. For everything else we
+assume a **nadir (straight-down) camera** and size the footprint from AGL + FOV,
+using real gimbal data when the format provides it. This is **Approach A**,
+chosen over nadir-only (B) and DAT-attitude oblique projection (C). C — oblique
+trapezoids from `dat_parser.py` attitude, time-aligned to the SRT — remains a
+future follow-up.
+
+## Goals
+
+- Add per-interval ground **footprint polygons** to the existing GeoJSON and KML
+  exports, behind a `--footprint` flag.
+- Use a nadir model sized by AGL + FOV; rotate to flight heading, or to real
+  gimbal yaw when the format carries it.
+- Reuse the existing parser, `Track`, and redaction. No new runtime
+  dependencies (pure-stdlib math).
+- Degrade gracefully: missing AGL/FOV, strongly-oblique gimbal, or redaction all
+  fall back to the track without footprints.
+
+## Non-goals
+
+- **Oblique-trapezoid projection** (camera not pointing straight down). Gated
+  out in v1; deferred to the DAT-attitude follow-up (Approach C).
+- **View frustums** (3D camera-to-ground volumes). Deferred with C.
+- **DAT flight-log attitude** integration and SRT↔DAT time-sync.
+- **Terrain / DEM-aware projection.** Flat-earth approximation only; documented.
+
+## Architecture: augment, don't add a format
+
+A footprint is not a new export format — it augments GeoJSON/KML. So the existing
+`geo/` one-module-per-format pattern is preserved and a single new module adds
+the geometry:
+
+```
+Track (geo/track.py, redaction applied here)
+   │
+   ├─ geo/footprint.py   NEW: Track + FOV spec → list[FootprintPolygon]
+   │
+   ├─ geo/geojson.py     gains optional footprints= param (Polygon features)
+   └─ geo/kml.py         gains optional footprints= param (Polygon placemarks)
+```
+
+### Data-layer extension
+
+The footprint needs height-above-ground, FOV inputs, and optional gimbal, none
+of which the parser captures today. Extend `TelemetrySample` (utilities.py) and
+`TrackPoint` (geo/track.py) with **optional** fields, all defaulting to `None`
+so every existing consumer is untouched:
+
+- `rel_alt: float | None` — from `[rel_alt: … abs_alt: …]` (adjacent to the
+  existing `abs_alt` regex).
+- `focal_len: float | None` — the **35 mm-equivalent** focal length, normalized
+  to mm. The bracket formats write it two ways (legacy `240` = 24 mm ×10; newer
+  literal `24.00`); normalize on parse. The ×10-vs-literal disambiguation is a
+  heuristic (e.g. values ≥ 100 are ×10) refined against the format fixtures —
+  the one edge case to validate is a ≥100 mm-equivalent literal (long tele).
+- `gimbal_yaw: float | None`, `gimbal_pitch: float | None` — from `gb_yaw` /
+  `gb_pitch` (Avata 360 format only).
+
+**AGL source** (judgment call): use `rel_alt` when present; else fall back to
+`abs_alt − first_fix_abs_alt` (the first GPS-fix point as the ground datum); if
+neither yields a positive height, skip that point's footprint.
+
+## Projection math
+
+Per sampled point: center `(lat, lon)`, AGL height `h`, horizontal/vertical FOV
+`HFOV`/`VFOV`, bearing `θ`.
+
+```
+half_width  = h * tan(HFOV / 2)     # across-track, metres
+half_height = h * tan(VFOV / 2)     # along-track, metres
+```
+
+Four corners in a local east/north frame: `(±half_width, ±half_height)`. Rotate
+the rectangle by `θ`:
+
+- `θ` = great-circle course over ground from consecutive track points (the same
+  bearing derivation `geo/cot.py` already uses for course/speed).
+- **Gimbal yaw overrides `θ` when present** (Avata 360).
+
+Local east/north → lat/lon via the equirectangular approximation (accurate at
+footprint scale, tens–hundreds of metres):
+
+```
+dLat = dNorth / 111320
+dLon = dEast  / (111320 * cos(lat))
+```
+
+The polygon is the four rotated/offset corners, ring-closed.
+
+**Gimbal pitch is a gate, not a shape** (judgment call): if the camera is
+strongly oblique — pitch more than a threshold off straight-down (default ~30°
+from nadir; a module constant) — **skip the footprint** for that frame rather
+than draw an inaccurate rectangle. Full oblique-trapezoid projection is Approach
+C / future. In v1, gimbal therefore contributes rotation (yaw) plus an honesty
+gate (pitch), not oblique geometry. Frames with no gimbal data are treated as
+nadir.
+
+## FOV / sensor table
+
+Because the SRT reports a **35 mm-equivalent** focal length, FOV is computed
+against a full-frame (36×24 mm) reference rather than the real sensor — this
+keeps the table tiny and sidesteps the equivalent-vs-actual-focal mismatch:
+
+```
+HFOV = 2 * atan(36 / (2 * f_equiv))      # 4:3 readout uses 36×27;
+VFOV = 2 * atan(27 / (2 * f_equiv))      # 16:9 readout uses 36×20.25
+```
+
+The reference height is chosen by the model's readout **aspect** (4:3 vs 16:9).
+A module-level table keyed by model name supplies the aspect plus a native
+equivalent focal for the no-`focal_len` fallback:
+
+```python
+@dataclass(frozen=True)
+class LensSpec:
+    native_focal_equiv_mm: float   # used when the SRT carries no focal_len
+    aspect: tuple[int, int]        # sensor readout, e.g. (4, 3) or (16, 9)
+
+FOV_TABLE: dict[str, LensSpec] = {
+    "air3":     LensSpec(native_focal_equiv_mm=24.0, aspect=(4, 3)),
+    "avata2":   LensSpec(native_focal_equiv_mm=12.7, aspect=(4, 3)),
+    "mini4pro": LensSpec(native_focal_equiv_mm=24.0, aspect=(4, 3)),
+    "avata360": LensSpec(native_focal_equiv_mm=24.0, aspect=(4, 3)),
+}
+```
+
+(The numeric values above are first-pass estimates from published specs; they
+are confirmed against each model's fixtures at implementation.) Use the SRT's
+`focal_len` when present (handles zoom), else the model's
+`native_focal_equiv_mm`.
+
+The SRT rarely identifies the exact model, so model selection is **explicit**: a
+`--model <name>` option picks the table entry. When no model is given and the SRT
+carries no `focal_len`, fall back to a **generic wide default (~84° HFOV, 4:3
+aspect)**. Document how to add entries (see CLAUDE.md §7).
+
+## CLI & output
+
+- `dji-embed convert geojson <SRT> --footprint [--footprint-interval 2.0] [--model air3]`
+- `dji-embed convert kml <SRT> --footprint [--footprint-interval 2.0] [--model air3]`
+- Batch support mirrors the existing `convert` subcommands; wired into the
+  existing `convert` `run_one` in `cli.py`.
+- `--footprint-interval` (seconds, default `2.0`) downsamples footprints so files
+  stay small — one polygon per interval, not per frame. The track LineString and
+  Points are unchanged.
+
+**GeoJSON:** add `Polygon` features alongside the existing LineString + Points:
+
+```json
+{
+  "type": "Feature",
+  "geometry": {"type": "Polygon", "coordinates": [[[lon,lat], …, [lon,lat]]]},
+  "properties": {"kind": "footprint", "index": 12, "timestamp": "00:00:24,000",
+                 "agl": 41.2, "hfov": 73.7, "vfov": 58.7}
+}
+```
+
+**KML:** a `<Folder>` named "Camera footprints" holding one `<Polygon>`
+placemark per footprint, `<altitudeMode>clampToGround</altitudeMode>`.
+
+## Redaction & fallback
+
+- **Footprints render only under `--redact none`** (judgment call). A precise
+  ~50 m polygon around a deliberately *fuzzed* centre re-sharpens exactly what
+  `fuzz` blurred; `drop` already yields an empty track. So footprint generation
+  is gated to `redact=none`; under `fuzz`/`drop` the output is track-only (no
+  Polygon features).
+- Per-point fallback: missing AGL or FOV, or too-oblique gimbal → skip that
+  footprint, keep the track. A whole clip with no AGL → track only, plus a
+  logged note. `--footprint` never removes the LineString/Point features.
+
+## Verification
+
+- **Projection unit tests:** known input → expected corners. e.g. 100 m AGL,
+  80° HFOV → `half_width = 100·tan40° ≈ 83.9 m` → corner lat/lon within
+  tolerance; nadir + zero heading → axis-aligned rectangle; non-zero heading →
+  rotated corners.
+- **Gimbal path:** Avata 360 fixture → footprint uses `gb_yaw`; a frame with
+  oblique `gb_pitch` → skipped.
+- **Parser:** `rel_alt` / `focal_len` (both ×10 and literal) / `gb_*` extraction
+  across the format fixtures in `samples/`.
+- **Privacy:** `--redact fuzz` and `--redact drop` → zero footprint features.
+- **CLI smoke:** `convert geojson --footprint` and `convert kml --footprint`
+  emit footprint Polygon features; golden-fixture structure check.
+
+## Docs
+
+- `docs/geospatial.md` — `--footprint` usage, the nadir/flat-earth assumptions
+  and their limits, `--model` and the FOV table, how to add a model.
+- README — note footprint export under the geospatial feature.
+- `docs/SRT_FORMATS.md` — note which fields (`rel_alt`, `focal_len`, `gb_*`) feed
+  the footprint and which formats carry them.
+
+## Issue / roadmap mapping
+
+- Completes the **camera-footprint follow-up** checklist on #215 (the track-only
+  Phase 1 already shipped).
+- Consumed by the map viewers: the standalone HTML viewer (#221, shipped) and the
+  web-UI map panel (#222, next) can render the footprint `Polygon` features.
+- **Deferred to a future issue:** oblique-trapezoid projection + view frustums
+  via DAT-log attitude (Approach C), and terrain/DEM-aware projection.

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -194,6 +194,15 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     metavar="CODE",
     help="cot only: CoT event type/affiliation code (default neutral air).",
 )
+@click.option("--footprint", is_flag=True, help="Add camera footprint polygons (geojson/kml, redact=none only)")
+@click.option(
+    "--footprint-interval",
+    type=float,
+    default=2.0,
+    show_default=True,
+    help="Seconds between footprint samples",
+)
+@click.option("--model", default=None, help="Drone model for the footprint FOV table (e.g. air3, mini4pro)")
 @click.option("-v", "--verbose", is_flag=True)
 @click.option("-q", "--quiet", is_flag=True)
 def convert(
@@ -205,6 +214,9 @@ def convert(
     redact: str,
     interval: float,
     cot_type: str,
+    footprint: bool,
+    footprint_interval: float,
+    model: str | None,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -230,9 +242,15 @@ def convert(
         elif command == "csv":
             extract_telemetry_to_csv(srt, out, tz_offset=offset)
         elif command == "geojson":
-            convert_to_geojson(srt, out, redact=redact)
+            convert_to_geojson(
+                srt, out, redact=redact,
+                footprint=footprint, footprint_interval=footprint_interval, model=model,
+            )
         elif command == "kml":
-            convert_to_kml(srt, out, redact=redact)
+            convert_to_kml(
+                srt, out, redact=redact,
+                footprint=footprint, footprint_interval=footprint_interval, model=model,
+            )
         elif command == "cot":
             convert_to_cot(
                 srt, out, redact=redact, tz_offset=offset,

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -1,6 +1,7 @@
 """Geospatial track model and exporters (GeoJSON, KML, HTML, CoT)."""
 
 from .cot import convert_to_cot, track_to_cot
+from .footprint import FOV_TABLE, Footprint, build_footprints, lens_for
 from .geojson import convert_to_geojson, track_to_geojson
 from .html_viewer import convert_to_html, track_to_html
 from .kml import convert_to_kml, track_to_kml
@@ -20,4 +21,8 @@ __all__ = [
     "convert_to_kml",
     "track_to_html",
     "convert_to_html",
+    "Footprint",
+    "build_footprints",
+    "lens_for",
+    "FOV_TABLE",
 ]

--- a/src/dji_metadata_embedder/geo/cot.py
+++ b/src/dji_metadata_embedder/geo/cot.py
@@ -14,11 +14,16 @@ against are not applicable here.
 from __future__ import annotations
 
 import logging
-import math
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
+from .geometry import (
+    downsample_by_time,
+    haversine_m,
+    initial_bearing_deg,
+    point_utc,
+)
 from .track import Track, TrackPoint, build_track
 
 logger = logging.getLogger(__name__)
@@ -26,56 +31,6 @@ logger = logging.getLogger(__name__)
 # CoT sentinel for unknown circular/linear error (90% containment, metres).
 _CE_LE_UNKNOWN = "9999999.0"
 _COT_TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
-# Mean Earth radius (m, IUGG) for the haversine helpers.
-_EARTH_R = 6371008.8
-
-
-def _utc(p: TrackPoint) -> datetime:
-    """Return *p*'s resolved UTC, enforcing the CoT precondition.
-
-    ``build_track`` always populates ``TrackPoint.utc``; this guard turns a
-    hand-built track that skipped it into a clear error instead of a cryptic
-    ``NoneType`` failure (and narrows the type for the serializer)."""
-    if p.utc is None:
-        raise ValueError(
-            "TrackPoint.utc is None; CoT export requires build_track to "
-            "populate it (got a Track built another way)"
-        )
-    return p.utc
-
-
-def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """Great-circle distance in metres between two WGS84 points."""
-    p1, p2 = math.radians(lat1), math.radians(lat2)
-    dphi = math.radians(lat2 - lat1)
-    dlmb = math.radians(lon2 - lon1)
-    a = math.sin(dphi / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
-    return 2 * _EARTH_R * math.asin(math.sqrt(a))
-
-
-def _initial_bearing_deg(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """Initial great-circle bearing (degrees, 0..360) from point 1 to point 2."""
-    p1, p2 = math.radians(lat1), math.radians(lat2)
-    dl = math.radians(lon2 - lon1)
-    y = math.sin(dl) * math.cos(p2)
-    x = math.cos(p1) * math.sin(p2) - math.sin(p1) * math.cos(p2) * math.cos(dl)
-    return (math.degrees(math.atan2(y, x)) + 360.0) % 360.0
-
-
-def _downsample(points: list[TrackPoint], interval: float) -> list[TrackPoint]:
-    """Keep the first point, then each point at least ``interval`` s after the
-    last kept one (by ``utc``), always keeping the final point."""
-    if not points:
-        return []
-    kept = [points[0]]
-    last = _utc(points[0])
-    for p in points[1:-1]:
-        if (_utc(p) - last).total_seconds() >= interval:
-            kept.append(p)
-            last = _utc(p)
-    if len(points) > 1:
-        kept.append(points[-1])
-    return kept
 
 
 def _add_point(ev: ET.Element, p: TrackPoint) -> None:
@@ -101,7 +56,7 @@ def _append_pli_event(
     cot_type: str,
     stale_seconds: float,
 ) -> None:
-    p_utc = _utc(p)
+    p_utc = point_utc(p)
     t = p_utc.strftime(_COT_TIME_FMT)
     stale = (p_utc + timedelta(seconds=stale_seconds)).strftime(_COT_TIME_FMT)
     ev = ET.SubElement(
@@ -122,14 +77,14 @@ def _append_pli_event(
     ET.SubElement(detail, "contact", {"callsign": name})
     ET.SubElement(detail, "precisionlocation", {"altsrc": "GPS"})
     if nxt is not None:
-        dt = (_utc(nxt) - p_utc).total_seconds()
+        dt = (point_utc(nxt) - p_utc).total_seconds()
         if dt > 0:
-            dist = _haversine_m(p.lat, p.lon, nxt.lat, nxt.lon)
+            dist = haversine_m(p.lat, p.lon, nxt.lat, nxt.lon)
             ET.SubElement(
                 detail,
                 "track",
                 {
-                    "course": f"{_initial_bearing_deg(p.lat, p.lon, nxt.lat, nxt.lon):.1f}",
+                    "course": f"{initial_bearing_deg(p.lat, p.lon, nxt.lat, nxt.lon):.1f}",
                     "speed": f"{dist / dt:.2f}",
                 },
             )
@@ -138,8 +93,8 @@ def _append_pli_event(
 
 def _append_route_event(root: ET.Element, name: str, sampled: list[TrackPoint]) -> None:
     first, last = sampled[0], sampled[-1]
-    t = _utc(first).strftime(_COT_TIME_FMT)
-    stale = (_utc(last) + timedelta(hours=1)).strftime(_COT_TIME_FMT)
+    t = point_utc(first).strftime(_COT_TIME_FMT)
+    stale = (point_utc(last) + timedelta(hours=1)).strftime(_COT_TIME_FMT)
     ev = ET.SubElement(
         root,
         "event",
@@ -183,7 +138,7 @@ def track_to_cot(
     (default neutral air). Requires each kept point to carry ``utc`` (always set
     by :func:`build_track`).
     """
-    sampled = _downsample(track.points, interval)
+    sampled = downsample_by_time(track.points, interval)
     root = ET.Element("events")
     for i, p in enumerate(sampled):
         nxt = sampled[i + 1] if i + 1 < len(sampled) else None

--- a/src/dji_metadata_embedder/geo/footprint.py
+++ b/src/dji_metadata_embedder/geo/footprint.py
@@ -13,6 +13,9 @@ import logging
 import math
 from dataclasses import dataclass
 
+from .geometry import downsample_by_time, initial_bearing_deg
+from .track import Track, TrackPoint
+
 logger = logging.getLogger(__name__)
 
 # DJI gimbal pitch: 0 deg = forward/horizon, -90 deg = straight down (nadir).
@@ -108,3 +111,68 @@ def ground_footprint(
         ring.append((lon + east / m_per_deg_lon, lat + north / _M_PER_DEG_LAT))
     ring.append(ring[0])
     return ring
+
+
+@dataclass(frozen=True)
+class Footprint:
+    """A camera ground footprint: a closed ``[(lon, lat), ...]`` ring plus the
+    properties that describe how it was projected."""
+
+    ring: list[tuple[float, float]]
+    index: int
+    timestamp: str
+    agl: float
+    hfov: float
+    vfov: float
+
+
+def _agl(point: TrackPoint, ground_ref: float) -> float | None:
+    """Height above ground for *point*: ``rel_alt`` when present, else
+    ``abs_alt - ground_ref``."""
+    if point.rel_alt is not None:
+        return point.rel_alt
+    return point.alt - ground_ref
+
+
+def _bearing(points: list[TrackPoint], i: int) -> float:
+    """Course over ground at sampled index *i* (gimbal yaw overrides it)."""
+    p = points[i]
+    if p.gimbal_yaw is not None:
+        return p.gimbal_yaw % 360.0
+    if i + 1 < len(points):
+        nxt = points[i + 1]
+        if (nxt.lat, nxt.lon) != (p.lat, p.lon):
+            return initial_bearing_deg(p.lat, p.lon, nxt.lat, nxt.lon)
+    if i > 0:
+        prv = points[i - 1]
+        if (prv.lat, prv.lon) != (p.lat, p.lon):
+            return initial_bearing_deg(prv.lat, prv.lon, p.lat, p.lon)
+    return 0.0
+
+
+def build_footprints(
+    track: Track, *, lens: LensSpec = DEFAULT_LENS, interval: float = 2.0
+) -> list[Footprint]:
+    """Project per-interval ground footprints for *track*.
+
+    Points are downsampled to roughly one per ``interval`` seconds. A point is
+    skipped when its AGL is non-positive/unknown, or when gimbal pitch shows the
+    camera is strongly oblique. Heading comes from course over ground, or gimbal
+    yaw when present. Redaction is the caller's responsibility (footprints should
+    only be built for ``redact == "none"``).
+    """
+    sampled = downsample_by_time(track.points, interval)
+    if not sampled:
+        return []
+    ground_ref = track.points[0].alt
+    out: list[Footprint] = []
+    for i, p in enumerate(sampled):
+        if p.gimbal_pitch is not None and abs(p.gimbal_pitch - NADIR_PITCH_DEG) > OBLIQUE_GATE_DEG:
+            continue
+        agl = _agl(p, ground_ref)
+        if agl is None or agl <= 0:
+            continue
+        hfov, vfov = fov_degrees(lens, p.focal_len)
+        ring = ground_footprint(p.lat, p.lon, agl, hfov, vfov, _bearing(sampled, i))
+        out.append(Footprint(ring, i, p.timestamp, agl, hfov, vfov))
+    return out

--- a/src/dji_metadata_embedder/geo/footprint.py
+++ b/src/dji_metadata_embedder/geo/footprint.py
@@ -1,0 +1,110 @@
+"""Camera ground-footprint polygons projected from a :class:`Track`.
+
+Model (spec 2026-06-20): assume a nadir (straight-down) camera and size the
+footprint from height-above-ground and a 35mm-equivalent field of view, rotated
+to flight heading or to real gimbal yaw when the format carries it. Strongly
+oblique gimbal frames are skipped, not drawn. Flat-earth equirectangular
+projection (accurate at footprint scale).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# DJI gimbal pitch: 0 deg = forward/horizon, -90 deg = straight down (nadir).
+NADIR_PITCH_DEG = -90.0
+# Skip footprints whose gimbal pitch is more than this far off nadir.
+OBLIQUE_GATE_DEG = 30.0
+# Metres per degree of latitude (WGS84 mean).
+_M_PER_DEG_LAT = 111320.0
+
+
+@dataclass(frozen=True)
+class LensSpec:
+    """A camera's 35mm-equivalent native focal length and sensor readout aspect."""
+
+    native_focal_equiv_mm: float
+    aspect: tuple[int, int]
+
+
+# Generic wide fallback (~84 deg HFOV, 4:3) when the model is unknown and the
+# SRT carries no focal_len. First-pass estimates; confirm against fixtures.
+DEFAULT_LENS = LensSpec(native_focal_equiv_mm=20.0, aspect=(4, 3))
+
+FOV_TABLE: dict[str, LensSpec] = {
+    "air3": LensSpec(native_focal_equiv_mm=24.0, aspect=(4, 3)),
+    "avata2": LensSpec(native_focal_equiv_mm=12.7, aspect=(4, 3)),
+    "mini4pro": LensSpec(native_focal_equiv_mm=24.0, aspect=(4, 3)),
+    "avata360": LensSpec(native_focal_equiv_mm=24.0, aspect=(4, 3)),
+}
+
+
+def lens_for(model: str | None) -> LensSpec:
+    """Return the :class:`LensSpec` for *model*, falling back to the generic wide
+    default (with a warning) when the model is unknown."""
+    if model is None:
+        return DEFAULT_LENS
+    lens = FOV_TABLE.get(model.lower())
+    if lens is None:
+        logger.warning(
+            "Unknown --model %r; using a generic wide lens. Known: %s",
+            model,
+            ", ".join(sorted(FOV_TABLE)),
+        )
+        return DEFAULT_LENS
+    return lens
+
+
+def fov_degrees(lens: LensSpec, focal_len_equiv: float | None) -> tuple[float, float]:
+    """Return (HFOV, VFOV) in degrees for *lens*.
+
+    Uses *focal_len_equiv* (a 35mm-equivalent focal length from the SRT, handling
+    zoom) when given, else the lens's native equivalent focal. FOV is computed
+    against a full-frame (36 mm wide) reference; the reference height follows the
+    lens aspect.
+    """
+    f = focal_len_equiv if focal_len_equiv else lens.native_focal_equiv_mm
+    aw, ah = lens.aspect
+    full_w = 36.0
+    full_h = 36.0 * ah / aw
+    hfov = math.degrees(2 * math.atan(full_w / (2 * f)))
+    vfov = math.degrees(2 * math.atan(full_h / (2 * f)))
+    return hfov, vfov
+
+
+def ground_footprint(
+    lat: float,
+    lon: float,
+    agl: float,
+    hfov_deg: float,
+    vfov_deg: float,
+    bearing_deg: float,
+) -> list[tuple[float, float]]:
+    """Return a closed footprint ring as ``[(lon, lat), ...]``.
+
+    The rectangle is centred under ``(lat, lon)``, sized by ``agl`` and the
+    field of view, and rotated so its along-track axis points to ``bearing_deg``
+    (clockwise from north).
+    """
+    half_w = agl * math.tan(math.radians(hfov_deg) / 2)  # across-track, metres
+    half_h = agl * math.tan(math.radians(vfov_deg) / 2)  # along-track, metres
+    th = math.radians(bearing_deg)
+    cos_t, sin_t = math.cos(th), math.sin(th)
+    m_per_deg_lon = _M_PER_DEG_LAT * max(math.cos(math.radians(lat)), 1e-6)
+
+    ring: list[tuple[float, float]] = []
+    for e0, n0 in (
+        (half_w, half_h),
+        (half_w, -half_h),
+        (-half_w, -half_h),
+        (-half_w, half_h),
+    ):
+        east = e0 * cos_t + n0 * sin_t
+        north = -e0 * sin_t + n0 * cos_t
+        ring.append((lon + east / m_per_deg_lon, lat + north / _M_PER_DEG_LAT))
+    ring.append(ring[0])
+    return ring

--- a/src/dji_metadata_embedder/geo/geojson.py
+++ b/src/dji_metadata_embedder/geo/geojson.py
@@ -11,12 +11,31 @@ import json
 import logging
 from pathlib import Path
 
+from .footprint import Footprint, build_footprints, lens_for
 from .track import Track, build_track
 
 logger = logging.getLogger(__name__)
 
 
-def track_to_geojson(track: Track) -> dict:
+def _footprint_feature(fp: Footprint) -> dict:
+    return {
+        "type": "Feature",
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[lon, lat] for lon, lat in fp.ring]],
+        },
+        "properties": {
+            "kind": "footprint",
+            "index": fp.index,
+            "timestamp": fp.timestamp,
+            "agl": round(fp.agl, 3),
+            "hfov": round(fp.hfov, 1),
+            "vfov": round(fp.vfov, 1),
+        },
+    }
+
+
+def track_to_geojson(track: Track, footprints: list[Footprint] | None = None) -> dict:
     """Return a GeoJSON ``FeatureCollection`` dict for *track*."""
     # RFC 7946 §3.1.4 requires a LineString to have two or more positions, so a
     # track with fewer points (e.g. --redact drop, or a clip that never got a
@@ -48,22 +67,38 @@ def track_to_geojson(track: Track) -> dict:
                 },
             }
         )
+    for fp in footprints or []:
+        features.append(_footprint_feature(fp))
     return {"type": "FeatureCollection", "features": features}
 
 
-def write_geojson(track: Track, output_path: Path) -> Path:
+def write_geojson(track: Track, output_path: Path, footprints: list[Footprint] | None = None) -> Path:
     """Write *track* as GeoJSON to *output_path* and return it."""
     output_path.write_text(
-        json.dumps(track_to_geojson(track), indent=2), encoding="utf-8"
+        json.dumps(track_to_geojson(track, footprints), indent=2), encoding="utf-8"
     )
     logger.info("GeoJSON file created: %s", output_path)
     return output_path
 
 
 def convert_to_geojson(
-    srt_file: Path | str, output_file: Path | str | None = None, redact: str = "none"
+    srt_file: Path | str,
+    output_file: Path | str | None = None,
+    redact: str = "none",
+    *,
+    footprint: bool = False,
+    footprint_interval: float = 2.0,
+    model: str | None = None,
 ) -> Path:
-    """Convert a DJI SRT file to GeoJSON. Defaults output to ``<srt>.geojson``."""
+    """Convert a DJI SRT file to GeoJSON. Defaults output to ``<srt>.geojson``.
+
+    When ``footprint`` is set and ``redact == "none"``, per-interval camera
+    ground-footprint polygons are added. Footprints are suppressed under any
+    redaction (a precise polygon would re-sharpen a fuzzed centre)."""
     srt_path = Path(srt_file)
     output_path = Path(output_file) if output_file else srt_path.with_suffix(".geojson")
-    return write_geojson(build_track(srt_path, redact=redact), output_path)
+    track = build_track(srt_path, redact=redact)
+    footprints = None
+    if footprint and redact == "none":
+        footprints = build_footprints(track, lens=lens_for(model), interval=footprint_interval)
+    return write_geojson(track, output_path, footprints)

--- a/src/dji_metadata_embedder/geo/geometry.py
+++ b/src/dji_metadata_embedder/geo/geometry.py
@@ -1,0 +1,59 @@
+"""Shared great-circle and time-downsampling helpers for the geo exporters.
+
+Extracted from ``cot.py`` so the CoT and footprint paths share one
+implementation of bearing/distance/downsampling.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+
+from .track import TrackPoint
+
+# Mean Earth radius (m, IUGG) for the haversine helpers.
+EARTH_R = 6371008.8
+
+
+def point_utc(p: TrackPoint) -> datetime:
+    """Return *p*'s resolved UTC, or raise if a hand-built track skipped it."""
+    if p.utc is None:
+        raise ValueError(
+            "TrackPoint.utc is None; this export requires build_track to "
+            "populate it (got a Track built another way)"
+        )
+    return p.utc
+
+
+def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in metres between two WGS84 points."""
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlmb = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
+    return 2 * EARTH_R * math.asin(math.sqrt(a))
+
+
+def initial_bearing_deg(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Initial great-circle bearing (degrees, 0..360) from point 1 to point 2."""
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dl = math.radians(lon2 - lon1)
+    y = math.sin(dl) * math.cos(p2)
+    x = math.cos(p1) * math.sin(p2) - math.sin(p1) * math.cos(p2) * math.cos(dl)
+    return (math.degrees(math.atan2(y, x)) + 360.0) % 360.0
+
+
+def downsample_by_time(points: list[TrackPoint], interval: float) -> list[TrackPoint]:
+    """Keep the first point, then each point at least ``interval`` s after the
+    last kept one (by ``utc``), always keeping the final point."""
+    if not points:
+        return []
+    kept = [points[0]]
+    last = point_utc(points[0])
+    for p in points[1:-1]:
+        if (point_utc(p) - last).total_seconds() >= interval:
+            kept.append(p)
+            last = point_utc(p)
+    if len(points) > 1:
+        kept.append(points[-1])
+    return kept

--- a/src/dji_metadata_embedder/geo/kml.py
+++ b/src/dji_metadata_embedder/geo/kml.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from xml.sax.saxutils import escape
 
+from .footprint import Footprint
 from .track import Track, build_track
 
 logger = logging.getLogger(__name__)
@@ -20,29 +21,68 @@ _KML_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
         <altitudeMode>absolute</altitudeMode>
         <coordinates>{coordinates}</coordinates>
       </LineString>
-    </Placemark>
+    </Placemark>{footprints}
   </Document>
 </kml>
 """
 
 
-def track_to_kml(track: Track) -> str:
+def _footprints_folder(footprints: list[Footprint]) -> str:
+    if not footprints:
+        return ""
+    placemarks = []
+    for fp in footprints:
+        coords = " ".join(f"{lon},{lat},0" for lon, lat in fp.ring)
+        placemarks.append(
+            "\n      <Placemark><name>footprint {idx}</name>"
+            "<Polygon><altitudeMode>clampToGround</altitudeMode>"
+            "<outerBoundaryIs><LinearRing>"
+            "<coordinates>{coords}</coordinates>"
+            "</LinearRing></outerBoundaryIs></Polygon></Placemark>".format(
+                idx=fp.index, coords=coords
+            )
+        )
+    return (
+        "\n    <Folder><name>Camera footprints</name>" + "".join(placemarks) + "\n    </Folder>"
+    )
+
+
+def track_to_kml(track: Track, footprints: list[Footprint] | None = None) -> str:
     """Return a KML document string for *track* (coordinates as lon,lat,alt)."""
     coordinates = " ".join(f"{p.lon},{p.lat},{p.alt}" for p in track.points)
-    return _KML_TEMPLATE.format(name=escape(track.name), coordinates=coordinates)
+    return _KML_TEMPLATE.format(
+        name=escape(track.name),
+        coordinates=coordinates,
+        footprints=_footprints_folder(footprints or []),
+    )
 
 
-def write_kml(track: Track, output_path: Path) -> Path:
+def write_kml(track: Track, output_path: Path, footprints: list[Footprint] | None = None) -> Path:
     """Write *track* as KML to *output_path* and return it."""
-    output_path.write_text(track_to_kml(track), encoding="utf-8")
+    output_path.write_text(track_to_kml(track, footprints), encoding="utf-8")
     logger.info("KML file created: %s", output_path)
     return output_path
 
 
 def convert_to_kml(
-    srt_file: Path | str, output_file: Path | str | None = None, redact: str = "none"
+    srt_file: Path | str,
+    output_file: Path | str | None = None,
+    redact: str = "none",
+    *,
+    footprint: bool = False,
+    footprint_interval: float = 2.0,
+    model: str | None = None,
 ) -> Path:
-    """Convert a DJI SRT file to KML. Defaults output to ``<srt>.kml``."""
+    """Convert a DJI SRT file to KML. Defaults output to ``<srt>.kml``.
+
+    With ``footprint`` and ``redact == "none"``, a folder of per-interval camera
+    footprint polygons is added."""
+    from .footprint import build_footprints, lens_for
+
     srt_path = Path(srt_file)
     output_path = Path(output_file) if output_file else srt_path.with_suffix(".kml")
-    return write_kml(build_track(srt_path, redact=redact), output_path)
+    track = build_track(srt_path, redact=redact)
+    footprints = None
+    if footprint and redact == "none":
+        footprints = build_footprints(track, lens=lens_for(model), interval=footprint_interval)
+    return write_kml(track, output_path, footprints)

--- a/src/dji_metadata_embedder/geo/track.py
+++ b/src/dji_metadata_embedder/geo/track.py
@@ -18,13 +18,18 @@ from ..utilities import parse_telemetry_samples, redact_coords, resolve_utc_offs
 @dataclass
 class TrackPoint:
     """One GPS-fixed sample: WGS84 lat/lon, absolute altitude (m), raw cue time,
-    and best-effort UTC datetime."""
+    best-effort UTC datetime, and optional footprint inputs (AGL via rel_alt,
+    35mm-equivalent focal length, gimbal yaw/pitch) when the format carries them."""
 
     lat: float
     lon: float
     alt: float
     timestamp: str
     utc: datetime | None = None
+    rel_alt: float | None = None
+    focal_len: float | None = None
+    gimbal_yaw: float | None = None
+    gimbal_pitch: float | None = None
 
 
 @dataclass
@@ -89,7 +94,17 @@ def build_track(
             else:
                 utc = mtime_utc + timedelta(seconds=_cue_seconds(s.cue) - base_cue)
             points.append(
-                TrackPoint(lat=c[0], lon=c[1], alt=s.alt, timestamp=s.cue, utc=utc)
+                TrackPoint(
+                    lat=c[0],
+                    lon=c[1],
+                    alt=s.alt,
+                    timestamp=s.cue,
+                    utc=utc,
+                    rel_alt=s.rel_alt,
+                    focal_len=s.focal_len,
+                    gimbal_yaw=s.gimbal_yaw,
+                    gimbal_pitch=s.gimbal_pitch,
+                )
             )
 
     return Track(name=srt_path.stem, points=points)

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -104,13 +104,19 @@ def resolve_utc_offset(
 
 @dataclass
 class TelemetrySample:
-    """One GPS-fixed SRT block: position, raw cue time, and absolute datetime."""
+    """One GPS-fixed SRT block: position, raw cue time, absolute datetime, and
+    optional footprint inputs (relative altitude, 35mm-equivalent focal length,
+    gimbal yaw/pitch) when the format carries them."""
 
     lat: float
     lon: float
     alt: float
     cue: str
     dt: datetime | None
+    rel_alt: float | None = None
+    focal_len: float | None = None
+    gimbal_yaw: float | None = None
+    gimbal_pitch: float | None = None
 
 
 def iso6709(lat: float, lon: float, alt: float = 0.0) -> str:
@@ -127,6 +133,21 @@ def is_gps_fix(lat: float, lon: float) -> bool:
     excluded from geotagging and exported tracks.
     """
     return not (lat == 0.0 and lon == 0.0)
+
+
+def _normalize_focal_len(raw: str) -> float | None:
+    """Normalize a DJI ``focal_len`` token to a 35mm-equivalent in mm.
+
+    DJI writes it two ways: legacy ``240`` (== 24 mm, x10) and newer literal
+    ``24.00``. Values >= 100 are treated as the x10 form. The one ambiguous
+    case (a real >= 100 mm-equivalent literal, i.e. a long tele) is rare on the
+    supported models; documented in docs/SRT_FORMATS.md.
+    """
+    try:
+        value = float(raw)
+    except ValueError:
+        return None
+    return value / 10.0 if value >= 100.0 else value
 
 
 def parse_telemetry_samples(srt_path: Path) -> List[TelemetrySample]:
@@ -150,6 +171,14 @@ def parse_telemetry_samples(srt_path: Path) -> List[TelemetrySample]:
         if "<font" in tele_line:
             tele_line = re.sub(r"<[^>]+>", "", tele_line)
         dt = _parse_srt_datetime(tele_line)
+        rel_match = re.search(r"rel_alt:\s*([+-]?\d+\.?\d*)", tele_line)
+        focal_match = re.search(r"\[focal_len\s*:\s*([+-]?\d+\.?\d*)", tele_line)
+        gb_yaw_match = re.search(r"gb_yaw:\s*([+-]?\d+\.?\d*)", tele_line)
+        gb_pitch_match = re.search(r"gb_pitch:\s*([+-]?\d+\.?\d*)", tele_line)
+        rel_alt = float(rel_match.group(1)) if rel_match else None
+        focal_len = _normalize_focal_len(focal_match.group(1)) if focal_match else None
+        gimbal_yaw = float(gb_yaw_match.group(1)) if gb_yaw_match else None
+        gimbal_pitch = float(gb_pitch_match.group(1)) if gb_pitch_match else None
         lat_match = re.search(r"\[latitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
         lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
         alt_match = re.search(r"abs_alt:\s*([+-]?\d+\.?\d*)\]", tele_line)
@@ -178,7 +207,19 @@ def parse_telemetry_samples(srt_path: Path) -> List[TelemetrySample]:
             # Skip pre-GPS-lock ``(0, 0)`` no-fix frames so exported tracks do
             # not include Null Island points.
             if is_gps_fix(lat, lon):
-                samples.append(TelemetrySample(lat, lon, alt, timestamp, dt))
+                samples.append(
+                    TelemetrySample(
+                        lat,
+                        lon,
+                        alt,
+                        timestamp,
+                        dt,
+                        rel_alt=rel_alt,
+                        focal_len=focal_len,
+                        gimbal_yaw=gimbal_yaw,
+                        gimbal_pitch=gimbal_pitch,
+                    )
+                )
     return samples
 
 

--- a/tests/test_cli_convert_geo.py
+++ b/tests/test_cli_convert_geo.py
@@ -2,6 +2,7 @@ import json
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from dji_metadata_embedder.cli import main
@@ -122,14 +123,21 @@ def test_convert_kml_footprint_cli(tmp_path):
     assert "Camera footprints" in out.read_text()
 
 
-def test_convert_geojson_footprint_suppressed_by_redaction(tmp_path):
-    out = tmp_path / "clip.geojson"
+@pytest.mark.parametrize("fmt", ["geojson", "kml"])
+@pytest.mark.parametrize("redact", ["fuzz", "drop"])
+def test_convert_footprint_suppressed_by_redaction(tmp_path, fmt, redact):
+    out = tmp_path / f"clip.{fmt}"
     runner = CliRunner()
     result = runner.invoke(
-        main, ["convert", "geojson", str(AIR3), "-o", str(out),
-                "--footprint", "--redact", "fuzz"]
+        main,
+        ["convert", fmt, str(AIR3), "-o", str(out), "--footprint", "--redact", redact],
     )
     assert result.exit_code == 0, result.output
-    data = json.loads(out.read_text())
-    assert not [f for f in data["features"]
-                if f["geometry"] and f["geometry"]["type"] == "Polygon"]
+    text = out.read_text()
+    if fmt == "geojson":
+        data = json.loads(text)
+        assert not [f for f in data["features"]
+                    if f["geometry"] and f["geometry"]["type"] == "Polygon"]
+    else:
+        assert "Camera footprints" not in text
+        assert "<Polygon>" not in text

--- a/tests/test_cli_convert_geo.py
+++ b/tests/test_cli_convert_geo.py
@@ -93,3 +93,43 @@ def test_convert_cot_redact_drop_empties_events(tmp_path):
     assert result.exit_code == 0, result.output
     root = ET.fromstring(out.read_text(encoding="utf-8"))
     assert len(root) == 0
+
+
+AIR3 = SAMPLES / "air3" / "clip.SRT"
+
+
+def test_convert_geojson_footprint_cli(tmp_path):
+    out = tmp_path / "clip.geojson"
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["convert", "geojson", str(AIR3), "-o", str(out), "--footprint",
+                "--footprint-interval", "0"]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(out.read_text())
+    polys = [f for f in data["features"]
+             if f["geometry"] and f["geometry"]["type"] == "Polygon"]
+    assert polys and polys[0]["properties"]["kind"] == "footprint"
+
+
+def test_convert_kml_footprint_cli(tmp_path):
+    out = tmp_path / "clip.kml"
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["convert", "kml", str(AIR3), "-o", str(out), "--footprint"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Camera footprints" in out.read_text()
+
+
+def test_convert_geojson_footprint_suppressed_by_redaction(tmp_path):
+    out = tmp_path / "clip.geojson"
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["convert", "geojson", str(AIR3), "-o", str(out),
+                "--footprint", "--redact", "fuzz"]
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(out.read_text())
+    assert not [f for f in data["features"]
+                if f["geometry"] and f["geometry"]["type"] == "Polygon"]

--- a/tests/test_footprint_parsing.py
+++ b/tests/test_footprint_parsing.py
@@ -25,9 +25,16 @@ def test_avata2_gps_format_has_no_rel_alt():
     assert s.rel_alt is None
 
 
-def test_legacy_focal_len_times_ten_is_normalized():
-    srt = SAMPLES / "air3S" / "DJI_20260516195553_0001_D.SRT"
-    samples = parse_telemetry_samples(srt)
-    for s in samples:
-        if s.focal_len is not None:
-            assert s.focal_len < 100.0
+def test_legacy_focal_len_times_ten_is_normalized(tmp_path):
+    # Legacy bracket format writes focal_len as x10 (350 -> 35.0 mm-equivalent).
+    srt = tmp_path / "legacy.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "<font size='36'>SrtCnt : 1, DiffTime : 33ms\n"
+        "2024-01-01 12:00:00,000\n"
+        "[iso : 100] [shutter : 1/1000] [fnum : 280] [focal_len : 350] "
+        "[latitude: 59.30] [longitude: 18.20] [rel_alt: 10.0 abs_alt: 142.0]</font>\n",
+        encoding="utf-8",
+    )
+    s = parse_telemetry_samples(srt)[0]
+    assert s.focal_len == 35.0

--- a/tests/test_footprint_parsing.py
+++ b/tests/test_footprint_parsing.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from dji_metadata_embedder.utilities import parse_telemetry_samples
+
+SAMPLES = Path(__file__).resolve().parents[1] / "samples"
+
+
+def test_air3_has_rel_alt_no_focal_no_gimbal():
+    s = parse_telemetry_samples(SAMPLES / "air3" / "clip.SRT")[0]
+    assert s.rel_alt == 5.0
+    assert s.focal_len is None
+    assert s.gimbal_yaw is None
+    assert s.gimbal_pitch is None
+
+
+def test_avata360_has_focal_and_gimbal():
+    s = parse_telemetry_samples(SAMPLES / "Avata360" / "clip.SRT")[0]
+    assert s.focal_len == 28.0
+    assert s.gimbal_yaw == -162.8
+    assert s.gimbal_pitch == 0.0
+
+
+def test_avata2_gps_format_has_no_rel_alt():
+    s = parse_telemetry_samples(SAMPLES / "avata2" / "clip.SRT")[0]
+    assert s.rel_alt is None
+
+
+def test_legacy_focal_len_times_ten_is_normalized():
+    srt = SAMPLES / "air3S" / "DJI_20260516195553_0001_D.SRT"
+    samples = parse_telemetry_samples(srt)
+    for s in samples:
+        if s.focal_len is not None:
+            assert s.focal_len < 100.0

--- a/tests/test_geo_footprint.py
+++ b/tests/test_geo_footprint.py
@@ -47,3 +47,44 @@ def test_ground_footprint_rotates_with_bearing():
 def test_default_lens_and_table_present():
     assert isinstance(DEFAULT_LENS, LensSpec)
     assert "air3" in FOV_TABLE
+
+
+from datetime import datetime, timedelta
+
+from dji_metadata_embedder.geo.footprint import Footprint, build_footprints
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+
+def _pt(lat, lon, secs, **kw):
+    base = datetime(2026, 1, 1)
+    return TrackPoint(lat=lat, lon=lon, alt=kw.pop("alt", 100.0), timestamp=f"{secs}",
+                      utc=base + timedelta(seconds=secs), **kw)
+
+
+def test_build_footprints_uses_rel_alt():
+    pts = [_pt(0.0, 0.0, 0, rel_alt=50.0), _pt(0.0001, 0.0, 1, rel_alt=50.0)]
+    fps = build_footprints(Track("t", pts), interval=0.0)
+    assert len(fps) == 2
+    assert all(isinstance(f, Footprint) for f in fps)
+    assert fps[0].agl == 50.0
+
+
+def test_build_footprints_agl_fallback_to_abs_minus_ground():
+    # No rel_alt -> AGL = abs_alt - first abs_alt. Ground ref 100 -> AGL 20.
+    pts = [_pt(0.0, 0.0, 0, alt=100.0), _pt(0.0001, 0.0, 1, alt=120.0)]
+    fps = build_footprints(Track("t", pts), interval=0.0)
+    # First point AGL is 0 -> skipped; second is 20.
+    assert [f.agl for f in fps] == [20.0]
+
+
+def test_build_footprints_skips_oblique_gimbal():
+    pts = [_pt(0.0, 0.0, 0, rel_alt=50.0, gimbal_pitch=0.0),
+           _pt(0.0001, 0.0, 1, rel_alt=50.0, gimbal_pitch=0.0)]
+    assert build_footprints(Track("t", pts), interval=0.0) == []
+
+
+def test_build_footprints_uses_gimbal_yaw_when_present():
+    pts = [_pt(0.0, 0.0, 0, rel_alt=50.0, gimbal_pitch=-90.0, gimbal_yaw=90.0),
+           _pt(0.0, 0.0001, 1, rel_alt=50.0, gimbal_pitch=-90.0, gimbal_yaw=90.0)]
+    fps = build_footprints(Track("t", pts), interval=0.0)
+    assert fps  # nadir gimbal -> drawn; yaw 90 rotates the ring

--- a/tests/test_geo_footprint.py
+++ b/tests/test_geo_footprint.py
@@ -1,12 +1,15 @@
-import math
+from datetime import datetime, timedelta
 
 from dji_metadata_embedder.geo.footprint import (
     DEFAULT_LENS,
     FOV_TABLE,
+    Footprint,
     LensSpec,
+    build_footprints,
     fov_degrees,
     ground_footprint,
 )
+from dji_metadata_embedder.geo.track import Track, TrackPoint
 
 M_PER_DEG = 111320.0
 
@@ -47,12 +50,6 @@ def test_ground_footprint_rotates_with_bearing():
 def test_default_lens_and_table_present():
     assert isinstance(DEFAULT_LENS, LensSpec)
     assert "air3" in FOV_TABLE
-
-
-from datetime import datetime, timedelta
-
-from dji_metadata_embedder.geo.footprint import Footprint, build_footprints
-from dji_metadata_embedder.geo.track import Track, TrackPoint
 
 
 def _pt(lat, lon, secs, **kw):

--- a/tests/test_geo_footprint.py
+++ b/tests/test_geo_footprint.py
@@ -81,7 +81,12 @@ def test_build_footprints_skips_oblique_gimbal():
 
 
 def test_build_footprints_uses_gimbal_yaw_when_present():
-    pts = [_pt(0.0, 0.0, 0, rel_alt=50.0, gimbal_pitch=-90.0, gimbal_yaw=90.0),
-           _pt(0.0, 0.0001, 1, rel_alt=50.0, gimbal_pitch=-90.0, gimbal_yaw=90.0)]
-    fps = build_footprints(Track("t", pts), interval=0.0)
-    assert fps  # nadir gimbal -> drawn; yaw 90 rotates the ring
+    # Single-point tracks so heading comes purely from gimbal_yaw.
+    p0 = [_pt(0.0, 0.0, 0, rel_alt=50.0, gimbal_pitch=-90.0, gimbal_yaw=0.0)]
+    p90 = [_pt(0.0, 0.0, 0, rel_alt=50.0, gimbal_pitch=-90.0, gimbal_yaw=90.0)]
+    fp0 = build_footprints(Track("t", p0), interval=0.0)[0]
+    fp90 = build_footprints(Track("t", p90), interval=0.0)[0]
+    lat_extent_0 = max(lat for _, lat in fp0.ring) - min(lat for _, lat in fp0.ring)
+    lat_extent_90 = max(lat for _, lat in fp90.ring) - min(lat for _, lat in fp90.ring)
+    # Default lens HFOV != VFOV, so a 90 deg yaw changes the N-S extent.
+    assert abs(lat_extent_0 - lat_extent_90) > 1e-7

--- a/tests/test_geo_footprint.py
+++ b/tests/test_geo_footprint.py
@@ -1,0 +1,49 @@
+import math
+
+from dji_metadata_embedder.geo.footprint import (
+    DEFAULT_LENS,
+    FOV_TABLE,
+    LensSpec,
+    fov_degrees,
+    ground_footprint,
+)
+
+M_PER_DEG = 111320.0
+
+
+def test_fov_24mm_fullframe_4x3():
+    hfov, vfov = fov_degrees(LensSpec(24.0, (4, 3)), None)
+    assert abs(hfov - 73.7398) < 1e-3
+    assert abs(vfov - 58.7155) < 1e-3
+
+
+def test_fov_uses_srt_focal_when_present():
+    # 12 mm-equivalent is wider than the 24 mm native focal.
+    wide, _ = fov_degrees(LensSpec(24.0, (4, 3)), 12.0)
+    native, _ = fov_degrees(LensSpec(24.0, (4, 3)), None)
+    assert wide > native
+
+
+def test_ground_footprint_nadir_north_aligned():
+    # 100 m AGL, 24mm/4:3 -> half_width 75.0 m, half_height 56.25 m.
+    hfov, vfov = fov_degrees(LensSpec(24.0, (4, 3)), None)
+    ring = ground_footprint(0.0, 0.0, 100.0, hfov, vfov, 0.0)
+    assert len(ring) == 5
+    assert ring[0] == ring[-1]
+    lon, lat = ring[0]
+    assert abs(lon - 75.0 / M_PER_DEG) < 1e-6
+    assert abs(lat - 56.25 / M_PER_DEG) < 1e-6
+
+
+def test_ground_footprint_rotates_with_bearing():
+    hfov, vfov = fov_degrees(LensSpec(24.0, (4, 3)), None)
+    nadir = ground_footprint(0.0, 0.0, 100.0, hfov, vfov, 0.0)
+    east = ground_footprint(0.0, 0.0, 100.0, hfov, vfov, 90.0)
+    # Rotating by 90 deg moves the along-track (north) extent onto east.
+    assert abs(max(lon for lon, _ in east) - 56.25 / M_PER_DEG) < 1e-6
+    assert abs(max(lon for lon, _ in nadir) - 75.0 / M_PER_DEG) < 1e-6
+
+
+def test_default_lens_and_table_present():
+    assert isinstance(DEFAULT_LENS, LensSpec)
+    assert "air3" in FOV_TABLE

--- a/tests/test_geo_geojson.py
+++ b/tests/test_geo_geojson.py
@@ -45,3 +45,32 @@ def test_convert_to_geojson_default_output_path(tmp_path):
     result = convert_to_geojson(srt)
     assert result == srt.with_suffix(".geojson")
     assert result.exists()
+
+
+def test_geojson_includes_footprint_polygons():
+    from pathlib import Path
+    from dji_metadata_embedder.geo.track import build_track
+    from dji_metadata_embedder.geo.footprint import build_footprints
+    from dji_metadata_embedder.geo.geojson import track_to_geojson
+
+    samples = Path(__file__).resolve().parents[1] / "samples"
+    track = build_track(samples / "air3" / "clip.SRT")
+    fps = build_footprints(track, interval=0.0)
+    gj = track_to_geojson(track, footprints=fps)
+    polys = [f for f in gj["features"]
+             if f["geometry"] and f["geometry"]["type"] == "Polygon"]
+    assert polys, "expected at least one footprint polygon"
+    assert polys[0]["properties"]["kind"] == "footprint"
+    assert "agl" in polys[0]["properties"]
+
+
+def test_geojson_without_footprints_unchanged():
+    from pathlib import Path
+    from dji_metadata_embedder.geo.track import build_track
+    from dji_metadata_embedder.geo.geojson import track_to_geojson
+
+    samples = Path(__file__).resolve().parents[1] / "samples"
+    track = build_track(samples / "air3" / "clip.SRT")
+    gj = track_to_geojson(track)
+    assert not [f for f in gj["features"]
+                if f["geometry"] and f["geometry"]["type"] == "Polygon"]

--- a/tests/test_geo_geometry.py
+++ b/tests/test_geo_geometry.py
@@ -1,4 +1,3 @@
-import math
 from datetime import datetime, timedelta
 
 from dji_metadata_embedder.geo.geometry import (

--- a/tests/test_geo_geometry.py
+++ b/tests/test_geo_geometry.py
@@ -1,0 +1,31 @@
+import math
+from datetime import datetime, timedelta
+
+from dji_metadata_embedder.geo.geometry import (
+    haversine_m,
+    initial_bearing_deg,
+    downsample_by_time,
+    point_utc,
+)
+from dji_metadata_embedder.geo.track import TrackPoint
+
+
+def _p(lat, lon, secs):
+    base = datetime(2026, 1, 1, 0, 0, 0)
+    return TrackPoint(lat=lat, lon=lon, alt=0.0, timestamp="", utc=base + timedelta(seconds=secs))
+
+
+def test_haversine_known_distance():
+    # 0.001 deg latitude ~= 111.32 m.
+    assert abs(haversine_m(0.0, 0.0, 0.001, 0.0) - 111.32) < 0.5
+
+
+def test_initial_bearing_due_east():
+    assert abs(initial_bearing_deg(0.0, 0.0, 0.0, 1.0) - 90.0) < 1e-6
+
+
+def test_downsample_keeps_first_and_last():
+    pts = [_p(0.0, 0.0, s) for s in (0, 1, 2, 3, 4)]
+    kept = downsample_by_time(pts, 2.0)
+    # First, one >=2s later, and the final point.
+    assert [round((point_utc(p) - point_utc(pts[0])).total_seconds()) for p in kept] == [0, 2, 4]

--- a/tests/test_geo_kml.py
+++ b/tests/test_geo_kml.py
@@ -25,3 +25,28 @@ def test_convert_to_kml_writes_file(tmp_path):
     result = convert_to_kml(CLIP, out)
     assert result == out
     assert "<kml" in out.read_text()
+
+
+def test_kml_includes_footprint_folder():
+    from pathlib import Path
+    from dji_metadata_embedder.geo.track import build_track
+    from dji_metadata_embedder.geo.footprint import build_footprints
+    from dji_metadata_embedder.geo.kml import track_to_kml
+
+    samples = Path(__file__).resolve().parents[1] / "samples"
+    track = build_track(samples / "air3" / "clip.SRT")
+    fps = build_footprints(track, interval=0.0)
+    kml = track_to_kml(track, footprints=fps)
+    assert "<Folder>" in kml
+    assert "Camera footprints" in kml
+    assert "clampToGround" in kml
+
+
+def test_kml_without_footprints_has_no_folder():
+    from pathlib import Path
+    from dji_metadata_embedder.geo.track import build_track
+    from dji_metadata_embedder.geo.kml import track_to_kml
+
+    samples = Path(__file__).resolve().parents[1] / "samples"
+    track = build_track(samples / "air3" / "clip.SRT")
+    assert "<Folder>" not in track_to_kml(track)

--- a/tests/test_geo_track.py
+++ b/tests/test_geo_track.py
@@ -55,3 +55,21 @@ def test_build_track_synthesizes_utc_without_datetime(tmp_path):
     # Cue times are 1s apart -> synthesized UTC preserves that spacing.
     delta = track.points[1].utc - track.points[0].utc
     assert delta.total_seconds() == 1.0
+
+
+def test_build_track_carries_footprint_fields():
+    samples = Path(__file__).resolve().parents[1] / "samples"
+    track = build_track(samples / "Avata360" / "clip.SRT")
+    p = track.points[0]
+    assert p.rel_alt == 5.4
+    assert p.focal_len == 28.0
+    assert p.gimbal_yaw == -162.8
+    assert p.gimbal_pitch == 0.0
+
+
+def test_build_track_footprint_fields_default_none():
+    samples = Path(__file__).resolve().parents[1] / "samples"
+    track = build_track(samples / "air3" / "clip.SRT")
+    assert track.points[0].rel_alt == 5.0
+    assert track.points[0].focal_len is None
+    assert track.points[0].gimbal_yaw is None


### PR DESCRIPTION
## Summary

Completes the camera-footprint follow-up on #215 (the track-only Phase 1 shipped in v1.6.0). Adds per-interval camera ground-footprint polygons to `dji-embed convert geojson` and `convert kml`, behind a `--footprint` flag — for mapping / SAR coverage / OSINT verification.

- **Nadir model** (spec Approach A): footprint rectangle sized from height-above-ground + a 35 mm-equivalent FOV, rotated to flight heading — or to real gimbal yaw when the format carries attitude (Avata 360). Strongly-oblique frames (gimbal pitch >~30° off nadir) are skipped, not mis-drawn. Flat-earth, pure-stdlib math.
- **Per-model FOV** via a small `FOV_TABLE` + `--model`; `--footprint-interval` (default 2 s) controls sampling cadence.
- **Parser** now captures optional `rel_alt`, `focal_len` (×10-or-literal normalized), `gb_yaw`/`gb_pitch`; `TrackPoint` carries them.
- **Shared geo math** (`haversine`/`bearing`/`downsample`) extracted from `cot.py` into a new `geo/geometry.py` (behavior-preserving DRY refactor).
- **Privacy:** footprints are emitted only under `--redact none`; under `fuzz`/`drop` zero footprint features are produced (a precise polygon would re-sharpen a fuzzed centre).
- **Deferred to a future issue:** oblique-trapezoid projection + view frustums via DAT-log attitude, and terrain/DEM-aware projection.

Design spec: `docs/superpowers/specs/2026-06-20-camera-footprint-export-design.md`.

## Test Plan
- [x] `uv run pytest -q` → 184 passed, 1 skipped (pre-existing flask-not-installed UI test)
- [x] `uv run ruff check .` → clean
- [x] `uv run mypy` → clean (29 source files)
- [x] `uv run mkdocs build --strict` → clean
- [x] CLI smoke: `convert geojson/kml --footprint` emits footprint polygons; `--redact fuzz|drop` suppresses them (parametrized test across both formats)
- [x] Independent review confirmed rotation math, AGL fallback, oblique gate, and the privacy gate (verified by running the CLI for all fuzz/drop × geojson/kml combos)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKFeqKaEBqXURyRSEQYWHx