### PR TITLE
feat(photomap): #245 follow-ups — recursive names, clampToGround, DNG previews + Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,26 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: ['ubuntu-22.04']
         python-version:
           - '3.10'
           - '3.11'
           - '3.12'
+        # Add a single Windows leg so the ExifTool-backed photomap / MP4
+        # timed-metadata tests actually run on Windows (path, subprocess and
+        # encoding handling differ). One Python version keeps CI cost down.
+        include:
+          - os: 'windows-latest'
+            python-version: '3.12'
+    defaults:
+      run:
+        # Git Bash ships on the Windows runners, so the bash-syntax steps
+        # below (|| true, ls -la, multi-line) work on every OS.
+        shell: bash
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
@@ -33,6 +46,9 @@ jobs:
       - name: Install ExifTool (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libimage-exiftool-perl
+      - name: Install ExifTool (Windows)
+        if: runner.os == 'Windows'
+        run: choco install exiftool --no-progress -y
       - name: Pytest
         run: uv run pytest
       - name: Build package

--- a/README.md
+++ b/README.md
@@ -390,6 +390,15 @@ Options:
 Requires ExifTool (`dji-embed doctor` checks it). Photos without GPS data are
 skipped and counted in a summary; `-v` lists the skipped filenames.
 
+Notes:
+- With `-r`, pins are labelled by their path relative to `DIRECTORY`, so
+  per-session folders that reuse DJI's restarting `DJI_0001.JPG` names stay
+  distinct on the map.
+- Popup previews use the small EXIF thumbnail, falling back to a size-capped
+  embedded preview for DNGs that carry no thumbnail.
+- Photos with no EXIF altitude are clamped to the ground in KML (Google Earth)
+  instead of being buried at 0 m below terrain.
+
 ```bash
 dji-embed photomap /path/to/photos                                    # -> photos/photomap.html
 dji-embed photomap /path/to/photos -f all                             # -> photos/photomap.{html,kml,geojson}

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -746,7 +746,7 @@ class DJIMetadataEmbedder:
                                 {"lat": h.lat, "lon": h.lon, "alt": h.alt} if h else None
                             )
                         try:
-                            with open(json_tmp_path, "w") as f:
+                            with open(json_tmp_path, "w", encoding="utf-8") as f:
                                 json.dump(json_data, f, indent=2)
                             os.replace(json_tmp_path, json_path)
                         except OSError as e:

--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -15,8 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from xml.sax.saxutils import escape
 
-from ..mp4_telemetry import _exiftool_exe
 from ..utilities import is_gps_fix
+from ..utils.exiftool import exiftool_exe
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,9 @@ _SCAN_TAGS = [
     "-EXIF:ExposureTime",
     "-EXIF:FNumber",
     "-EXIF:ThumbnailImage",
+    # DJI DNGs carry no EXIF:ThumbnailImage; their preview is PreviewImage
+    # (IFD0/SubIFD). Requested for all photos, used only as a fallback below.
+    "-PreviewImage",
 ]
 _PHOTO_EXTS = ("jpg", "jpeg", "dng")
 
@@ -51,15 +54,23 @@ _PHOTO_EXTS = ("jpg", "jpeg", "dng")
 # writers may embed it in CDATA/data URIs without further escaping.
 _BASE64_RE = re.compile(r"[A-Za-z0-9+/=\s]+")
 
+# Cap on the PreviewImage fallback so a DNG-heavy archive doesn't blow the
+# ~15-40 KB/photo embed budget (raw previews can be multi-MB). ~225 KB decoded.
+# UNVERIFIED against a real DJI DNG: the JSON shape is assumed identical to
+# ThumbnailImage ("base64:...") — the tag differs, the encoding does not.
+_MAX_PREVIEW_B64_CHARS = 300_000
+
 
 @dataclass
 class PhotoPoint:
-    """One GPS-tagged photo: WGS84 lat/lon, altitude (m, 0.0 when the EXIF has
-    none), source filename, and optional capture metadata for popups."""
+    """One GPS-tagged photo: WGS84 lat/lon, altitude (m, ``None`` when the EXIF
+    has no ``GPSAltitude``), source filename, and optional capture metadata for
+    popups. ``None`` altitude is kept distinct from a real 0 m fix so writers
+    can clamp such placemarks to the ground rather than burying them."""
 
     lat: float
     lon: float
-    alt: float
+    alt: float | None
     name: str
     timestamp: str | None = None
     model: str | None = None
@@ -95,6 +106,30 @@ def _maybe_str(value: object) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _clean_base64(raw: object) -> str | None:
+    """Return the base64 payload of an ExifTool ``-b`` blob (``base64:...``), else None."""
+    if isinstance(raw, str) and raw.startswith("base64:"):
+        candidate = raw[len("base64:"):]
+        if _BASE64_RE.fullmatch(candidate):
+            return candidate
+    return None
+
+
+def _extract_thumbnail_b64(entry: dict) -> str | None:
+    """Pick a preview blob: the small EXIF thumbnail, else a size-capped PreviewImage.
+
+    The EXIF thumbnail is always preferred (small, present on JPGs). PreviewImage
+    is the DNG fallback, taken only when it stays under ``_MAX_PREVIEW_B64_CHARS``.
+    """
+    thumb = _clean_base64(entry.get("ThumbnailImage"))
+    if thumb is not None:
+        return thumb
+    preview = _clean_base64(entry.get("PreviewImage"))
+    if preview is not None and len(preview) <= _MAX_PREVIEW_B64_CHARS:
+        return preview
+    return None
+
+
 def format_exposure(exposure: float | None) -> str | None:
     """Format ExposureTime seconds for display: ``0.001`` -> ``1/1000 s``."""
     if not exposure or exposure <= 0:
@@ -119,33 +154,50 @@ def camera_summary(p: PhotoPoint) -> str:
     return " · ".join(x for x in parts if x)
 
 
-def points_from_exiftool_json(data: list[dict]) -> tuple[list[PhotoPoint], list[str]]:
+def _display_name(source: str, root: Path | None) -> str:
+    """Display name for a scanned photo.
+
+    Basename by default. When *root* is given (recursive scans), use the path
+    relative to the scan root so per-session archives don't collapse to
+    indistinguishable ``DJI_0001.JPG`` pins — DJI restarts numbering per card.
+    ExifTool echoes the directory argument's separators, so both sides are
+    normalised to ``/`` before stripping; a SourceFile outside *root*
+    (unexpected) falls back to the basename.
+    """
+    if root is None:
+        return Path(source).name
+    src = source.replace("\\", "/")
+    prefix = str(root).replace("\\", "/").rstrip("/") + "/"
+    if src.startswith(prefix):
+        return src[len(prefix):]
+    return Path(source).name
+
+
+def points_from_exiftool_json(
+    data: list[dict], *, root: Path | None = None
+) -> tuple[list[PhotoPoint], list[str]]:
     """Map an ExifTool ``-json`` scan to ``(points, skipped_names)``.
 
     Photos without a usable GPS fix (missing tags, or the (0, 0) no-fix
     placeholder) go to ``skipped_names``. Both lists are sorted by filename so
-    output is deterministic regardless of scan order.
+    output is deterministic regardless of scan order. When *root* is supplied,
+    display names are relative to it (see :func:`_display_name`).
     """
     points: list[PhotoPoint] = []
     skipped: list[str] = []
     for entry in data:
-        name = Path(str(entry.get("SourceFile", "?"))).name
+        name = _display_name(str(entry.get("SourceFile", "?")), root)
         lat = _maybe_float(entry.get("GPSLatitude"))
         lon = _maybe_float(entry.get("GPSLongitude"))
         if lat is None or lon is None or not is_gps_fix(lat, lon):
             skipped.append(name)
             continue
-        thumb = entry.get("ThumbnailImage")
-        thumb_b64: str | None = None
-        if isinstance(thumb, str) and thumb.startswith("base64:"):
-            candidate = thumb[len("base64:"):]
-            if _BASE64_RE.fullmatch(candidate):
-                thumb_b64 = candidate
+        thumb_b64 = _extract_thumbnail_b64(entry)
         points.append(
             PhotoPoint(
                 lat=lat,
                 lon=lon,
-                alt=_maybe_float(entry.get("GPSAltitude")) or 0.0,
+                alt=_maybe_float(entry.get("GPSAltitude")),
                 name=name,
                 timestamp=_display_datetime(entry.get("DateTimeOriginal")),
                 model=_maybe_str(entry.get("Model")),
@@ -167,7 +219,7 @@ def _run_exiftool_scan(directory: Path, recursive: bool) -> list[dict]:
     "no photos", not an error. A non-zero exit with no JSON at all is a real
     failure (unreadable directory, broken install) and raises.
     """
-    args = [_exiftool_exe(), "-json", "-n", "-b"]
+    args = [exiftool_exe(), "-json", "-n", "-b"]
     if recursive:
         args.append("-r")
     args += _SCAN_TAGS
@@ -202,7 +254,11 @@ def scan_photos(
     directory: Path | str, recursive: bool = False
 ) -> tuple[list[PhotoPoint], list[str]]:
     """Scan *directory* for photos and return ``(gps_points, skipped_names)``."""
-    return points_from_exiftool_json(_run_exiftool_scan(Path(directory), recursive))
+    directory = Path(directory)
+    return points_from_exiftool_json(
+        _run_exiftool_scan(directory, recursive),
+        root=directory if recursive else None,
+    )
 
 
 def photos_to_geojson(
@@ -218,7 +274,11 @@ def photos_to_geojson(
         props: dict = {"name": p.name}
         if p.timestamp:
             props["timestamp"] = p.timestamp
-        props["alt"] = p.alt
+        # Missing altitude is omitted entirely (no property, 2D coordinate)
+        # rather than reported as a spurious 0 m.
+        coords = [p.lon, p.lat] if p.alt is None else [p.lon, p.lat, p.alt]
+        if p.alt is not None:
+            props["alt"] = p.alt
         camera = camera_summary(p)
         if camera:
             props["camera"] = camera
@@ -227,7 +287,7 @@ def photos_to_geojson(
         features.append(
             {
                 "type": "Feature",
-                "geometry": {"type": "Point", "coordinates": [p.lon, p.lat, p.alt]},
+                "geometry": {"type": "Point", "coordinates": coords},
                 "properties": props,
             }
         )
@@ -273,13 +333,20 @@ def photos_to_kml(points: list[PhotoPoint], title: str) -> str:
         camera = camera_summary(p)
         if camera:
             desc.append(escape(camera))
-        desc.append(f"altitude: {p.alt:g} m")
+        # No EXIF altitude -> clamp to terrain (a 0 m absolute placemark buries
+        # the pin below ground in Google Earth); the altitude value is ignored
+        # in that mode, so emit a placeholder 0.
+        if p.alt is None:
+            alt_mode, alt_coord = "clampToGround", "0"
+        else:
+            alt_mode, alt_coord = "absolute", f"{p.alt}"
+            desc.append(f"altitude: {p.alt:g} m")
         placemarks.append(
             "\n    <Placemark>"
             f"<name>{escape(p.name)}</name>"
             f"<description><![CDATA[{'<br/>'.join(desc)}]]></description>"
-            "<Point><altitudeMode>absolute</altitudeMode>"
-            f"<coordinates>{p.lon},{p.lat},{p.alt}</coordinates></Point>"
+            f"<Point><altitudeMode>{alt_mode}</altitudeMode>"
+            f"<coordinates>{p.lon},{p.lat},{alt_coord}</coordinates></Point>"
             "</Placemark>"
         )
     return _KML_TEMPLATE.format(name=escape(title), placemarks="".join(placemarks))

--- a/src/dji_metadata_embedder/mp4_telemetry.py
+++ b/src/dji_metadata_embedder/mp4_telemetry.py
@@ -8,13 +8,17 @@ model, so the convert exporters and verify-sun work on sidecar-less footage.
 from __future__ import annotations
 
 import json
-import os
 import re
 import subprocess
 from datetime import datetime
 from pathlib import Path
 
 from .utilities import TelemetrySample, is_gps_fix
+from .utils.exiftool import exiftool_exe
+
+# Back-compat alias: this private name predates the shared resolver in
+# utils/exiftool.py. Kept so any external importer of the old symbol still works.
+_exiftool_exe = exiftool_exe
 
 
 class Mp4TelemetryError(RuntimeError):
@@ -126,18 +130,10 @@ _EXIFTOOL_INSTALL_HINT = (
 )
 
 
-def _exiftool_exe() -> str:
-    """Resolve the ExifTool executable (env override, else PATH ``exiftool``)."""
-    env = os.environ.get("DJIEMBED_EXIFTOOL_PATH")
-    if env and Path(env).exists():
-        return env
-    return "exiftool"
-
-
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(
-            [_exiftool_exe(), *args], capture_output=True, text=True
+            [exiftool_exe(), *args], capture_output=True, text=True
         )
     except FileNotFoundError:
         raise Mp4TelemetryError(_EXIFTOOL_INSTALL_HINT) from None

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -158,7 +158,7 @@ def extract_telemetry_to_gpx(
                 f"    </wpt>\n"
             )
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
         f.write(gpx_header)
         f.write(home_wpt)
         f.write(trk_open)

--- a/src/dji_metadata_embedder/utils/exiftool.py
+++ b/src/dji_metadata_embedder/utils/exiftool.py
@@ -1,0 +1,20 @@
+"""Shared ExifTool executable resolver.
+
+A single place to resolve the ExifTool binary so every call site (MP4 timed
+metadata, the photomap scan, and any future consumer) agrees on the same
+override semantics: honour ``DJIEMBED_EXIFTOOL_PATH`` when it points at a real
+file, otherwise fall back to ``exiftool`` on ``PATH``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def exiftool_exe() -> str:
+    """Resolve the ExifTool executable (env override, else PATH ``exiftool``)."""
+    env = os.environ.get("DJIEMBED_EXIFTOOL_PATH")
+    if env and Path(env).exists():
+        return env
+    return "exiftool"

--- a/src/dji_metadata_embedder/utils/system_info.py
+++ b/src/dji_metadata_embedder/utils/system_info.py
@@ -50,7 +50,9 @@ def has_admin_privileges() -> bool:
             return False
         except Exception:  # noqa: BLE001
             return False
-    return os.geteuid() == 0
+    # POSIX-only; unreachable on Windows (os.name == "nt" returns above), but
+    # mypy on Windows can't see that, so silence the platform-specific attr.
+    return os.geteuid() == 0  # type: ignore[attr-defined]
 
 
 def get_system_architecture() -> str:

--- a/tests/generate_photo_fixtures.py
+++ b/tests/generate_photo_fixtures.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from dji_metadata_embedder.mp4_telemetry import _exiftool_exe
+from dji_metadata_embedder.utils.exiftool import exiftool_exe
 
 # Minimal valid 1x1 grey baseline JPEG (140 bytes, no EXIF).
 _MINIMAL_JPEG_B64 = (
@@ -32,7 +32,7 @@ _GPS = {
 
 
 def main() -> None:
-    exiftool = _exiftool_exe()
+    exiftool = exiftool_exe()
     if shutil.which(exiftool) is None and not Path(exiftool).is_file():
         sys.exit("ExifTool required to regenerate fixtures — see https://exiftool.org")
     _PHOTOS.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli_photomap.py
+++ b/tests/test_cli_photomap.py
@@ -187,4 +187,6 @@ def test_photomap_recursive_real_scan(tmp_path):
     points, _ = scan_photos(tmp_path)
     assert points == []
     points, skipped = scan_photos(tmp_path, recursive=True)
-    assert [p.name for p in points] == ["church1.jpg", "church2.jpg"]
+    # Recursive scans carry the subdirectory so per-session archives don't
+    # collide on DJI's restarting basenames.
+    assert [p.name for p in points] == ["sub/church1.jpg", "sub/church2.jpg"]

--- a/tests/test_geo_photomap.py
+++ b/tests/test_geo_photomap.py
@@ -1,6 +1,7 @@
 import json as jsonlib
 import subprocess
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 import pytest
 
@@ -59,11 +60,99 @@ def test_parses_gps_photos_and_skips_the_rest():
     assert p.exposure == 0.001 and p.fnum == 1.7
 
 
+# DJI restarts file numbering per card/session, so a recursive per-location
+# archive scan collides on basenames unless names carry their subdirectory.
+_RECURSIVE = [
+    {"SourceFile": "/scan/root/north/DJI_0001.JPG", "GPSLatitude": 1.0, "GPSLongitude": 2.0},
+    {"SourceFile": "/scan/root/south/DJI_0001.JPG", "GPSLatitude": 3.0, "GPSLongitude": 4.0},
+]
+
+
+def test_recursive_root_yields_relative_display_names():
+    points, _ = points_from_exiftool_json(_RECURSIVE, root=Path("/scan/root"))
+    assert [p.name for p in points] == ["north/DJI_0001.JPG", "south/DJI_0001.JPG"]
+
+
+def test_no_root_yields_basenames():
+    points, _ = points_from_exiftool_json(_RECURSIVE)
+    assert [p.name for p in points] == ["DJI_0001.JPG", "DJI_0001.JPG"]
+
+
+def test_relative_name_falls_back_to_basename_when_outside_root():
+    # SourceFile not under the given root (unexpected) -> safe basename.
+    points, _ = points_from_exiftool_json(
+        [{"SourceFile": "/elsewhere/x.jpg", "GPSLatitude": 1.0, "GPSLongitude": 2.0}],
+        root=Path("/scan/root"),
+    )
+    assert points[0].name == "x.jpg"
+
+
+def test_relative_name_normalises_backslash_separators():
+    # ExifTool echoes the directory arg's separators; a Windows root uses "\".
+    points, _ = points_from_exiftool_json(
+        [{"SourceFile": r"C:\scan\root/sub/DJI_0001.JPG",
+          "GPSLatitude": 1.0, "GPSLongitude": 2.0}],
+        root=Path(r"C:\scan\root"),
+    )
+    assert points[0].name == "sub/DJI_0001.JPG"
+
+
+def test_scan_photos_recursive_uses_relative_names(monkeypatch, tmp_path):
+    src = [{"SourceFile": f"{tmp_path}/a/DJI_0001.JPG",
+            "GPSLatitude": 1.0, "GPSLongitude": 2.0}]
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _Proc(stdout=jsonlib.dumps(src))
+    )
+    points, _ = scan_photos(tmp_path, recursive=True)
+    assert points[0].name == "a/DJI_0001.JPG"
+
+
 def test_thumbnail_base64_prefix_is_stripped():
     points, _ = points_from_exiftool_json(CANNED)
     by_name = {p.name: p for p in points}
     assert by_name["church2.jpg"].thumbnail_b64 == "/9j/THUMB2"
     assert by_name["church1.jpg"].thumbnail_b64 is None
+
+
+def test_dng_previewimage_used_when_no_thumbnail():
+    # DJI DNGs expose their preview as PreviewImage, not EXIF:ThumbnailImage.
+    points, _ = points_from_exiftool_json([{
+        "SourceFile": "a.dng", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+        "PreviewImage": "base64:/9j/PREVIEW",
+    }])
+    assert points[0].thumbnail_b64 == "/9j/PREVIEW"
+
+
+def test_thumbnail_preferred_over_preview():
+    # The small EXIF thumbnail wins over the (potentially large) preview.
+    points, _ = points_from_exiftool_json([{
+        "SourceFile": "a.jpg", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+        "ThumbnailImage": "base64:/9j/THUMB",
+        "PreviewImage": "base64:/9j/PREVIEW",
+    }])
+    assert points[0].thumbnail_b64 == "/9j/THUMB"
+
+
+def test_oversized_preview_is_dropped_to_protect_budget():
+    from dji_metadata_embedder.geo import photomap as pm
+    big = "A" * (pm._MAX_PREVIEW_B64_CHARS + 4)  # valid base64, over the cap
+    points, _ = points_from_exiftool_json([{
+        "SourceFile": "a.dng", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+        "PreviewImage": "base64:" + big,
+    }])
+    assert points[0].thumbnail_b64 is None
+
+
+def test_scan_photos_requests_preview_tag(monkeypatch, tmp_path):
+    seen: dict = {}
+
+    def fake_run(args, **kwargs):
+        seen["args"] = args
+        return _Proc(stdout="[]")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    scan_photos(tmp_path)
+    assert "-PreviewImage" in seen["args"]
 
 
 def test_non_base64_thumbnail_is_dropped():
@@ -76,12 +165,20 @@ def test_non_base64_thumbnail_is_dropped():
     assert points[0].thumbnail_b64 is None
 
 
-def test_missing_altitude_defaults_to_zero():
+def test_missing_altitude_is_none():
     points, _ = points_from_exiftool_json(
         [{"SourceFile": "a.jpg", "GPSLatitude": 1.0, "GPSLongitude": 2.0}]
     )
-    assert points[0].alt == 0.0
+    assert points[0].alt is None  # distinct from a real 0 m fix
     assert points[0].timestamp is None
+
+
+def test_real_zero_altitude_is_preserved_distinct_from_missing():
+    points, _ = points_from_exiftool_json(
+        [{"SourceFile": "z.jpg", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+          "GPSAltitude": 0.0}]
+    )
+    assert points[0].alt == 0.0
 
 
 def test_unparseable_numeric_fields_become_none():
@@ -239,6 +336,40 @@ def test_geojson_include_thumbnails_opt_in():
 
 def test_geojson_empty_points():
     assert photos_to_geojson([]) == {"type": "FeatureCollection", "features": []}
+
+
+# One photo with EXIF altitude, one without — exercises the alt: float | None split.
+_MIXED_ALT = [
+    PhotoPoint(lat=1.0, lon=2.0, alt=100.0, name="has_alt.jpg"),
+    PhotoPoint(lat=3.0, lon=4.0, alt=None, name="no_alt.jpg"),
+]
+
+
+def test_geojson_omits_altitude_when_missing():
+    by_name = {
+        f["properties"]["name"]: f for f in photos_to_geojson(_MIXED_ALT)["features"]
+    }
+    has = by_name["has_alt.jpg"]
+    assert has["geometry"]["coordinates"] == [2.0, 1.0, 100.0]
+    assert has["properties"]["alt"] == 100.0
+    missing = by_name["no_alt.jpg"]
+    assert missing["geometry"]["coordinates"] == [4.0, 3.0]  # 2D — no altitude
+    assert "alt" not in missing["properties"]
+
+
+def test_kml_clamps_to_ground_when_altitude_missing():
+    root = ET.fromstring(photos_to_kml(_MIXED_ALT, title="t"))
+    pms = {
+        pm.find(f"{_KML_NS}name").text: pm
+        for pm in root.iter(f"{_KML_NS}Placemark")
+    }
+    has = pms["has_alt.jpg"].find(f"{_KML_NS}Point")
+    assert has.find(f"{_KML_NS}altitudeMode").text == "absolute"
+    assert has.find(f"{_KML_NS}coordinates").text == "2.0,1.0,100.0"
+    missing = pms["no_alt.jpg"].find(f"{_KML_NS}Point")
+    assert missing.find(f"{_KML_NS}altitudeMode").text == "clampToGround"
+    # altitude is ignored under clampToGround; emit a placeholder 0
+    assert missing.find(f"{_KML_NS}coordinates").text == "4.0,3.0,0"
 
 
 def test_write_photos_geojson(tmp_path):

--- a/tests/test_golden_fixtures.py
+++ b/tests/test_golden_fixtures.py
@@ -27,7 +27,7 @@ class TestGoldenFixtures:
         """Test Mini 3/4 Pro square bracket format parsing."""
         sample = GOLDEN_SAMPLES["mini_3_4_pro"]
         
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
         
@@ -57,7 +57,7 @@ class TestGoldenFixtures:
         """Test Air 3 HTML-formatted SRT with extended telemetry."""
         sample = GOLDEN_SAMPLES["air3_html_extended"]
         
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
         
@@ -85,7 +85,7 @@ class TestGoldenFixtures:
         """Test Avata 2 legacy GPS format with BAROMETER data."""
         sample = GOLDEN_SAMPLES["avata2_legacy_gps"]
         
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
         
@@ -113,7 +113,7 @@ class TestGoldenFixtures:
         """Test Matrice 300 / legacy-with-unit GPS format (altitude unit suffix)."""
         sample = GOLDEN_SAMPLES["m300_legacy_unit"]
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
 
@@ -137,7 +137,7 @@ class TestGoldenFixtures:
         """Test Phantom 4 RTK / P4P compact single-line format."""
         sample = GOLDEN_SAMPLES["p4rtk_compact"]
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
 
@@ -161,7 +161,7 @@ class TestGoldenFixtures:
         """Test Mavic 3 Enterprise format with RTK and extended data."""
         sample = GOLDEN_SAMPLES["mavic3_enterprise"]
         
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
         
@@ -193,7 +193,7 @@ class TestLenientParserMode:
         """Test parser handles missing timestamps in lenient mode."""
         sample = EDGE_CASE_SAMPLES["missing_timestamps"]
         
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
         
@@ -214,7 +214,7 @@ class TestLenientParserMode:
         """Test parser handles mixed telemetry formats."""
         sample = EDGE_CASE_SAMPLES["mixed_formats"]
         
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
         
@@ -234,7 +234,7 @@ class TestLenientParserMode:
         """Test parser handles extreme coordinate values."""
         sample = EDGE_CASE_SAMPLES["extreme_coordinates"]
         
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
             f.write(sample["srt_content"])
             temp_path = Path(f.name)
         
@@ -338,7 +338,7 @@ class TestComprehensiveValidation:
     def test_all_golden_samples(self):
         """Test all golden samples can be parsed without errors."""
         for sample_name, sample in GOLDEN_SAMPLES.items():
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False) as f:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.SRT', delete=False, encoding='utf-8') as f:
                 f.write(sample["srt_content"])
                 temp_path = Path(f.name)
             

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -7,7 +7,7 @@ from dji_metadata_embedder import DJIMetadataEmbedder
 # Helper to run parser on provided SRT string
 def _parse_from_string(tmp_path, text):
     srt_file = tmp_path / "test.srt"
-    srt_file.write_text(text)
+    srt_file.write_text(text, encoding="utf-8")
     embedder = DJIMetadataEmbedder(tmp_path)
     return embedder.parse_dji_srt(srt_file)
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -21,9 +21,9 @@ def run_sample(name: str, tmp_path, monkeypatch):
     video = tmp_path / "clip.mp4"
     dat = tmp_path / "clip.DAT"
     if video_b64.exists():
-        video.write_bytes(base64.b64decode(video_b64.read_text()))
+        video.write_bytes(base64.b64decode(video_b64.read_text(encoding="utf-8")))
     if dat_b64.exists():
-        dat.write_bytes(base64.b64decode(dat_b64.read_text()))
+        dat.write_bytes(base64.b64decode(dat_b64.read_text(encoding="utf-8")))
     srt = base / "clip.SRT"
     output = tmp_path / "out.mp4"
 

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -44,8 +44,12 @@ path = "src/pkg/__init__.py"
     (root / "HOUSEKEEPING.md").write_text(
         f"**Current state:** v{version}, production-ready\n"
     )
+    # This one carries non-ASCII (·), so it must be written UTF-8 explicitly:
+    # sync_version.py reads it as UTF-8, and a locale-default (cp1252) write on
+    # Windows would produce bytes it can't decode.
     (root / "docs/development_roadmap.md").write_text(
-        f"_Last updated: 2026-06-21 · Current version: **v{version}** · Status: x_\n"
+        f"_Last updated: 2026-06-21 · Current version: **v{version}** · Status: x_\n",
+        encoding="utf-8",
     )
     # Two matrix rows (first column) + the `dji-embed X.Y.Z` example line; the
     # FFmpeg column must stay untouched.
@@ -78,19 +82,19 @@ def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
         "docs/development_roadmap.md",
         "docs/external-tool-versions.md",
     ]:
-        assert "1.2.3" in (tmp_path / rel).read_text()
+        assert "1.2.3" in (tmp_path / rel).read_text(encoding="utf-8")
 
     # external-tool-versions.md has the version in multiple spots (both matrix
     # rows + the example line); re.subn must bump them all while leaving the
     # FFmpeg tool version alone.
-    ext = (tmp_path / "docs/external-tool-versions.md").read_text()
+    ext = (tmp_path / "docs/external-tool-versions.md").read_text(encoding="utf-8")
     assert ext.count("1.2.3") == 3
     assert "0.1.0" not in ext
     assert "6.1.1" in ext
 
     # Release-tag links (ReleaseNotesUrl) should be bumped too, so the winget
     # manifest never ships stale release notes.
-    assert "releases/tag/v1.2.3" in (tmp_path / "winget/manifest.yaml").read_text()
+    assert "releases/tag/v1.2.3" in (tmp_path / "winget/manifest.yaml").read_text(encoding="utf-8")
 
     # Explicit check with matching version should pass
     sync_version.main(["1.2.3", "--check"], project_root=tmp_path)

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -13,6 +13,16 @@ def _load_module():
     return module
 
 
+def _read_stderr(capsys: pytest.CaptureFixture[str]) -> str:
+    """Captured stderr with path separators normalised to ``/``.
+
+    sync_version.py reports OS-native paths, so on Windows the offending file
+    reads ``winget\\manifest.yaml``; normalising lets the forward-slash path
+    assertions below hold on every platform.
+    """
+    return capsys.readouterr().err.replace("\\", "/")
+
+
 def _write_project(root: Path, version: str) -> None:
     (root / "src/pkg").mkdir(parents=True)
     (root / "tools").mkdir()
@@ -106,7 +116,7 @@ def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     )
     with pytest.raises(SystemExit):
         sync_version.main(["1.2.3", "--check"], project_root=tmp_path)
-    err = capsys.readouterr().err
+    err = _read_stderr(capsys)
     assert "winget/manifest.yaml" in err
     # restore so later assertions in this test see an otherwise-synced tree
     (tmp_path / "winget/manifest.yaml").write_text(
@@ -117,7 +127,7 @@ def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     # Providing a mismatched version should fail with a helpful message
     with pytest.raises(SystemExit):
         sync_version.main(["9.9.9", "--check"], project_root=tmp_path)
-    err = capsys.readouterr().err
+    err = _read_stderr(capsys)
     assert "expected 9.9.9" in err
     assert "src/pkg/__init__.py" in err
 
@@ -127,7 +137,7 @@ def test_sync_and_check(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     )
     with pytest.raises(SystemExit):
         sync_version.main(["1.2.3", "--check"], project_root=tmp_path)
-    err = capsys.readouterr().err
+    err = _read_stderr(capsys)
     assert "expected 1.2.3" in err
     assert "README.md" in err
 
@@ -146,6 +156,6 @@ def test_doc_version_stamp_drift_is_caught(
     (tmp_path / "CLAUDE.md").write_text("**Project Version:** v0.0.1\n")
     with pytest.raises(SystemExit):
         sync_version.main(["1.2.3", "--check"], project_root=tmp_path)
-    err = capsys.readouterr().err
+    err = _read_stderr(capsys)
     assert "CLAUDE.md" in err
 

--- a/tests/test_utils_exiftool.py
+++ b/tests/test_utils_exiftool.py
@@ -1,0 +1,27 @@
+from dji_metadata_embedder.utils.exiftool import exiftool_exe
+
+
+def test_defaults_to_path_exiftool(monkeypatch):
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    assert exiftool_exe() == "exiftool"
+
+
+def test_env_override_used_when_it_exists(monkeypatch, tmp_path):
+    exe = tmp_path / "exiftool.exe"
+    exe.write_text("stub")
+    monkeypatch.setenv("DJIEMBED_EXIFTOOL_PATH", str(exe))
+    assert exiftool_exe() == str(exe)
+
+
+def test_env_override_ignored_when_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("DJIEMBED_EXIFTOOL_PATH", str(tmp_path / "nope"))
+    assert exiftool_exe() == "exiftool"
+
+
+def test_mp4_telemetry_and_photomap_share_the_resolver():
+    # The two ExifTool call sites resolve through the one public helper.
+    from dji_metadata_embedder import mp4_telemetry
+    from dji_metadata_embedder.geo import photomap
+
+    assert mp4_telemetry._exiftool_exe is exiftool_exe
+    assert photomap.exiftool_exe is exiftool_exe


### PR DESCRIPTION
Closes the implementable items on the #245 photomap follow-up checklist, plus adds the missing Windows CI leg.

## Changes

- [x] **Relative-path display names for `-r` scans** — recursive scans label pins by their path relative to the scan root, so per-session archives no longer collapse to indistinguishable `DJI_0001.JPG` pins. Verified end-to-end against real ExifTool.
- [x] **KML `clampToGround` for missing altitude** — `PhotoPoint.alt` is now `float | None` (missing EXIF altitude kept distinct from a real 0 m fix). GeoJSON omits the altitude (2D coordinate, no `alt` property); KML emits `clampToGround`. Verified end-to-end via the real `photomap` CLI on an altitude-stripped photo.
- [x] **Shared ExifTool resolver** — promoted to `utils/exiftool.py::exiftool_exe`; `mp4_telemetry._exiftool_exe` kept as a back-compat alias.
- [x] **ExifTool on the Windows CI leg** — there was **no Windows leg at all** (the workflow was `ubuntu-22.04`-only). Added a `windows-latest`/py3.12 matrix leg with `choco install exiftool` and a `bash` default shell so the existing bash-syntax steps run cross-OS. ⚠️ Only validated once this PR's CI runs.
- [x] **DNG `PreviewImage` fallback** — request `-PreviewImage` and fall back to it (size-capped) when a photo carries no EXIF thumbnail. ⚠️ **The DNG round-trip is `UNVERIFIED` against a real DJI DNG** (documented in-code): no DJI DNG was available, and a synthetic JPEG `PreviewImage` does not round-trip through `exiftool -json -b` the way a DNG's IFD0/SubIFD preview would. The mapping logic + size cap are unit-tested and real ExifTool accepts the new scan arg. **A real DJI DNG is needed to confirm.**

## Verification
- `ruff` ✅, `mypy` ✅ (33 files), `pytest` ✅ **311 passed, 3 skipped** (local ExifTool 12.76).
- Items 2 & 3 verified end-to-end against real ExifTool; item 4 pending this PR's Windows CI run; item 1 pending a real DNG sample.

## Not in this PR
Two deferred follow-ups that were living only in notes are now tracked as #248 (redact the per-frame track in gpx/csv) and #249 (oblique/non-nadir footprints).

Refs #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01393YHCNffi2KCjZGCxL25N