### PR TITLE
fix(embed): loosen --audio-sidecar duration-mismatch tolerance

### DIFF
--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -656,13 +656,16 @@ class DJIMetadataEmbedder:
                     else:
                         # Sanity check: flag a large video/audio length gap (wrong
                         # pairing, truncated recording) but still mux — the user
-                        # opted in and may want whatever audio exists.
+                        # opted in and may want whatever audio exists. The tolerance
+                        # is relative (max of a 2s floor and 5% of the clip) so
+                        # normal container-rounding gaps on a correctly paired clip
+                        # don't cry wolf, while gross mispairings still warn.
                         video_dur = _ffprobe_duration(video_path)
                         audio_dur = _ffprobe_duration(audio_file)
                         if (
                             video_dur is not None
                             and audio_dur is not None
-                            and abs(video_dur - audio_dur) > 1.0
+                            and abs(video_dur - audio_dur) > max(2.0, 0.05 * video_dur)
                         ):
                             warning_msg = (
                                 f"Audio sidecar duration ({audio_dur:.1f}s) differs "

--- a/tests/test_audio_sidecar.py
+++ b/tests/test_audio_sidecar.py
@@ -255,6 +255,60 @@ class TestProcessDirectoryAudioSidecar:
             "duration" in w.lower() for w in result["warnings"]
         ), f"expected a duration-mismatch warning, got {result['warnings']}"
 
+    def test_small_duration_gap_within_tolerance_does_not_warn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sub-tolerance gap (container rounding, not a mispairing) must not
+        warn — a 1.5s gap on a 60s clip is normal."""
+        _audio, out_dir = self._prep(tmp_path, with_audio=True)
+        captured: list = []
+        durations = {
+            "DJI_20240101_123456.mp4": 60.0,
+            "DJI_20240101_123456.m4a": 58.5,
+        }
+        monkeypatch.setattr(
+            subprocess, "run", _make_run_capture(captured, durations)
+        )
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress", _fake_progress_class()
+        )
+
+        embedder = DJIMetadataEmbedder(
+            str(tmp_path), output_dir=str(out_dir), audio_sidecar=True
+        )
+        result = embedder.process_directory(use_exiftool=False)
+
+        assert not any(
+            "sidecar duration" in w.lower() for w in result["warnings"]
+        ), f"did not expect a sidecar duration warning, got {result['warnings']}"
+
+    def test_duration_tolerance_scales_with_clip_length(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On a long clip, an 8s gap (2.7%) is within tolerance — the relative
+        band scales so it no longer trips the old 1s absolute threshold."""
+        _audio, out_dir = self._prep(tmp_path, with_audio=True)
+        captured: list = []
+        durations = {
+            "DJI_20240101_123456.mp4": 300.0,
+            "DJI_20240101_123456.m4a": 292.0,
+        }
+        monkeypatch.setattr(
+            subprocess, "run", _make_run_capture(captured, durations)
+        )
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress", _fake_progress_class()
+        )
+
+        embedder = DJIMetadataEmbedder(
+            str(tmp_path), output_dir=str(out_dir), audio_sidecar=True
+        )
+        result = embedder.process_directory(use_exiftool=False)
+
+        assert not any(
+            "sidecar duration" in w.lower() for w in result["warnings"]
+        ), f"did not expect a sidecar duration warning, got {result['warnings']}"
+
 
 class TestCliAudioSidecarFlag:
     """The embed command exposes --audio-sidecar and threads it through."""


### PR DESCRIPTION
## What
The `--audio-sidecar` duration sanity check warned whenever the video/audio lengths differed by more than **1.0s absolute** (`embedder.py`). That's tight enough that ordinary container-rounding on a *correctly paired* clip can trip it, producing a spurious `duration differs … muxing anyway` warning.

Replace it with a **relative tolerance**: `max(2s, 5% of the clip length)`. Gross mispairings (wrong file, truncated recording) still warn; audio is still muxed in every case (behaviour unchanged there).

Examples:
- 60s clip, 58.5s audio (1.5s gap) → **no warning** (was: warned)
- 300s clip, 292s audio (8s gap) → **no warning** (was: warned)
- 60s clip, 10s audio (50s gap) → **still warns** (gross mispairing)

## Why
Reported by @stevevrporter after testing `--audio-sidecar` on real Neo 2 footage (v1.13.0) — see discussion #230. The feature otherwise worked end-to-end: audio muxed in sync, telemetry preserved, mixed audio/no-audio folders handled.

## Tests
- New: sub-tolerance gap does not warn; tolerance scales with clip length.
- Existing gross-mismatch-still-warns test unchanged and green.
- `ruff` ✅, `mypy` ✅, `pytest` ✅ (297 passed, 3 skipped).

Refs #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01393YHCNffi2KCjZGCxL25N