### PR TITLE
feat: opt-in HOME-point (launch location) extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Options:
   --redact [none|drop|fuzz]  Redact GPS coordinates (default: none)
   --container [mp4|mkv]      Output container; 'mkv' preserves DJI djmd/dbgi
                              data streams (default: mp4)
+  --extract-home             Extract the drone's HOME / launch point into the
+                             JSON sidecar. **The HOME point is the operator's
+                             launch location** — it is off by default, never
+                             written to the MP4, and always honours `--redact`
+                             (`drop` removes it, `fuzz` coarsens to ~100 m).
   -v, --verbose              Verbose output
   -q, --quiet                Suppress progress output
 ```

--- a/README.md
+++ b/README.md
@@ -316,13 +316,19 @@ Options:
   -b, --batch                Batch process directory
   --tz-offset OFFSET         UTC offset for GPX/CoT timestamps, e.g. '+05:30' or
                              '-8' ('auto' detects from file mtime; default: auto)
-  --redact [none|drop|fuzz]  GPS redaction for geojson/kml/html/cot (default: none)
+  --redact [none|drop|fuzz]  GPS redaction (default: none). drop/fuzz cover the
+                             track for geojson/kml/html/cot and the HOME marker
+                             in all formats; for gpx/csv only the HOME marker is
+                             redacted (the track there is unredacted)
   --interval FLOAT           cot only: seconds between sampled points (default: 1.0)
   --cot-type CODE            cot only: CoT type/affiliation code (default: a-n-A)
   --footprint                geojson/kml only: add camera footprint polygons
                              (requires --redact none)
   --footprint-interval FLOAT geojson/kml only: seconds between footprints (default: 2.0)
   --model NAME               footprint FOV-table entry, e.g. air3, mini4pro
+  --extract-home             Opt-in: extract the HOME / launch point (operator
+                             location) into gpx/csv/geojson output. Off by
+                             default; subject to --redact
   -v, --verbose              Verbose output
   -q, --quiet                Suppress info output
 ```

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -37,6 +37,9 @@ HOME(39.906206,116.391400) D=5.2m H=1.5m
 - `D`: Distance from home point
 - `H`: Height above home point
 
+> The HOME point is parsed only when `--extract-home` is passed (it is the
+> operator's launch location). When extracted it is subject to `--redact`.
+
 ### Format 2b: Legacy-with-Unit (Matrice 300 lineage)
 
 Used by: DJI Matrice 300 RTK and adjacent enterprise models.

--- a/docs/superpowers/specs/2026-06-21-home-point-opt-in-design.md
+++ b/docs/superpowers/specs/2026-06-21-home-point-opt-in-design.md
@@ -1,0 +1,176 @@
+# Design: Opt-in HOME-point (launch location) extraction
+
+_Date: 2026-06-21_
+
+## Context
+
+DJI SRT telemetry carries a **HOME point** — the drone's recorded launch
+location — in two documented variants (`docs/SRT_FORMATS.md`):
+
+```
+HOME(39.906206,116.391400) D=5.2m H=1.5m
+HOME (-58.847509, -34.232707, -57.98m), D 698.70m, H 85.80m,
+```
+
+The parser does **not** extract it today (confirmed: every `home` reference in
+`src/` is `Path.home()` / config-dir code). This was noticed while
+cross-referencing `JuanIrache/DJI_SRT_Parser`, which does surface HOME.
+
+HOME is the **single most sensitive field** in the SRT: it is the operator's
+launch position, more revealing than the flight track itself. So the goal is not
+"parse another field" — it is to make HOME available for **provenance /
+verification** ("confirm this flight launched from X", the project's
+[use-for-good direction](https://github.com/CallMarcus/dji-drone-metadata-embedder#intended-use--scope))
+**only on explicit opt-in**, never by default, and always under the existing GPS
+redaction guard.
+
+### The constraint that shaped the design
+
+Redaction is wired **unevenly** across the three telemetry paths:
+
+| Path | Output | Redaction today |
+| --- | --- | --- |
+| `embed` → `embedder.parse_dji_srt` | JSON sidecar | `apply_redaction()` (`utilities.py`) |
+| `convert geojson/kml/html/cot` → `geo/track.py` `Track` | GeoJSON etc. | redaction at the `Track` layer (`build_track_from_samples`) |
+| `convert gpx` / `convert csv` → `telemetry_converter.py` | GPX, CSV | **none** — `cli.py` calls `extract_telemetry_to_gpx(srt, out, tz_offset=…)` with no `redact`; the `--redact` help already scopes itself to "geojson/kml/html/cot" |
+
+Because HOME must always honor `--redact`, and GPX/CSV have no redaction
+pathway, this spec threads redaction into the GPX/CSV path **for the HOME marker
+only**. The pre-existing fact that the per-frame *track* in GPX/CSV is
+un-redactable is a separate gap, left to a follow-up issue (see Roadmap).
+
+## Goals
+
+- Extract the HOME point **only** when an explicit `--extract-home` flag is set,
+  on both `embed` and `convert`. Default behaviour and default output bytes are
+  unchanged.
+- Surface HOME as a first-class geographic **marker** in JSON, GPX, GeoJSON, and
+  CSV.
+- HOME is **always** subject to `--redact` (`drop` → removed; `fuzz` → ~100 m).
+- HOME is **never** written into the embedded MP4.
+- No new runtime dependencies.
+
+## Non-goals
+
+- **HOME in the embedded MP4 metadata.** Never — the MP4 stays as today.
+- **KML / HTML viewer / CoT** HOME markers. Deferred; the same marker idiom can
+  extend to them later.
+- **Closing the GPX/CSV track-redaction gap.** Out of scope; follow-up issue.
+  This spec only makes the *HOME marker* redaction-aware in GPX/CSV.
+- **GPS smoothing/averaging** (as `DJI_SRT_Parser` does). Rejected: smoothing
+  fabricates positions and works against provenance fidelity.
+
+## Approach: gate the parse itself (Approach A)
+
+Chosen over "always parse, gate at output" (B) and "separate post-processor"
+(C). A is the only one that makes "by default never extracted" a literal,
+testable property: the HOME regex never runs unless the flag is set, so the
+value never enters the telemetry structures by default. It also reuses the exact
+threading pattern `--redact` already established.
+
+A boolean `extract_home` (default `False`) is threaded through all three paths,
+mirroring `redact`:
+
+```
+embed     : DJIEmbedder(extract_home=…) → parse_dji_srt → JSON sidecar
+convert    : extract_home param → telemetry_converter (gpx/csv)
+           : extract_home param → geo/track.py Track (geojson)
+```
+
+## Parsing
+
+One regex handles both documented variants (optional leading space, optional
+third altitude value with a trailing `m`):
+
+```
+HOME\s*\(\s*([+-]?\d+\.?\d*)\s*,\s*([+-]?\d+\.?\d*)(?:\s*,\s*([+-]?\d+\.?\d*)\s*m?)?\s*\)
+```
+
+Captures: lat (g1), lon (g2), optional alt (g3). HOME is constant within a file,
+so we capture the **first** match and stop scanning for it.
+
+- When `extract_home` is `False`: the regex is never evaluated; the `home` key is
+  **omitted entirely** from the telemetry dict / not added as a column — default
+  output stays byte-identical (no golden-fixture churn, and reinforces the
+  guarantee).
+- When `extract_home` is `True` and no HOME line is present: `home` is `None`
+  (JSON `null`); no GPX/GeoJSON marker; CSV columns present but empty.
+
+The field is added as an **optional** attribute on `TelemetrySample`
+(`utilities.py`) defaulting to `None`, so existing consumers are untouched (same
+pattern the footprint spec used for `rel_alt`/`focal_len`/`gb_*`).
+
+## Flag / CLI
+
+`--extract-home` (Click flag, default off) on both `embed` and `convert`. Help
+text:
+
+> Opt-in: extract the HOME/launch point (operator location) into JSON/GPX/
+> GeoJSON/CSV outputs. Never written to the MP4. Subject to `--redact`.
+
+## Redaction coverage (the safety guarantee)
+
+Redaction always runs **after** parse, so it always wins over `--extract-home`.
+
+- **JSON / embed path:** extend `apply_redaction()` (`utilities.py`) to cover
+  `home`: `drop` → `None`; `fuzz` → lat/lon rounded to 3 decimals (~100 m),
+  matching how it already treats `first_gps`/`avg_gps`. Altitude, if present, is
+  rounded too (it is not locating, but kept consistent).
+- **GeoJSON / Track path:** apply the same `drop`/`fuzz` rule to the HOME marker
+  where the `Track` layer already applies redaction (`build_track_from_samples`),
+  so HOME rides the existing redaction point.
+- **GPX / CSV path:** thread `redact` into `extract_telemetry_to_gpx` /
+  `extract_telemetry_to_csv` **for the HOME marker only** — `drop` emits no
+  waypoint / empty columns; `fuzz` rounds to 3 decimals. The per-frame track in
+  these two formats is unchanged (pre-existing behaviour; see Roadmap).
+
+When both `--extract-home` and `--redact drop` are passed (contradictory but
+safe), emit a single one-line log note so the user understands no HOME was
+written.
+
+## Output representation (marker idiom)
+
+Emitted only when `extract_home` is on **and** HOME survived redaction:
+
+- **JSON** (embed sidecar + any JSON): `"home": {"lat": .., "lon": .., "alt": ..|null}`
+- **GPX**: a waypoint before the track —
+  `<wpt lat=".." lon=".."><name>HOME</name>[<ele>..</ele>]</wpt>`
+- **GeoJSON**: a `Point` feature alongside the track `LineString` —
+  `{"type":"Feature","geometry":{"type":"Point","coordinates":[lon,lat]},"properties":{"type":"home"}}`
+- **CSV**: repeated `home_lat,home_lon` columns (one constant value per row;
+  `home_alt` only if the variant carried altitude)
+
+## Verification
+
+- **Parser:** both HOME variants → `home` populated when flag on; **absent** when
+  flag off; `None` when flag on but no HOME line. Altitude captured for the
+  3-value variant, `None` for the 2-value variant.
+- **Precedence:** `extract_home` + `redact drop` → `home` is `None` / no marker
+  in every format; `+ fuzz` → lat/lon rounded to 3 decimals.
+- **Per-format markers:** GPX `<wpt name="HOME">` present; GeoJSON `Point`
+  feature with `properties.type == "home"`; CSV `home_lat`/`home_lon` columns;
+  JSON `home` key.
+- **No-regression (the core privacy test):** with the flag **off**, every output
+  (JSON, GPX, GeoJSON, CSV) is byte-identical to current output — no `home` key,
+  no waypoint, no columns.
+- **Fixtures:** current `samples/` use the bracketed `[latitude: …]` format and
+  likely contain no HOME line — verify, then add a minimal SRT fixture for each
+  HOME variant (`HOME(...)` no-space/no-alt, and `HOME (..., ..., ...m)`
+  space/alt).
+
+## Docs
+
+- `README` — `--extract-home` under usage, with the **operator-location caveat**
+  and that it is opt-in + redaction-aware + never in the MP4.
+- `docs/user_guide.md` — a short example for `embed` and `convert`.
+- `docs/SRT_FORMATS.md` — note HOME is parsed only on opt-in, and which formats
+  carry it.
+- Privacy/redaction docs — HOME is covered by `--redact`.
+
+## Roadmap / follow-up
+
+- **Follow-up issue:** thread `--redact` through the GPX/CSV *track* (not just
+  HOME), closing the pre-existing gap where per-frame coordinates in GPX/CSV are
+  un-redactable.
+- **Possible later:** HOME markers in KML / HTML viewer / CoT exporters, and a
+  HOME pin in the web-UI map panel (#222), reusing this marker.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -70,6 +70,16 @@ Notes:
 - SRT formats without an absolute wall-clock datetime can't be resolved to UTC, so the sun columns stay blank and `verify-sun` reports `sun_not_computable`.
 - UTC auto-detection relies on the file's modification time still reflecting the recording; if the file was copied or edited, pass `--tz-offset` explicitly for reliable results.
 
+## Extracting the HOME (launch) point
+
+`--extract-home` is opt-in because the HOME point reveals the operator's launch location. It never touches the MP4 and always respects `--redact`:
+
+```bash
+dji-embed embed FOOTAGE/ --extract-home              # HOME in the .json sidecar
+dji-embed convert gpx flight.SRT --extract-home      # HOME waypoint in the GPX
+dji-embed convert geojson flight.SRT --extract-home --redact fuzz   # HOME coarsened ~100 m
+```
+
 ## Web UI
 
 If you'd rather click buttons than type commands, install the `[ui]` extra

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -187,8 +187,9 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     type=click.Choice(["none", "drop", "fuzz"], case_sensitive=False),
     default="none",
     show_default=True,
-    help="GPS redaction for geojson/kml/html/cot: drop removes the track, "
-    "fuzz coarsens to ~100 m.",
+    help="GPS redaction: drop removes the track (geojson/kml/html/cot) and the "
+    "HOME marker; fuzz coarsens to ~100 m. For gpx/csv only the HOME marker is "
+    "redacted (the track is unredacted there).",
 )
 @click.option(
     "--interval",
@@ -213,6 +214,12 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     help="Seconds between footprint samples",
 )
 @click.option("--model", default=None, help="Drone model for the footprint FOV table (e.g. air3, mini4pro)")
+@click.option(
+    "--extract-home",
+    is_flag=True,
+    help="Opt-in: extract the HOME/launch point (operator location) into "
+    "gpx/csv/geojson output. Subject to --redact.",
+)
 @click.option("-v", "--verbose", is_flag=True)
 @click.option("-q", "--quiet", is_flag=True)
 def convert(
@@ -227,6 +234,7 @@ def convert(
     footprint: bool,
     footprint_interval: float,
     model: str | None,
+    extract_home: bool,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -248,13 +256,16 @@ def convert(
 
     def run_one(srt: Path, out: str | None) -> None:
         if command == "gpx":
-            extract_telemetry_to_gpx(srt, out, tz_offset=offset)
+            extract_telemetry_to_gpx(srt, out, tz_offset=offset,
+                                     extract_home=extract_home, redact=redact)
         elif command == "csv":
-            extract_telemetry_to_csv(srt, out, tz_offset=offset)
+            extract_telemetry_to_csv(srt, out, tz_offset=offset,
+                                     extract_home=extract_home, redact=redact)
         elif command == "geojson":
             convert_to_geojson(
                 srt, out, redact=redact,
                 footprint=footprint, footprint_interval=footprint_interval, model=model,
+                extract_home=extract_home,
             )
         elif command == "kml":
             convert_to_kml(

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -106,6 +106,12 @@ def main(ctx: click.Context, log_json: bool) -> None:
     help="Output container. Use 'mkv' to preserve DJI djmd/dbgi data streams "
     "(dropped by the mp4 muxer).",
 )
+@click.option(
+    "--extract-home",
+    is_flag=True,
+    help="Opt-in: extract the HOME/launch point (operator location) into the "
+    "JSON sidecar. Never written to the MP4. Subject to --redact.",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress progress output")
 def embed(
@@ -117,6 +123,7 @@ def embed(
     dat_auto: bool,
     redact: str,
     container: str,
+    extract_home: bool,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -135,6 +142,7 @@ def embed(
         dat_autoscan=dat_auto,
         redact=redact,
         container=container.lower(),
+        extract_home=extract_home,
     )
     embedder.process_directory(use_exiftool=exiftool)
 

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 from rich.progress import Progress
 
 from .dat_parser import parse_v13 as parse_dat_v13
-from .utilities import apply_redaction, is_gps_fix, setup_logging
+from .utilities import apply_redaction, is_gps_fix, parse_home, setup_logging
 from .utils import system_info
 
 logger = logging.getLogger(__name__)
@@ -155,6 +155,7 @@ class DJIMetadataEmbedder:
         time_offset: float = 0.0,
         resample_strategy: str = "linear",
         container: str = "mp4",
+        extract_home: bool = False,
     ):
         self.directory = Path(directory)
         self.output_dir = (
@@ -172,6 +173,9 @@ class DJIMetadataEmbedder:
         # data streams; "mkv" preserves them — Matroska's codec table accepts
         # the codec=none streams the MP4 muxer rejects (issue #197).
         self.container = container
+        # Opt-in only: the HOME/launch point is the operator's location, so it
+        # is parsed solely when explicitly requested and never written to MP4.
+        self.extract_home = extract_home
 
     def parse_dji_srt(self, srt_path: Path) -> Dict[str, Any]:
         """Parse DJI SRT file and extract telemetry data."""
@@ -391,6 +395,9 @@ class DJIMetadataEmbedder:
             # Get camera settings from first frame
             if telemetry_data["camera_info"]:
                 telemetry_data["camera_settings"] = telemetry_data["camera_info"][0]
+
+            if self.extract_home:
+                telemetry_data["home"] = parse_home(content)
 
         except Exception as e:
             logger.error("Error parsing SRT file %s: %s", srt_path, e)
@@ -673,6 +680,14 @@ class DJIMetadataEmbedder:
                         # (Avata 2 / Matrice 300); include it when captured.
                         if telemetry.get("barometers"):
                             json_data["barometers"] = telemetry["barometers"]
+                        # HOME is opt-in; emit the key only when extracted. It is
+                        # null when requested but absent/dropped, present as a
+                        # marker otherwise. Never affects the MP4 itself.
+                        if "home" in telemetry:
+                            h = telemetry["home"]
+                            json_data["home"] = (
+                                {"lat": h.lat, "lon": h.lon, "alt": h.alt} if h else None
+                            )
                         try:
                             with open(json_tmp_path, "w") as f:
                                 json.dump(json_data, f, indent=2)

--- a/src/dji_metadata_embedder/geo/geojson.py
+++ b/src/dji_metadata_embedder/geo/geojson.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from .footprint import Footprint, build_footprints, lens_for
 from .track import Track, build_track
+from ..utilities import Home, parse_home, redact_home
+from ..mp4_telemetry import is_video
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +37,11 @@ def _footprint_feature(fp: Footprint) -> dict:
     }
 
 
-def track_to_geojson(track: Track, footprints: list[Footprint] | None = None) -> dict:
+def track_to_geojson(
+    track: Track,
+    footprints: list[Footprint] | None = None,
+    home: Home | None = None,
+) -> dict:
     """Return a GeoJSON ``FeatureCollection`` dict for *track*."""
     # RFC 7946 §3.1.4 requires a LineString to have two or more positions, so a
     # track with fewer points (e.g. --redact drop, or a clip that never got a
@@ -69,13 +75,26 @@ def track_to_geojson(track: Track, footprints: list[Footprint] | None = None) ->
         )
     for fp in footprints or []:
         features.append(_footprint_feature(fp))
+    if home is not None:
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [home.lon, home.lat]},
+                "properties": {"type": "home"},
+            }
+        )
     return {"type": "FeatureCollection", "features": features}
 
 
-def write_geojson(track: Track, output_path: Path, footprints: list[Footprint] | None = None) -> Path:
+def write_geojson(
+    track: Track,
+    output_path: Path,
+    footprints: list[Footprint] | None = None,
+    home: Home | None = None,
+) -> Path:
     """Write *track* as GeoJSON to *output_path* and return it."""
     output_path.write_text(
-        json.dumps(track_to_geojson(track, footprints), indent=2), encoding="utf-8"
+        json.dumps(track_to_geojson(track, footprints, home), indent=2), encoding="utf-8"
     )
     logger.info("GeoJSON file created: %s", output_path)
     return output_path
@@ -89,6 +108,7 @@ def convert_to_geojson(
     footprint: bool = False,
     footprint_interval: float = 2.0,
     model: str | None = None,
+    extract_home: bool = False,
 ) -> Path:
     """Convert a DJI SRT file to GeoJSON. Defaults output to ``<srt>.geojson``.
 
@@ -101,4 +121,7 @@ def convert_to_geojson(
     footprints = None
     if footprint and redact == "none":
         footprints = build_footprints(track, lens=lens_for(model), interval=footprint_interval)
-    return write_geojson(track, output_path, footprints)
+    home = None
+    if extract_home and not is_video(srt_path):
+        home = redact_home(parse_home(srt_path.read_text(encoding="utf-8")), redact)
+    return write_geojson(track, output_path, footprints, home=home)

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -341,6 +341,8 @@ def extract_telemetry_to_csv(
     srt_file: Path | str,
     output_file: Path | str | None = None,
     tz_offset: timedelta | None = None,
+    extract_home: bool = False,
+    redact: str = "none",
 ) -> Path:
     """Extract all telemetry data from a DJI SRT file to CSV.
 
@@ -358,6 +360,13 @@ def extract_telemetry_to_csv(
 
     if is_video(srt_path):
         return _csv_from_samples(load_samples(srt_path), output_path)
+
+    home_cols: list[str] = []
+    home = None
+    if extract_home:
+        home = redact_home(parse_home(srt_path.read_text(encoding="utf-8")), redact)
+        home_cols = ["home_lat", "home_lon", "home_alt"]
+    columns = list(_CSV_COLUMNS) + home_cols
 
     rows = []
     # Per-row solar inputs, index-aligned with ``rows``: (abs_dt, lat, lon).
@@ -378,7 +387,11 @@ def extract_telemetry_to_csv(
             if "<font" in telemetry_line:
                 telemetry_line = re.sub(r"<[^>]+>", "", telemetry_line)
 
-            row = {c: "" for c in _CSV_COLUMNS}
+            row = {c: "" for c in columns}
+            if home is not None:
+                row["home_lat"] = f"{home.lat}"
+                row["home_lon"] = f"{home.lon}"
+                row["home_alt"] = "" if home.alt is None else f"{home.alt}"
             row["timestamp"] = timestamp_match.group(1) if timestamp_match else ""
 
             # GPS coordinates
@@ -453,7 +466,7 @@ def extract_telemetry_to_csv(
 
     with open(output_path, "w", newline="", encoding="utf-8") as f:
         if rows:
-            writer = csv.DictWriter(f, fieldnames=list(_CSV_COLUMNS))
+            writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
             writer.writerows(rows)
 

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -15,6 +15,7 @@ import logging
 from rich.progress import Progress
 from .utilities import TelemetrySample, is_gps_fix, setup_logging
 from .utilities import _parse_srt_datetime, resolve_utc_offset
+from .utilities import parse_home, redact_home
 # Re-exported for backwards compatibility — cli.py and tests/test_timezone.py
 # import these from here:
 from .utilities import parse_utc_offset, estimate_utc_offset  # noqa: F401
@@ -80,6 +81,8 @@ def extract_telemetry_to_gpx(
     srt_file: Path | str,
     output_file: Path | str | None = None,
     tz_offset: timedelta | None = None,
+    extract_home: bool = False,
+    redact: str = "none",
 ) -> Path:
     """Extract GPS telemetry from a DJI SRT file and create a GPX file.
 
@@ -132,19 +135,33 @@ def extract_telemetry_to_gpx(
     <name>{}</name>
     <time>{}</time>
 </metadata>
-<trk>
+""".format(Path(srt_file).stem, metadata_time)
+
+    trk_open = """<trk>
     <name>DJI Flight Path</name>
     <trkseg>
-""".format(
-        Path(srt_file).stem, metadata_time
-    )
+"""
 
     gpx_footer = """    </trkseg>
 </trk>
 </gpx>"""
 
+    home_wpt = ""
+    if extract_home:
+        home = redact_home(parse_home(srt_path.read_text(encoding="utf-8")), redact)
+        if home is not None:
+            ele = f"        <ele>{home.alt}</ele>\n" if home.alt is not None else ""
+            home_wpt = (
+                f'    <wpt lat="{home.lat}" lon="{home.lon}">\n'
+                f"{ele}"
+                f"        <name>HOME</name>\n"
+                f"    </wpt>\n"
+            )
+
     with open(output_path, "w") as f:
         f.write(gpx_header)
+        f.write(home_wpt)
+        f.write(trk_open)
         for point in gps_points:
             f.write(f'        <trkpt lat="{point["lat"]}" lon="{point["lon"]}">\n')
             f.write(f'            <ele>{point["ele"]}</ele>\n')

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -309,6 +309,8 @@ def redact_home(home: "Home | None", mode: str) -> "Home | None":
 def apply_redaction(telemetry: dict, mode: str) -> None:
     """Modify ``telemetry`` in place according to the redaction ``mode``."""
     telemetry["gps_coords"] = redact_coords(telemetry.get("gps_coords", []), mode)
+    if "home" in telemetry:
+        telemetry["home"] = redact_home(telemetry["home"], mode)
 
     if mode == "drop":
         telemetry["first_gps"] = None

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -257,6 +257,55 @@ def redact_coords(
     return coords
 
 
+@dataclass
+class Home:
+    """The drone's recorded HOME (launch) point — the operator's location.
+
+    Extracted only on explicit opt-in (``--extract-home``) and always passed
+    through :func:`redact_home`. Never written into the embedded MP4.
+    """
+
+    lat: float
+    lon: float
+    alt: float | None = None
+
+
+# Two documented SRT variants (docs/SRT_FORMATS.md):
+#   HOME(39.906206,116.391400) D=5.2m H=1.5m            -> no space, no altitude
+#   HOME (-58.847509, -34.232707, -57.98m), D 698.70m,  -> space, altitude with trailing m
+_HOME_RE = re.compile(
+    r"HOME\s*\(\s*([+-]?\d+\.?\d*)\s*,\s*([+-]?\d+\.?\d*)"
+    r"(?:\s*,\s*([+-]?\d+\.?\d*)\s*m?)?\s*\)"
+)
+
+
+def parse_home(text: str) -> "Home | None":
+    """Return the first HOME point in SRT *text*, or ``None``.
+
+    The caller is responsible for gating on the opt-in flag; this function does
+    not check it. HOME is constant within a file, so the first match is used.
+    """
+    m = _HOME_RE.search(text)
+    if not m:
+        return None
+    alt = float(m.group(3)) if m.group(3) is not None else None
+    return Home(lat=float(m.group(1)), lon=float(m.group(2)), alt=alt)
+
+
+def redact_home(home: "Home | None", mode: str) -> "Home | None":
+    """Apply GPS redaction to a HOME point: ``drop`` -> ``None``; ``fuzz`` ->
+    coordinates rounded to 3 decimals (~100 m); ``none`` -> unchanged."""
+    if home is None or mode == "drop":
+        return None
+    if mode == "fuzz":
+        return Home(
+            lat=round(home.lat, 3),
+            lon=round(home.lon, 3),
+            alt=round(home.alt, 3) if home.alt is not None else None,
+        )
+    return home
+
+
 def apply_redaction(telemetry: dict, mode: str) -> None:
     """Modify ``telemetry`` in place according to the redaction ``mode``."""
     telemetry["gps_coords"] = redact_coords(telemetry.get("gps_coords", []), mode)

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -1,10 +1,11 @@
+import csv as _csv
 from pathlib import Path
 
 from click.testing import CliRunner
 from dji_metadata_embedder.embedder import DJIMetadataEmbedder
 from dji_metadata_embedder.cli import main
 from dji_metadata_embedder.utilities import Home, apply_redaction, parse_home, redact_home
-from dji_metadata_embedder.telemetry_converter import extract_telemetry_to_gpx
+from dji_metadata_embedder.telemetry_converter import extract_telemetry_to_gpx, extract_telemetry_to_csv
 
 # Variant 1: HOME(lat,lon) no space, no altitude
 SRT_V1 = "HOME(39.906206,116.391400) D=5.2m H=1.5m"
@@ -132,3 +133,33 @@ def test_gpx_home_dropped_under_redact(tmp_path):
     srt.write_text(GPX_SRT, encoding="utf-8")
     out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx", extract_home=True, redact="drop")
     assert "<wpt" not in out.read_text(encoding="utf-8")
+
+
+def _read_csv(path):
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(_csv.DictReader(f))
+
+
+def test_csv_no_home_columns_when_flag_off(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
+    out = extract_telemetry_to_csv(srt, tmp_path / "f.csv")
+    rows = _read_csv(out)
+    assert "home_lat" not in rows[0]
+
+
+def test_csv_home_columns_when_flag_on(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
+    out = extract_telemetry_to_csv(srt, tmp_path / "f.csv", extract_home=True)
+    rows = _read_csv(out)
+    assert rows[0]["home_lat"] == "39.906206"
+    assert rows[0]["home_lon"] == "116.3914"
+
+
+def test_csv_home_dropped_under_redact(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
+    out = extract_telemetry_to_csv(srt, tmp_path / "f.csv", extract_home=True, redact="drop")
+    rows = _read_csv(out)
+    assert rows[0]["home_lat"] == ""

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -4,6 +4,7 @@ from click.testing import CliRunner
 from dji_metadata_embedder.embedder import DJIMetadataEmbedder
 from dji_metadata_embedder.cli import main
 from dji_metadata_embedder.utilities import Home, apply_redaction, parse_home, redact_home
+from dji_metadata_embedder.telemetry_converter import extract_telemetry_to_gpx
 
 # Variant 1: HOME(lat,lon) no space, no altitude
 SRT_V1 = "HOME(39.906206,116.391400) D=5.2m H=1.5m"
@@ -101,3 +102,30 @@ def test_embed_help_lists_extract_home():
     res = CliRunner().invoke(main, ["embed", "--help"])
     assert res.exit_code == 0
     assert "--extract-home" in res.output
+
+
+GPX_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,033\n"
+    "HOME(39.906206,116.391400) [latitude: 39.900000] [longitude: 116.400000] "
+    "[rel_alt: 1.5 abs_alt: 100.0]\n"
+)
+
+
+def test_gpx_no_home_when_flag_off(tmp_path):
+    srt = tmp_path / "f.SRT"; srt.write_text(GPX_SRT, encoding="utf-8")
+    out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx")
+    assert "<wpt" not in out.read_text(encoding="utf-8")
+
+
+def test_gpx_home_waypoint_when_flag_on(tmp_path):
+    srt = tmp_path / "f.SRT"; srt.write_text(GPX_SRT, encoding="utf-8")
+    out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx", extract_home=True)
+    text = out.read_text(encoding="utf-8")
+    assert '<wpt lat="39.906206" lon="116.3914">' in text
+    assert "<name>HOME</name>" in text
+
+
+def test_gpx_home_dropped_under_redact(tmp_path):
+    srt = tmp_path / "f.SRT"; srt.write_text(GPX_SRT, encoding="utf-8")
+    out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx", extract_home=True, redact="drop")
+    assert "<wpt" not in out.read_text(encoding="utf-8")

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -112,13 +112,15 @@ GPX_SRT = (
 
 
 def test_gpx_no_home_when_flag_off(tmp_path):
-    srt = tmp_path / "f.SRT"; srt.write_text(GPX_SRT, encoding="utf-8")
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
     out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx")
     assert "<wpt" not in out.read_text(encoding="utf-8")
 
 
 def test_gpx_home_waypoint_when_flag_on(tmp_path):
-    srt = tmp_path / "f.SRT"; srt.write_text(GPX_SRT, encoding="utf-8")
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
     out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx", extract_home=True)
     text = out.read_text(encoding="utf-8")
     assert '<wpt lat="39.906206" lon="116.3914">' in text
@@ -126,6 +128,7 @@ def test_gpx_home_waypoint_when_flag_on(tmp_path):
 
 
 def test_gpx_home_dropped_under_redact(tmp_path):
-    srt = tmp_path / "f.SRT"; srt.write_text(GPX_SRT, encoding="utf-8")
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
     out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx", extract_home=True, redact="drop")
     assert "<wpt" not in out.read_text(encoding="utf-8")

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -1,11 +1,13 @@
 import csv as _csv
+import json as _json
 from pathlib import Path
 
 from click.testing import CliRunner
-from dji_metadata_embedder.embedder import DJIMetadataEmbedder
 from dji_metadata_embedder.cli import main
-from dji_metadata_embedder.utilities import Home, apply_redaction, parse_home, redact_home
+from dji_metadata_embedder.embedder import DJIMetadataEmbedder
+from dji_metadata_embedder.geo.geojson import convert_to_geojson
 from dji_metadata_embedder.telemetry_converter import extract_telemetry_to_gpx, extract_telemetry_to_csv
+from dji_metadata_embedder.utilities import Home, apply_redaction, parse_home, redact_home
 
 # Variant 1: HOME(lat,lon) no space, no altitude
 SRT_V1 = "HOME(39.906206,116.391400) D=5.2m H=1.5m"
@@ -164,9 +166,6 @@ def test_csv_home_dropped_under_redact(tmp_path):
     rows = _read_csv(out)
     assert rows[0]["home_lat"] == ""
 
-
-import json as _json
-from dji_metadata_embedder.geo.geojson import convert_to_geojson
 
 GEO_SRT = (
     "1\n00:00:00,000 --> 00:00:00,033\n"

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -201,3 +201,18 @@ def test_geojson_home_dropped_under_redact(tmp_path):
     srt.write_text(GEO_SRT, encoding="utf-8")
     out = convert_to_geojson(srt, tmp_path / "f.geojson", extract_home=True, redact="drop")
     assert _home_features(out) == []
+
+
+def test_convert_help_lists_extract_home():
+    res = CliRunner().invoke(main, ["convert", "--help"])
+    assert res.exit_code == 0
+    assert "--extract-home" in res.output
+
+
+def test_convert_gpx_home_end_to_end(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
+    out = tmp_path / "f.gpx"
+    res = CliRunner().invoke(main, ["convert", "gpx", str(srt), "-o", str(out), "--extract-home"])
+    assert res.exit_code == 0
+    assert "<name>HOME</name>" in out.read_text(encoding="utf-8")

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -1,0 +1,37 @@
+from dji_metadata_embedder.utilities import Home, parse_home, redact_home
+
+# Variant 1: HOME(lat,lon) no space, no altitude
+SRT_V1 = "HOME(39.906206,116.391400) D=5.2m H=1.5m"
+# Variant 2: HOME (lat, lon, altm) leading space + altitude with trailing m
+SRT_V2 = "HOME (-58.847509, -34.232707, -57.98m), D 698.70m, H 85.80m,"
+
+
+def test_parse_home_variant1_no_alt():
+    home = parse_home(SRT_V1)
+    assert home == Home(lat=39.906206, lon=116.391400, alt=None)
+
+
+def test_parse_home_variant2_with_alt():
+    home = parse_home(SRT_V2)
+    assert home == Home(lat=-58.847509, lon=-34.232707, alt=-57.98)
+
+
+def test_parse_home_absent_returns_none():
+    assert parse_home("[latitude: 1.0] [longitude: 2.0]") is None
+
+
+def test_redact_home_drop():
+    assert redact_home(Home(1.23456, 2.34567, 10.0), "drop") is None
+
+
+def test_redact_home_fuzz_rounds_to_3dp():
+    assert redact_home(Home(1.23456, 2.34567, 10.12345), "fuzz") == Home(1.235, 2.346, 10.123)
+
+
+def test_redact_home_none_passthrough():
+    h = Home(1.23456, 2.34567, None)
+    assert redact_home(h, "none") == h
+
+
+def test_redact_home_handles_none_input():
+    assert redact_home(None, "fuzz") is None

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
+from click.testing import CliRunner
 from dji_metadata_embedder.embedder import DJIMetadataEmbedder
+from dji_metadata_embedder.cli import main
 from dji_metadata_embedder.utilities import Home, apply_redaction, parse_home, redact_home
 
 # Variant 1: HOME(lat,lon) no space, no altitude
@@ -93,3 +95,9 @@ def test_parse_home_none_when_flag_on_but_absent(tmp_path):
                    encoding="utf-8")
     tel = _embedder(tmp_path, extract_home=True).parse_dji_srt(srt)
     assert tel["home"] is None
+
+
+def test_embed_help_lists_extract_home():
+    res = CliRunner().invoke(main, ["embed", "--help"])
+    assert res.exit_code == 0
+    assert "--extract-home" in res.output

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -216,3 +216,63 @@ def test_convert_gpx_home_end_to_end(tmp_path):
     res = CliRunner().invoke(main, ["convert", "gpx", str(srt), "-o", str(out), "--extract-home"])
     assert res.exit_code == 0
     assert "<name>HOME</name>" in out.read_text(encoding="utf-8")
+
+
+# HOME with the 3-value altitude form: HOME(lat,lon,altm)
+HOME_ALT_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,033\n"
+    "HOME(39.906206,116.391400,57.98m) [latitude: 39.900000] [longitude: 116.400000] "
+    "[rel_alt: 1.5 abs_alt: 100.0]\n"
+)
+
+
+def test_flag_off_no_home_anywhere(tmp_path):
+    """Core privacy guarantee: with the flag off, no HOME marker appears in any
+    format even though the SRT contains a HOME line."""
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GEO_SRT, encoding="utf-8")
+    gpx = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx")
+    csv_out = extract_telemetry_to_csv(srt, tmp_path / "f.csv")
+    geo = convert_to_geojson(srt, tmp_path / "f.geojson")
+    assert "HOME" not in gpx.read_text(encoding="utf-8")
+    assert "home_lat" not in csv_out.read_text(encoding="utf-8")
+    assert '"home"' not in geo.read_text(encoding="utf-8")
+
+
+def test_gpx_home_fuzz_rounds_coords(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
+    out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx", extract_home=True, redact="fuzz")
+    assert '<wpt lat="39.906" lon="116.391">' in out.read_text(encoding="utf-8")
+
+
+def test_csv_home_fuzz_rounds_coords(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
+    out = extract_telemetry_to_csv(srt, tmp_path / "f.csv", extract_home=True, redact="fuzz")
+    rows = _read_csv(out)
+    assert rows[0]["home_lat"] == "39.906"
+    assert rows[0]["home_lon"] == "116.391"
+
+
+def test_geojson_home_fuzz_rounds_coords(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GPX_SRT, encoding="utf-8")
+    out = convert_to_geojson(srt, tmp_path / "f.geojson", extract_home=True, redact="fuzz")
+    assert _home_features(out)[0]["geometry"]["coordinates"] == [116.391, 39.906]
+
+
+def test_gpx_home_includes_ele_when_alt_present(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(HOME_ALT_SRT, encoding="utf-8")
+    out = extract_telemetry_to_gpx(srt, tmp_path / "f.gpx", extract_home=True)
+    text = out.read_text(encoding="utf-8")
+    assert "<name>HOME</name>" in text
+    assert "<ele>57.98</ele>" in text
+
+
+def test_csv_home_alt_filled_when_alt_present(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(HOME_ALT_SRT, encoding="utf-8")
+    out = extract_telemetry_to_csv(srt, tmp_path / "f.csv", extract_home=True)
+    assert _read_csv(out)[0]["home_alt"] == "57.98"

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -163,3 +163,42 @@ def test_csv_home_dropped_under_redact(tmp_path):
     out = extract_telemetry_to_csv(srt, tmp_path / "f.csv", extract_home=True, redact="drop")
     rows = _read_csv(out)
     assert rows[0]["home_lat"] == ""
+
+
+import json as _json
+from dji_metadata_embedder.geo.geojson import convert_to_geojson
+
+GEO_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,033\n"
+    "HOME(39.906206,116.391400) [latitude: 39.900000] [longitude: 116.400000] [rel_alt: 1.5 abs_alt: 100.0]\n\n"
+    "2\n00:00:00,033 --> 00:00:00,066\n"
+    "HOME(39.906206,116.391400) [latitude: 39.900100] [longitude: 116.400100] [rel_alt: 1.6 abs_alt: 101.0]\n"
+)
+
+
+def _home_features(path):
+    fc = _json.loads(path.read_text(encoding="utf-8"))
+    return [f for f in fc["features"] if f["properties"].get("type") == "home"]
+
+
+def test_geojson_no_home_feature_when_flag_off(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GEO_SRT, encoding="utf-8")
+    out = convert_to_geojson(srt, tmp_path / "f.geojson")
+    assert _home_features(out) == []
+
+
+def test_geojson_home_feature_when_flag_on(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GEO_SRT, encoding="utf-8")
+    out = convert_to_geojson(srt, tmp_path / "f.geojson", extract_home=True)
+    feats = _home_features(out)
+    assert len(feats) == 1
+    assert feats[0]["geometry"]["coordinates"] == [116.3914, 39.906206]
+
+
+def test_geojson_home_dropped_under_redact(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(GEO_SRT, encoding="utf-8")
+    out = convert_to_geojson(srt, tmp_path / "f.geojson", extract_home=True, redact="drop")
+    assert _home_features(out) == []

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+from dji_metadata_embedder.embedder import DJIMetadataEmbedder
 from dji_metadata_embedder.utilities import Home, apply_redaction, parse_home, redact_home
 
 # Variant 1: HOME(lat,lon) no space, no altitude
@@ -55,3 +58,38 @@ def test_apply_redaction_no_home_key_is_noop():
     tel = {"gps_coords": [(1.0, 2.0)], "first_gps": (1.0, 2.0), "avg_gps": (1.0, 2.0)}
     apply_redaction(tel, "drop")  # must not raise
     assert "home" not in tel
+
+
+SRT_BLOCK = (
+    "1\n"
+    "00:00:00,000 --> 00:00:00,033\n"
+    "HOME(39.906206,116.391400) D=5.2m H=1.5m [latitude: 39.900000] "
+    "[longitude: 116.400000] [rel_alt: 1.500 abs_alt: 100.000]\n"
+)
+
+
+def _embedder(tmp_path: Path, **kw) -> DJIMetadataEmbedder:
+    (tmp_path / "out").mkdir(exist_ok=True)
+    return DJIMetadataEmbedder(str(tmp_path), output_dir=str(tmp_path / "out"), **kw)
+
+
+def test_parse_omits_home_when_flag_off(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(SRT_BLOCK, encoding="utf-8")
+    tel = _embedder(tmp_path).parse_dji_srt(srt)
+    assert "home" not in tel
+
+
+def test_parse_extracts_home_when_flag_on(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(SRT_BLOCK, encoding="utf-8")
+    tel = _embedder(tmp_path, extract_home=True).parse_dji_srt(srt)
+    assert tel["home"] == Home(lat=39.906206, lon=116.391400, alt=None)
+
+
+def test_parse_home_none_when_flag_on_but_absent(tmp_path):
+    srt = tmp_path / "f.SRT"
+    srt.write_text(SRT_BLOCK.replace("HOME(39.906206,116.391400) D=5.2m H=1.5m ", ""),
+                   encoding="utf-8")
+    tel = _embedder(tmp_path, extract_home=True).parse_dji_srt(srt)
+    assert tel["home"] is None

--- a/tests/test_home_point.py
+++ b/tests/test_home_point.py
@@ -1,4 +1,4 @@
-from dji_metadata_embedder.utilities import Home, parse_home, redact_home
+from dji_metadata_embedder.utilities import Home, apply_redaction, parse_home, redact_home
 
 # Variant 1: HOME(lat,lon) no space, no altitude
 SRT_V1 = "HOME(39.906206,116.391400) D=5.2m H=1.5m"
@@ -35,3 +35,23 @@ def test_redact_home_none_passthrough():
 
 def test_redact_home_handles_none_input():
     assert redact_home(None, "fuzz") is None
+
+
+def test_apply_redaction_drops_home():
+    tel = {"gps_coords": [(1.0, 2.0)], "first_gps": (1.0, 2.0), "avg_gps": (1.0, 2.0),
+           "home": Home(1.23456, 2.34567, 10.0)}
+    apply_redaction(tel, "drop")
+    assert tel["home"] is None
+
+
+def test_apply_redaction_fuzzes_home():
+    tel = {"gps_coords": [(1.0, 2.0)], "first_gps": (1.0, 2.0), "avg_gps": (1.0, 2.0),
+           "home": Home(1.23456, 2.34567, 10.0)}
+    apply_redaction(tel, "fuzz")
+    assert tel["home"] == Home(1.235, 2.346, 10.0)
+
+
+def test_apply_redaction_no_home_key_is_noop():
+    tel = {"gps_coords": [(1.0, 2.0)], "first_gps": (1.0, 2.0), "avg_gps": (1.0, 2.0)}
+    apply_redaction(tel, "drop")  # must not raise
+    assert "home" not in tel


### PR DESCRIPTION
## Summary

Adds an opt-in `--extract-home` flag (default **off**) to `dji-embed embed` and `dji-embed convert` that surfaces the DJI SRT **HOME / launch point** as a redaction-aware geographic marker. The HOME point is the operator's launch location, so it is treated as the most sensitive field:

- **Opt-in only** — the HOME regex is gated at parse time, so the value never enters any telemetry structure when the flag is off (default output is byte-for-byte unchanged).
- **Never written to the MP4** — only the JSON sidecar (`embed`) and GPX waypoint / GeoJSON `Point` feature / CSV `home_lat,home_lon,home_alt` columns (`convert`).
- **Always subject to `--redact`** in every output — `drop` removes it, `fuzz` coarsens to ~100 m (3-dp).

DRY core: a single `Home` model + `parse_home` + `redact_home` in `utilities.py`, reused by all paths. Threaded redaction into the GPX/CSV HOME marker (those paths previously had no redaction wiring at all).

Design spec: `docs/superpowers/specs/2026-06-21-home-point-opt-in-design.md`.

## Test Plan

- [x] `uv run pytest -q` → 264 passed, 2 skipped (pre-existing ExifTool fixture skips)
- [x] `uv run ruff check src tests` → clean
- [x] `uv run mypy src` → clean
- [x] Unit + integration tests in `tests/test_home_point.py`: both HOME SRT variants, redaction precedence (drop/fuzz) per format, per-format markers, and a no-leak guard (flag off → no HOME in any format)
- [ ] Manual: `dji-embed convert gpx <home.SRT> --extract-home` emits a `<name>HOME</name>` waypoint; `--redact drop` emits none

## Non-goals / follow-ups

- **Not** in this PR (deferred per spec): KML / HTML-viewer / CoT HOME markers; the broader GPX/CSV **track** redaction gap (only the HOME marker is redacted there — the per-frame track is unchanged).
- Minor nits from final review: the spec's optional one-line log note on `--extract-home --redact drop` is not implemented; `home_alt` column is always present when `--extract-home` is on (empty for the 2-value HOME variant) for a stable CSV schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)