### PR TITLE
feat(embed): --audio-sidecar — auto-mux Neo 2's separate .m4a audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Options:
   --exiftool                 Also use ExifTool for GPS metadata
   --dat PATH                 DAT flight log to merge
   --dat-auto                 Auto-detect DAT logs matching videos
+  --audio-sidecar            Auto-detect a same-basename .m4a audio sidecar
+                             (e.g. DJI Neo 2) and mux it in (no re-encode)
   --redact [none|drop|fuzz]  Redact GPS coordinates (default: none)
   --container [mp4|mkv]      Output container; 'mkv' preserves DJI djmd/dbgi
                              data streams (default: mp4)
@@ -284,6 +286,8 @@ Options:
   --exiftool                 Also use ExifTool for GPS metadata
   --dat PATH                 DAT flight log to merge
   --dat-auto                 Auto-detect DAT logs matching videos
+  --audio-sidecar            Auto-detect a same-basename .m4a audio sidecar
+                             (e.g. DJI Neo 2) and mux it in (no re-encode)
   --redact [none|drop|fuzz]  Redact GPS coordinates (default: none)
   --container [mp4|mkv]      Output container; 'mkv' preserves DJI djmd/dbgi
                              data streams (default: mp4)

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -222,7 +222,7 @@ if new_format_match:
 | DJI Air 3 | Format 3 | Comprehensive with HTML tags |
 | DJI Mini 5 Pro | Format 3b | FrameCnt + decimal fnum/focal_len |
 | DJI Avata 360 | Format 3b | FrameCnt + decimal units; `.OSV`/`.LRF` video, `pp_*` stabilization fields |
-| DJI Neo 2 | Format 3b | FrameCnt + decimal units; `pp_*` stabilization fields; MP4 carries `djmd`/`dbgi` streams |
+| DJI Neo 2 | Format 3b | FrameCnt + decimal units; `pp_*` stabilization fields; MP4 carries `djmd`/`dbgi` streams; audio recorded to a **separate same-basename `.m4a`** (see `--audio-sidecar`) |
 | DJI Air 3S | Format 3b | FrameCnt + decimal units; `color_md: hlg`; MP4 carries `djmd`/`dbgi` streams |
 | DJI Mavic Pro | Format 2 | GPS function format |
 | DJI Phantom 4 | Format 2 | GPS function format |

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -17,8 +17,26 @@ A `processed` folder will be created containing new videos with embedded metadat
 - `-o DIR` – choose an output directory
 - `--exiftool` – also write metadata via ExifTool (requires ExifTool)
 - `--dat FILE` – merge a DAT flight log with the video
+- `--audio-sidecar` – auto-pair a same-basename `.m4a` audio file and mux it in
+  (see [Drones with separate audio](#drones-with-separate-audio-neo-2))
 
 Run `dji-embed --help` to see all available options.
+
+## Drones with separate audio (Neo 2)
+
+Some DJI drones — notably the **Neo 2** — record video and audio as **two
+files**: a silent `DJI_0001.MP4` plus a `DJI_0001.m4a` alongside it. Pass
+`--audio-sidecar` to have `embed` find the matching `.m4a` and mux it into the
+output automatically:
+
+```bash
+dji-embed embed /path/to/footage --audio-sidecar
+```
+
+- Audio is stream-copied (no re-encode), consistent with the rest of the tool.
+- The telemetry subtitle track is preserved.
+- Clips without a matching `.m4a` are processed as usual (a warning is logged).
+- A large video/audio length mismatch is flagged as a warning but still muxed.
 
 ## Converting telemetry
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -103,6 +103,12 @@ def main(ctx: click.Context, log_json: bool) -> None:
 @click.option("--dat", type=click.Path(exists=True), help="DAT flight log to merge")
 @click.option("--dat-auto", is_flag=True, help="Auto-detect DAT logs matching videos")
 @click.option(
+    "--audio-sidecar",
+    is_flag=True,
+    help="Auto-detect a same-basename .m4a audio sidecar (e.g. DJI Neo 2) and "
+    "mux it into the output (no re-encode).",
+)
+@click.option(
     "--redact",
     type=click.Choice(["none", "drop", "fuzz"], case_sensitive=False),
     default="none",
@@ -132,6 +138,7 @@ def embed(
     exiftool: bool,
     dat: str | None,
     dat_auto: bool,
+    audio_sidecar: bool,
     redact: str,
     container: str,
     extract_home: bool,
@@ -154,6 +161,7 @@ def embed(
         redact=redact,
         container=container.lower(),
         extract_home=extract_home,
+        audio_sidecar=audio_sidecar,
     )
     embedder.process_directory(use_exiftool=exiftool)
 

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -156,6 +156,7 @@ class DJIMetadataEmbedder:
         resample_strategy: str = "linear",
         container: str = "mp4",
         extract_home: bool = False,
+        audio_sidecar: bool = False,
     ):
         self.directory = Path(directory)
         self.output_dir = (
@@ -176,6 +177,9 @@ class DJIMetadataEmbedder:
         # Opt-in only: the HOME/launch point is the operator's location, so it
         # is parsed solely when explicitly requested and never written to MP4.
         self.extract_home = extract_home
+        # Opt-in: Neo 2 records audio to a separate .m4a; when set, auto-pair and
+        # mux the same-basename sidecar into the output (issue #246).
+        self.audio_sidecar = audio_sidecar
 
     def parse_dji_srt(self, srt_path: Path) -> Dict[str, Any]:
         """Parse DJI SRT file and extract telemetry data."""
@@ -410,8 +414,15 @@ class DJIMetadataEmbedder:
         srt_path: Path,
         telemetry: Dict[str, Any],
         output_path: Path,
+        audio_path: Optional[Path] = None,
     ) -> bool:
-        """Embed SRT as subtitle track and add metadata using ffmpeg."""
+        """Embed SRT as subtitle track and add metadata using ffmpeg.
+
+        When *audio_path* is given (Neo 2 records audio to a separate .m4a,
+        issue #246), it is added as a third input and its audio stream is muxed
+        into the output. Audio is appended last so the SRT keeps input index 1
+        and the existing ``-map 1`` subtitle mapping stays correct.
+        """
         import os
         import platform
 
@@ -443,12 +454,17 @@ class DJIMetadataEmbedder:
             else:
                 stream_maps = ["-map", "0", "-map", "-0:d", "-map", "1"]
                 subtitle_codec = "mov_text"
+
+            # Audio sidecar is the third input (index 2); pull its audio stream
+            # with -map 2:a. Keeping it last preserves the SRT's input index 1.
+            inputs = ["-i", str(video_path), "-i", str(srt_path)]
+            if audio_path is not None:
+                inputs += ["-i", str(audio_path)]
+                stream_maps += ["-map", "2:a"]
+
             cmd = [
                 ffmpeg_cmd,
-                "-i",
-                str(video_path),
-                "-i",
-                str(srt_path),
+                *inputs,
                 *stream_maps,
                 "-c",
                 "copy",
@@ -619,6 +635,43 @@ class DJIMetadataEmbedder:
                             "Failed to parse DAT file %s: %s", dat_file.name, e
                         )
 
+                # Optionally pair a separate audio sidecar. The Neo 2 records
+                # audio to a same-basename .m4a next to the silent video; mux it
+                # back in on request (issue #246). Warn-and-continue when absent
+                # so mixed folders (some clips with audio, some without) still
+                # process every video.
+                audio_file = None
+                if self.audio_sidecar:
+                    for ext in (".m4a", ".M4A"):
+                        cand = video_path.with_suffix(ext)
+                        if cand.exists():
+                            audio_file = cand
+                            break
+                    if audio_file is None:
+                        warning_msg = (
+                            f"No .m4a audio sidecar found for: {video_path.name}"
+                        )
+                        logger.warning(warning_msg)
+                        result["warnings"].append(warning_msg)
+                    else:
+                        # Sanity check: flag a large video/audio length gap (wrong
+                        # pairing, truncated recording) but still mux — the user
+                        # opted in and may want whatever audio exists.
+                        video_dur = _ffprobe_duration(video_path)
+                        audio_dur = _ffprobe_duration(audio_file)
+                        if (
+                            video_dur is not None
+                            and audio_dur is not None
+                            and abs(video_dur - audio_dur) > 1.0
+                        ):
+                            warning_msg = (
+                                f"Audio sidecar duration ({audio_dur:.1f}s) differs "
+                                f"from video ({video_dur:.1f}s) for "
+                                f"{video_path.name}; muxing anyway"
+                            )
+                            logger.warning(warning_msg)
+                            result["warnings"].append(warning_msg)
+
                 # Final output path; write to temp first, then atomic move (issue #162).
                 # When overwrite (issue #163), destination = same as input file.
                 if self.overwrite:
@@ -638,7 +691,11 @@ class DJIMetadataEmbedder:
 
                 # Embed metadata using ffmpeg into temp file
                 if self.embed_metadata_ffmpeg(
-                    video_path, srt_path, telemetry, temp_output_path
+                    video_path,
+                    srt_path,
+                    telemetry,
+                    temp_output_path,
+                    audio_path=audio_file,
                 ):
                     if _validate_embedded_output(video_path, temp_output_path):
                         try:

--- a/tests/test_audio_sidecar.py
+++ b/tests/test_audio_sidecar.py
@@ -1,0 +1,302 @@
+"""Tests for --audio-sidecar: auto-merge Neo 2's separate .m4a audio (issue #246).
+
+The DJI Neo 2 records video and audio as separate files (DJI_xxx.MP4 with no
+audio stream + DJI_xxx.m4a). With --audio-sidecar, the paired .m4a is muxed in
+as a third ffmpeg input (stream-copied, no re-encode) while the telemetry
+subtitle track is preserved.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+import dji_metadata_embedder.cli as cli
+from dji_metadata_embedder.cli import main
+from dji_metadata_embedder.embedder import DJIMetadataEmbedder
+
+
+def _minimal_telemetry() -> dict:
+    """Smallest telemetry dict embed_metadata_ffmpeg will accept."""
+    return {"first_gps": None, "max_altitude": None}
+
+
+def _fake_progress_class():
+    """Minimal Progress-like class (conftest stubs Progress as object)."""
+    class Task:
+        def advance(self, _=None):
+            pass
+
+    class FakeProgress:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def add_task(self, *args, **kwargs):
+            return Task()
+
+        def update(self, task, description=None):
+            pass
+
+        def advance(self, task):
+            pass
+
+    return FakeProgress
+
+
+class TestEmbedMetadataFfmpegAudio:
+    """Unit tests for embed_metadata_ffmpeg's audio_path argument."""
+
+    def test_audio_path_adds_third_input_and_maps_audio(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With audio_path set, ffmpeg gets the audio as a third input (index 2)
+        and -map 2:a, while the SRT subtitle stays at -map 1 (unshifted)."""
+        video = tmp_path / "DJI_0001.mp4"
+        srt = tmp_path / "DJI_0001.srt"
+        audio = tmp_path / "DJI_0001.m4a"
+        for f in (video, srt, audio):
+            f.write_bytes(b"data")
+        out = tmp_path / "out.mp4"
+
+        captured: list = []
+
+        def fake_run(cmd, *args, **kwargs):
+            captured.append(cmd)
+            Path(cmd[-1]).write_bytes(b"embedded")
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        embedder = DJIMetadataEmbedder(str(tmp_path), output_dir=str(tmp_path / "processed"))
+        ok = embedder.embed_metadata_ffmpeg(
+            video, srt, _minimal_telemetry(), out, audio_path=audio
+        )
+
+        assert ok is True
+        assert captured, "ffmpeg was not invoked"
+        cmd = captured[0]
+
+        # Input order: video (0), srt (1), audio (2).
+        i_flags = [i for i, tok in enumerate(cmd) if tok == "-i"]
+        inputs = [cmd[i + 1] for i in i_flags]
+        assert inputs == [str(video), str(srt), str(audio)], (
+            f"expected video, srt, audio inputs in order, got {inputs}"
+        )
+
+        # Map targets: subtitle stays at 1, audio pulled from input 2.
+        map_targets = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-map"]
+        assert "1" in map_targets, f"srt subtitle map shifted: {map_targets}"
+        assert "2:a" in map_targets, f"expected -map 2:a, got {map_targets}"
+
+    def test_no_audio_path_leaves_command_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without audio_path, no third input and no audio map are added."""
+        video = tmp_path / "DJI_0001.mp4"
+        srt = tmp_path / "DJI_0001.srt"
+        for f in (video, srt):
+            f.write_bytes(b"data")
+        out = tmp_path / "out.mp4"
+
+        captured: list = []
+
+        def fake_run(cmd, *args, **kwargs):
+            captured.append(cmd)
+            Path(cmd[-1]).write_bytes(b"embedded")
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        embedder = DJIMetadataEmbedder(str(tmp_path), output_dir=str(tmp_path / "processed"))
+        embedder.embed_metadata_ffmpeg(video, srt, _minimal_telemetry(), out)
+
+        cmd = captured[0]
+        i_flags = [i for i, tok in enumerate(cmd) if tok == "-i"]
+        inputs = [cmd[i + 1] for i in i_flags]
+        assert inputs == [str(video), str(srt)], f"unexpected extra input: {inputs}"
+        map_targets = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-map"]
+        assert "2:a" not in map_targets
+
+
+def _make_run_capture(captured: list, durations: dict | None = None):
+    """subprocess.run replacement: captures ffmpeg cmds (writing their output),
+    and answers ffprobe duration queries. *durations* maps a filename to its
+    duration; anything absent falls back to 10.0."""
+    durations = durations or {}
+
+    def fake_run(cmd, *args, **kwargs):
+        ok = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        if cmd and "ffmpeg" in str(cmd[0]).lower():
+            captured.append(cmd)
+            Path(cmd[-1]).write_bytes(b"embedded content")
+            return ok
+        if cmd and "ffprobe" in str(cmd[0]).lower():
+            name = Path(cmd[-1]).name
+            value = durations.get(name, 10.0)
+            return type("R", (), {"returncode": 0, "stdout": f"{value}\n", "stderr": ""})()
+        return ok
+
+    return fake_run
+
+
+class TestProcessDirectoryAudioSidecar:
+    """process_directory pairing behaviour for --audio-sidecar."""
+
+    def _prep(self, tmp_path: Path, with_audio: bool) -> tuple[Path, Path]:
+        video = tmp_path / "DJI_20240101_123456.mp4"
+        srt = tmp_path / "DJI_20240101_123456.srt"
+        video.write_bytes(b"fake mp4 content here")
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nGPS(1,2,3)")
+        audio = tmp_path / "DJI_20240101_123456.m4a"
+        if with_audio:
+            audio.write_bytes(b"fake audio")
+        out_dir = tmp_path / "processed"
+        out_dir.mkdir()
+        return audio, out_dir
+
+    def test_paired_m4a_is_muxed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A same-basename .m4a next to the video is added as the audio input."""
+        audio, out_dir = self._prep(tmp_path, with_audio=True)
+        captured: list = []
+        monkeypatch.setattr(subprocess, "run", _make_run_capture(captured))
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress", _fake_progress_class()
+        )
+
+        embedder = DJIMetadataEmbedder(
+            str(tmp_path), output_dir=str(out_dir), audio_sidecar=True
+        )
+        result = embedder.process_directory(use_exiftool=False)
+
+        assert result["processed"] == 1
+        assert captured, "ffmpeg was not invoked"
+        cmd = captured[0]
+        inputs = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-i"]
+        assert str(audio) in inputs, f"audio sidecar not passed to ffmpeg: {inputs}"
+        map_targets = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-map"]
+        assert "2:a" in map_targets
+
+    def test_missing_m4a_warns_and_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No .m4a → warn-and-continue: the video still processes, no audio
+        input is added, and a warning is recorded."""
+        _audio, out_dir = self._prep(tmp_path, with_audio=False)
+        captured: list = []
+        monkeypatch.setattr(subprocess, "run", _make_run_capture(captured))
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress", _fake_progress_class()
+        )
+
+        embedder = DJIMetadataEmbedder(
+            str(tmp_path), output_dir=str(out_dir), audio_sidecar=True
+        )
+        result = embedder.process_directory(use_exiftool=False)
+
+        assert result["processed"] == 1
+        cmd = captured[0]
+        inputs = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-i"]
+        assert len(inputs) == 2, f"expected no audio input, got {inputs}"
+        assert any(
+            "m4a" in w.lower() or "audio" in w.lower() for w in result["warnings"]
+        ), f"expected a missing-sidecar warning, got {result['warnings']}"
+
+    def test_flag_off_ignores_m4a(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --audio-sidecar, a present .m4a is left untouched."""
+        _audio, out_dir = self._prep(tmp_path, with_audio=True)
+        captured: list = []
+        monkeypatch.setattr(subprocess, "run", _make_run_capture(captured))
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress", _fake_progress_class()
+        )
+
+        embedder = DJIMetadataEmbedder(str(tmp_path), output_dir=str(out_dir))
+        embedder.process_directory(use_exiftool=False)
+
+        cmd = captured[0]
+        inputs = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-i"]
+        assert len(inputs) == 2, f"audio muxed without the flag: {inputs}"
+
+    def test_duration_mismatch_warns_but_still_muxes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A large video/audio duration gap warns but still muxes (user opted in)."""
+        audio, out_dir = self._prep(tmp_path, with_audio=True)
+        captured: list = []
+        # Video 60s, audio 10s — a 50s gap the sanity check should flag.
+        durations = {
+            "DJI_20240101_123456.mp4": 60.0,
+            "DJI_20240101_123456.m4a": 10.0,
+        }
+        monkeypatch.setattr(
+            subprocess, "run", _make_run_capture(captured, durations)
+        )
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress", _fake_progress_class()
+        )
+
+        embedder = DJIMetadataEmbedder(
+            str(tmp_path), output_dir=str(out_dir), audio_sidecar=True
+        )
+        result = embedder.process_directory(use_exiftool=False)
+
+        cmd = captured[0]
+        inputs = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-i"]
+        assert str(audio) in inputs, "audio should still be muxed despite mismatch"
+        assert any(
+            "duration" in w.lower() for w in result["warnings"]
+        ), f"expected a duration-mismatch warning, got {result['warnings']}"
+
+
+class TestCliAudioSidecarFlag:
+    """The embed command exposes --audio-sidecar and threads it through."""
+
+    def test_flag_passed_to_embedder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+
+        class FakeEmbedder:
+            def __init__(self, *args, **kwargs):
+                captured.update(kwargs)
+
+            def process_directory(self, *args, **kwargs):
+                return {"processed": 0, "warnings": []}
+
+        monkeypatch.setattr(cli, "check_dependencies", lambda: (True, []))
+        monkeypatch.setattr(cli, "DJIMetadataEmbedder", FakeEmbedder)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["embed", str(tmp_path), "--audio-sidecar"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("audio_sidecar") is True
+
+    def test_flag_defaults_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+
+        class FakeEmbedder:
+            def __init__(self, *args, **kwargs):
+                captured.update(kwargs)
+
+            def process_directory(self, *args, **kwargs):
+                return {"processed": 0, "warnings": []}
+
+        monkeypatch.setattr(cli, "check_dependencies", lambda: (True, []))
+        monkeypatch.setattr(cli, "DJIMetadataEmbedder", FakeEmbedder)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["embed", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("audio_sidecar") is False


### PR DESCRIPTION
Closes #246

The DJI Neo 2 records video and audio as **separate files** — a silent `DJI_xxx.MP4` plus a same-basename `DJI_xxx.m4a` in the same folder. Users previously had to mux them by hand after embedding. The new opt-in `--audio-sidecar` flag does it automatically.

## What it does
```bash
dji-embed embed /path/to/footage --audio-sidecar
```
- Auto-pairs the same-basename `.m4a`/`.M4A` next to each video (mirrors `--dat-auto` semantics).
- Muxes the sidecar audio in as a **third ffmpeg input** with `-map 2:a`, **stream-copied** (`-c copy`, no re-encode) — consistent with the project's no-re-encode principle.
- Audio is appended **last** so the SRT keeps input index 1 and the telemetry subtitle track (`-map 1`) is untouched.
- **Warn-and-continue** when a video has no matching `.m4a` (mixed folders still process every clip).
- **Duration sanity check** via the existing `_ffprobe_duration`: warns on a large video/audio length gap but still muxes (user opted in).
- Behavior is **unchanged** when the flag is omitted.

## Resulting ffmpeg command (mp4)
```
-i video.mp4 -i telem.srt -i audio.m4a \
  -map 0 -map -0:d -map 1 -map 2:a -c copy -c:s mov_text …
```
(mkv: `-map 0 -map 1 -map 2:a` with `-c:s srt`.)

## Testing
- New `tests/test_audio_sidecar.py` (8 tests): ffmpeg command shape + input/map ordering, `process_directory` pairing, missing sidecar, flag-off regression, duration-mismatch warning, and CLI flag wiring. Written test-first (TDD).
- Full suite: **295 passed, 3 skipped** (pre-existing skips); `ruff` and `mypy` clean.
- Verified end-to-end by driving the real `dji-embed embed` CLI with shim ffmpeg/ffprobe binaries and inspecting the actual invoked argv across 6 scenarios (happy path, missing `.m4a`, flag-off, duration mismatch, uppercase `.M4A`, `--container mkv`).

## Docs
- README embed options (both option blocks)
- `docs/user_guide.md` — new "Drones with separate audio (Neo 2)" section
- `docs/SRT_FORMATS.md` — Neo 2 row notes the separate `.m4a`

## PR checklist
- [x] Tests added for new functionality
- [x] Documentation updated (user-facing change)
- [x] Cross-platform: pure ffmpeg arg change, no OS-specific paths
- [x] No breaking changes (opt-in flag, default off)
- [x] Conventional commit format in title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz35dC2SUwUFAWoUqTzjb6