### PR TITLE
fix(convert): exclude pre-GPS-lock (0,0) frames from GPX tracks

### DIFF
--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -46,10 +46,16 @@ def _parse_gps_points(content: str) -> list[dict[str, Any]]:
         lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
         alt_match = re.search(r"abs_alt:\s*([+-]?\d+\.?\d*)\]", telemetry_line)
         if lat_match and lon_match:
+            lat, lon = float(lat_match.group(1)), float(lon_match.group(1))
+            # Frames recorded before GPS lock carry the (0, 0) sentinel and
+            # must not become Null Island trackpoints (#256). The video path
+            # already filters these in load_samples.
+            if not is_gps_fix(lat, lon):
+                continue
             gps_points.append(
                 {
-                    "lat": float(lat_match.group(1)),
-                    "lon": float(lon_match.group(1)),
+                    "lat": lat,
+                    "lon": lon,
                     "ele": float(alt_match.group(1)) if alt_match else 0,
                     "time": timestamp_match.group(1) if timestamp_match else None,
                     "datetime": _parse_srt_datetime(telemetry_line),

--- a/tests/test_gps_nofix.py
+++ b/tests/test_gps_nofix.py
@@ -11,6 +11,7 @@ pre-lock -> lock transition, plus a synthetic all-zero clip.
 from pathlib import Path
 
 from dji_metadata_embedder import DJIMetadataEmbedder
+from dji_metadata_embedder.telemetry_converter import extract_telemetry_to_gpx
 from dji_metadata_embedder.utilities import parse_telemetry_points, is_gps_fix
 
 SAMPLES = Path(__file__).resolve().parents[1] / "samples"
@@ -47,6 +48,17 @@ def test_telemetry_points_drop_no_fix(tmp_path):
     lat, lon, alt, _ts = points[0]
     assert (lat, lon) == LOCKED_GPS
     assert alt == LOCKED_ALT
+
+
+def test_gpx_track_excludes_no_fix_frames(tmp_path):
+    """GPX export must not write Null Island trackpoints (issue #256)."""
+    out = tmp_path / "track.gpx"
+    extract_telemetry_to_gpx(NOFIX_CLIP, out)
+    content = out.read_text()
+    # Only the three locked frames become trackpoints.
+    assert content.count("<trkpt") == 3
+    assert 'lat="0.0"' not in content
+    assert f'lat="{LOCKED_GPS[0]}"' in content
 
 
 def _write_all_zero_srt(path: Path) -> Path:

--- a/tests/test_sun_summary.py
+++ b/tests/test_sun_summary.py
@@ -78,5 +78,7 @@ def test_summarize_sun_skips_no_fix_frames(tmp_path):
         "[latitude: 59.0] [longitude: 18.0] [rel_alt: 1.0 abs_alt: 100.0]</font>\n"
     )
     s = summarize_sun(srt, tz_offset=timedelta(hours=2))
-    assert s["points"] == 2          # both GPS-bearing lines parsed
-    assert s["sun_computed"] == 1    # only the genuine fix gets a sun angle
+    # No-fix frames are dropped at parse time (#256), matching the video
+    # path, so only the genuine fix is counted and gets a sun angle.
+    assert s["points"] == 1
+    assert s["sun_computed"] == 1


### PR DESCRIPTION
Closes #256

## Problem

`convert gpx` wrote a `<trkpt lat="0.0" lon="0.0">` for every frame recorded before GPS lock. On a real Neo 2 field sample where lock arrived mid-flight, 407 of 569 trackpoints landed on Null Island.

## Fix

Apply `is_gps_fix()` in `_parse_gps_points()` — the one export path that was missing it. This makes the SRT path consistent with the video path, where `load_samples()` already drops the sentinel.

Side effect (intentional): `summarize_sun`'s `points` stat now counts usable GPS points only on the SRT path, matching what the video path already reported; `test_sun_summary.py` updated accordingly.

## Testing

- New regression test `test_gpx_track_excludes_no_fix_frames` using the existing `samples/neo2/clip_nogps.SRT` pre-lock→lock fixture (written first, watched fail: 6 trkpts → expected 3).
- Full suite: 362 passed. ruff + mypy clean.
- Verified E2E on the real field sample: 162 trackpoints, zero at (0,0), track starts at the first genuine fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fJTKv5fNwQjQDoA97WwHd