### PR TITLE
fix(cli): accept a directory for convert -o, writing <stem>.<ext> into it

### DIFF
--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -275,6 +275,12 @@ def convert(
     if batch and not src.is_dir():
         raise click.ClickException("--batch requires a directory input")
 
+    # -o pointing at an existing directory means "write <stem>.<ext> in there",
+    # matching embed -o semantics (#257).
+    if output is not None and Path(output).is_dir():
+        suffix = ".cot.xml" if command == "cot" else f".{command}"
+        output = str(Path(output) / (src.stem + suffix))
+
     def run_one(srt: Path, out: str | None) -> None:
         if command == "gpx":
             extract_telemetry_to_gpx(srt, out, tz_offset=offset,

--- a/tests/test_cli_convert_output_dir.py
+++ b/tests/test_cli_convert_output_dir.py
@@ -1,0 +1,35 @@
+"""``convert ... -o <existing directory>`` writes ``<stem>.<ext>`` into it (#257).
+
+``embed -o`` takes a directory, so users reasonably pass one to ``convert``
+too; it must not crash with a raw ``IsADirectoryError`` traceback.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dji_metadata_embedder.cli import main
+
+SAMPLES = Path(__file__).resolve().parents[1] / "samples"
+CLIP = SAMPLES / "air3S" / "clip.SRT"
+
+
+@pytest.mark.parametrize(
+    "fmt, expected_name",
+    [
+        ("gpx", "clip.gpx"),
+        ("csv", "clip.csv"),
+        ("geojson", "clip.geojson"),
+        ("kml", "clip.kml"),
+        ("html", "clip.html"),
+        ("cot", "clip.cot.xml"),
+    ],
+)
+def test_convert_output_directory_writes_stem_file(tmp_path, fmt, expected_name):
+    runner = CliRunner()
+    result = runner.invoke(main, ["convert", fmt, str(CLIP), "-o", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    out = tmp_path / expected_name
+    assert out.exists(), f"expected {out} to be created"
+    assert out.stat().st_size > 0


### PR DESCRIPTION
## Summary

`dji-embed convert gpx clip.SRT -o /existing/dir` crashed with a raw `IsADirectoryError` traceback. Since `embed -o` takes a directory, users reasonably pass one to `convert` too.

The fix normalises `-o` once in the CLI: when it points at an existing directory, the default filename is written into it (`clip.gpx`, `clip.csv`, `clip.geojson`, `clip.kml`, `clip.html`, `clip.cot.xml`). All six convert formats are covered by one code path and a parametrised CLI smoke test.

Closes #257

## Checklist
- [x] Tests added (parametrised over all six formats; watched them fail first)
- [x] `uv run pytest -q` — 368 passed
- [x] ruff + mypy clean
- [x] Verified E2E with the real CLI against `samples/air3S/clip.SRT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sm44CjMpvu1nfmv9JPjGF