### PR TITLE
feat: ExifTool-backed MP4 timed-metadata extractor for sidecar-less footage (#206)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 
 **Don't see your model?** We're happy to add support in exchange for sample SRT files we can parse the telemetry format from. Open an [issue](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/new) and attach one or two raw `.SRT` files from your drone (a short clip is plenty), and we'll add a parser for it. See the [Contributing Guide](CONTRIBUTING.md) for details.
 
+**Sidecar-less models (Air 3S, Mini 5 Pro, …):** telemetry is read straight from
+the MP4's embedded `djmd`/`dbgi` track via ExifTool — no `.SRT` needed —
+for `dji-embed convert <fmt> FILE.MP4` and `dji-embed verify-sun FILE.MP4`.
+Requires a recent ExifTool (Air 3S ≥ 13.39, Mini 5 Pro ≥ 13.52); see
+[docs/MP4_TIMED_METADATA.md](docs/MP4_TIMED_METADATA.md).
+
 ## Requirements
 
  - Python 3.10 or higher

--- a/docs/MP4_TIMED_METADATA.md
+++ b/docs/MP4_TIMED_METADATA.md
@@ -1,0 +1,41 @@
+# MP4 Timed Metadata (sidecar-less DJI footage)
+
+Newer DJI models (Air 3S, Mini 5 Pro, and others) record telemetry **inside the
+MP4** as DJI's `djmd`/`dbgi` protobuf timed-metadata track, with no sidecar
+`.SRT`. `dji-embed` reads it via ExifTool, so the `convert` exporters and
+`verify-sun` work directly on the video:
+
+    dji-embed convert gpx     DJI_0001.MP4
+    dji-embed convert geojson DJI_0001.MP4 --redact fuzz
+    dji-embed verify-sun      DJI_0001.MP4
+
+Input is auto-detected by extension: `.mp4`/`.mov` use the ExifTool extractor,
+`.srt` uses the subtitle parser. A folder of clips works with
+`dji-embed convert geojson FOLDER --batch`.
+
+## ExifTool version matters
+
+ExifTool decodes each model's protobuf schema in a specific release:
+
+| Model | ExifTool ≥ |
+|-------|-----------|
+| baseline `djmd`/`dbgi` | 13.05 |
+| DJI Neo | 13.35 |
+| Air 3S | 13.39 |
+| Mini 5 Pro | 13.52 |
+
+Newer models land in later releases — check the ExifTool change history. If your
+ExifTool is too old, the stream is recognised but no GPS is decoded, and
+`dji-embed` reports which schema needs a newer ExifTool. Ubuntu/Debian packages
+lag; install a current ExifTool from <https://exiftool.org> (or set
+`DJIEMBED_EXIFTOOL_PATH`).
+
+## What you get
+
+`GPSDateTime` in the stream is true UTC, so GPX/CoT timestamps, CSV
+`datetime_utc`, and `verify-sun` are correct without any timezone guessing.
+Field coverage varies by model (e.g. Air 3S includes gimbal angles; Mini 5 Pro
+is GPS + altitude only). CSV from an MP4 fills geo/altitude/`datetime_utc`/solar
+columns; SRT-only camera columns (iso, shutter, …) stay blank.
+
+> UTC note: an MP4's time is intrinsic, so `--tz-offset` is ignored for video.

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -44,6 +44,8 @@ This guide helps you choose the right command and approach for your specific use
 | Directory of SRT files | Multiple CSV files | `dji-embed convert csv /path/to/srt/dir --batch` |
 | Directory of SRT files | Multiple HTML maps | `dji-embed convert html /path/to/srt/dir --batch` |
 | Custom output filename | Specific output file | `dji-embed convert gpx input.SRT -o custom.gpx` |
+| MP4 with no sidecar SRT (Air 3S, Mini 5 Pro) | GPX/CSV/GeoJSON/KML track | `dji-embed convert <fmt> FILE.MP4` (ExifTool-backed; needs recent ExifTool — see [MP4 Timed Metadata](MP4_TIMED_METADATA.md)) |
+| MP4 with no sidecar SRT (Air 3S, Mini 5 Pro) | Sun/shadow verification | `dji-embed verify-sun FILE.MP4` (ExifTool-backed; needs recent ExifTool — see [MP4 Timed Metadata](MP4_TIMED_METADATA.md)) |
 
 ### For Analysis and Validation
 
@@ -126,6 +128,7 @@ dji-embed --version
 |---------------|----------------|-------------------|-----------|
 | **Mini 3/4 Pro** | `[latitude: X] [longitude: Y]` | ✅ Fully supported | Most common format |
 | **Air 3** | HTML-style with extended data | ✅ Fully supported | Rich telemetry data |
+| **Air 3S / Mini 5 Pro** | MP4 `djmd`/`dbgi` embedded track | ✅ Fully supported | Sidecar-less; ExifTool ≥ 13.39/13.52; see [MP4 Timed Metadata](MP4_TIMED_METADATA.md) |
 | **Avata 2** | `GPS(lat,lon,alt)` legacy format | ✅ Fully supported | BAROMETER data included |
 | **Mavic 3 Enterprise** | Extended format with RTK | ✅ Fully supported | Professional features |
 | **Other models** | Various formats | ⚠️ May work | Use `validate` command first |

--- a/docs/superpowers/specs/2026-06-20-mp4-timed-metadata-extractor-design.md
+++ b/docs/superpowers/specs/2026-06-20-mp4-timed-metadata-extractor-design.md
@@ -1,0 +1,298 @@
+# Design: ExifTool-backed MP4 timed-metadata extractor (#206)
+
+_Date: 2026-06-20_
+
+## Context
+
+Newer DJI models (Air 3S, Mini 5 Pro, Mavic 4 Pro, Matrice 4E, Osmo 360, …) ship
+footage with **no sidecar `.SRT`**. Their telemetry lives inside the MP4 as a
+timed-metadata track — DJI's `djmd` / `dbgi` protobuf streams (`MetaFormat:
+djmd`, handler `CAM meta` / `CAM dbgi`). ExifTool decodes these per model, so
+`dji-embed` can read them by shelling out to the ExifTool binary the project
+already documents — no reverse-engineering, no licence entanglement.
+
+This is **Stage 1** of #206: an ExifTool-backed extractor that normalises the
+MP4 timed metadata into the project's existing telemetry model, wired into the
+**`convert` exporters and `verify-sun`** so every mapping/verification output
+works on sidecar-less footage. (Stage 2 — native clean-room protobuf decoding —
+remains a separate future effort, e.g. #202.)
+
+### Empirical grounding (validated 2026-06-20)
+
+Probed against real local fixtures with ExifTool **13.55** (the current CPAN
+production release):
+
+- **Air 3S** (`dvtm_Air3s.proto`): rich decode — 3214 samples each of GPS
+  lat/lon, absolute + relative altitude, shutter, F-number, colour temperature,
+  gimbal yaw/pitch, drone yaw/pitch/roll, plus `SampleTime`, `SampleDuration`,
+  and `GPSDateTime` per sample.
+- **Mini 5 Pro** (`dvtm_Mini5Pro.proto`): lean decode — GPS, absolute altitude,
+  temperature only. **Field sets vary per model.**
+- **Neo 2** (`dvtm_NEO2.proto`): stream present but **not decoded** by 13.55
+  (proto not yet registered) — only `SampleTime` returns.
+
+Decode coverage is per-model and tracks ExifTool's release cadence (Air 3S
+landed ~13.39, Mini 5 Pro ~13.52; Neo 2 still pending). **New models become
+supported by upgrading ExifTool — no code change in this extractor.**
+
+Two findings shape the design:
+
+1. **Consumption pattern:** `exiftool -ee -j -g3 -n -api LargeFileSupport=1
+   <file>` returns JSON whose first element holds `Doc1 … DocN` nested objects —
+   one per timed sample, each carrying only the fields present for that sample.
+   This is robust to varying/missing fields (`.get()` mapping). The `-p`
+   print-format alternative is rejected: it silently *skips* any sample missing
+   a referenced tag.
+2. **Absolute UTC for free:** `GPSDateTime` is true per-sample UTC
+   (`2026:05:16 23:55:53.000Z`). The MP4 path therefore supplies wall-clock UTC
+   *directly*, unlike the SRT path, which must infer the local→UTC offset from
+   the file mtime. This makes `verify-sun` strictly more reliable on MP4 input.
+
+## Goals
+
+- Read DJI `djmd`/`dbgi` timed metadata from an MP4/MOV via ExifTool and
+  normalise it to the project's canonical `TelemetrySample` model.
+- Make `dji-embed convert <fmt> FILE` and `dji-embed verify-sun FILE` accept a
+  **video** file as input (auto-detected by extension), in addition to `.SRT`.
+- Thread the MP4 path's **true UTC** through so timestamped outputs (GPX, CoT,
+  CSV `datetime_utc`, sun geometry) are correct without mtime guessing.
+- Stay **model-agnostic**: gain models purely through ExifTool upgrades.
+- Fail loudly and usefully when a stream is present but undecodable.
+
+## Non-goals
+
+- **Embed fall-through** (`dji-embed embed` on sidecar-less MP4s). The issue's
+  Stage 1 named this; we deliberately target the higher-value convert/verify-sun
+  surface first. The embed mux requires an SRT subtitle track, so embed support
+  is a clean follow-up (synthesise an SRT from samples, or a GPS-tags-only mode).
+- **Native protobuf decoding** (Stage 2 / #202). We shell out to ExifTool.
+- **Stream preservation through the mux** (#197) — orthogonal.
+- **New CSV columns / richer schema.** CSV from an MP4 fills the columns the
+  stream provides; it does not add columns.
+- **A `--telemetry-source` flag.** Single-file `convert`/`verify-sun` dispatch on
+  the input's extension; the flag was an embed-batch concern (both files present
+  side-by-side), out of scope here.
+- **ffprobe dependency.** ExifTool itself is the detector.
+
+## Architecture
+
+```
+                         ┌─ .srt  → parse_telemetry_samples()      (dt = local wall-clock)
+load_samples(path) ─dispatch┤
+                         └─ .mp4/.mov → mp4_telemetry.extract_samples()  (dt = UTC)
+                                            │  shells: exiftool -ee -j -g3 -n
+                                            ▼
+                                 list[TelemetrySample]
+                          ┌──────────────────┼─────────────────────────┐
+                          ▼                  ▼                          ▼
+                   build_track()      gpx / verify-sun            csv (rich rows)
+              (geojson/kml/cot/html)  (via _parse_gps_points     (bespoke; fills the
+                                       dict shape)                fields the stream has)
+```
+
+One new module (`mp4_telemetry.py`), one dispatcher (`load_samples`), and a
+small video-aware adapter for the legacy dict/CSV consumers. The `Track`-based
+exporters (geojson/kml/cot/html) need no change beyond `build_track` dispatch.
+
+## Component: `src/dji_metadata_embedder/mp4_telemetry.py`
+
+A focused module with no dependency on the embedder pipeline.
+
+- `VIDEO_SUFFIXES = {".mp4", ".mov"}` (case-insensitive) and
+  `is_video(path) -> bool`.
+
+- `probe(path) -> str | None` — cheap detection, **no `-ee`**:
+  `exiftool -s -api LargeFileSupport=1 -MetaFormat -Category <file>`. Returns the
+  schema descriptor (e.g. `dvtm_Air3s.proto;model_name:FC9113;…`) when a
+  `djmd`/`dbgi` track exists, else `None`. Used to distinguish "no telemetry
+  track" from "track present but undecoded".
+
+- `extract_samples(path) -> list[TelemetrySample]` — the core:
+  1. Run `exiftool -ee -j -g3 -n -api LargeFileSupport=1 <file>` via
+     `subprocess.run(capture_output=True)`. The exiftool executable is resolved
+     via the existing `utils.dependency_manager` (`_find_exiftool_executable`),
+     falling back to `shutil.which("exiftool")`.
+  2. `json.loads(stdout)`; take element `[0]`; iterate keys matching `^Doc\d+$`
+     in numeric order.
+  3. For each sample doc, map (all via `.get`, tolerant of absence):
+     | TelemetrySample | ExifTool tag | notes |
+     |---|---|---|
+     | `lat` | `GPSLatitude` | float (from `-n`) |
+     | `lon` | `GPSLongitude` | float |
+     | `alt` | `AbsoluteAltitude` | float; `0.0` if absent |
+     | `cue` | `SampleTime` | seconds → `HH:MM:SS,mmm` string |
+     | `dt`  | `GPSDateTime` | parsed as UTC `datetime` (strip trailing `Z`); `None` if absent |
+     | `rel_alt` | `RelativeAltitude` | optional |
+     | `gimbal_yaw` | `GimbalYaw` | optional |
+     | `gimbal_pitch` | `GimbalPitch` | optional |
+     | `focal_len` | — | `None` (stream carries no 35mm-equiv focal length) |
+  4. Drop samples without both `GPSLatitude` and `GPSLongitude`, and apply the
+     same `(0, 0)` no-fix filter as the SRT path (`is_gps_fix`).
+  5. **Undecoded-vs-no-fix distinction.** If `probe()` found a stream but the
+     `Doc`s carry **no recognised telemetry at all** (only `SampleTime` — the
+     Neo 2 signature), raise `Mp4TelemetryError`: this ExifTool can't decode the
+     model. If telemetry fields *are* present but no sample is a valid GPS fix
+     (a legitimately GPS-less clip), return an **empty list** — not an error.
+     Concretely: track whether any `Doc` had a GPS or altitude key; raise only
+     when none did.
+
+- `Mp4TelemetryError(RuntimeError)` — module-specific exception with actionable
+  messages.
+
+`SampleTime` → cue formatting: `SampleTime` is elapsed seconds from track
+start (e.g. `0`, `0.0166833…`). Format as `HH:MM:SS,mmm` so it matches the SRT
+cue shape the rest of the code expects. (This is a *relative* cue, consistent
+with how the SRT cue is relative; absolute time lives in `dt`.)
+
+## Component: dispatcher + the UTC rule
+
+Add to `utilities.py`, beside `parse_telemetry_samples`:
+
+- `load_samples(path) -> list[TelemetrySample]` — `is_video(path)` →
+  `mp4_telemetry.extract_samples(path)`; else `parse_telemetry_samples(path)`.
+
+**The UTC rule (the crux):** SRT `dt` is *local wall-clock* (consumers subtract
+an mtime-derived offset); MP4 `dt` is *already UTC*. So any consumer that
+resolves an offset must use **offset 0 for video sources**.
+
+`build_track` is refactored to make this explicit and reusable:
+
+- Extract the Track-assembly body into
+  `build_track_from_samples(name, samples, redact, *, assume_utc, tz_offset,
+  mtime_utc) -> Track`.
+- `build_track(path, redact, tz_offset)`:
+  - `samples = load_samples(path)`.
+  - If `is_video(path)`: `assume_utc=True` → each point's `utc = sample.dt`
+    (no offset resolution). `name = path.stem`.
+  - Else: today's behaviour exactly — resolve offset from
+    `tz_offset`/mtime, `utc = dt - offset`, synthesise from cue when `dt is
+    None`. **SRT output is unchanged, byte-for-byte.**
+
+This single change lights up geojson, kml, cot, and html for MP4 input.
+
+## Component: legacy dict + CSV consumers
+
+`gpx`, `verify-sun`, and `csv` do not go through `build_track`; they parse SRT
+text directly. They are routed through a shared video-aware loader so SRT
+behaviour is untouched and video input is added.
+
+- `load_gps_points(path) -> tuple[list[dict], bool]` (in `telemetry_converter.py`)
+  — returns `(_parse_gps_points`-shaped dicts, `is_utc)`:
+  - SRT: `(_parse_gps_points(content), False)` — unchanged.
+  - Video: map `load_samples(path)` into the same dict shape
+    (`lat`, `lon`, `ele`←alt, `time`←cue, `datetime`←`dt`), `is_utc=True`.
+  - `extract_telemetry_to_gpx` and `summarize_sun` replace their
+    `open()+_parse_gps_points(content)` with `load_gps_points(path)`, and use
+    `offset = timedelta(0) if is_utc else resolve_utc_offset(...)`.
+
+- **CSV** (`extract_telemetry_to_csv`) keeps its bespoke rich per-block parser
+  for SRT. For a **video** input it builds its rows from `load_samples(path)`
+  instead, populating the columns the canonical `TelemetrySample` carries —
+  `latitude`, `longitude`, `rel_altitude`, `abs_altitude`, `datetime_utc` (from
+  the true UTC `dt`), and `sun_azimuth`/`sun_elevation` (computed from `dt` +
+  lat/lon). The camera columns (`iso`, `shutter`, `fnum`, `ev`, `ct`,
+  `color_md`, `focal_len`) stay **blank** for MP4 sources — `TelemetrySample`
+  does not model them, and adding them would mean bloating the track model.
+  The column set is unchanged; only the source and which columns are filled
+  differ. (Camera-column support from MP4 is a deliberate follow-up.)
+
+## CLI surface
+
+- `convert`'s `input` argument is already `click.Path(exists=True)` — it accepts
+  a video path today with no signature change. Only `run_one` changes: it now
+  receives any telemetry source and the exporters dispatch internally.
+- `--batch` currently globs `*.SRT`. Extend to also glob `*.MP4`/`*.MOV` so a
+  folder of sidecar-less clips converts in one call. (SRT-only folders behave as
+  before.)
+- `verify-sun`'s argument likewise accepts a video path; `summarize_sun`
+  dispatches internally.
+- No new flags. `--tz-offset` is ignored for video input (UTC is intrinsic); a
+  one-line note in `--help`/docs states this.
+
+## Data flow & redaction
+
+Redaction is unchanged and still applied at the `Track`/exporter layer
+(`redact_coords`, `redact` of `none`/`drop`/`fuzz`). The extractor returns raw
+samples; `build_track`/exporters redact exactly as they do for SRT, so `drop`
+still yields an empty track and `fuzz` still coarsens to ~100 m. No exact
+coordinate handling changes.
+
+## Error handling
+
+`mp4_telemetry` raises `Mp4TelemetryError` with actionable text; the CLI surfaces
+it as a `click.ClickException`:
+
+- **Stream present, zero GPS decoded** (e.g. Neo 2 on 13.55):
+  `"Telemetry stream present (<schema>) but ExifTool <ver> decoded no GPS — this
+  model needs a newer ExifTool (see docs/MP4_TIMED_METADATA.md)."` Includes the
+  schema from `probe()` and `exiftool -ver`.
+- **No djmd/dbgi track at all:** `"No embedded telemetry found in <file>; is
+  there a sidecar .SRT for this clip?"`
+- **exiftool not found:** reuse the existing install hint
+  (`pip install …[ui]`-style message already used elsewhere for ExifTool).
+- **exiftool nonzero exit / unparseable JSON:** raise with stderr tail.
+- Empty or fully redacted tracks flow through identically to the SRT path (no
+  crash; exporters emit their empty-state output).
+
+## Testing & verification
+
+Fixture strategy: **no media or real GPS committed.**
+
+- Commit `tests/fixtures/mp4_telemetry/air3s_g3j.json` — a real
+  `exiftool -ee -j -g3 -n` capture from the Air 3S fixture, **trimmed to a
+  handful of `Doc` samples** and with **GPS coordinates offset to a safe
+  location**. This is the golden input for the mapper.
+- **Unit tests** (`tests/test_mp4_telemetry.py`), mocking
+  `subprocess.run`/the exiftool call to return the committed JSON:
+  - mapper field-mapping → correct `TelemetrySample` list (lat/lon/alt/cue/dt/
+    rel_alt/gimbal).
+  - `dt` parsed as UTC and **not shifted** when threaded through `build_track`
+    (`assume_utc`) / `load_gps_points` (`is_utc`).
+  - `SampleTime` → `HH:MM:SS,mmm` cue formatting.
+  - `(0, 0)` and missing-GPS samples filtered.
+  - `probe()` returns the schema vs `None`.
+  - stream-present-but-zero-GPS → `Mp4TelemetryError` (drive via a JSON capture
+    that has `Doc`s without GPS).
+- **Integration test** (`tests/test_mp4_telemetry_integration.py`),
+  `@pytest.mark.skipif` on real `exiftool` ≥ 13.39 **and** a local, git-ignored
+  sample MP4 (path via env var, e.g. `DJI_MP4_FIXTURE`): runs the real
+  subprocess end-to-end and asserts a non-empty `Track`. Skips cleanly in CI.
+- **Consumer tests:** `convert geojson FILE.mp4` (mocked extractor) yields a
+  `FeatureCollection`; `verify-sun FILE.mp4` computes sun geometry from the true
+  UTC; `convert csv FILE.mp4` fills geo + `datetime_utc` + sun, blanks SRT-only
+  columns.
+- `uv run pytest -q`, `uv run ruff`, and `uv run mypy` all green before commit.
+
+## Docs
+
+- New `docs/MP4_TIMED_METADATA.md`: how MP4 timed metadata works, the ExifTool
+  version requirement (≥13.05 baseline; per-model: Air 3S ≥13.39, Mini 5 Pro
+  ≥13.52; check the ExifTool changelog for newer models), how to install a
+  recent ExifTool, and the per-model field-coverage caveat.
+- `README.md`: note Air 3S / Mini 5 Pro are now usable **without** a sidecar SRT
+  via `convert`/`verify-sun`, with the ExifTool-version caveat.
+- `docs/user_guide.md` + `docs/decision-table.md`: mention `convert`/`verify-sun`
+  accept an MP4 directly.
+
+## Open decisions (resolved)
+
+- **CSV camera columns from MP4:** **out of scope** for v1. CSV from an MP4 fills
+  only the columns `TelemetrySample` models (geo, alt, `datetime_utc`, sun);
+  camera columns stay blank rather than bloat the track model. A follow-up can
+  add them via a richer CSV-specific extraction if there's demand.
+- **Video suffixes:** `.mp4` + `.mov` only. `.lrf`/`.osv` proxies are out of
+  scope (they carry no usable djmd GPS).
+- **`shutter`/`fnum`/`ct` are decoded** by ExifTool for some models (Air 3S),
+  but the extractor does not surface them in v1 — see the CSV decision above.
+
+## Issue / roadmap mapping
+
+- Implements the **convert + verify-sun** half of **#206 Stage 1** (ExifTool
+  extractor). Embed fall-through and `--telemetry-source` are explicitly
+  deferred to a follow-up.
+- Unblocks sidecar-less **Air 3S** and **Mini 5 Pro** today; **Neo 2** and the
+  rest of #182's model survey unlock automatically as ExifTool adds their
+  protos (see the ExifTool DJI-protobuf changelog timeline).
+- Aligns with the project's verification/provenance/mapping direction:
+  sidecar-less footage gains GPX/GeoJSON/KML/CoT/CSV export and sun-based
+  footage verification.

--- a/docs/superpowers/specs/2026-06-20-mp4-timed-metadata-extractor-design.md
+++ b/docs/superpowers/specs/2026-06-20-mp4-timed-metadata-extractor-design.md
@@ -73,6 +73,16 @@ Two findings shape the design:
   the input's extension; the flag was an embed-batch concern (both files present
   side-by-side), out of scope here.
 - **ffprobe dependency.** ExifTool itself is the detector.
+- **ExifTool auto-provisioning / version-check.** This spec relies on the user's
+  installed ExifTool and fails with a clear, actionable message when it is
+  missing or too old (see Error handling). Cross-platform on-demand download of a
+  pinned recent ExifTool — and bumping the stale `dependency_manager`
+  `exiftool-13.32_64.zip` pin (already too old for Air 3S, which needs ≥13.39) —
+  is a deliberate **follow-up (#235)**, not part of this work. Rationale: writing
+  our own decoder forfeits the "new models for free via ExifTool upgrade"
+  property, and vendoring the full binary bloats the wheel and entangles
+  licensing; on-demand provisioning is the right answer but is independently
+  scoped.
 
 ## Architecture
 
@@ -296,3 +306,5 @@ Fixture strategy: **no media or real GPS committed.**
 - Aligns with the project's verification/provenance/mapping direction:
   sidecar-less footage gains GPX/GeoJSON/KML/CoT/CSV export and sun-based
   footage verification.
+- **Follow-up #235** (cross-platform, version-aware ExifTool provisioning) makes
+  the dependency painless without bundling or reimplementing ExifTool.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -32,6 +32,17 @@ Use `csv` instead of `gpx` to create a CSV file.
 
 For detailed how-to guides such as creating Windows bundles or redacting location data, see the files in `docs/how-to`.
 
+### Sidecar-less footage (MP4 with embedded telemetry)
+
+Newer DJI models record telemetry inside the MP4 instead of a `.SRT`. Pass the
+video directly — `convert` and `verify-sun` auto-detect it:
+
+    dji-embed convert gpx DJI_0001.MP4
+    dji-embed verify-sun  DJI_0001.MP4
+
+This needs a recent ExifTool (see `docs/MP4_TIMED_METADATA.md`). `--tz-offset`
+is ignored for MP4 input because its embedded time is already UTC.
+
 ## Footage verification (sun / shadow check)
 
 For chronolocation and footage verification you can cross-check the **shadows** in a clip against where the sun actually was. Given each GPS point's position and UTC time, `dji-embed` computes the sun's **azimuth** (compass bearing) and **elevation** (height above the horizon).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - Reference:
       - API Reference: api.md
       - SRT Formats: SRT_FORMATS.md
+      - MP4 Timed Metadata: MP4_TIMED_METADATA.md
       - Release Process: RELEASE.md
 plugins:
   - search

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -17,6 +17,7 @@ from .telemetry_converter import (
     summarize_sun,
 )
 from .geo import convert_to_geojson, convert_to_kml, convert_to_html, convert_to_cot
+from .mp4_telemetry import Mp4TelemetryError
 from .utilities import check_dependencies, setup_logging, get_tool_versions
 
 
@@ -265,11 +266,18 @@ def convert(
         seen: set[Path] = set()
         for pattern in patterns:
             for path in src.glob(pattern):
-                if path not in seen:
-                    seen.add(path)
+                if path in seen:
+                    continue
+                seen.add(path)
+                try:
                     run_one(path, None)
+                except Mp4TelemetryError as e:
+                    click.echo(f"Skipping {path.name}: {e}", err=True)
     else:
-        run_one(src, output)
+        try:
+            run_one(src, output)
+        except Mp4TelemetryError as e:
+            raise click.ClickException(str(e))
 
 
 @main.command()

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -170,7 +170,8 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     show_default=True,
     metavar="OFFSET",
     help="UTC offset for GPX/CoT timestamps, e.g. '+05:30' or '-8'. "
-    "'auto' detects it from the SRT file mtime.",
+    "'auto' detects it from the SRT file mtime. Ignored for MP4 input "
+    "(its GPSDateTime is already UTC).",
 )
 @click.option(
     "--redact",
@@ -260,8 +261,13 @@ def convert(
             convert_to_html(srt, out, redact=redact)
 
     if batch:
-        for srt in src.glob("*.SRT"):
-            run_one(srt, None)
+        patterns = ("*.SRT", "*.srt", "*.MP4", "*.mp4", "*.MOV", "*.mov")
+        seen: set[Path] = set()
+        for pattern in patterns:
+            for path in src.glob(pattern):
+                if path not in seen:
+                    seen.add(path)
+                    run_one(path, None)
     else:
         run_one(src, output)
 

--- a/src/dji_metadata_embedder/geo/track.py
+++ b/src/dji_metadata_embedder/geo/track.py
@@ -94,8 +94,8 @@ def build_track_from_samples(
         offset: timedelta | None = timedelta(0)
     else:
         abs_times = [s.dt for s in samples if s.dt is not None]
-        _mtime = mtime_utc if mtime_utc is not None else datetime.min
-        offset = resolve_utc_offset(abs_times, tz_offset, _mtime)
+        assert mtime_utc is not None, "mtime_utc is required when assume_utc is False"
+        offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
     base_cue = _cue_seconds(samples[0].cue) if samples else 0.0
 
     coords = redact_coords([(s.lat, s.lon) for s in samples], redact)

--- a/src/dji_metadata_embedder/geo/track.py
+++ b/src/dji_metadata_embedder/geo/track.py
@@ -12,7 +12,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from ..utilities import parse_telemetry_samples, redact_coords, resolve_utc_offset
+from ..utilities import TelemetrySample, load_samples, redact_coords, resolve_utc_offset
+from ..mp4_telemetry import is_video
 
 
 @dataclass
@@ -54,57 +55,76 @@ def build_track(
     redact: str = "none",
     tz_offset: timedelta | None = None,
 ) -> Track:
-    """Build a :class:`Track` from a DJI SRT file.
+    """Build a :class:`Track` from a DJI ``.SRT`` or a video (MP4/MOV).
 
-    ``redact`` mirrors the embed pipeline: ``"drop"`` yields an empty track,
-    ``"fuzz"`` coarsens coordinates to ~100 m (3 decimals), ``"none"`` keeps
-    them. Each point's ``utc`` is the block's absolute datetime minus the
-    resolved local->UTC offset (``tz_offset`` if given, else auto-detected from
-    the file mtime); when the format carries no absolute datetime, ``utc`` is
-    synthesized as ``mtime + (cue - first_cue)`` so consumers that need a
-    timestamp (e.g. CoT) always have a monotonic one. Pre-GPS-lock ``(0, 0)``
-    frames are already excluded by :func:`parse_telemetry_samples`.
+    SRT ``dt`` is local wall-clock, so its UTC is resolved from ``tz_offset`` or
+    the file mtime (unchanged behaviour). A video's ``dt`` is already absolute
+    UTC (ExifTool ``GPSDateTime``), so it is used directly with a zero offset.
+    ``redact`` mirrors the embed pipeline: ``"drop"`` empties the track,
+    ``"fuzz"`` coarsens to ~100 m, ``"none"`` keeps coordinates.
     """
-    srt_path = Path(srt_file)
-    samples = parse_telemetry_samples(srt_path)
-
-    abs_times = [s.dt for s in samples if s.dt is not None]
+    path = Path(srt_file)
+    samples = load_samples(path)
+    if is_video(path):
+        return build_track_from_samples(path.stem, samples, redact, assume_utc=True)
     mtime_utc = datetime.fromtimestamp(
-        srt_path.stat().st_mtime, tz=timezone.utc
+        path.stat().st_mtime, tz=timezone.utc
     ).replace(tzinfo=None)
-    offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
+    return build_track_from_samples(
+        path.stem, samples, redact, tz_offset=tz_offset, mtime_utc=mtime_utc
+    )
+
+
+def build_track_from_samples(
+    name: str,
+    samples: list[TelemetrySample],
+    redact: str = "none",
+    *,
+    assume_utc: bool = False,
+    tz_offset: timedelta | None = None,
+    mtime_utc: datetime | None = None,
+) -> Track:
+    """Assemble a :class:`Track` from samples, resolving each point's UTC.
+
+    ``assume_utc`` (video): each ``sample.dt`` is already UTC -> zero offset.
+    Otherwise (SRT): resolve the local->UTC offset from ``tz_offset``/``mtime_utc``
+    and synthesise a monotonic UTC from the cue when a sample has no datetime.
+    """
+    if assume_utc:
+        offset: timedelta | None = timedelta(0)
+    else:
+        abs_times = [s.dt for s in samples if s.dt is not None]
+        _mtime = mtime_utc if mtime_utc is not None else datetime.min
+        offset = resolve_utc_offset(abs_times, tz_offset, _mtime)
     base_cue = _cue_seconds(samples[0].cue) if samples else 0.0
 
     coords = redact_coords([(s.lat, s.lon) for s in samples], redact)
     if redact == "drop":
-        points: list[TrackPoint] = []
-    else:
-        # ``redact_coords`` returns coordinates 1:1 for "none"/"fuzz". Guard the
-        # invariant so a future mode that filters points cannot silently
-        # truncate the track at the zip below.
-        if len(coords) != len(samples):
-            raise ValueError(
-                f"redact_coords returned {len(coords)} coords for {len(samples)} "
-                f"points (mode={redact!r}); cannot preserve alt/timestamp alignment"
+        return Track(name=name, points=[])
+    if len(coords) != len(samples):
+        raise ValueError(
+            f"redact_coords returned {len(coords)} coords for {len(samples)} "
+            f"points (mode={redact!r}); cannot preserve alt/timestamp alignment"
+        )
+    points: list[TrackPoint] = []
+    for c, s in zip(coords, samples):
+        if s.dt is not None and offset is not None:
+            utc = s.dt - offset
+        elif mtime_utc is not None:
+            utc = mtime_utc + timedelta(seconds=_cue_seconds(s.cue) - base_cue)
+        else:
+            utc = None
+        points.append(
+            TrackPoint(
+                lat=c[0],
+                lon=c[1],
+                alt=s.alt,
+                timestamp=s.cue,
+                utc=utc,
+                rel_alt=s.rel_alt,
+                focal_len=s.focal_len,
+                gimbal_yaw=s.gimbal_yaw,
+                gimbal_pitch=s.gimbal_pitch,
             )
-        points = []
-        for c, s in zip(coords, samples):
-            if s.dt is not None and offset is not None:
-                utc = s.dt - offset
-            else:
-                utc = mtime_utc + timedelta(seconds=_cue_seconds(s.cue) - base_cue)
-            points.append(
-                TrackPoint(
-                    lat=c[0],
-                    lon=c[1],
-                    alt=s.alt,
-                    timestamp=s.cue,
-                    utc=utc,
-                    rel_alt=s.rel_alt,
-                    focal_len=s.focal_len,
-                    gimbal_yaw=s.gimbal_yaw,
-                    gimbal_pitch=s.gimbal_pitch,
-                )
-            )
-
-    return Track(name=srt_path.stem, points=points)
+        )
+    return Track(name=name, points=points)

--- a/src/dji_metadata_embedder/mp4_telemetry.py
+++ b/src/dji_metadata_embedder/mp4_telemetry.py
@@ -7,7 +7,10 @@ model, so the convert exporters and verify-sun work on sidecar-less footage.
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -114,3 +117,89 @@ def _samples_from_exiftool(data: list) -> tuple[list[TelemetrySample], bool]:
             )
         )
     return samples, saw_telemetry
+
+
+_EXIFTOOL_INSTALL_HINT = (
+    "ExifTool not found. Install it (https://exiftool.org) or set "
+    "DJIEMBED_EXIFTOOL_PATH to the executable. Reading MP4 timed metadata "
+    "needs ExifTool >= 13.39 for Air 3S, >= 13.52 for Mini 5 Pro."
+)
+
+
+def _exiftool_exe() -> str:
+    """Resolve the ExifTool executable (env override, else PATH ``exiftool``)."""
+    env = os.environ.get("DJIEMBED_EXIFTOOL_PATH")
+    if env and Path(env).exists():
+        return env
+    return "exiftool"
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            [_exiftool_exe(), *args], capture_output=True, text=True
+        )
+    except FileNotFoundError:
+        raise Mp4TelemetryError(_EXIFTOOL_INSTALL_HINT) from None
+
+
+def _exiftool_version() -> str | None:
+    proc = _run(["-ver"])
+    return proc.stdout.strip() or None
+
+
+def _run_exiftool_json(path: Path) -> list:
+    """Run the embedded-metadata extraction and return parsed JSON (one element)."""
+    proc = _run(
+        ["-ee", "-j", "-g3", "-n", "-api", "LargeFileSupport=1", str(path)]
+    )
+    if proc.returncode != 0:
+        raise Mp4TelemetryError(
+            f"ExifTool failed on {path.name}: {proc.stderr.strip()[-300:]}"
+        )
+    try:
+        return json.loads(proc.stdout) if proc.stdout.strip() else []
+    except json.JSONDecodeError as exc:
+        raise Mp4TelemetryError(f"Could not parse ExifTool JSON for {path.name}: {exc}") from exc
+
+
+def probe(path: Path) -> str | None:
+    """Cheaply detect an embedded telemetry track without extracting samples.
+
+    Returns the schema descriptor (e.g. ``dvtm_Air3s.proto;model_name:FC9113;…``)
+    when the MP4 carries a ``djmd``/``dbgi`` metadata track, else ``None``.
+    """
+    proc = _run(
+        ["-s", "-api", "LargeFileSupport=1", "-MetaFormat", "-Category", str(path)]
+    )
+    out = proc.stdout
+    if "djmd" not in out and "dbgi" not in out:
+        return None
+    m = re.search(r"pb_file:\s*([^\s;]+\.proto[^\n]*)", out)
+    return m.group(1).strip() if m else "djmd"
+
+
+def extract_samples(path: Path) -> list[TelemetrySample]:
+    """Extract GPS-fixed telemetry samples from an MP4/MOV via ExifTool.
+
+    Raises :class:`Mp4TelemetryError` when there is no telemetry track, or a
+    track is present but this ExifTool cannot decode the model. A clip that
+    decodes but never acquired a GPS fix yields an empty list (not an error).
+    """
+    path = Path(path)
+    samples, saw_telemetry = _samples_from_exiftool(_run_exiftool_json(path))
+    if samples:
+        return samples
+    schema = probe(path)
+    if schema is None:
+        raise Mp4TelemetryError(
+            f"No embedded telemetry found in {path.name}; is there a sidecar "
+            f".SRT for this clip?"
+        )
+    if not saw_telemetry:
+        raise Mp4TelemetryError(
+            f"Telemetry stream present ({schema}) in {path.name} but ExifTool "
+            f"{_exiftool_version()} decoded no GPS for this model. Upgrade "
+            f"ExifTool (see docs/MP4_TIMED_METADATA.md)."
+        )
+    return []  # decoded, but no GPS fix in this clip

--- a/src/dji_metadata_embedder/mp4_telemetry.py
+++ b/src/dji_metadata_embedder/mp4_telemetry.py
@@ -7,8 +7,11 @@ model, so the convert exporters and verify-sun work on sidecar-less footage.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from pathlib import Path
+
+from .utilities import TelemetrySample, is_gps_fix
 
 
 class Mp4TelemetryError(RuntimeError):
@@ -49,3 +52,65 @@ def _parse_gps_datetime(value: str) -> datetime | None:
         except ValueError:
             continue
     return None
+
+
+# Mapped per-sample tags other than SampleTime. Presence of any of these on any
+# Doc means ExifTool decoded the protobuf (vs. an unsupported model where only
+# SampleTime survives).
+_TELEMETRY_KEYS = (
+    "GPSLatitude",
+    "GPSLongitude",
+    "AbsoluteAltitude",
+    "RelativeAltitude",
+    "GimbalYaw",
+    "GimbalPitch",
+)
+
+_DOC_KEY_RE = re.compile(r"^Doc(\d+)$")
+
+
+def _samples_from_exiftool(data: list) -> tuple[list[TelemetrySample], bool]:
+    """Map ExifTool ``-g3 -j`` JSON to samples and whether telemetry was decoded.
+
+    ``data`` is ExifTool's JSON: a one-element list whose object holds ``Doc1 …
+    DocN`` per-sample sub-documents. Returns ``(samples, saw_telemetry)`` where
+    ``saw_telemetry`` is True if any sample carried a recognised telemetry field.
+    Samples without a GPS fix (missing or ``(0, 0)``) are dropped.
+    """
+    if not data:
+        return [], False
+    root = data[0]
+    docs = sorted(
+        ((m.group(1), v) for k, v in root.items() if (m := _DOC_KEY_RE.match(k))),
+        key=lambda kv: int(kv[0]),
+    )
+    samples: list[TelemetrySample] = []
+    saw_telemetry = False
+    for _, doc in docs:
+        if any(key in doc for key in _TELEMETRY_KEYS):
+            saw_telemetry = True
+        lat = doc.get("GPSLatitude")
+        lon = doc.get("GPSLongitude")
+        if lat is None or lon is None:
+            continue
+        lat, lon = float(lat), float(lon)
+        if not is_gps_fix(lat, lon):
+            continue
+        alt = float(doc.get("AbsoluteAltitude", 0.0))
+        rel = doc.get("RelativeAltitude")
+        gy = doc.get("GimbalYaw")
+        gp = doc.get("GimbalPitch")
+        samples.append(
+            TelemetrySample(
+                lat,
+                lon,
+                alt,
+                _sample_time_to_cue(doc.get("SampleTime", 0.0)),
+                _parse_gps_datetime(doc.get("GPSDateTime", "")),
+                rel_alt=float(rel) if rel is not None else None,
+                focal_len=None,
+                gimbal_yaw=float(gy) if gy is not None else None,
+                gimbal_pitch=float(gp) if gp is not None else None,
+            )
+        )
+    return samples, saw_telemetry

--- a/src/dji_metadata_embedder/mp4_telemetry.py
+++ b/src/dji_metadata_embedder/mp4_telemetry.py
@@ -1,0 +1,51 @@
+"""ExifTool-backed extractor for DJI MP4 timed metadata (djmd/dbgi).
+
+Reads the per-sample protobuf telemetry ExifTool decodes from a DJI MP4/MOV and
+normalises it to the canonical :class:`~dji_metadata_embedder.utilities.TelemetrySample`
+model, so the convert exporters and verify-sun work on sidecar-less footage.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+
+class Mp4TelemetryError(RuntimeError):
+    """Raised when an MP4's timed metadata cannot be read or decoded."""
+
+
+VIDEO_SUFFIXES = {".mp4", ".mov"}
+
+
+def is_video(path: Path) -> bool:
+    """True when ``path`` is a video we can probe for embedded telemetry."""
+    return Path(path).suffix.lower() in VIDEO_SUFFIXES
+
+
+def _sample_time_to_cue(seconds: float) -> str:
+    """Format elapsed ``SampleTime`` seconds as an SRT-style ``HH:MM:SS,mmm`` cue."""
+    total_ms = int(float(seconds) * 1000)
+    ms = total_ms % 1000
+    total_s = total_ms // 1000
+    h, rem = divmod(total_s, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def _parse_gps_datetime(value: str) -> datetime | None:
+    """Parse ExifTool ``GPSDateTime`` (``2026:05:16 23:55:53.017Z``) as naive UTC.
+
+    Returns ``None`` when the string is missing or unparseable. The result is
+    timezone-naive to match the SRT ``dt`` convention; for video sources it is
+    already UTC, so consumers apply a zero offset.
+    """
+    if not value:
+        return None
+    text = value.strip().rstrip("Z").strip()
+    for fmt in ("%Y:%m:%d %H:%M:%S.%f", "%Y:%m:%d %H:%M:%S"):
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+    return None

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -13,7 +13,7 @@ import re
 import logging
 
 from rich.progress import Progress
-from .utilities import is_gps_fix, setup_logging
+from .utilities import TelemetrySample, is_gps_fix, setup_logging
 from .utilities import _parse_srt_datetime, resolve_utc_offset
 # Re-exported for backwards compatibility — cli.py and tests/test_timezone.py
 # import these from here:
@@ -277,6 +277,49 @@ def batch_convert_to_csv(directory: Path | str) -> None:
     logger.info("CSV files saved to: %s", csv_dir)
 
 
+# CSV columns, in output order. Shared by the SRT and video paths so the header
+# is identical regardless of source.
+_CSV_COLUMNS = (
+    "timestamp", "latitude", "longitude", "rel_altitude", "abs_altitude",
+    "iso", "shutter", "fnum", "ev", "ct", "color_md", "focal_len",
+    "datetime_utc", "sun_azimuth", "sun_elevation",
+)
+
+
+def _csv_from_samples(samples: list[TelemetrySample], output_path: Path) -> Path:
+    """Write CSV rows from video-sourced samples (UTC is intrinsic).
+
+    Fills geo, altitude, ``datetime_utc`` and solar columns; camera columns that
+    only the SRT text carries (iso/shutter/fnum/ev/ct/color_md/focal_len) stay
+    blank.
+    """
+    import csv
+
+    rows = []
+    for s in samples:
+        row = {c: "" for c in _CSV_COLUMNS}
+        row["timestamp"] = s.cue
+        row["latitude"] = f"{s.lat}"
+        row["longitude"] = f"{s.lon}"
+        if s.rel_alt is not None:
+            row["rel_altitude"] = f"{s.rel_alt}"
+        row["abs_altitude"] = f"{s.alt}"
+        if s.dt is not None:
+            row["datetime_utc"] = s.dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if is_gps_fix(s.lat, s.lon):
+                az, el = sun_position(s.lat, s.lon, s.dt)
+                row["sun_azimuth"] = f"{az:.3f}"
+                row["sun_elevation"] = f"{el:.3f}"
+        rows.append(row)
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(_CSV_COLUMNS))
+        writer.writeheader()
+        writer.writerows(rows)
+    logger.info("CSV file created: %s", output_path)
+    return output_path
+
+
 def extract_telemetry_to_csv(
     srt_file: Path | str,
     output_file: Path | str | None = None,
@@ -292,6 +335,12 @@ def extract_telemetry_to_csv(
     """
     srt_path = Path(srt_file)
     output_path = Path(output_file) if output_file else srt_path.with_suffix(".csv")
+
+    from .mp4_telemetry import is_video
+    from .utilities import load_samples
+
+    if is_video(srt_path):
+        return _csv_from_samples(load_samples(srt_path), output_path)
 
     rows = []
     # Per-row solar inputs, index-aligned with ``rows``: (abs_dt, lat, lon).

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -361,23 +361,8 @@ def extract_telemetry_to_csv(
             if "<font" in telemetry_line:
                 telemetry_line = re.sub(r"<[^>]+>", "", telemetry_line)
 
-            row = {
-                "timestamp": timestamp_match.group(1) if timestamp_match else "",
-                "latitude": "",
-                "longitude": "",
-                "rel_altitude": "",
-                "abs_altitude": "",
-                "iso": "",
-                "shutter": "",
-                "fnum": "",
-                "ev": "",
-                "ct": "",
-                "color_md": "",
-                "focal_len": "",
-                "datetime_utc": "",
-                "sun_azimuth": "",
-                "sun_elevation": "",
-            }
+            row = {c: "" for c in _CSV_COLUMNS}
+            row["timestamp"] = timestamp_match.group(1) if timestamp_match else ""
 
             # GPS coordinates
             lat_match = re.search(r"\[latitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
@@ -451,7 +436,7 @@ def extract_telemetry_to_csv(
 
     with open(output_path, "w", newline="", encoding="utf-8") as f:
         if rows:
-            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+            writer = csv.DictWriter(f, fieldnames=list(_CSV_COLUMNS))
             writer.writeheader()
             writer.writerows(rows)
 

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -57,6 +57,25 @@ def _parse_gps_points(content: str) -> list[dict[str, Any]]:
     return gps_points
 
 
+def load_gps_points(path: Path) -> tuple[list[dict[str, Any]], bool]:
+    """Return GPS points (``_parse_gps_points`` shape) and whether they are UTC.
+
+    SRT: parse the text (datetimes are local wall-clock) -> ``is_utc=False``.
+    Video: read via ``load_samples`` (ExifTool ``GPSDateTime`` is absolute UTC)
+    -> ``is_utc=True``, so callers apply a zero local->UTC offset.
+    """
+    from .mp4_telemetry import is_video
+    from .utilities import load_samples
+
+    if is_video(path):
+        points = [
+            {"lat": s.lat, "lon": s.lon, "ele": s.alt, "time": s.cue, "datetime": s.dt}
+            for s in load_samples(path)
+        ]
+        return points, True
+    return _parse_gps_points(path.read_text(encoding="utf-8")), False
+
+
 def extract_telemetry_to_gpx(
     srt_file: Path | str,
     output_file: Path | str | None = None,
@@ -74,17 +93,20 @@ def extract_telemetry_to_gpx(
     srt_path = Path(srt_file)
     output_path = Path(output_file) if output_file else srt_path.with_suffix(".gpx")
 
-    with open(srt_path, "r", encoding="utf-8") as f:
-        content = f.read()
+    gps_points, is_utc = load_gps_points(srt_path)
 
-    gps_points = _parse_gps_points(content)
-
-    # Resolve the local->UTC offset for points that carry an absolute datetime.
+    # Needed by the metadata <time> block below regardless of source.
     abs_times = [p["datetime"] for p in gps_points if p["datetime"] is not None]
-    mtime_utc = datetime.fromtimestamp(
-        srt_path.stat().st_mtime, tz=timezone.utc
-    ).replace(tzinfo=None)
-    offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
+    offset: timedelta | None
+    if is_utc:
+        # Video GPSDateTime is already UTC -> zero offset.
+        offset = timedelta(0)
+    else:
+        # Resolve the local->UTC offset for points that carry an absolute datetime.
+        mtime_utc = datetime.fromtimestamp(
+            srt_path.stat().st_mtime, tz=timezone.utc
+        ).replace(tzinfo=None)
+        offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
 
     def _point_time(point: dict) -> str | None:
         """Return the GPX <time> string for a point (UTC if datetime known)."""
@@ -148,14 +170,17 @@ def summarize_sun(
     are ``None`` when nothing could be computed.
     """
     srt_path = Path(srt_file)
-    content = srt_path.read_text(encoding="utf-8")
-    points = _parse_gps_points(content)
+    points, is_utc = load_gps_points(srt_path)
 
-    abs_times = [p["datetime"] for p in points if p["datetime"] is not None]
-    mtime_utc = datetime.fromtimestamp(
-        srt_path.stat().st_mtime, tz=timezone.utc
-    ).replace(tzinfo=None)
-    offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
+    offset: timedelta | None
+    if is_utc:
+        offset = timedelta(0)
+    else:
+        abs_times = [p["datetime"] for p in points if p["datetime"] is not None]
+        mtime_utc = datetime.fromtimestamp(
+            srt_path.stat().st_mtime, tz=timezone.utc
+        ).replace(tzinfo=None)
+        offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
 
     track: list[tuple[datetime, float, float]] = []  # (utc, azimuth, elevation)
     if offset is not None:

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -223,6 +223,21 @@ def parse_telemetry_samples(srt_path: Path) -> List[TelemetrySample]:
     return samples
 
 
+def load_samples(path: Path) -> List[TelemetrySample]:
+    """Load telemetry samples from a DJI ``.SRT`` or a video (MP4/MOV) source.
+
+    SRT files are parsed directly; videos are read via the ExifTool-backed
+    :mod:`dji_metadata_embedder.mp4_telemetry` extractor. Imported lazily to
+    avoid a module-load cycle (``mp4_telemetry`` imports from this module).
+    """
+    from .mp4_telemetry import extract_samples, is_video
+
+    path = Path(path)
+    if is_video(path):
+        return extract_samples(path)
+    return parse_telemetry_samples(path)
+
+
 def parse_telemetry_points(srt_path: Path) -> List[Tuple[float, float, float, str]]:
     """Parse an SRT file into a list of (lat, lon, alt, timestamp).
 

--- a/tests/fixtures/mp4_telemetry/air3s_g3j.json
+++ b/tests/fixtures/mp4_telemetry/air3s_g3j.json
@@ -1,0 +1,41 @@
+[
+  {
+    "SourceFile": "scrubbed.mp4",
+    "Doc1": {
+      "SampleTime": 0,
+      "GPSLatitude": 51.4778,
+      "GPSLongitude": -0.0014,
+      "AbsoluteAltitude": 325.591,
+      "GPSDateTime": "2026:05:16 23:55:53.000Z",
+      "GimbalYaw": -7.1
+    },
+    "Doc2": {
+      "SampleTime": 0.0166833333333333,
+      "GPSLatitude": 51.4778,
+      "GPSLongitude": -0.0014,
+      "AbsoluteAltitude": 325.591,
+      "GPSDateTime": "2026:05:16 23:55:53.017Z",
+      "GimbalYaw": -7.1
+    },
+    "Doc3": {
+      "SampleTime": 41.5248166666667,
+      "GPSLatitude": 51.47779733,
+      "GPSLongitude": -0.00142546,
+      "AbsoluteAltitude": 330.993,
+      "RelativeAltitude": 5.4,
+      "GPSDateTime": "2026:05:16 23:56:34.525Z",
+      "GimbalYaw": -9.3,
+      "GimbalPitch": -90
+    },
+    "Doc4": {
+      "SampleTime": 41.5415,
+      "GPSLatitude": 51.47779733,
+      "GPSLongitude": -0.00142546,
+      "AbsoluteAltitude": 330.993,
+      "RelativeAltitude": 5.4,
+      "GPSDateTime": "2026:05:16 23:56:34.542Z",
+      "GimbalYaw": -9.3,
+      "GimbalPitch": -90
+    }
+  }
+]

--- a/tests/fixtures/mp4_telemetry/neo2_undecoded_g3j.json
+++ b/tests/fixtures/mp4_telemetry/neo2_undecoded_g3j.json
@@ -1,0 +1,8 @@
+[
+  {
+    "SourceFile": "scrubbed.mp4",
+    "Doc1": {"SampleTime": 0},
+    "Doc2": {"SampleTime": 0.0333666666666667},
+    "Doc3": {"SampleTime": 0.0667333333333333}
+  }
+]

--- a/tests/test_cli_convert_geo.py
+++ b/tests/test_cli_convert_geo.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from dji_metadata_embedder import mp4_telemetry as mt
 from dji_metadata_embedder.cli import main
 
 SAMPLES = Path(__file__).resolve().parents[1] / "samples"
@@ -141,3 +142,25 @@ def test_convert_footprint_suppressed_by_redaction(tmp_path, fmt, redact):
     else:
         assert "Camera footprints" not in text
         assert "<Polygon>" not in text
+
+
+_FIX = Path(__file__).parent / "fixtures" / "mp4_telemetry" / "air3s_g3j.json"
+
+
+def test_convert_geojson_single_mp4(monkeypatch, tmp_path):
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: json.loads(_FIX.read_text()))
+    mp4 = tmp_path / "clip.mp4"
+    mp4.write_bytes(b"\x00")
+    out = tmp_path / "clip.geojson"
+    res = CliRunner().invoke(main, ["convert", "geojson", str(mp4), "-o", str(out)])
+    assert res.exit_code == 0, res.output
+    data = json.loads(out.read_text())
+    assert data["type"] == "FeatureCollection"
+
+
+def test_convert_batch_includes_mp4(monkeypatch, tmp_path):
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: json.loads(_FIX.read_text()))
+    (tmp_path / "a.mp4").write_bytes(b"\x00")
+    res = CliRunner().invoke(main, ["convert", "geojson", str(tmp_path), "--batch"])
+    assert res.exit_code == 0, res.output
+    assert (tmp_path / "a.geojson").exists()

--- a/tests/test_cli_convert_geo.py
+++ b/tests/test_cli_convert_geo.py
@@ -164,3 +164,21 @@ def test_convert_batch_includes_mp4(monkeypatch, tmp_path):
     res = CliRunner().invoke(main, ["convert", "geojson", str(tmp_path), "--batch"])
     assert res.exit_code == 0, res.output
     assert (tmp_path / "a.geojson").exists()
+
+
+def test_convert_mp4_too_old_exiftool_clean_error(monkeypatch, tmp_path):
+    # Stream present but nothing decoded (Neo-2 style) -> extract_samples raises.
+    monkeypatch.setattr(
+        mt, "_run_exiftool_json",
+        lambda p: [{"Doc1": {"SampleTime": 0}}],
+    )
+    monkeypatch.setattr(mt, "probe", lambda p: "dvtm_NEO2.proto")
+    monkeypatch.setattr(mt, "_exiftool_version", lambda: "12.76")
+    mp4 = tmp_path / "neo2.mp4"
+    mp4.write_bytes(b"\x00")
+    res = CliRunner().invoke(main, ["convert", "geojson", str(mp4)])
+    assert res.exit_code != 0
+    # Clean ClickException, NOT an uncaught traceback:
+    from dji_metadata_embedder.mp4_telemetry import Mp4TelemetryError
+    assert not isinstance(res.exception, Mp4TelemetryError)
+    assert "ExifTool" in res.output

--- a/tests/test_convert_mp4.py
+++ b/tests/test_convert_mp4.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from dji_metadata_embedder import mp4_telemetry as mt
+from dji_metadata_embedder.telemetry_converter import (
+    extract_telemetry_to_gpx,
+    summarize_sun,
+)
+
+_FIX = Path(__file__).parent / "fixtures" / "mp4_telemetry" / "air3s_g3j.json"
+
+
+def _patch(monkeypatch):
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: json.loads(_FIX.read_text()))
+
+
+def test_gpx_from_mp4_uses_true_utc(monkeypatch, tmp_path):
+    _patch(monkeypatch)
+    mp4 = tmp_path / "clip.mp4"
+    mp4.write_bytes(b"\x00")
+    out = extract_telemetry_to_gpx(mp4, tmp_path / "clip.gpx")
+    text = out.read_text()
+    # true UTC from GPSDateTime, not shifted by mtime
+    assert "2026-05-16T23:55:53Z" in text
+    assert text.count("<trkpt") == 4
+
+
+def test_verify_sun_from_mp4(monkeypatch, tmp_path):
+    _patch(monkeypatch)
+    mp4 = tmp_path / "clip.mp4"
+    mp4.write_bytes(b"\x00")
+    summary = summarize_sun(mp4)
+    assert summary["points"] == 4
+    assert summary["sun_computed"] == 4
+    assert summary["utc_start"].startswith("2026-05-16T23:55:53")

--- a/tests/test_convert_mp4.py
+++ b/tests/test_convert_mp4.py
@@ -1,8 +1,10 @@
+import csv
 import json
 from pathlib import Path
 
 from dji_metadata_embedder import mp4_telemetry as mt
 from dji_metadata_embedder.telemetry_converter import (
+    extract_telemetry_to_csv,
     extract_telemetry_to_gpx,
     summarize_sun,
 )
@@ -33,3 +35,18 @@ def test_verify_sun_from_mp4(monkeypatch, tmp_path):
     assert summary["points"] == 4
     assert summary["sun_computed"] == 4
     assert summary["utc_start"].startswith("2026-05-16T23:55:53")
+
+
+def test_csv_from_mp4_fills_geo_and_sun(monkeypatch, tmp_path):
+    _patch(monkeypatch)
+    mp4 = tmp_path / "clip.mp4"
+    mp4.write_bytes(b"\x00")
+    out = extract_telemetry_to_csv(mp4, tmp_path / "clip.csv")
+    rows = list(csv.DictReader(out.open()))
+    assert len(rows) == 4
+    r0, r3 = rows[0], rows[3]
+    assert round(float(r0["latitude"]), 4) == 51.4778
+    assert r0["datetime_utc"] == "2026-05-16T23:55:53Z"
+    assert r0["sun_azimuth"] and r0["sun_elevation"]   # computed from true UTC
+    assert r3["rel_altitude"] == "5.4"
+    assert r0["iso"] == "" and r0["shutter"] == ""      # SRT-only cols blank

--- a/tests/test_geo_track.py
+++ b/tests/test_geo_track.py
@@ -1,6 +1,8 @@
+import json
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from dji_metadata_embedder import mp4_telemetry as mt
 from dji_metadata_embedder.geo.track import build_track
 
 SAMPLES = Path(__file__).resolve().parents[1] / "samples"
@@ -73,3 +75,26 @@ def test_build_track_footprint_fields_default_none():
     assert track.points[0].rel_alt == 5.0
     assert track.points[0].focal_len is None
     assert track.points[0].gimbal_yaw is None
+
+
+_FIX = Path(__file__).parent / "fixtures" / "mp4_telemetry" / "air3s_g3j.json"
+
+
+def test_build_track_from_video_uses_true_utc(monkeypatch, tmp_path):
+    f = tmp_path / "clip.mp4"
+    f.write_bytes(b"\x00")
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: json.loads(_FIX.read_text()))
+    track = build_track(f)
+    assert track.name == "clip"
+    assert len(track.points) == 4
+    # GPSDateTime is true UTC and must NOT be offset-shifted
+    assert track.points[0].utc == datetime(2026, 5, 16, 23, 55, 53, 0)
+    assert track.points[-1].gimbal_pitch == -90
+
+
+def test_build_track_video_drop_redaction_empty(monkeypatch, tmp_path):
+    f = tmp_path / "clip.mp4"
+    f.write_bytes(b"\x00")
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: json.loads(_FIX.read_text()))
+    track = build_track(f, redact="drop")
+    assert track.points == []

--- a/tests/test_mp4_telemetry.py
+++ b/tests/test_mp4_telemetry.py
@@ -1,8 +1,16 @@
+import json
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
 from dji_metadata_embedder import mp4_telemetry as mt
+
+FIXTURES = Path(__file__).parent / "fixtures" / "mp4_telemetry"
+
+
+def _load(name):
+    return json.loads((FIXTURES / name).read_text())
 
 
 @pytest.mark.parametrize(
@@ -27,3 +35,35 @@ def test_parse_gps_datetime_utc_naive():
 def test_parse_gps_datetime_none_on_garbage():
     assert mt._parse_gps_datetime("") is None
     assert mt._parse_gps_datetime("not-a-date") is None
+
+
+def test_samples_from_exiftool_maps_air3s():
+    samples, saw = mt._samples_from_exiftool(_load("air3s_g3j.json"))
+    assert saw is True
+    assert len(samples) == 4
+    first, last = samples[0], samples[-1]
+    assert (round(first.lat, 4), round(first.lon, 4)) == (51.4778, -0.0014)
+    assert first.alt == 325.591
+    assert first.cue == "00:00:00,000"
+    assert first.dt == datetime(2026, 5, 16, 23, 55, 53, 0)
+    assert first.gimbal_yaw == -7.1
+    # sparse early sample: optional fields absent
+    assert first.rel_alt is None and first.gimbal_pitch is None
+    # rich mid-flight sample: optional fields present
+    assert last.rel_alt == 5.4
+    assert last.gimbal_pitch == -90
+    assert last.focal_len is None  # stream carries no focal length
+
+
+def test_samples_from_exiftool_undecoded_sets_saw_false():
+    samples, saw = mt._samples_from_exiftool(_load("neo2_undecoded_g3j.json"))
+    assert samples == []
+    assert saw is False  # only SampleTime present -> nothing decoded
+
+
+def test_samples_from_exiftool_filters_null_island():
+    data = [{"Doc1": {"SampleTime": 0, "GPSLatitude": 0.0, "GPSLongitude": 0.0,
+                      "AbsoluteAltitude": 10.0}}]
+    samples, saw = mt._samples_from_exiftool(data)
+    assert samples == []      # (0,0) no-fix dropped
+    assert saw is True        # but telemetry WAS decoded (AbsoluteAltitude)

--- a/tests/test_mp4_telemetry.py
+++ b/tests/test_mp4_telemetry.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from dji_metadata_embedder import mp4_telemetry as mt
+from dji_metadata_embedder.utilities import load_samples
 
 FIXTURES = Path(__file__).parent / "fixtures" / "mp4_telemetry"
 
@@ -108,3 +109,23 @@ def test_extract_samples_decoded_but_no_fix_returns_empty(monkeypatch, tmp_path)
     monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: data)
     monkeypatch.setattr(mt, "probe", lambda p: "dvtm_Air3s.proto")
     assert mt.extract_samples(f) == []  # decoded, just no fix -> not an error
+
+
+def test_load_samples_dispatches_video(monkeypatch, tmp_path):
+    f = tmp_path / "clip.MP4"
+    f.write_bytes(b"\x00")
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: _load("air3s_g3j.json"))
+    samples = load_samples(f)
+    assert len(samples) == 4
+
+
+def test_load_samples_dispatches_srt(tmp_path):
+    srt = tmp_path / "clip.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "[latitude: 51.4778] [longitude: -0.0014] [rel_alt: 0.0 abs_alt: 10.0]\n",
+        encoding="utf-8",
+    )
+    samples = load_samples(srt)
+    assert len(samples) == 1
+    assert round(samples[0].lat, 4) == 51.4778

--- a/tests/test_mp4_telemetry.py
+++ b/tests/test_mp4_telemetry.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -129,3 +130,30 @@ def test_load_samples_dispatches_srt(tmp_path):
     samples = load_samples(srt)
     assert len(samples) == 1
     assert round(samples[0].lat, 4) == 51.4778
+
+
+def test_probe_parses_schema_from_category(monkeypatch, tmp_path):
+    out = (
+        "MetaFormat                      : dbgi\n"
+        "Category                        : pb_file:dvtm_Air3s.proto;"
+        "model_name:FC9113;pb_version:02.00.02;\n"
+    )
+    monkeypatch.setattr(
+        mt, "_run", lambda args: subprocess.CompletedProcess([], 0, out, "")
+    )
+    f = tmp_path / "x.mp4"
+    f.write_bytes(b"\x00")
+    schema = mt.probe(f)
+    assert schema is not None
+    assert schema.startswith("dvtm_Air3s.proto")
+
+
+def test_probe_none_when_no_track(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        mt,
+        "_run",
+        lambda args: subprocess.CompletedProcess([], 0, "MajorBrand : MP4\n", ""),
+    )
+    f = tmp_path / "x.mp4"
+    f.write_bytes(b"\x00")
+    assert mt.probe(f) is None

--- a/tests/test_mp4_telemetry.py
+++ b/tests/test_mp4_telemetry.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+import pytest
+
+from dji_metadata_embedder import mp4_telemetry as mt
+
+
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [
+        (0, "00:00:00,000"),
+        (0.0166833333333333, "00:00:00,016"),
+        (41.5248166666667, "00:00:41,524"),
+        (3661.5, "01:01:01,500"),
+    ],
+)
+def test_sample_time_to_cue(seconds, expected):
+    assert mt._sample_time_to_cue(seconds) == expected
+
+
+def test_parse_gps_datetime_utc_naive():
+    dt = mt._parse_gps_datetime("2026:05:16 23:55:53.017Z")
+    assert dt == datetime(2026, 5, 16, 23, 55, 53, 17000)
+    assert dt.tzinfo is None  # naive, matches the SRT dt convention
+
+
+def test_parse_gps_datetime_none_on_garbage():
+    assert mt._parse_gps_datetime("") is None
+    assert mt._parse_gps_datetime("not-a-date") is None

--- a/tests/test_mp4_telemetry.py
+++ b/tests/test_mp4_telemetry.py
@@ -67,3 +67,44 @@ def test_samples_from_exiftool_filters_null_island():
     samples, saw = mt._samples_from_exiftool(data)
     assert samples == []      # (0,0) no-fix dropped
     assert saw is True        # but telemetry WAS decoded (AbsoluteAltitude)
+
+
+def test_extract_samples_happy(monkeypatch, tmp_path):
+    f = tmp_path / "clip.mp4"
+    f.write_bytes(b"\x00")
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: _load("air3s_g3j.json"))
+    samples = mt.extract_samples(f)
+    assert len(samples) == 4
+    assert samples[0].dt == datetime(2026, 5, 16, 23, 55, 53, 0)
+
+
+def test_extract_samples_undecoded_raises(monkeypatch, tmp_path):
+    f = tmp_path / "neo2.mp4"
+    f.write_bytes(b"\x00")
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: _load("neo2_undecoded_g3j.json"))
+    monkeypatch.setattr(mt, "probe", lambda p: "dvtm_NEO2.proto;model_name:FC9470")
+    monkeypatch.setattr(mt, "_exiftool_version", lambda: "13.55")
+    with pytest.raises(mt.Mp4TelemetryError) as exc:
+        mt.extract_samples(f)
+    assert "dvtm_NEO2.proto" in str(exc.value)
+    assert "13.55" in str(exc.value)
+
+
+def test_extract_samples_no_stream_raises(monkeypatch, tmp_path):
+    f = tmp_path / "plain.mp4"
+    f.write_bytes(b"\x00")
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: [{"SourceFile": str(f)}])
+    monkeypatch.setattr(mt, "probe", lambda p: None)
+    with pytest.raises(mt.Mp4TelemetryError) as exc:
+        mt.extract_samples(f)
+    assert "sidecar" in str(exc.value).lower()
+
+
+def test_extract_samples_decoded_but_no_fix_returns_empty(monkeypatch, tmp_path):
+    f = tmp_path / "nofix.mp4"
+    f.write_bytes(b"\x00")
+    data = [{"Doc1": {"SampleTime": 0, "AbsoluteAltitude": 5.0,
+                      "GPSLatitude": 0.0, "GPSLongitude": 0.0}}]
+    monkeypatch.setattr(mt, "_run_exiftool_json", lambda p: data)
+    monkeypatch.setattr(mt, "probe", lambda p: "dvtm_Air3s.proto")
+    assert mt.extract_samples(f) == []  # decoded, just no fix -> not an error

--- a/tests/test_mp4_telemetry_integration.py
+++ b/tests/test_mp4_telemetry_integration.py
@@ -1,0 +1,48 @@
+"""End-to-end ExifTool extraction. Skipped unless a recent ExifTool and a local
+DJI MP4 fixture are both available (never runs in CI).
+
+Run locally with, e.g.:
+    DJIEMBED_EXIFTOOL_PATH=~/.local/dji-tools/Image-ExifTool-13.55/exiftool \\
+    DJI_MP4_FIXTURE=/path/to/air3s.mp4 uv run pytest tests/test_mp4_telemetry_integration.py -v
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder import mp4_telemetry as mt
+
+_FIXTURE = os.environ.get("DJI_MP4_FIXTURE")
+
+
+def _exiftool_ok() -> bool:
+    try:
+        ver = mt._exiftool_version()
+    except Exception:
+        return False
+    if not ver:
+        return False
+    try:
+        major, minor = (int(x) for x in ver.split(".")[:2])
+    except ValueError:
+        return False
+    return (major, minor) >= (13, 39)
+
+
+pytestmark = pytest.mark.skipif(
+    not (_FIXTURE and Path(_FIXTURE).is_file() and _exiftool_ok()),
+    reason="needs DJI_MP4_FIXTURE and ExifTool >= 13.39",
+)
+
+
+def test_extract_real_mp4():
+    samples = mt.extract_samples(Path(_FIXTURE))
+    assert samples, "expected a non-empty track from the real MP4"
+    s = samples[0]
+    assert -90 <= s.lat <= 90 and -180 <= s.lon <= 180
+    assert s.dt is not None  # GPSDateTime present
+
+
+def test_probe_real_mp4():
+    assert mt.probe(Path(_FIXTURE)) is not None


### PR DESCRIPTION
## Summary

Reads DJI's embedded `djmd`/`dbgi` protobuf telemetry straight from the **MP4** via ExifTool, so `dji-embed convert <fmt> FILE` and `dji-embed verify-sun FILE` now work on **sidecar-less** footage (Air 3S, Mini 5 Pro, …) — no `.SRT` needed. Input is auto-detected by extension.

This is the convert + verify-sun half of #206 (Stage 1). Embed fall-through and a `--telemetry-source` flag are intentionally deferred; cross-platform ExifTool provisioning is split out to #235.

### What changed
- **New `mp4_telemetry.py`** — `probe()` (cheap `-MetaFormat`/`-Category` detect) + `extract_samples()` (`exiftool -ee -j -g3 -n` → `Doc1…DocN` → canonical `TelemetrySample`). Distinguishes "model not decoded by this ExifTool" (actionable upgrade error) from "decoded but no GPS fix" (empty track).
- **`load_samples()` dispatcher** (utilities) routes SRT vs video.
- **`build_track` refactor** → `build_track_from_samples(..., assume_utc=)`: a video's `GPSDateTime` is **true UTC** (zero offset), while SRT stays mtime-resolved. SRT output is byte-for-byte unchanged. Lights up geojson/kml/cot/html for free.
- **gpx / verify-sun / csv** gained video branches (`load_gps_points` + `_csv_from_samples`). CSV fills geo/alt/`datetime_utc`/solar; SRT-only camera columns stay blank.
- **CLI:** `convert --batch` globs `*.MP4`/`*.MOV`; `Mp4TelemetryError` surfaces as a clean CLI error (single-file aborts, batch logs-and-skips); `--tz-offset` noted as ignored for MP4.
- **Docs:** new `docs/MP4_TIMED_METADATA.md` + README/user-guide/decision-table.

### Why ExifTool (not a bundled/own decoder)
Models become supported by **upgrading ExifTool — zero code change**. Coverage is version-gated (Air 3S ≥13.39, Mini 5 Pro ≥13.52; Neo 2 not yet decodable). A bundled decoder would forfeit that and mean per-model reverse-engineering forever.

## Test plan
- [x] `uv run pytest -q` → **233 passed, 2 skipped** (integration tests gated on a real MP4 + ExifTool ≥13.39)
- [x] `uv run ruff check .` clean; `uv run mypy src/dji_metadata_embedder` clean; `uv run mkdocs build --strict` clean
- [x] Unit tests mock the subprocess at `_run_exiftool_json` against a committed, GPS-scrubbed ExifTool JSON fixture (no media/real-GPS in repo)
- [x] **Validated end-to-end on real footage** (ExifTool 13.55): Air 3S `convert geojson` → 3215 features, `verify-sun` → true `utc_start` `2026-05-16T23:55:53Z`; Neo 2 → clean "Upgrade ExifTool" error (no traceback)
- [x] SRT behaviour unchanged (existing SRT suite green); SRT `dt` is local-wall-clock and still mtime-resolved

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)