### PR TITLE
docs: sync documentation with v1.11.0 reality (+ version-stamp auto-sync)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude Code Instructions
 
-_Last updated: 2026-06-04_
+_Last updated: 2026-06-21_
 
 ## Purpose
 This file provides context and guidelines for Claude Code when contributing to the **dji-drone-metadata-embedder** repository. It ensures consistent, high-quality contributions aligned with the project's production-ready status.
@@ -43,7 +43,7 @@ src/dji_metadata_embedder/
 ### Key Features
 - **Batch processing** of DJI drone footage (MP4 + SRT pairs)
 - **GPS metadata embedding** via FFmpeg (no re-encoding)
-- **Multiple DJI formats**: Mini 3/4 Pro, Air 3, Avata 2, Mavic 3 Enterprise
+- **Multiple DJI formats**: Mini 3/4/5 Pro, Air 3/3S, Avata 2/360, Neo 2, Mavic 3 Enterprise, Matrice 300, Phantom 4 RTK/P4P
 - **Export formats**: JSON, GPX, CSV
 - **Privacy controls**: GPS redaction (drop/fuzz)
 - **Cross-platform**: Windows, macOS, Linux
@@ -399,6 +399,6 @@ The previous `agents.md` was more generic for multiple AI assistants and focused
 
 ---
 
-**Last Updated:** 2026-06-04
-**Project Version:** v1.5.1
+**Last Updated:** 2026-06-21
+**Project Version:** v1.11.0
 **Status:** Production Ready ✅

--- a/HOUSEKEEPING.md
+++ b/HOUSEKEEPING.md
@@ -1,7 +1,7 @@
 # Repository Housekeeping Recommendations
 
-**Last refreshed:** 2026-06-06
-**Current state:** v1.6.0, production-ready, root directory already slim
+**Last refreshed:** 2026-06-21
+**Current state:** v1.11.0, production-ready, root directory already slim
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -134,12 +134,10 @@ Commands:
   embed    Embed telemetry from SRT files into MP4 videos
   validate Validate SRT/MP4 pairs and report drift
   convert  Convert SRT telemetry to GPX, CSV, GeoJSON, KML, HTML, or CoT
-  check    Check media files for embedded metadata
-  doctor   Show system information and verify dependencies
-  ui       Launch the local web UI in your browser
-  wizard   Launch interactive setup wizard
-  gui      Launch graphical interface (placeholder)
-  init     Perform initial setup (placeholder)
+  check      Check media files for embedded metadata
+  doctor     Show system information and verify dependencies
+  ui         Launch the local web UI in your browser
+  verify-sun Summarise the sun's position over a clip for shadow cross-checking
 
 Global Options:
   --version   Show the version and exit
@@ -178,7 +176,9 @@ Arguments:
   DIRECTORY          Directory containing MP4 and SRT files
 
 Options:
-  -o, --output DIRECTORY     Output directory
+  -o, --output DIRECTORY     Output directory (ignored if --overwrite)
+  --overwrite                Overwrite original video files in place
+                             (destination = input folder)
   --exiftool                 Also use ExifTool for GPS metadata
   --dat PATH                 DAT flight log to merge
   --dat-auto                 Auto-detect DAT logs matching videos
@@ -276,13 +276,18 @@ Arguments:
   DIRECTORY                  Directory containing MP4 and SRT files
 
 Options:
-  -o, --output DIRECTORY     Output directory
-  --exiftool                 Also use ExifTool for GPS metadata  
+  -o, --output DIRECTORY     Output directory (ignored if --overwrite)
+  --overwrite                Overwrite original video files in place
+                             (destination = input folder)
+  --exiftool                 Also use ExifTool for GPS metadata
   --dat PATH                 DAT flight log to merge
   --dat-auto                 Auto-detect DAT logs matching videos
   --redact [none|drop|fuzz]  Redact GPS coordinates (default: none)
   --container [mp4|mkv]      Output container; 'mkv' preserves DJI djmd/dbgi
                              data streams (default: mp4)
+  --extract-home             Extract the HOME / launch point into the JSON
+                             sidecar; off by default, never written to the
+                             MP4, always honours --redact
   -v, --verbose              Verbose output
   -q, --quiet                Suppress progress output
 ```

--- a/docs/CHANGELOG_AUTOMATION.md
+++ b/docs/CHANGELOG_AUTOMATION.md
@@ -170,7 +170,8 @@ Use consistent scopes across the project:
    # Review unreleased changes
    git diff CHANGELOG.md
    
-   # Update version in pyproject.toml
+   # Set the version (writes __init__.py, the hatch source of truth, and
+   # syncs the README badge, bootstrap.ps1, dji-embed.spec, and winget manifests)
    python3 tools/sync_version.py 1.2.0
    ```
 

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -219,12 +219,14 @@ if new_format_match:
 | DJI Mini 4 Pro | Format 1 | Bracketed key-value pairs |
 | DJI Mavic 3 | Format 3 | Comprehensive with HTML tags |
 | DJI Air 2S | Format 3 | Comprehensive with HTML tags |
+| DJI Air 3 | Format 3 | Comprehensive with HTML tags |
 | DJI Mini 5 Pro | Format 3b | FrameCnt + decimal fnum/focal_len |
 | DJI Avata 360 | Format 3b | FrameCnt + decimal units; `.OSV`/`.LRF` video, `pp_*` stabilization fields |
 | DJI Neo 2 | Format 3b | FrameCnt + decimal units; `pp_*` stabilization fields; MP4 carries `djmd`/`dbgi` streams |
 | DJI Air 3S | Format 3b | FrameCnt + decimal units; `color_md: hlg`; MP4 carries `djmd`/`dbgi` streams |
 | DJI Mavic Pro | Format 2 | GPS function format |
 | DJI Phantom 4 | Format 2 | GPS function format |
+| DJI Avata 2 | Format 2 | GPS function format with BAROMETER data |
 | DJI Matrice 300 RTK | Format 2b | Legacy-with-unit (`0.0M` altitude) |
 | DJI Phantom 4 RTK / P4P | Format 2c | P4 RTK compact single-line |
 | DJI Mavic Air 2 | Format 1 | Bracketed key-value pairs |

--- a/docs/ci_baseline.md
+++ b/docs/ci_baseline.md
@@ -1,6 +1,6 @@
 # CI Baseline – Known Good Expectations
 
-_Last verified: 2026-04-19 on Linux with Python 3.11.15 and `uv` 0.8.17._
+_Last verified: 2026-06-21 on Linux with Python 3.12.3 and `uv` 0.11.19._
 
 The project's roadmap expects contributors to run validation before adding new
 work. This page records the "known good" pass/fail baseline so you can tell a
@@ -20,7 +20,7 @@ uv run python validation_tests/run_all_tests.py   # requires FFmpeg + samples
 | Suite | Command | Expected result |
 |-------|---------|-----------------|
 | Lint | `uv run ruff check src/ tests/` | `All checks passed!` |
-| Unit tests | `uv run pytest -q` | **55 passed** (fast, < 5 s) |
+| Unit tests | `uv run pytest -q` | **264 passed, 2 skipped** (fast, ~11 s) |
 | CLI smoke | `uv run dji-embed --version` | Prints version plus availability of FFmpeg/ExifTool |
 | Validation – Installation & Dependencies | `validation_tests/test_installation_and_dependencies.py` | Passes only when FFmpeg + ExifTool are on `PATH`. FFmpeg/ExifTool missing ⇒ expected failure outside release CI |
 | Validation – SRT Parsing | `validation_tests/test_srt_parsing.py` | Passes against the bundled `samples/` fixtures |
@@ -58,32 +58,6 @@ If `uv run pytest -q` is green and `uv run ruff check` is clean, your branch
 matches the PR gate. Run the validation suite before cutting a release or
 whenever you change parsing / FFmpeg command assembly; otherwise the unit
 tests and golden fixtures are sufficient for day-to-day development.
-
-## Pending: first Dependabot run (2026-04-19)
-
-Dependabot's first run opened two grouped PRs that will shift the numbers
-above once merged. Re-run the commands in this file and update the recorded
-versions when either lands:
-
-- **[#180](https://github.com/CallMarcus/dji-drone-metadata-embedder/pull/180)
-  — `actions` group (8 updates).** `actions/checkout 4→6`,
-  `actions/setup-python 5→6`, `astral-sh/setup-uv 5→7`,
-  `peter-evans/create-pull-request 6→8`, `actions/upload-pages-artifact 3→5`,
-  `actions/configure-pages 4→6`, `actions/deploy-pages 4→5`,
-  `softprops/action-gh-release 2→3`. No local effect, but the CI matrix in
-  `.github/workflows/ci.yml` needs to go green on the new versions.
-- **[#181](https://github.com/CallMarcus/dji-drone-metadata-embedder/pull/181)
-  — `development-deps` group (9 updates).** `pytest 8.3.2→9.0.3`,
-  `pytest-cov 5.0.0→7.1.0`, `coverage 7.6.0→7.13.5`, `black 24.4.2→26.3.1`,
-  **`ruff 0.4.6→0.15.11`**, `mypy 1.8.0→1.20.1`, `build 1.2.1→1.4.3`,
-  `hatchling 1.25.0→1.29.0`, `twine 5.1.1→6.2.0`. The ruff jump is the
-  biggest risk — the 0.5–0.15 series enabled several new default rules, so
-  "ruff clean" on `master` is not guaranteed to hold on this branch. Run
-  `uv sync --extra dev` + `uv run ruff check src/ tests/` on the branch
-  before merging and fix any new lint findings in the same PR.
-  _Verified locally 2026-04-19: on the Dependabot branch
-  `uv run ruff check src/ tests/` is clean and `uv run pytest -q` reports
-  55 passed (41 passed + 14 UI tests when `--extra ui` is installed)._
 
 ## Updating this baseline
 

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -1,6 +1,6 @@
 # Development Roadmap
 
-_Last updated: 2026-06-04 · Current version: **v1.5.1** · Status: **Production Ready**_
+_Last updated: 2026-06-21 · Current version: **v1.11.0** · Status: **Production Ready**_
 
 This roadmap tracks the evolution of **DJI Drone Metadata Embedder**. The
 original Phase 1–6 plan (standalone Windows GUI, dependency bootstrap,
@@ -44,7 +44,7 @@ from pre-existing environmental gaps.
   skeleton was removed in the 2026-06 cleanup pass; no Tk work is planned.
 
 ### Testing & CI
-- Unit test suite (`tests/`, 55 tests) covering parsing, embedding, DAT,
+- Unit test suite (`tests/`, 264 tests) covering parsing, embedding, DAT,
   redaction, sync, UI server, and CLI smoke.
 - End-to-end validation suite (`validation_tests/`) for release verification
   when FFmpeg/ExifTool and real media are available.
@@ -80,30 +80,27 @@ from pre-existing environmental gaps.
   Matrice 4 / M30 / M350 RTK, and FPV v2 for SRT documentation and sample
   availability, then spin off per-model parser issues following the "Adding
   Support for New DJI Models" checklist in `CLAUDE.md` §7.
-- **Geospatial / mapping.** Render the flight path on a map. Three phases,
-  designed in
-  [`docs/superpowers/specs/2026-06-04-flight-path-mapping-design.md`](superpowers/specs/2026-06-04-flight-path-mapping-design.md):
-  GeoJSON/KML **track export** as the canonical foundation
-  ([#215](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/215),
-  track-only **shipped** in #223 via `dji-embed convert geojson|kml`;
-  camera-footprint polygons remain a follow-up), a **standalone
-  HTML viewer**
-  ([#221](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/221),
-  Leaflet/OSM, no API key), and an **interactive map panel in the web UI**
-  ([#222](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/222),
-  gated on #170). Every renderer consumes the same GeoJSON.
+- **Geospatial / mapping — SHIPPED.** The three-phase plan in
+  [`docs/superpowers/specs/2026-06-04-flight-path-mapping-design.md`](superpowers/specs/2026-06-04-flight-path-mapping-design.md)
+  is complete: GeoJSON/KML **track export** (#215/#223, `dji-embed convert
+  geojson|kml`), the **standalone HTML viewer** (#221, `convert html`,
+  Leaflet/OSM, no API key, v1.7.0), the **interactive map panel in the web UI**
+  (#222, v1.9.0), and **camera-footprint polygons** (#215, `--footprint`,
+  v1.9.0). Every renderer consumes the same GeoJSON. Remaining follow-ups are
+  oblique-trapezoid / view-frustum footprints (needs DAT attitude) and
+  terrain/DEM draping.
 - **Richer web UI.** Incremental improvements to the Flask UI
   (`src/dji_metadata_embedder/ui/`) – nicer job progress, downloadable
   per-job artefacts, and richer previews – instead of new GUI frameworks.
 - **Performance work on large batches.** Candidates include parallel
   per-clip embedding and streaming SRT parsing for long flights.
-- **Winget re-enablement.** Blocked on
-  [#175](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/175):
-  `CallMarcus.DJIMetadataEmbedder` needs a manual first-publisher submission
-  to `microsoft/winget-pkgs`, after which `release-winget.yml` should be
-  rewritten on top of `winget-releaser` and the three hand-maintained
-  manifests in `winget/` retired. The workflow currently fires only on
-  manual dispatch.
+- **Winget catalog publish — in Microsoft's queue.** #175 is closed (the
+  `release-winget.yml` workflow was fixed, not rewritten). The first-publisher
+  submission for `CallMarcus.DJIMetadataEmbedder` is open as
+  [microsoft/winget-pkgs#391183](https://github.com/microsoft/winget-pkgs/pull/391183),
+  awaiting moderator approval. The workflow stays `workflow_dispatch`-only and
+  the three hand-maintained manifests in `winget/` remain in use; a future
+  `winget-releaser` rewrite is optional, not required.
 
 ## Explicitly out of scope
 

--- a/docs/external-tool-versions.md
+++ b/docs/external-tool-versions.md
@@ -75,10 +75,10 @@ RUN curl -L "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-stat
 
 | dji-embed | FFmpeg | ExifTool | Status |
 |-----------|---------|----------|--------|
-| 1.0.4     | 6.1.1   | 12.76    | ✅ Recommended |
-| 1.0.4     | 6.0.x   | 12.70+   | ✅ Supported |  
-| 1.0.4     | 5.1.x   | 12.50+   | ⚠️ Limited testing |
-| 1.0.4     | 4.4.x   | 11.00+   | ⚠️ Minimum support |
+| 1.11.0    | 6.1.1   | 12.76    | ✅ Recommended |
+| 1.11.0    | 6.0.x   | 12.70+   | ✅ Supported |
+| 1.11.0    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
+| 1.11.0    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
 
 ## Known Issues
 
@@ -95,7 +95,7 @@ RUN curl -L "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-stat
 The `dji-embed --version` command now shows detected tool versions:
 
 ```
-dji-embed 1.0.4
+dji-embed 1.11.0
   python: python
   ffmpeg: 6.1.1
   exiftool: 12.76

--- a/docs/how-to/generate-gpx.md
+++ b/docs/how-to/generate-gpx.md
@@ -1,18 +1,19 @@
 # Generate GPX
 
-The package can convert DJI SRT telemetry files into GPX tracks using the
-`telemetry_converter` module.
+The `dji-embed convert` command turns DJI SRT telemetry files into GPX tracks
+(it can also emit CSV, GeoJSON, KML, HTML, or CoT).
 
 Convert a single file:
 
 ```bash
-python -m dji_metadata_embedder.telemetry_converter gpx DJI_0001.SRT
+dji-embed convert gpx DJI_0001.SRT
 ```
 
 Process an entire directory:
 
 ```bash
-python -m dji_metadata_embedder.telemetry_converter gpx /path/to/srt --batch
+dji-embed convert gpx /path/to/srt --batch
 ```
 
-GPX files are saved to a `gpx_tracks` directory in the input folder.
+By default the `.gpx` file is written next to the input SRT (e.g.
+`DJI_0001.gpx`). Pass `-o/--output` to choose a different location.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,14 +14,25 @@ iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedd
 ```powershell
 pip install dji-drone-metadata-embedder
 ```
+
+### macOS
+
 ```bash
 brew install ffmpeg exiftool
+pip install dji-drone-metadata-embedder
+```
+
+### Linux
+
+```bash
 sudo apt update && sudo apt install ffmpeg exiftool
 pip install dji-drone-metadata-embedder
 ```
 
+### Docker
+
 ```bash
-docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
+docker run --rm -v "$PWD":/data callmarcus/dji-embed embed /data
 ```
 
 ## Optional: browser-based UI

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -308,10 +308,8 @@ dji-embed validate /footage
 # Check video frame rate pattern
 ffprobe -v quiet -show_streams video.mp4 | grep -E "(r_frame_rate|avg_frame_rate)"
 
-# For severe drift, try manual time offset
-dji-embed embed /footage --time-offset 0.5  # Adjust timing by 0.5s
-
-# Alternative: Use ffmpeg to fix frame rate first
+# There is no built-in timing offset. For severe drift, normalise the
+# frame rate with ffmpeg first, then re-run the embed:
 ffmpeg -i input.mp4 -r 30 -c:v libx264 -crf 18 output.mp4
 ```
 
@@ -347,11 +345,11 @@ ffmpeg -i input.mp4 -r 30 -c:v libx264 -preset medium -crf 20 output.mp4
    # Process each part separately
    ```
 
-2. **Use time offset compensation:**
+2. **Process each segment separately:**
    ```bash
-   # For each segment, adjust timing
-   dji-embed embed part1/ --time-offset 0.0
-   dji-embed embed part2/ --time-offset -0.5
+   # Embed each split part on its own; shorter clips accumulate less drift
+   dji-embed embed part1/
+   dji-embed embed part2/
    ```
 
 ---

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -22,13 +22,14 @@ Run `dji-embed --help` to see all available options.
 
 ## Converting telemetry
 
-The package also includes a converter for GPX or CSV output:
+Use `dji-embed convert` to export telemetry to GPX, CSV, GeoJSON, KML, HTML,
+or CoT:
 
 ```bash
-python -m dji_metadata_embedder.telemetry_converter gpx DJI_0001.SRT
+dji-embed convert gpx DJI_0001.SRT
 ```
 
-Use `csv` instead of `gpx` to create a CSV file.
+Swap `gpx` for `csv`, `geojson`, `kml`, `html`, or `cot` to pick the format.
 
 For detailed how-to guides such as creating Windows bundles or redacting location data, see the files in `docs/how-to`.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -24,6 +24,22 @@ Each directory contains a complete set of test files:
 - **Duration**: ~100ms (3 frames at 30fps)  
 - **GPS**: Stockholm, Sweden area (redacted coordinates)
 
+### `air3S/` - DJI Air 3S Format
+- **Format**: HTML-style SRT (`FrameCnt`/`DiffTime`) with decimal `focal_len` and HLG color mode (`color_md: hlg`)
+- **Features**: GPS, altitude, rich camera metadata; the MP4 also carries embedded `djmd`/`dbgi` data streams (sidecar-less telemetry)
+
+### `Mini5PRO/` - DJI Mini 5 Pro Format
+- **Format**: HTML-style SRT with decimal aperture (`fnum: 1.8`)
+- **Features**: GPS, altitude, camera settings
+
+### `neo2/` - DJI Neo 2 Format
+- **Format**: HTML-style SRT with stabilization (`pp_*`) fields
+- **Features**: GPS, altitude, camera metadata; MP4 also carries embedded `djmd`/`dbgi` data streams. Includes a `clip_nogps.SRT` variant for no-GPS handling.
+
+### `Avata360/` - DJI Avata 360 Format
+- **Format**: HTML-style SRT (`FrameCnt`/`FrameId`) with stabilization (`pp_*`) fields
+- **Features**: Footage ships as `.OSV` (360 video) + `.LRF` proxy alongside the SRT
+
 ## 🧪 Testing Commands
 
 ### Basic Processing

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -17,6 +17,7 @@ def _write_project(root: Path, version: str) -> None:
     (root / "src/pkg").mkdir(parents=True)
     (root / "tools").mkdir()
     (root / "winget").mkdir()
+    (root / "docs").mkdir()
 
     (root / "pyproject.toml").write_text(
         """
@@ -38,6 +39,26 @@ path = "src/pkg/__init__.py"
         f"ReleaseNotesUrl: https://example.com/owner/repo/releases/tag/v{version}\n"
     )
 
+    # Doc "current version" stamps that sync_version.py keeps fresh.
+    (root / "CLAUDE.md").write_text(f"**Project Version:** v{version}\n")
+    (root / "HOUSEKEEPING.md").write_text(
+        f"**Current state:** v{version}, production-ready\n"
+    )
+    (root / "docs/development_roadmap.md").write_text(
+        f"_Last updated: 2026-06-21 · Current version: **v{version}** · Status: x_\n"
+    )
+    # Two matrix rows (first column) + the `dji-embed X.Y.Z` example line; the
+    # FFmpeg column must stay untouched.
+    (root / "docs/external-tool-versions.md").write_text(
+        "| dji-embed | FFmpeg |\n"
+        "|-----------|--------|\n"
+        f"| {version}    | 6.1.1   |\n"
+        f"| {version}    | 6.0.x   |\n"
+        "\n"
+        f"dji-embed {version}\n"
+        "  ffmpeg: 6.1.1\n"
+    )
+
 
 def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     sync_version = _load_module()
@@ -52,8 +73,20 @@ def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
         "tools/bootstrap.ps1",
         "dji-embed.spec",
         "winget/manifest.yaml",
+        "CLAUDE.md",
+        "HOUSEKEEPING.md",
+        "docs/development_roadmap.md",
+        "docs/external-tool-versions.md",
     ]:
         assert "1.2.3" in (tmp_path / rel).read_text()
+
+    # external-tool-versions.md has the version in multiple spots (both matrix
+    # rows + the example line); re.subn must bump them all while leaving the
+    # FFmpeg tool version alone.
+    ext = (tmp_path / "docs/external-tool-versions.md").read_text()
+    assert ext.count("1.2.3") == 3
+    assert "0.1.0" not in ext
+    assert "6.1.1" in ext
 
     # Release-tag links (ReleaseNotesUrl) should be bumped too, so the winget
     # manifest never ships stale release notes.
@@ -93,4 +126,22 @@ def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     err = capsys.readouterr().err
     assert "expected 1.2.3" in err
     assert "README.md" in err
+
+
+def test_doc_version_stamp_drift_is_caught(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """A stale 'current version' stamp in a doc must fail --check."""
+    sync_version = _load_module()
+    _write_project(tmp_path, "1.2.3")
+
+    # Everything is in sync to start with.
+    sync_version.main(["1.2.3", "--check"], project_root=tmp_path)
+
+    # Let a doc stamp rot, exactly the failure mode this wiring guards against.
+    (tmp_path / "CLAUDE.md").write_text("**Project Version:** v0.0.1\n")
+    with pytest.raises(SystemExit):
+        sync_version.main(["1.2.3", "--check"], project_root=tmp_path)
+    err = capsys.readouterr().err
+    assert "CLAUDE.md" in err
 

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -2,8 +2,11 @@
 
 This helper keeps the version defined in ``pyproject.toml`` (via
 ``[tool.hatch.version]``) in sync with other project files such as the
-README badge, bootstrap script, PyInstaller spec and optional winget
-manifests.
+README badge, bootstrap script, PyInstaller spec, optional winget
+manifests, and the "current version" stamps in a handful of docs
+(``CLAUDE.md``, ``HOUSEKEEPING.md``, ``docs/development_roadmap.md`` and the
+``docs/external-tool-versions.md`` compatibility table) so they stop rotting
+between releases.
 
 Usage::
 
@@ -46,6 +49,30 @@ TARGET_PATTERNS: dict[Path, tuple[str, str]] = {
     Path("dji-embed.spec"): (
         r"__version__\s*=\s*\"(?P<ver>\d+\.\d+\.\d+)\"",
         "__version__ = \"{version}\"",
+    ),
+    # "Current version" stamps in docs. These are prose/markdown version
+    # claims that previously drifted every release because nothing updated
+    # them. Each pattern carries a (?P<ver>...) group so --check can validate
+    # it, matching the rest of the targets above.
+    Path("CLAUDE.md"): (
+        r"\*\*Project Version:\*\* v(?P<ver>\d+\.\d+\.\d+)",
+        "**Project Version:** v{version}",
+    ),
+    Path("HOUSEKEEPING.md"): (
+        r"\*\*Current state:\*\* v(?P<ver>\d+\.\d+\.\d+)",
+        "**Current state:** v{version}",
+    ),
+    Path("docs/development_roadmap.md"): (
+        r"Current version: \*\*v(?P<ver>\d+\.\d+\.\d+)\*\*",
+        "Current version: **v{version}**",
+    ),
+    # external-tool-versions.md mentions the version in two places: every row
+    # of the compatibility matrix (first column, line-start "| X.Y.Z") and the
+    # `dji-embed X.Y.Z` --version example. The (?m) alternation matches both;
+    # re.subn updates all occurrences while --check validates the first.
+    Path("docs/external-tool-versions.md"): (
+        r"(?m)(?P<lead>^\| |^dji-embed )(?P<ver>\d+\.\d+\.\d+)",
+        r"\g<lead>{version}",
     ),
 }
 

--- a/winget/README.md
+++ b/winget/README.md
@@ -52,20 +52,29 @@ winget uninstall CallMarcus.DJIMetadataEmbedder
 
 ## 🚀 Release Process
 
-### Automatic Submission
+Winget submission is **manual**. The `release-winget.yml` workflow is
+`workflow_dispatch`-only — it does **not** fire automatically on a release tag
+(the auto-trigger was removed because it kept failing). Once the GitHub release
+with `dji-embed.exe` exists, trigger it by hand:
 
-The project uses GitHub Actions for automatic winget submissions:
+```bash
+gh workflow run release-winget.yml -f version=1.11.0
+```
 
-1. **Release Creation**: When a new release tag (e.g., `v1.2.0`) is pushed
-2. **EXE Build**: The `release-exe.yml` workflow builds `dji-embed.exe`  
-3. **Winget Submission**: The `release-winget.yml` workflow automatically:
-   - Validates version sync using `sync_version.py --check`
-   - Submits to the winget community repository using `wingetcreate`
-   - Creates a pull request to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
+When run, the workflow:
 
-### Manual Submission
+1. Validates version sync using `sync_version.py --check`
+2. Injects the real `dji-embed.exe` SHA256 into the installer manifest
+3. Submits the `winget/` manifest set to the winget community repository using
+   `wingetcreate`, opening a pull request to
+   [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
 
-If needed, you can manually submit to winget:
+A brand-new package version still requires a winget moderator to approve the PR
+before it appears in the catalog.
+
+### Manual Submission (run wingetcreate locally)
+
+If needed, you can submit from your own machine instead of the workflow:
 
 ```powershell
 # Set GitHub token for winget submissions


### PR DESCRIPTION
## Summary

A full audit of every living Markdown doc against the current code (v1.11.0) found and fixed factual drift, then closed the loop so the version-drift class of bug stops recurring.

### Doc fixes (14 files)
- **README**: drop non-existent `wizard`/`gui`/`init` commands, add `verify-sun`; document `--overwrite` (both embed blocks) and `--extract-home`.
- **troubleshooting**: remove fictional `embed --time-offset` examples (no such flag).
- **installation**: fix the Docker command (`-i *.MP4` → `embed /data`) and split the mixed Windows/macOS/Linux block.
- **winget/README**: correct the "automatic submission" claim — winget is manual (`workflow_dispatch` only).
- **CLAUDE.md / HOUSEKEEPING.md / development_roadmap.md**: refresh stale version footers (v1.5.1 / v1.6.0 → v1.11.0); complete the supported-model list; mark shipped geospatial/mapping work and the winget first submission as done.
- **user_guide / how-to/generate-gpx**: replace legacy `python -m ...telemetry_converter` examples with `dji-embed convert`.
- **SRT_FORMATS**: add Air 3 and Avata 2 to the model-format table.
- **samples/README**: document the air3S, Mini5PRO, neo2, Avata360 fixtures.
- **external-tool-versions**: refresh stale 1.0.4 → 1.11.0.
- **ci_baseline**: drop the resolved Dependabot section (#180/#181 merged), refresh verified env + pass count (55 → 264).
- **CHANGELOG_AUTOMATION**: correct the `sync_version.py` description.

### Stop the rot
Wire the four docs that hardcode a "current version" into `tools/sync_version.py`, so `sync_version.py X.Y.Z` bumps them and `--check` (run at release time) fails if they drift: `CLAUDE.md`, `HOUSEKEEPING.md`, `docs/development_roadmap.md`, and the `docs/external-tool-versions.md` compatibility matrix + `--version` example. `model_survey_brief.md` is intentionally left frozen (it documents a survey done at v1.2.0).

### Deliberately not changed
- `geospatial.md` FOV table — verified **correct** (`FOV_TABLE` has exactly those 4 models).
- `MP4_TIMED_METADATA.md` "DJI Neo" — **not a typo** (DJI Neo and Neo 2 are different drones).

## Test Plan
- [x] `uv run pytest -q` → 265 passed, 2 skipped
- [x] `uv run ruff check` → clean
- [x] `uv run mypy` → clean (30 files)
- [x] `uv run --extra docs mkdocs build --strict` → builds clean (no broken links)
- [x] `sync_version.py --check` passes at 1.11.0; round-trip bump verified to update all four docs and leave FFmpeg/ExifTool versions untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)