### PR TITLE
fix(convert): clamp estimate_utc_offset to plausible timezones and warn on failure

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -364,6 +364,34 @@ ffmpeg -i input.mp4 -r 30 -c:v libx264 -preset medium -crf 20 output.mp4
    dji-embed embed part2/
    ```
 
+### Wrong or Missing UTC Times in GPX/CSV Exports
+
+**Problem:** `convert` warns "Timezone auto-detection failed", or exported UTC
+times are hours off
+
+**Background:** DJI SRT timestamps are local wall-clock time with no timezone.
+With the default `--tz-offset auto`, the local→UTC offset is recovered from the
+SRT file's modification time, which only works when the mtime still marks the
+recording time.
+
+**Causes:**
+- Extracting a zip usually resets the mtime to the extraction time. The
+  detected offset then lands outside the real UTC−12..UTC+14 range, detection
+  refuses (falling back to raw cue timestamps), and a warning is printed.
+- Cloud transfers (Drive, Dropbox, messaging apps) often rewrite mtimes too.
+
+**Solution:** pass the offset explicitly:
+```bash
+# Footage recorded at UTC+2 (e.g. central Europe in summer)
+dji-embed convert gpx clip.SRT --tz-offset +2
+```
+
+**Known limitation — footage from another timezone:** zip timestamps are
+timezone-naive local times. A zip created in UTC−5 and extracted in UTC+2 with
+timestamps preserved yields a *plausible-looking* wrong offset that no sanity
+check can catch. For footage received from someone in another timezone, always
+pass `--tz-offset` with the **pilot's** offset.
+
 ---
 
 ## 📈 Performance Issues

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -9,9 +9,15 @@ import subprocess
 from rich.logging import RichHandler
 
 
+logger = logging.getLogger(__name__)
+
 # Seconds in a quarter hour — the granularity real-world UTC offsets use
 # (whole hours plus the :30 and :45 zones like India and Nepal).
 _QUARTER_HOUR = 15 * 60
+
+# Real-world UTC offsets span UTC-12 to UTC+14; a detected offset outside
+# +/-14h is proof the file mtime is not the recording time (#259).
+_MAX_PLAUSIBLE_OFFSET = timedelta(hours=14)
 
 # DJI SRT blocks carry an absolute wall-clock datetime on their own line, with
 # the milliseconds separated by either a comma (older firmware) or a dot
@@ -56,7 +62,7 @@ def estimate_utc_offset(
     first_local: datetime,
     last_local: datetime,
     file_mtime_utc: datetime,
-) -> timedelta:
+) -> timedelta | None:
     """Estimate the UTC offset of naive DJI SRT timestamps.
 
     DJI SRT wall-clock timestamps are local with no timezone, while the source
@@ -66,6 +72,11 @@ def estimate_utc_offset(
     hour (covering offsets such as UTC+5:30 and UTC+5:45), and the residual
     distance from that boundary is kept. The hypothesis with the smaller
     residual wins, since a genuine offset lands cleanly on a quarter hour.
+
+    Returns ``None`` when the best hypothesis falls outside the plausible
+    UTC-12..UTC+14 range (clamped symmetrically to +/-14h): the mtime then
+    cannot be the recording time — typically reset by a zip or cloud transfer
+    (#259). Callers fall back to raw cue timestamps.
 
     All three datetimes must be naive (``file_mtime_utc`` expressed in UTC).
 
@@ -81,6 +92,15 @@ def estimate_utc_offset(
         if best_residual is None or residual < best_residual:
             best_residual = residual
             best_offset = timedelta(seconds=rounded)
+    if abs(best_offset) > _MAX_PLAUSIBLE_OFFSET:
+        logger.warning(
+            "Timezone auto-detection failed: the file mtime does not match the "
+            "recording window (implied offset %+.1fh; real timezones are within "
+            "UTC-12..UTC+14). This is common after zip/cloud transfers. Pass "
+            "--tz-offset for absolute UTC times.",
+            best_offset.total_seconds() / 3600,
+        )
+        return None
     return best_offset
 
 

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,4 +1,5 @@
 import csv as _csv
+from datetime import timedelta
 from pathlib import Path
 
 from dji_metadata_embedder.telemetry_converter import (
@@ -121,7 +122,11 @@ TRACK_SRT_DT = (
 def test_csv_drop_keeps_datetime_but_blanks_sun(tmp_path):
     srt = tmp_path / "g.SRT"
     srt.write_text(TRACK_SRT_DT, encoding="utf-8")
-    out = extract_telemetry_to_csv(srt, tmp_path / "g.csv", redact="drop")
+    # Explicit offset: the tmp file's mtime is unrelated to the fixture's
+    # wall-clock datetime, so auto-detection would (correctly, #259) refuse.
+    out = extract_telemetry_to_csv(
+        srt, tmp_path / "g.csv", tz_offset=timedelta(hours=8), redact="drop"
+    )
     row = _read_csv(out)[0]
     assert row["datetime_utc"] != ""  # timestamps reveal when, not where
     assert row["sun_azimuth"] == "" and row["sun_elevation"] == ""
@@ -134,8 +139,12 @@ def test_csv_fuzz_sun_computed_from_fuzzed_coords(tmp_path):
 
     srt = tmp_path / "g.SRT"
     srt.write_text(TRACK_SRT_DT, encoding="utf-8")
-    fuzzed = _read_csv(extract_telemetry_to_csv(srt, tmp_path / "fz.csv", redact="fuzz"))[0]
-    raw = _read_csv(extract_telemetry_to_csv(srt, tmp_path / "raw.csv"))[0]
+    # Explicit offset for the same reason as above (#259).
+    tz = timedelta(hours=8)
+    fuzzed = _read_csv(
+        extract_telemetry_to_csv(srt, tmp_path / "fz.csv", tz_offset=tz, redact="fuzz")
+    )[0]
+    raw = _read_csv(extract_telemetry_to_csv(srt, tmp_path / "raw.csv", tz_offset=tz))[0]
     assert fuzzed["sun_azimuth"] != ""
     # Angles must match the FUZZED position, not the raw one.
     utc = datetime.strptime(raw["datetime_utc"], "%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -69,6 +69,58 @@ def test_rounds_noisy_offset_to_nearest_quarter_hour():
     assert estimate_utc_offset(first, last, mtime_utc) == timedelta(hours=2)
 
 
+def test_implausible_offset_returns_none():
+    """A zip-reset mtime yielding +28.5h is impossible (real zones are within
+    UTC-12..+14) and must be rejected, not trusted (#259)."""
+    first = datetime(2024, 6, 1, 14, 0, 0)
+    last = datetime(2024, 6, 1, 14, 10, 0)
+    mtime_utc = datetime(2024, 5, 31, 9, 40, 0)  # last - (+28.5h)
+    assert estimate_utc_offset(first, last, mtime_utc) is None
+
+
+def test_implausible_negative_offset_returns_none():
+    """Same clamp on the negative side (mtime far in the future)."""
+    first = datetime(2024, 6, 1, 14, 0, 0)
+    last = datetime(2024, 6, 1, 14, 10, 0)
+    mtime_utc = datetime(2024, 6, 2, 14, 10, 0)  # last + 24h -> UTC-24
+    assert estimate_utc_offset(first, last, mtime_utc) is None
+
+
+def test_implausible_offset_logs_warning(caplog):
+    import logging
+
+    first = datetime(2024, 6, 1, 14, 0, 0)
+    last = datetime(2024, 6, 1, 14, 10, 0)
+    mtime_utc = datetime(2024, 5, 31, 9, 40, 0)
+    with caplog.at_level(logging.WARNING):
+        estimate_utc_offset(first, last, mtime_utc)
+    assert any("--tz-offset" in r.message for r in caplog.records)
+
+
+def test_extreme_real_offset_kept():
+    """UTC+14 (Line Islands) is the real-world maximum and must survive."""
+    first = datetime(2024, 6, 1, 14, 0, 0)
+    last = datetime(2024, 6, 1, 14, 10, 0)
+    mtime_utc = datetime(2024, 6, 1, 0, 10, 0)  # last - 14h
+    assert estimate_utc_offset(first, last, mtime_utc) == timedelta(hours=14)
+
+
+def test_gpx_falls_back_when_offset_implausible(tmp_path):
+    """With a zip-reset mtime the GPX keeps cue timestamps instead of writing
+    absolute times a day off (#259)."""
+    srt = tmp_path / "clip.SRT"
+    srt.write_text(_HTML_SRT)
+    # mtime ~2.5 years after the recorded 2024-01-01 wall clock -> no
+    # plausible timezone explains it.
+    mtime = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    os.utime(srt, (mtime, mtime))
+    out = tmp_path / "clip.gpx"
+    extract_telemetry_to_gpx(srt, out)
+    text = out.read_text()
+    assert "2024-01-01T" not in text  # no fabricated absolute UTC times
+    assert "00:00:00,000" in text  # raw cue fallback
+
+
 @pytest.mark.parametrize(
     "value, expected",
     [


### PR DESCRIPTION
## Summary

Zip/cloud transfers usually reset the SRT mtime, and the mtime-based timezone auto-detection (#211) then computed an impossible offset (+28.5h on a real field sample), silently writing GPX `<time>` values a day off.

Real timezones span UTC−12..UTC+14. When the best hypothesis falls outside ±14h, `estimate_utc_offset` now returns `None` — callers already handle it by falling back to raw cue timestamps — and logs a warning explaining the mtime mismatch and suggesting `--tz-offset`.

Also adds a troubleshooting section covering the failure and the undetectable cross-timezone zip case (zip timestamps are timezone-naive local times): for footage received from another timezone, always pass the **pilot's** `--tz-offset`.

Two redaction tests leaned on the old trust-anything behaviour (fixture wall clock vs fresh tmp-file mtime); they now pass an explicit offset, which is what they meant to test anyway.

Closes #259

## Checklist
- [x] Tests added: implausible ± offsets rejected, warning logged, UTC+14 (Line Islands) still accepted, GPX cue-timestamp fallback (watched them fail first)
- [x] `uv run pytest -q` — 367 passed
- [x] ruff + mypy clean
- [x] Verified E2E: stale-mtime SRT prints the warning and keeps cue timestamps
- [x] Documentation updated (`docs/troubleshooting.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sm44CjMpvu1nfmv9JPjGF