### PR TITLE
feat(convert): redact the per-frame track in gpx/csv exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,10 +334,10 @@ Options:
   -b, --batch                Batch process directory
   --tz-offset OFFSET         UTC offset for GPX/CoT timestamps, e.g. '+05:30' or
                              '-8' ('auto' detects from file mtime; default: auto)
-  --redact [none|drop|fuzz]  GPS redaction (default: none). drop/fuzz cover the
-                             track for geojson/kml/html/cot and the HOME marker
-                             in all formats; for gpx/csv only the HOME marker is
-                             redacted (the track there is unredacted)
+  --redact [none|drop|fuzz]  GPS redaction (default: none), applied to the track
+                             in every format: drop removes the track (or blanks
+                             the GPS+sun columns in csv, rows kept); fuzz
+                             coarsens to ~100 m. HOME marker redacted the same way
   --interval FLOAT           cot only: seconds between sampled points (default: 1.0)
   --cot-type CODE            cot only: CoT type/affiliation code (default: a-n-A)
   --footprint                geojson/kml only: add camera footprint polygons

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -71,7 +71,7 @@ This guide helps you choose the right command and approach for your specific use
 ### Privacy & Redaction
 - `--redact none` - Keep all GPS data (default)
 - `--redact fuzz` - Round GPS coordinates to ~100m precision
-- `--redact drop` - Remove all GPS data completely
+- `--redact drop` - Remove all GPS data completely (csv keeps rows with GPS/sun columns blanked)
 
 ### Advanced Options
 - `--exiftool` - Use ExifTool for additional metadata formats

--- a/docs/superpowers/specs/2026-07-07-gpx-csv-track-redaction-design.md
+++ b/docs/superpowers/specs/2026-07-07-gpx-csv-track-redaction-design.md
@@ -1,0 +1,139 @@
+# Design: redact the per-frame track in gpx/csv exports (#248)
+
+_Date: 2026-07-07_
+
+## Context
+
+`dji-embed convert gpx|csv --redact drop|fuzz` currently redacts **only the
+opt-in HOME marker** (`redact_home` at the top of each exporter); the
+per-frame track is written at full resolution. The CLI help even documents
+the gap. This is surprising for a privacy flag and inconsistent with
+`geojson/kml/html/cot`, where `--redact` empties or coarsens the whole track.
+The gap was a deliberate scoped follow-up from #237.
+
+Additional hole found while scoping (2026-07-07): **CSV from MP4 input**
+(`convert csv DJI_0001.MP4`) returns early through `_csv_from_samples()`
+*before* any redact logic — `--redact` is silently ignored on that path.
+GPX from MP4 flows through the common point loop, so fixing the loop fixes
+it for free.
+
+Decisions taken during brainstorming (2026-07-07, all confirmed by
+maintainer):
+
+1. **CSV `drop` blanks the GPS columns, keeps the rows** (not "drop whole
+   rows" as the issue AC literally said). CSV is a telemetry table where GPS
+   is 2 of ~15 columns; blanking lets users share a camera-settings/exposure
+   log without revealing where they flew, while `drop` still honestly means
+   "the GPS is gone". GPX has nothing to salvage (pure geometry), so GPX
+   `drop` = empty `<trkseg>`, matching geojson's empty track.
+2. **Sun columns are treated as location data.** `sun_azimuth`/
+   `sun_elevation` are computed *from* lat/lon — precise solar angles can be
+   inverted to a location fix (our own `verify-sun` exists because of
+   exactly this property). So: `drop` blanks the sun columns; `fuzz`
+   computes them from the *fuzzed* coordinates (at ~100 m the angles barely
+   move — sun position shifts ~1° per ~111 km).
+3. **Implementation = shared primitive per exporter** (option A): both
+   exporters apply the same policy helpers (`redact_coords` semantics:
+   3-decimal rounding ≈ 100 m) already used by the geo pipeline. No routing
+   of gpx/csv through `geo/track.py` (option B rejected: CSV carries camera
+   columns `Track` doesn't model; big refactor, zero user-visible gain).
+4. **MP4 CSV path is in scope**: thread `redact` into `_csv_from_samples()`.
+
+## Goals
+
+- `--redact drop|fuzz` affects the per-frame track in gpx and csv (SRT and
+  MP4 input alike), consistently with the geo exporters.
+- Solar columns never disclose more location precision than the coordinate
+  columns in the same file.
+- HOME marker / `home_*` columns behave exactly as today.
+
+## Non-goals
+
+- No change to `geojson/kml/html/cot` (already correct).
+- No change to redaction *policy* (3-decimal fuzz stays; no new modes).
+- No unification of the gpx/csv exporters onto the `Track` pipeline.
+- Timestamps and camera columns are not redacted (they reveal *when*, not
+  *where*). Altitude columns (`rel_altitude`, `abs_altitude`, GPX `<ele>` on
+  fuzzed points) are kept: rel-alt is takeoff-relative (harmless) and
+  abs-alt alone is a very weak elevation-band signal; blanking them would
+  gut the CSV's usefulness for no meaningful privacy gain.
+
+## Design
+
+### 1. GPX — `extract_telemetry_to_gpx` (`telemetry_converter.py`)
+
+In the `<trkpt>` writing loop:
+
+- `drop`: skip the loop entirely — header, optional HOME `<wpt>` (already
+  redacted independently), empty `<trk><trkseg/></trk>`, footer. Valid GPX.
+- `fuzz`: write `round(lat, 3)` / `round(lon, 3)` per point; `<ele>` and
+  `<time>` unchanged.
+- `none`: unchanged output, byte-identical to today.
+
+### 2. CSV from SRT — `extract_telemetry_to_csv`
+
+Apply fuzz **at parse time**: when `--redact fuzz`, round `lat_val`/
+`lon_val` to 3 decimals before they are written into the row *and* before
+they are appended to `solar_inputs` — the existing solar pass then computes
+sun angles from the fuzzed coordinates with no further change.
+
+When `--redact drop`: leave `latitude`/`longitude` cells blank and append
+`(abs_dt, None, None)` to `solar_inputs`. Note the existing solar loop uses
+one combined guard (`abs_dt is None or lat_val is None or lon_val is None →
+continue`) that would also skip `datetime_utc`; **split it** so
+`datetime_utc` fills whenever `abs_dt` is known (timestamps reveal *when*,
+not *where*) and only the `sun_*` columns require coordinates. Rows, camera
+columns, altitudes, timestamps all remain.
+
+`home_*` columns: untouched (already handled via `redact_home`).
+
+### 3. CSV from MP4 — `_csv_from_samples`
+
+New parameter `redact: str = "none"`, passed from
+`extract_telemetry_to_csv`'s early-return call site. Same policy:
+
+- `drop`: `latitude`/`longitude`/`sun_azimuth`/`sun_elevation` blank;
+  `timestamp`, altitudes, `datetime_utc` kept.
+- `fuzz`: rounded coords written; `sun_position()` called with the rounded
+  values.
+
+### 4. CLI help + docs
+
+- `cli.py` `--redact` help: delete the "For gpx/csv only the HOME marker is
+  redacted (the track is unredacted there)" caveat; state that drop/fuzz
+  applies to the track in every format.
+- Grep docs for the same caveat (user_guide / recipes / geospatial docs)
+  and update any occurrence.
+
+## Testing
+
+Extend the existing redaction/convert test modules (follow current test
+style; use small inline SRT fixtures as the neighbouring tests do):
+
+- **GPX**: `drop` → no `<trkpt` in output, `<trkseg>` still present, HOME
+  `<wpt>` absent; `fuzz` → all trkpt lat/lon have ≤3 decimals and differ
+  from the raw values; `none` → unchanged (guard against regression).
+- **CSV (SRT)**: `drop` → same row count as unredacted, `latitude`/
+  `longitude`/`sun_azimuth`/`sun_elevation` empty, `iso`/`shutter`/
+  `rel_altitude`/`datetime_utc` still populated; `fuzz` → coords rounded to
+  3 decimals and sun angles equal to `sun_position(fuzzed…)` (not the
+  raw-coordinate angles).
+- **CSV (MP4)**: with mocked `load_samples`, `--redact drop|fuzz` now
+  affects the output (regression test for the silently-ignored path).
+- **HOME**: `--extract-home --redact fuzz` still yields the 3-decimal HOME
+  waypoint/columns exactly as today.
+
+## Acceptance criteria (supersedes the issue's AC where they differ)
+
+- [ ] `convert gpx --redact drop` writes no `<trkpt>`s (HOME wpt behaviour
+      unchanged)
+- [ ] `convert gpx --redact fuzz` coarsens trackpoints to ~100 m
+- [ ] `convert csv --redact drop` keeps rows but blanks lat/lon **and sun
+      columns**; camera/altitude/timestamp columns intact
+- [ ] `convert csv --redact fuzz` coarsens coords; sun columns computed
+      from fuzzed coords
+- [ ] `convert csv <video>.MP4 --redact …` honours the flag (was silently
+      ignored)
+- [ ] `--redact none` output byte-identical to today for both formats
+- [ ] Help text + docs updated; tests cover drop + fuzz × gpx + csv × SRT +
+      MP4-csv

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -207,9 +207,10 @@ def check(paths: tuple[str, ...], verbose: bool, quiet: bool) -> None:
     type=click.Choice(["none", "drop", "fuzz"], case_sensitive=False),
     default="none",
     show_default=True,
-    help="GPS redaction: drop removes the track (geojson/kml/html/cot) and the "
-    "HOME marker; fuzz coarsens to ~100 m. For gpx/csv only the HOME marker is "
-    "redacted (the track is unredacted there).",
+    help="GPS redaction, applied to the track in every format: drop removes "
+    "the track (gpx/geojson/kml/html/cot) or blanks the GPS+sun columns "
+    "(csv, rows kept); fuzz coarsens to ~100 m. The opt-in HOME marker is "
+    "redacted the same way.",
 )
 @click.option(
     "--interval",

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -162,13 +162,19 @@ def extract_telemetry_to_gpx(
         f.write(gpx_header)
         f.write(home_wpt)
         f.write(trk_open)
-        for point in gps_points:
-            f.write(f'        <trkpt lat="{point["lat"]}" lon="{point["lon"]}">\n')
-            f.write(f'            <ele>{point["ele"]}</ele>\n')
-            time_str = _point_time(point)
-            if time_str:
-                f.write(f'            <time>{time_str}</time>\n')
-            f.write("        </trkpt>\n")
+        # Track redaction (#248): drop -> empty <trkseg/>; fuzz -> 3 decimals
+        # (~100 m), the same policy as redact_coords/redact_home.
+        if redact != "drop":
+            for point in gps_points:
+                lat, lon = point["lat"], point["lon"]
+                if redact == "fuzz":
+                    lat, lon = round(lat, 3), round(lon, 3)
+                f.write(f'        <trkpt lat="{lat}" lon="{lon}">\n')
+                f.write(f'            <ele>{point["ele"]}</ele>\n')
+                time_str = _point_time(point)
+                if time_str:
+                    f.write(f'            <time>{time_str}</time>\n')
+                f.write("        </trkpt>\n")
         f.write(gpx_footer)
 
     logger.info("GPX file created: %s", output_path)

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -406,10 +406,20 @@ def extract_telemetry_to_csv(
             lat_val: float | None = None
             lon_val: float | None = None
             if lat_match and lon_match:
-                row["latitude"] = lat_match.group(1)
-                row["longitude"] = lon_match.group(1)
                 lat_val = float(lat_match.group(1))
                 lon_val = float(lon_match.group(1))
+                # Track redaction (#248): fuzz -> 3 decimals (~100 m, same
+                # policy as redact_coords); drop -> blank GPS cells. Fuzzing
+                # lat_val/lon_val here also feeds the fuzzed position into
+                # the solar pass below.
+                if redact == "fuzz":
+                    lat_val, lon_val = round(lat_val, 3), round(lon_val, 3)
+                if redact == "drop":
+                    lat_val = None
+                    lon_val = None
+                else:
+                    row["latitude"] = f"{lat_val}"
+                    row["longitude"] = f"{lon_val}"
 
             # Altitude
             alt_match = re.search(
@@ -457,11 +467,13 @@ def extract_telemetry_to_csv(
     offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
     if offset is not None:
         for row, (abs_dt, lat_val, lon_val) in zip(rows, solar_inputs):
-            if abs_dt is None or lat_val is None or lon_val is None:
+            if abs_dt is None:
                 continue
             utc = abs_dt - offset
+            # datetime_utc reveals when, not where — filled even when the
+            # coordinates are redacted away (#248).
             row["datetime_utc"] = utc.strftime("%Y-%m-%dT%H:%M:%SZ")
-            if not is_gps_fix(lat_val, lon_val):
+            if lat_val is None or lon_val is None or not is_gps_fix(lat_val, lon_val):
                 continue
             az, el = sun_position(lat_val, lon_val, utc)
             row["sun_azimuth"] = f"{az:.3f}"

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -309,7 +309,9 @@ _CSV_COLUMNS = (
 )
 
 
-def _csv_from_samples(samples: list[TelemetrySample], output_path: Path) -> Path:
+def _csv_from_samples(
+    samples: list[TelemetrySample], output_path: Path, redact: str = "none"
+) -> Path:
     """Write CSV rows from video-sourced samples (UTC is intrinsic).
 
     Fills geo, altitude, ``datetime_utc`` and solar columns; camera columns that
@@ -322,15 +324,24 @@ def _csv_from_samples(samples: list[TelemetrySample], output_path: Path) -> Path
     for s in samples:
         row = {c: "" for c in _CSV_COLUMNS}
         row["timestamp"] = s.cue
-        row["latitude"] = f"{s.lat}"
-        row["longitude"] = f"{s.lon}"
+        # Track redaction (#248): same policy as the SRT path.
+        lat: float | None = s.lat
+        lon: float | None = s.lon
+        if redact == "fuzz":
+            lat, lon = round(s.lat, 3), round(s.lon, 3)
+        if redact == "drop":
+            lat = None
+            lon = None
+        else:
+            row["latitude"] = f"{lat}"
+            row["longitude"] = f"{lon}"
         if s.rel_alt is not None:
             row["rel_altitude"] = f"{s.rel_alt}"
         row["abs_altitude"] = f"{s.alt}"
         if s.dt is not None:
             row["datetime_utc"] = s.dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-            if is_gps_fix(s.lat, s.lon):
-                az, el = sun_position(s.lat, s.lon, s.dt)
+            if lat is not None and lon is not None and is_gps_fix(lat, lon):
+                az, el = sun_position(lat, lon, s.dt)
                 row["sun_azimuth"] = f"{az:.3f}"
                 row["sun_elevation"] = f"{el:.3f}"
         rows.append(row)
@@ -365,7 +376,7 @@ def extract_telemetry_to_csv(
     from .utilities import load_samples
 
     if is_video(srt_path):
-        return _csv_from_samples(load_samples(srt_path), output_path)
+        return _csv_from_samples(load_samples(srt_path), output_path, redact)
 
     home_cols: list[str] = []
     home = None

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -172,3 +172,14 @@ def test_csv_from_mp4_honours_redact(tmp_path, monkeypatch):
     assert fuzz["latitude"] == "39.123"
     assert fuzz["longitude"] == "116.654"
     assert fuzz["sun_azimuth"] != ""
+
+
+def test_convert_redact_help_has_no_gpx_csv_caveat():
+    from click.testing import CliRunner
+
+    from dji_metadata_embedder import cli as cli_mod
+
+    res = CliRunner().invoke(cli_mod.main, ["convert", "--help"])
+    flat = " ".join(res.output.split())  # click wraps help text; unwrap first
+    assert "unredacted" not in flat
+    assert "every format" in flat

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -142,3 +142,33 @@ def test_csv_fuzz_sun_computed_from_fuzzed_coords(tmp_path):
     az, el = sun_position(39.123, 116.654, utc)
     assert fuzzed["sun_azimuth"] == f"{az:.3f}"
     assert fuzzed["sun_elevation"] == f"{el:.3f}"
+
+
+def test_csv_from_mp4_honours_redact(tmp_path, monkeypatch):
+    """MP4 input previously bypassed --redact entirely (#248)."""
+    from datetime import datetime
+
+    from dji_metadata_embedder import telemetry_converter as tc
+    from dji_metadata_embedder.utilities import TelemetrySample
+
+    samples = [
+        TelemetrySample(
+            39.123456, 116.654321, 100.0, "00:00:00,000",
+            datetime(2026, 7, 1, 4, 0, 0),
+        )
+    ]
+    monkeypatch.setattr("dji_metadata_embedder.utilities.load_samples", lambda p: samples)
+
+    video = tmp_path / "DJI_0001.MP4"
+    video.write_bytes(b"\x00")
+
+    drop = _read_csv(tc.extract_telemetry_to_csv(video, tmp_path / "d.csv", redact="drop"))[0]
+    assert drop["latitude"] == "" and drop["longitude"] == ""
+    assert drop["sun_azimuth"] == "" and drop["sun_elevation"] == ""
+    assert drop["datetime_utc"] != ""
+    assert drop["abs_altitude"] != ""
+
+    fuzz = _read_csv(tc.extract_telemetry_to_csv(video, tmp_path / "z.csv", redact="fuzz"))[0]
+    assert fuzz["latitude"] == "39.123"
+    assert fuzz["longitude"] == "116.654"
+    assert fuzz["sun_azimuth"] != ""

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -72,3 +72,73 @@ def test_gpx_none_unchanged(tmp_path):
     text = out.read_text(encoding="utf-8")
     assert '<trkpt lat="39.123456" lon="116.654321">' in text
     assert '<trkpt lat="39.123789" lon="116.654987">' in text
+
+
+def _read_csv(path: Path) -> list[dict]:
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(_csv.DictReader(f))
+
+
+def test_csv_drop_blanks_gps_and_sun_but_keeps_rows(tmp_path):
+    out = extract_telemetry_to_csv(_write_srt(tmp_path), tmp_path / "f.csv", redact="drop")
+    rows = _read_csv(out)
+    assert len(rows) == 2  # rows kept — camera log still shareable
+    for row in rows:
+        assert row["latitude"] == ""
+        assert row["longitude"] == ""
+        assert row["sun_azimuth"] == ""
+        assert row["sun_elevation"] == ""
+        # non-location telemetry intact
+        assert row["iso"] == "100"
+        assert row["rel_altitude"] != ""
+        assert row["timestamp"] != ""
+
+
+def test_csv_fuzz_coarsens_gps(tmp_path):
+    out = extract_telemetry_to_csv(_write_srt(tmp_path), tmp_path / "f.csv", redact="fuzz")
+    rows = _read_csv(out)
+    assert rows[0]["latitude"] == "39.123"
+    assert rows[0]["longitude"] == "116.654"
+    assert rows[1]["latitude"] == "39.124"  # 39.123789 rounds up
+
+
+def test_csv_none_unchanged(tmp_path):
+    out = extract_telemetry_to_csv(_write_srt(tmp_path), tmp_path / "f.csv")
+    rows = _read_csv(out)
+    assert rows[0]["latitude"] == "39.123456"
+    assert rows[1]["longitude"] == "116.654987"
+
+
+# Fixture WITH an absolute datetime (regex needs milliseconds) so the
+# datetime_utc / sun-column policy under redaction is actually exercised.
+TRACK_SRT_DT = (
+    "1\n00:00:00,000 --> 00:00:00,033\n"
+    "2026-07-01 12:00:00.000 [latitude: 39.123456] [longitude: 116.654321] "
+    "[rel_alt: 1.5 abs_alt: 100.0]\n"
+)
+
+
+def test_csv_drop_keeps_datetime_but_blanks_sun(tmp_path):
+    srt = tmp_path / "g.SRT"
+    srt.write_text(TRACK_SRT_DT, encoding="utf-8")
+    out = extract_telemetry_to_csv(srt, tmp_path / "g.csv", redact="drop")
+    row = _read_csv(out)[0]
+    assert row["datetime_utc"] != ""  # timestamps reveal when, not where
+    assert row["sun_azimuth"] == "" and row["sun_elevation"] == ""
+
+
+def test_csv_fuzz_sun_computed_from_fuzzed_coords(tmp_path):
+    from datetime import datetime
+
+    from dji_metadata_embedder.geo.solar import sun_position
+
+    srt = tmp_path / "g.SRT"
+    srt.write_text(TRACK_SRT_DT, encoding="utf-8")
+    fuzzed = _read_csv(extract_telemetry_to_csv(srt, tmp_path / "fz.csv", redact="fuzz"))[0]
+    raw = _read_csv(extract_telemetry_to_csv(srt, tmp_path / "raw.csv"))[0]
+    assert fuzzed["sun_azimuth"] != ""
+    # Angles must match the FUZZED position, not the raw one.
+    utc = datetime.strptime(raw["datetime_utc"], "%Y-%m-%dT%H:%M:%SZ")
+    az, el = sun_position(39.123, 116.654, utc)
+    assert fuzzed["sun_azimuth"] == f"{az:.3f}"
+    assert fuzzed["sun_elevation"] == f"{el:.3f}"

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,3 +1,10 @@
+import csv as _csv
+from pathlib import Path
+
+from dji_metadata_embedder.telemetry_converter import (
+    extract_telemetry_to_csv,
+    extract_telemetry_to_gpx,
+)
 from dji_metadata_embedder.utilities import apply_redaction
 
 
@@ -23,3 +30,45 @@ def test_redact_fuzz():
     assert telemetry["gps_coords"] == [(59.123, 18.654)]
     assert telemetry["first_gps"] == (59.123, 18.654)
     assert telemetry["avg_gps"] == (59.123, 18.654)
+
+
+# ---------------------------------------------------------------------------
+# Track redaction in the gpx/csv exporters (#248). Fixture style mirrors
+# tests/test_home_point.py.
+
+TRACK_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,033\n"
+    "HOME(39.906206,116.391400) [latitude: 39.123456] [longitude: 116.654321] "
+    "[rel_alt: 1.5 abs_alt: 100.0] [iso : 100] [shutter : 1/1000]\n\n"
+    "2\n00:00:00,033 --> 00:00:00,066\n"
+    "HOME(39.906206,116.391400) [latitude: 39.123789] [longitude: 116.654987] "
+    "[rel_alt: 1.6 abs_alt: 101.0] [iso : 100] [shutter : 1/1000]\n"
+)
+
+
+def _write_srt(tmp_path: Path) -> Path:
+    srt = tmp_path / "f.SRT"
+    srt.write_text(TRACK_SRT, encoding="utf-8")
+    return srt
+
+
+def test_gpx_drop_writes_no_trackpoints(tmp_path):
+    out = extract_telemetry_to_gpx(_write_srt(tmp_path), tmp_path / "f.gpx", redact="drop")
+    text = out.read_text(encoding="utf-8")
+    assert "<trkpt" not in text
+    assert "<trkseg>" in text  # still valid GPX structure
+
+
+def test_gpx_fuzz_coarsens_trackpoints(tmp_path):
+    out = extract_telemetry_to_gpx(_write_srt(tmp_path), tmp_path / "f.gpx", redact="fuzz")
+    text = out.read_text(encoding="utf-8")
+    assert '<trkpt lat="39.123" lon="116.654">' in text
+    assert "39.123456" not in text
+    assert "116.654987" not in text
+
+
+def test_gpx_none_unchanged(tmp_path):
+    out = extract_telemetry_to_gpx(_write_srt(tmp_path), tmp_path / "f.gpx")
+    text = out.read_text(encoding="utf-8")
+    assert '<trkpt lat="39.123456" lon="116.654321">' in text
+    assert '<trkpt lat="39.123789" lon="116.654987">' in text


### PR DESCRIPTION
Closes #248.

- `convert gpx --redact drop` -> empty `<trkseg/>`; `fuzz` -> trackpoints coarsened to ~100 m (3 decimals, same policy as the geo exporters)
- `convert csv --redact drop` -> rows kept, `latitude`/`longitude`/`sun_azimuth`/`sun_elevation` blanked (sun angles are invertible to a location fix — blanking coords while keeping precise sun angles would leak position); `fuzz` -> coords coarsened, sun angles computed from the fuzzed position
- Fixes an adjacent hole: `convert csv <video>.MP4` previously bypassed `--redact` entirely
- `datetime_utc` now fills whenever a block carries an absolute datetime, even without GPS (reveals when, not where)
- HOME marker behaviour unchanged; `--redact none` output pinned unchanged by regression tests; CLI help / README / decision-table caveat removed

Design: docs/superpowers/specs/2026-07-07-gpx-csv-track-redaction-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013h7twuBKV8xn5vddUdELZT