### PR TITLE
chore(winget): fix manifests + flow for first-time submission

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -81,10 +81,10 @@ jobs:
           $actualHash = Get-FileHash "temp-dji-embed.exe" -Algorithm SHA256
           Write-Host "Actual EXE hash: $($actualHash.Hash)"
           
-          # Update installer manifest with correct hash and URLs
+          # Inject the real installer hash. The InstallerUrl version is already
+          # kept current by tools/sync_version.py at release-prep time.
           $installerManifest = Get-Content "winget/CallMarcus.DJIMetadataEmbedder.installer.yaml" -Raw
           $installerManifest = $installerManifest -replace "PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE", $actualHash.Hash
-          $installerManifest = $installerManifest -replace "v1\.1\.2", $tag  # Update URL to actual tag
           Set-Content "winget/CallMarcus.DJIMetadataEmbedder.installer.yaml" $installerManifest
           
           # Submit using prepared manifests (exclude README.md)

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -33,7 +33,10 @@ path = "src/pkg/__init__.py"
         f'$fallbackVersion = "{version}"\n'
     )
     (root / "dji-embed.spec").write_text(f'__version__ = "{version}"\n')
-    (root / "winget/manifest.yaml").write_text(f'PackageVersion: {version}\n')
+    (root / "winget/manifest.yaml").write_text(
+        f"PackageVersion: {version}\n"
+        f"ReleaseNotesUrl: https://example.com/owner/repo/releases/tag/v{version}\n"
+    )
 
 
 def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
@@ -52,8 +55,27 @@ def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     ]:
         assert "1.2.3" in (tmp_path / rel).read_text()
 
+    # Release-tag links (ReleaseNotesUrl) should be bumped too, so the winget
+    # manifest never ships stale release notes.
+    assert "releases/tag/v1.2.3" in (tmp_path / "winget/manifest.yaml").read_text()
+
     # Explicit check with matching version should pass
     sync_version.main(["1.2.3", "--check"], project_root=tmp_path)
+
+    # A stale ReleaseNotesUrl tag (right PackageVersion, wrong tag) is caught
+    (tmp_path / "winget/manifest.yaml").write_text(
+        "PackageVersion: 1.2.3\n"
+        "ReleaseNotesUrl: https://example.com/owner/repo/releases/tag/v0.0.1\n"
+    )
+    with pytest.raises(SystemExit):
+        sync_version.main(["1.2.3", "--check"], project_root=tmp_path)
+    err = capsys.readouterr().err
+    assert "winget/manifest.yaml" in err
+    # restore so later assertions in this test see an otherwise-synced tree
+    (tmp_path / "winget/manifest.yaml").write_text(
+        "PackageVersion: 1.2.3\n"
+        "ReleaseNotesUrl: https://example.com/owner/repo/releases/tag/v1.2.3\n"
+    )
 
     # Providing a mismatched version should fail with a helpful message
     with pytest.raises(SystemExit):

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -106,7 +106,10 @@ def _update_targets(version: str, root: Path) -> None:
         yaml_files = list(winget_dir.rglob("*.yaml"))
         for manifest in yml_files + yaml_files:
             _replace_in_file(manifest, r"(?m)^PackageVersion:\s*(?P<ver>\d+\.\d+\.\d+)", f"PackageVersion: {version}")
-            
+            # Keep release-tag links (e.g. ReleaseNotesUrl) pointing at the
+            # current version so the manifest never ships stale release notes.
+            _replace_in_file(manifest, r"(releases/tag/v)(?P<ver>\d+\.\d+\.\d+)", rf"\g<1>{version}")
+
         # Update installer URL version references in installer manifest
         installer_files = list(winget_dir.glob("*.installer.yaml")) + list(winget_dir.glob("*.installer.yml"))
         for installer_file in installer_files:
@@ -150,7 +153,12 @@ def _check_targets(version: str, root: Path) -> bool:
             match = re.search(r"(?m)^PackageVersion:\s*(?P<ver>\d+\.\d+\.\d+)", text)
             if not match or match.group("ver") != version:
                 mismatches.append(manifest)
-            
+
+            # Check release-tag links (e.g. ReleaseNotesUrl) stay current
+            tag_match = re.search(r"releases/tag/v(?P<ver>\d+\.\d+\.\d+)", text)
+            if tag_match and tag_match.group("ver") != version:
+                mismatches.append(manifest)
+
             # For installer manifests, also check download URL versions
             if ".installer." in manifest.name:
                 url_match = re.search(r"https://github\.com/[^/]+/[^/]+/releases/download/v(?P<ver>\d+\.\d+\.\d+)/", text)

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -20,8 +20,5 @@ Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.11.0/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
-  InstallerSwitches:
-    Silent: ""
-    SilentWithProgress: ""
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -37,15 +37,7 @@ Tags:
 - srt
 - ffmpeg
 - cli
-ReleaseNotes: |
-  M4 Milestone - Documentation & Release Hygiene:
-  - Added comprehensive documentation with decision tables and troubleshooting guides
-  - Created public sample MP4/SRT fixtures for testing across 3 DJI model families
-  - Implemented auto-changelog generation from conventional commits
-  - Enhanced CLI with professional subcommand structure and JSON logging
-  - Added lenient parser mode with structured warnings for malformed files
-  - Complete golden test fixtures and drift analysis validation
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v1.1.0
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v1.11.0
 PurchaseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder
 InstallationNotes: |
   After installation, run 'dji-embed doctor' to verify dependencies are installed.


### PR DESCRIPTION
## Summary

Cleans up the winget manifests and submission workflow so the **first-time** submission to the winget community repo (microsoft/winget-pkgs) can actually pass validation. Findings came from reviewing the manifests against winget's [FirstContribution checklist](https://github.com/microsoft/winget-pkgs/blob/master/doc/FirstContribution.md).

- **installer manifest:** removed `InstallerSwitches` (Silent/SilentWithProgress) — invalid for `InstallerType: portable`, which runs unattended without switches.
- **locale manifest:** dropped the stale hand-maintained `ReleaseNotes` (still described the "M4 milestone") and fixed `ReleaseNotesUrl` (was pinned to v1.1.0). The GitHub release page already hosts the auto-generated changelog, so `ReleaseNotesUrl` → that page is enough.
- **sync_version.py:** now also rewrites release-tag links (`releases/tag/vX.Y.Z`, i.e. `ReleaseNotesUrl`) on every version bump, with a matching `--check`, so they never drift again. Covered by `tests/test_sync_version.py`.
- **release-winget.yml:** removed the dead `-replace "v1\.1\.2"` step; the installer URL version is already set by `sync_version` at release-prep time.

## Test Plan

- [x] `uv run pytest -q` → 264 passed, 2 skipped
- [x] `uv run python tools/sync_version.py --check` → in sync at 1.11.0 (incl. new ReleaseNotesUrl check)
- [x] `uv run ruff check tools/sync_version.py tests/test_sync_version.py` → clean

## Still needed for the actual first submission (maintainer / Windows-only, not in this PR)

- Bump `ManifestVersion` from **1.6.0** to the current schema (verify latest + field compat) — winget asks for "latest manifest version".
- Local validation on Windows: `winget validate --manifest winget/` + `Tools/SandboxTest.ps1` (the replacement for the now-archived `winget-pkgs-submission-test` mirror).
- Ensure the `WINGET_PAT` account has a fork of microsoft/winget-pkgs with the right scopes, then run `gh workflow run release-winget.yml -f version=1.11.0` and respond to the validation bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)