### PR TITLE
feat(flightmap): combined map of every flight in a folder of SRT logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **Subtitle Track Preservation**: Keep telemetry data as subtitle track for overlay viewing
 - **Multiple Format Support**: Handles different DJI SRT telemetry formats
 - **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, KML, or CoT (see [docs/geospatial.md](docs/geospatial.md))
-- **Flight Map**: `dji-embed flightmap DIR` draws every flight in a folder of `.SRT` logs on one combined HTML map (or KML/GeoJSON) — fast, the videos are never opened; `dji-embed convert html FLIGHT.SRT` maps a single flight with an altitude-coloured track — see [Put your flights and photos on a map](#put-your-flights-and-photos-on-a-map)
+- **Flight Map** *(experimental)*: `dji-embed flightmap DIR` draws every flight in a folder of `.SRT` logs on one combined HTML map (or KML/GeoJSON) — fast, the videos are never opened; `dji-embed convert html FLIGHT.SRT` maps a single flight with an altitude-coloured track — see [Put your flights and photos on a map](#put-your-flights-and-photos-on-a-map)
 - **Photo Map**: `dji-embed photomap DIR` plots a whole folder of GPS-tagged still photos (JPG/JPEG/DNG) on a single clustered HTML map (or KML/GeoJSON) with EXIF thumbnail popups — requires ExifTool
 - **Camera Footprint Polygons**: `convert geojson/kml … --footprint` adds nadir ground-footprint rectangles to GeoJSON/KML output (gimbal-aware on formats that carry attitude; suppressed under `--redact`). See [docs/geospatial.md](docs/geospatial.md).
 - **CoT Export**: `dji-embed convert cot FLIGHT.SRT` writes Cursor-on-Target XML for ATAK/TAK (route + timed track). See [docs/fmv-interop.md](docs/fmv-interop.md).
@@ -273,11 +273,11 @@ dji-embed convert html DJI_0001.SRT              # -> DJI_0001.html
 dji-embed convert html DJI_0042.MP4              # sidecar-less models: read telemetry from the MP4
 ```
 
-**A folder of flights → one combined map.** Reads only the `.SRT` telemetry
-sidecars (the videos are never opened, so a whole archive scans in seconds)
-and draws each flight as its own coloured track with a summary popup and a
-layer toggle. Recordings that DJI split at the 4 GB file limit are
-automatically stitched back into one flight:
+**A folder of flights → one combined map** *(experimental — feedback
+welcome!)*. Reads only the `.SRT` telemetry sidecars (the videos are never
+opened, so a whole archive scans in seconds) and draws each flight as its own
+coloured track with a summary popup and a layer toggle. Recordings that DJI
+split at the 4 GB file limit are automatically stitched back into one flight:
 
 ```bash
 dji-embed flightmap /path/to/footage             # -> footage/flightmap.html
@@ -419,8 +419,14 @@ dji-embed convert geojson DJI_0001.SRT --footprint --model air3
 dji-embed convert kml DJI_0001.SRT --footprint --footprint-interval 5
 ```
 
-#### `dji-embed flightmap` - Combined Flight Map
+#### `dji-embed flightmap` - Combined Flight Map (experimental)
 Map every flight in a folder of DJI `.SRT` logs on one combined map.
+
+> **Experimental:** `flightmap` is new and its size-split joining heuristics
+> may still be tuned based on real-world feedback. If it joins flights it
+> shouldn't (or misses ones it should), please
+> [open an issue](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues)
+> with the SRT file names and timestamps.
 
 ```bash
 dji-embed flightmap [OPTIONS] DIRECTORY
@@ -442,6 +448,11 @@ Options:
                                   the next file's telemetry starts within
                                   SECONDS and resumes where the previous file
                                   ended. 0 disables joining (default: 15.0)
+  --tz-offset OFFSET              UTC offset of the SRT timestamps, e.g.
+                                  '+05:30' or '-8'. 'auto' detects it from each
+                                  file's mtime; pass it explicitly when the
+                                  files were copied through zip/cloud transfers
+                                  that rewrote the mtimes (default: auto)
   -v, --verbose                   Verbose output
   -q, --quiet                     Suppress info output
 ```
@@ -468,6 +479,10 @@ Notes:
   position) where the previous one ended — measured on the SRT's own
   timestamps, so it survives copied files with rewritten mtimes. The popup
   lists the joined files; tune or disable with `--join-gap`.
+- Popup start times are converted to UTC using each file's mtime. On archives
+  whose mtimes were rewritten (zip/cloud transfers) the tool warns once and
+  falls back to the mtime; pass `--tz-offset` with your recording timezone to
+  get correct absolute times. Joining itself is unaffected either way.
 - Sidecar-less models whose telemetry lives inside the MP4 (Air 3S,
   Mini 5 Pro, …) are not scanned; map those per clip with
   `dji-embed convert html VIDEO.MP4`.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **GPS Metadata Embedding**: Embed GPS coordinates as standard metadata tags
 - **Subtitle Track Preservation**: Keep telemetry data as subtitle track for overlay viewing
 - **Multiple Format Support**: Handles different DJI SRT telemetry formats
-- **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, KML, or a standalone HTML map (see [docs/geospatial.md](docs/geospatial.md))
-- **Photo Map**: `dji-embed photomap DIR` plots GPS-tagged still photos (JPG/JPEG/DNG) on a clustered HTML map (or KML/GeoJSON) with EXIF thumbnail popups — requires ExifTool
+- **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, KML, or CoT (see [docs/geospatial.md](docs/geospatial.md))
+- **Flight Map**: `dji-embed convert html FLIGHT.SRT` renders a flight as a standalone HTML map (altitude-coloured track) you can open in any browser — see [Put your flights and photos on a map](#put-your-flights-and-photos-on-a-map)
+- **Photo Map**: `dji-embed photomap DIR` plots a whole folder of GPS-tagged still photos (JPG/JPEG/DNG) on a single clustered HTML map (or KML/GeoJSON) with EXIF thumbnail popups — requires ExifTool
 - **Camera Footprint Polygons**: `convert geojson/kml … --footprint` adds nadir ground-footprint rectangles to GeoJSON/KML output (gimbal-aware on formats that carry attitude; suppressed under `--redact`). See [docs/geospatial.md](docs/geospatial.md).
 - **CoT Export**: `dji-embed convert cot FLIGHT.SRT` writes Cursor-on-Target XML for ATAK/TAK (route + timed track). See [docs/fmv-interop.md](docs/fmv-interop.md).
 - **Footage verification:** `dji-embed verify-sun clip.SRT` reports the sun's azimuth/elevation over a clip for shadow cross-checking; CSV export gains `datetime_utc` / `sun_azimuth` / `sun_elevation` columns.
@@ -139,9 +140,9 @@ dji-embed embed /path/to/drone/footage
 dji-embed [OPTIONS] COMMAND [ARGS]...
 
 Commands:
-  embed    Embed telemetry from SRT files into MP4 videos
-  validate Validate SRT/MP4 pairs and report drift
-  convert  Convert SRT telemetry to GPX, CSV, GeoJSON, KML, HTML, or CoT
+  embed      Embed telemetry from SRT files into MP4 videos
+  validate   Validate SRT/MP4 pairs and report drift
+  convert    Convert SRT telemetry to GPX, CSV, GeoJSON, KML, HTML, or CoT
   photomap   Map GPS-tagged still photos to an HTML/KML/GeoJSON map
   check      Check media files for embedded metadata
   doctor     Show system information and verify dependencies
@@ -259,6 +260,43 @@ Batch convert directory to CSV:
 dji-embed convert csv /path/to/srt/files --batch
 ```
 
+### Put Your Flights and Photos on a Map
+
+Two commands cover the "show me where this was shot" workflows:
+
+**One flight → one HTML map.** Renders the flight path coloured by altitude,
+viewable in any browser:
+
+```bash
+dji-embed convert html DJI_0001.SRT              # -> DJI_0001.html
+dji-embed convert html DJI_0042.MP4              # sidecar-less models: read telemetry from the MP4
+```
+
+**A folder of flights → one map per clip:**
+
+```bash
+dji-embed convert html /path/to/footage --batch  # -> one .html next to each clip
+```
+
+Note: `--batch` writes a *separate* map per flight — there is currently no
+single combined map for a folder of videos. If you want that, GPX/GeoJSON
+batch output imports cleanly into tools like [Google My Maps](https://www.google.com/mymaps)
+or [GPX Studio](https://gpx.studio) as one layer per flight.
+
+**A folder of still photos → one combined, clustered map** with an EXIF
+thumbnail popup per pin (requires ExifTool):
+
+```bash
+dji-embed photomap /path/to/photos               # -> photos/photomap.html
+dji-embed photomap /path/to/photos -f kml        # Google Earth instead
+```
+
+`photomap` scans JPG/JPEG/DNG stills only; videos are mapped per-clip with
+`convert html` as above. All HTML maps embed your data but load the basemap
+tiles from the internet, so they need a connection to render — and they reveal
+your shooting locations, so share them deliberately. Details and more formats
+(KML, GeoJSON, CoT, camera footprints): [docs/geospatial.md](docs/geospatial.md).
+
 ### Check Existing Metadata
 
 You can check if your videos or photos already contain GPS or altitude
@@ -356,6 +394,7 @@ Options:
 ```bash
 dji-embed convert html DJI_0001.SRT              # -> DJI_0001.html
 dji-embed convert html DJI_0001.SRT -o flight.html
+dji-embed convert html /path/to/footage --batch  # one map per clip (not combined)
 ```
 
 **CoT (Cursor-on-Target) example** — for ATAK/TAK; see [docs/fmv-interop.md](docs/fmv-interop.md):

--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ dji-embed convert html DJI_0042.MP4              # sidecar-less models: read tel
 **A folder of flights → one combined map.** Reads only the `.SRT` telemetry
 sidecars (the videos are never opened, so a whole archive scans in seconds)
 and draws each flight as its own coloured track with a summary popup and a
-layer toggle:
+layer toggle. Recordings that DJI split at the 4 GB file limit are
+automatically stitched back into one flight:
 
 ```bash
 dji-embed flightmap /path/to/footage             # -> footage/flightmap.html
@@ -436,6 +437,11 @@ Options:
   --title TEXT                    Map title (default: directory name)
   --redact [none|fuzz]            GPS redaction: fuzz coarsens every flight to
                                   ~100 m before writing (default: none)
+  --join-gap SECONDS              Chain size-split recordings (DJI starts a new
+                                  file at the 4 GB limit) into one flight when
+                                  the next file's telemetry starts within
+                                  SECONDS and resumes where the previous file
+                                  ended. 0 disables joining (default: 15.0)
   -v, --verbose                   Verbose output
   -q, --quiet                     Suppress info output
 ```
@@ -457,6 +463,11 @@ Notes:
 - With `-r`, flights are labelled by their path relative to `DIRECTORY`
   (`session1/DJI_0001`), so per-session folders that reuse DJI's restarting
   file numbering stay distinct.
+- Long recordings that DJI split at the 4 GB file limit are stitched back
+  into one flight when the next file's telemetry continues (in time and
+  position) where the previous one ended — measured on the SRT's own
+  timestamps, so it survives copied files with rewritten mtimes. The popup
+  lists the joined files; tune or disable with `--join-gap`.
 - Sidecar-less models whose telemetry lives inside the MP4 (Air 3S,
   Mini 5 Pro, …) are not scanned; map those per clip with
   `dji-embed convert html VIDEO.MP4`.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed -i *.MP4
 - **Subtitle Track Preservation**: Keep telemetry data as subtitle track for overlay viewing
 - **Multiple Format Support**: Handles different DJI SRT telemetry formats
 - **Telemetry Export**: Export flight data to JSON, GPX, CSV, GeoJSON, KML, or CoT (see [docs/geospatial.md](docs/geospatial.md))
-- **Flight Map**: `dji-embed convert html FLIGHT.SRT` renders a flight as a standalone HTML map (altitude-coloured track) you can open in any browser — see [Put your flights and photos on a map](#put-your-flights-and-photos-on-a-map)
+- **Flight Map**: `dji-embed flightmap DIR` draws every flight in a folder of `.SRT` logs on one combined HTML map (or KML/GeoJSON) — fast, the videos are never opened; `dji-embed convert html FLIGHT.SRT` maps a single flight with an altitude-coloured track — see [Put your flights and photos on a map](#put-your-flights-and-photos-on-a-map)
 - **Photo Map**: `dji-embed photomap DIR` plots a whole folder of GPS-tagged still photos (JPG/JPEG/DNG) on a single clustered HTML map (or KML/GeoJSON) with EXIF thumbnail popups — requires ExifTool
 - **Camera Footprint Polygons**: `convert geojson/kml … --footprint` adds nadir ground-footprint rectangles to GeoJSON/KML output (gimbal-aware on formats that carry attitude; suppressed under `--redact`). See [docs/geospatial.md](docs/geospatial.md).
 - **CoT Export**: `dji-embed convert cot FLIGHT.SRT` writes Cursor-on-Target XML for ATAK/TAK (route + timed track). See [docs/fmv-interop.md](docs/fmv-interop.md).
@@ -143,6 +143,7 @@ Commands:
   embed      Embed telemetry from SRT files into MP4 videos
   validate   Validate SRT/MP4 pairs and report drift
   convert    Convert SRT telemetry to GPX, CSV, GeoJSON, KML, HTML, or CoT
+  flightmap  Map every flight in a folder of SRT logs on one combined map
   photomap   Map GPS-tagged still photos to an HTML/KML/GeoJSON map
   check      Check media files for embedded metadata
   doctor     Show system information and verify dependencies
@@ -272,16 +273,19 @@ dji-embed convert html DJI_0001.SRT              # -> DJI_0001.html
 dji-embed convert html DJI_0042.MP4              # sidecar-less models: read telemetry from the MP4
 ```
 
-**A folder of flights → one map per clip:**
+**A folder of flights → one combined map.** Reads only the `.SRT` telemetry
+sidecars (the videos are never opened, so a whole archive scans in seconds)
+and draws each flight as its own coloured track with a summary popup and a
+layer toggle:
 
 ```bash
-dji-embed convert html /path/to/footage --batch  # -> one .html next to each clip
+dji-embed flightmap /path/to/footage             # -> footage/flightmap.html
+dji-embed flightmap /path/to/footage -r          # scan subdirectories too
+dji-embed flightmap /path/to/footage -f kml      # Google Earth / My Maps instead
 ```
 
-Note: `--batch` writes a *separate* map per flight — there is currently no
-single combined map for a folder of videos. If you want that, GPX/GeoJSON
-batch output imports cleanly into tools like [Google My Maps](https://www.google.com/mymaps)
-or [GPX Studio](https://gpx.studio) as one layer per flight.
+Prefer one map per clip? `dji-embed convert html /path/to/footage --batch`
+writes a separate `.html` next to each video.
 
 **A folder of still photos → one combined, clustered map** with an EXIF
 thumbnail popup per pin (requires ExifTool):
@@ -291,11 +295,12 @@ dji-embed photomap /path/to/photos               # -> photos/photomap.html
 dji-embed photomap /path/to/photos -f kml        # Google Earth instead
 ```
 
-`photomap` scans JPG/JPEG/DNG stills only; videos are mapped per-clip with
-`convert html` as above. All HTML maps embed your data but load the basemap
-tiles from the internet, so they need a connection to render — and they reveal
-your shooting locations, so share them deliberately. Details and more formats
-(KML, GeoJSON, CoT, camera footprints): [docs/geospatial.md](docs/geospatial.md).
+`photomap` scans JPG/JPEG/DNG stills; `flightmap` scans `.SRT` flight logs.
+All HTML maps embed your data but load the basemap tiles from the internet, so
+they need a connection to render — and they reveal your flying locations, so
+share them deliberately (`flightmap --redact fuzz` coarsens tracks to ~100 m).
+Details and more formats (KML, GeoJSON, CoT, camera footprints):
+[docs/geospatial.md](docs/geospatial.md).
 
 ### Check Existing Metadata
 
@@ -412,6 +417,53 @@ Leaflet and the basemap tiles load from the internet; the flight data itself is 
 dji-embed convert geojson DJI_0001.SRT --footprint --model air3
 dji-embed convert kml DJI_0001.SRT --footprint --footprint-interval 5
 ```
+
+#### `dji-embed flightmap` - Combined Flight Map
+Map every flight in a folder of DJI `.SRT` logs on one combined map.
+
+```bash
+dji-embed flightmap [OPTIONS] DIRECTORY
+
+Arguments:
+  DIRECTORY                       Directory containing .SRT flight logs
+
+Options:
+  -o, --output FILE               Output file; used as the base name when
+                                  --format all
+  -f, --format [html|kml|geojson|all]
+                                  Map output format (default: html)
+  -r, --recursive                 Scan subdirectories too
+  --title TEXT                    Map title (default: directory name)
+  --redact [none|fuzz]            GPS redaction: fuzz coarsens every flight to
+                                  ~100 m before writing (default: none)
+  -v, --verbose                   Verbose output
+  -q, --quiet                     Suppress info output
+```
+
+Reads only the `.SRT` telemetry sidecars — the videos are never opened and no
+external tool is needed — so scanning a large archive is fast. Each flight
+becomes its own coloured track with a popup (start time, duration, altitude
+range, GPS points) and a layer toggle; the KML imports into Google Earth and
+Google My Maps as one line per flight. SRT files without GPS telemetry
+(e.g. ordinary subtitles) are skipped and counted in a summary; `-v` lists them.
+
+```bash
+dji-embed flightmap /path/to/footage                        # -> footage/flightmap.html
+dji-embed flightmap /path/to/footage -f all                 # -> footage/flightmap.{html,kml,geojson}
+dji-embed flightmap /path/to/footage -r --title "Road trip" # recurse + custom title
+```
+
+Notes:
+- With `-r`, flights are labelled by their path relative to `DIRECTORY`
+  (`session1/DJI_0001`), so per-session folders that reuse DJI's restarting
+  file numbering stay distinct.
+- Sidecar-less models whose telemetry lives inside the MP4 (Air 3S,
+  Mini 5 Pro, …) are not scanned; map those per clip with
+  `dji-embed convert html VIDEO.MP4`.
+- Leaflet and the OpenStreetMap basemap tiles load from the internet; the
+  flight data itself is embedded, so the HTML file is portable but needs a
+  connection to render. A flight map publishes where you fly — share it
+  deliberately, or use `--redact fuzz`.
 
 #### `dji-embed photomap` - Map Still Photos
 Map GPS-tagged still photos (JPG/JPEG/DNG) as an HTML, KML, or GeoJSON map.

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -14,7 +14,7 @@ This guide helps you choose the right command and approach for your specific use
 | **Validate file quality** | `dji-embed validate` | Check for timing drift or file issues |
 | **System diagnostics** | `dji-embed doctor` | Troubleshoot installation or dependencies |
 | **Drive it from a browser** | `dji-embed ui` | You prefer a GUI; requires the `[ui]` extra |
-| **Map a whole folder of flights** | `dji-embed flightmap` | You want every flight's track on one combined map |
+| **Map a whole folder of flights** | `dji-embed flightmap` | You want every flight's track on one combined map (experimental) |
 | **Map your still photos** | `dji-embed photomap` | You shot geotagged photos and want them on a map |
 
 ---

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -14,6 +14,7 @@ This guide helps you choose the right command and approach for your specific use
 | **Validate file quality** | `dji-embed validate` | Check for timing drift or file issues |
 | **System diagnostics** | `dji-embed doctor` | Troubleshoot installation or dependencies |
 | **Drive it from a browser** | `dji-embed ui` | You prefer a GUI; requires the `[ui]` extra |
+| **Map a whole folder of flights** | `dji-embed flightmap` | You want every flight's track on one combined map |
 | **Map your still photos** | `dji-embed photomap` | You shot geotagged photos and want them on a map |
 
 ---
@@ -44,6 +45,7 @@ This guide helps you choose the right command and approach for your specific use
 | Directory of SRT files | Multiple GPX files | `dji-embed convert gpx /path/to/srt/dir --batch` |
 | Directory of SRT files | Multiple CSV files | `dji-embed convert csv /path/to/srt/dir --batch` |
 | Directory of SRT files | Multiple HTML maps | `dji-embed convert html /path/to/srt/dir --batch` |
+| Directory of SRT files | ONE combined HTML/KML/GeoJSON map | `dji-embed flightmap /path/to/srt/dir` |
 | Custom output filename | Specific output file | `dji-embed convert gpx input.SRT -o custom.gpx` |
 | MP4 with no sidecar SRT (Air 3S, Mini 5 Pro) | GPX/CSV/GeoJSON/KML track | `dji-embed convert <fmt> FILE.MP4` (ExifTool-backed; needs recent ExifTool — see [MP4 Timed Metadata](MP4_TIMED_METADATA.md)) |
 | MP4 with no sidecar SRT (Air 3S, Mini 5 Pro) | Sun/shadow verification | `dji-embed verify-sun FILE.MP4` (ExifTool-backed; needs recent ExifTool — see [MP4 Timed Metadata](MP4_TIMED_METADATA.md)) |

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -171,6 +171,31 @@ reuse DJI's restarting file numbering stay distinct. Sidecar-less models whose
 telemetry lives inside the MP4 (Air 3S, Mini 5 Pro, …) are not scanned — map
 those per clip with `dji-embed convert html VIDEO.MP4`.
 
+### Size-split recordings are joined
+
+DJI closes the MP4/SRT pair when a recording hits the 4 GB file-size limit and
+keeps recording into the next numbered file, so a long flight arrives as
+several files. `flightmap` stitches these back into one flight when the next
+file sits in the same directory and its telemetry starts within `--join-gap`
+seconds (default 15) of the previous file ending *and* resumes within the
+distance the drone could plausibly have covered in that gap. A joined flight
+keeps the first segment's name; its popup, KML description, and GeoJSON
+`segments` property list the source files.
+
+Details worth knowing:
+
+- Gaps are measured on the SRT's own per-block timestamps, never on file
+  mtimes — so joining still works on archives whose mtimes were rewritten by
+  zip/cloud transfers. Formats without a datetime line in the SRT are never
+  joined for the same reason.
+- Consecutive file numbers are *not* required: photos share DJI's numbering
+  counter, so a split flight can legitimately jump `DJI_0010` → `DJI_0012`.
+- Two flights flown back-to-back from the same launch point are kept apart by
+  the time check; two files recorded around the same time in different
+  locations are kept apart by the position check.
+- `--join-gap 0` disables joining entirely; raise it if your drone pauses
+  longer between segments.
+
 ## Privacy
 
 All three geo formats honour `--redact`:

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -143,6 +143,34 @@ dji-embed convert html DJI_0001.SRT --redact drop   # empty track, no coords
 dji-embed convert html DJI_0001.SRT --redact fuzz   # ~100 m coarsened coords
 ```
 
+## Combined flight map (`flightmap`)
+
+```bash
+dji-embed flightmap ./footage                    # -> footage/flightmap.html
+dji-embed flightmap ./footage -r                 # scan subdirectories too
+dji-embed flightmap ./footage -f all             # html + kml + geojson
+dji-embed flightmap ./footage --redact fuzz      # ~100 m coarsened tracks
+```
+
+Where `convert html` maps one flight, `flightmap` maps a whole folder: every
+`.SRT` log becomes its own coloured track on a single standalone HTML map,
+with a start marker, a summary popup (start time, duration, altitude range,
+GPS point count), and a layer control to toggle flights. Only the SRT sidecars
+are read — the videos are never opened — so scanning a large archive takes
+seconds and needs no external tools.
+
+The GeoJSON output is one `LineString` feature per flight carrying the same
+summary properties (no per-sample points — at archive scale they would swamp
+the file); the KML is one path placemark per flight, which Google Earth and
+Google My Maps import as separate lines.
+
+SRT files without GPS telemetry (ordinary subtitles, clips that never got a
+fix) are skipped and counted; `-v` lists them. With `-r`, flights are labelled
+by their path relative to the scanned folder so per-session directories that
+reuse DJI's restarting file numbering stay distinct. Sidecar-less models whose
+telemetry lives inside the MP4 (Air 3S, Mini 5 Pro, …) are not scanned — map
+those per clip with `dji-embed convert html VIDEO.MP4`.
+
 ## Privacy
 
 All three geo formats honour `--redact`:
@@ -160,3 +188,6 @@ Pre-GPS-lock `(0, 0)` frames are always excluded.
 dji-embed convert geojson ./footage --batch     # all *.SRT in the folder
 dji-embed convert html ./footage --batch        # one .html map per *.SRT
 ```
+
+For a single combined map of the whole folder instead, see
+[`flightmap`](#combined-flight-map-flightmap) above.

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -145,6 +145,11 @@ dji-embed convert html DJI_0001.SRT --redact fuzz   # ~100 m coarsened coords
 
 ## Combined flight map (`flightmap`)
 
+> **Experimental:** `flightmap` is new and its size-split joining heuristics
+> may still be tuned based on real-world feedback. If it joins flights it
+> shouldn't (or misses ones it should), please open an issue with the SRT
+> file names and timestamps.
+
 ```bash
 dji-embed flightmap ./footage                    # -> footage/flightmap.html
 dji-embed flightmap ./footage -r                 # scan subdirectories too
@@ -171,6 +176,13 @@ reuse DJI's restarting file numbering stay distinct. Sidecar-less models whose
 telemetry lives inside the MP4 (Air 3S, Mini 5 Pro, …) are not scanned — map
 those per clip with `dji-embed convert html VIDEO.MP4`.
 
+Popup start times are converted to UTC by auto-detecting the recording
+timezone from each file's mtime. On archives whose mtimes were rewritten by
+zip/cloud transfers the auto-detection fails; `flightmap` then warns once
+(with a file count) and falls back to mtime-based times. Pass
+`--tz-offset '+02:00'` (your recording timezone) for correct absolute times —
+track shapes, durations, and joining are unaffected either way.
+
 ### Size-split recordings are joined
 
 DJI closes the MP4/SRT pair when a recording hits the 4 GB file-size limit and
@@ -195,6 +207,10 @@ Details worth knowing:
   locations are kept apart by the position check.
 - `--join-gap 0` disables joining entirely; raise it if your drone pauses
   longer between segments.
+- Known limitation: segments are only compared against the most recent
+  flight in time order, so if two drones recorded into the same folder at
+  the same time, a split flight interleaved with the other drone's files
+  is not joined. Rare in practice — open an issue if it bites you.
 
 ## Privacy
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -431,6 +431,16 @@ def photomap(
     show_default=True,
     help="GPS redaction: fuzz coarsens every flight to ~100 m before writing",
 )
+@click.option(
+    "--join-gap",
+    type=float,
+    default=15.0,
+    show_default=True,
+    metavar="SECONDS",
+    help="Chain size-split recordings (DJI starts a new file at the 4 GB "
+    "limit) into one flight when the next file's telemetry starts within "
+    "SECONDS and resumes where the previous file ended. 0 disables joining.",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
 def flightmap(
@@ -440,6 +450,7 @@ def flightmap(
     recursive: bool,
     title: str | None,
     redact: str,
+    join_gap: float,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -447,13 +458,16 @@ def flightmap(
 
     Reads only the .SRT telemetry sidecars (fast — the videos are never
     opened) and draws each flight as its own coloured track with a summary
-    popup, as HTML, KML, or GeoJSON. Sidecar-less models whose telemetry
-    lives inside the MP4 (Air 3S, Mini 5 Pro, ...) need
-    'dji-embed convert html VIDEO.MP4' per clip instead.
+    popup, as HTML, KML, or GeoJSON. Recordings split at the 4 GB file
+    limit are chained back into one flight (see --join-gap). Sidecar-less
+    models whose telemetry lives inside the MP4 (Air 3S, Mini 5 Pro, ...)
+    need 'dji-embed convert html VIDEO.MP4' per clip instead.
     """
     setup_logging(verbose, quiet)
     src = Path(directory)
-    tracks, skipped = scan_flights(src, recursive=recursive, redact=redact.lower())
+    tracks, skipped = scan_flights(
+        src, recursive=recursive, redact=redact.lower(), join_gap=join_gap
+    )
     total = len(tracks) + len(skipped)
     if total == 0:
         raise click.ClickException(
@@ -476,6 +490,13 @@ def flightmap(
         else:
             click.echo(
                 f"Mapped {len(tracks)} flight{'s' if len(tracks) != 1 else ''}"
+            )
+        joined = [t for t in tracks if t.segments]
+        if joined:
+            files_joined = sum(len(t.segments or []) for t in joined)
+            click.echo(
+                f"Joined {files_joined} size-split files into "
+                f"{len(joined)} flight{'s' if len(joined) != 1 else ''}"
             )
     map_title = title or src.resolve().name
     if fmt.lower() == "all":

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -23,7 +23,11 @@ from .geo import (
     convert_to_html,
     convert_to_cot,
     PhotomapError,
+    scan_flights,
     scan_photos,
+    write_flights_geojson,
+    write_flights_html,
+    write_flights_kml,
     write_photos_geojson,
     write_photos_html,
     write_photos_kml,
@@ -81,6 +85,7 @@ def main(ctx: click.Context, log_json: bool) -> None:
       embed     Embed telemetry from SRT files into MP4 videos
       validate  Validate SRT/MP4 pairs and report drift
       convert   Convert SRT telemetry to GPX or CSV formats
+      flightmap Map every flight in a folder of SRT logs on one combined map
       photomap  Map GPS-tagged still photos to an HTML/KML/GeoJSON map
       check     Analyze video files for embedded metadata
       doctor    Check system dependencies and configuration
@@ -402,6 +407,92 @@ def photomap(
                 write_photos_kml(points, out, map_title)
             else:
                 write_photos_geojson(points, out)
+        except OSError as e:
+            raise click.ClickException(f"Could not write {out}: {e}")
+
+
+@main.command()
+@click.argument("directory", type=click.Path(exists=True, file_okay=False))
+@click.option(
+    "-o", "--output", type=click.Path(dir_okay=False),
+    help="Output file; used as the base name when --format all",
+)
+@click.option(
+    "-f", "--format", "fmt",
+    type=click.Choice(["html", "kml", "geojson", "all"], case_sensitive=False),
+    default="html", show_default=True, help="Map output format",
+)
+@click.option("-r", "--recursive", is_flag=True, help="Scan subdirectories too")
+@click.option("--title", default=None, help="Map title (default: directory name)")
+@click.option(
+    "--redact",
+    type=click.Choice(["none", "fuzz"], case_sensitive=False),
+    default="none",
+    show_default=True,
+    help="GPS redaction: fuzz coarsens every flight to ~100 m before writing",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Verbose output")
+@click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
+def flightmap(
+    directory: str,
+    output: str | None,
+    fmt: str,
+    recursive: bool,
+    title: str | None,
+    redact: str,
+    verbose: bool,
+    quiet: bool,
+) -> None:
+    """Map every flight in a folder of DJI .SRT logs on one combined map.
+
+    Reads only the .SRT telemetry sidecars (fast — the videos are never
+    opened) and draws each flight as its own coloured track with a summary
+    popup, as HTML, KML, or GeoJSON. Sidecar-less models whose telemetry
+    lives inside the MP4 (Air 3S, Mini 5 Pro, ...) need
+    'dji-embed convert html VIDEO.MP4' per clip instead.
+    """
+    setup_logging(verbose, quiet)
+    src = Path(directory)
+    tracks, skipped = scan_flights(src, recursive=recursive, redact=redact.lower())
+    total = len(tracks) + len(skipped)
+    if total == 0:
+        raise click.ClickException(
+            f"No .SRT telemetry files found in {src}"
+            + ("" if recursive else " (use -r to scan subdirectories)")
+        )
+    if not tracks:
+        raise click.ClickException(
+            f"None of the {total} SRT files in {src} contain GPS telemetry"
+        )
+    if verbose:
+        for name in skipped:
+            click.echo(f"Skipped (no GPS telemetry): {name}", err=True)
+    if not quiet:
+        if skipped:
+            click.echo(
+                f"Mapped {len(tracks)} of {total} flights; "
+                f"{len(skipped)} had no GPS telemetry (use -v to list them)"
+            )
+        else:
+            click.echo(
+                f"Mapped {len(tracks)} flight{'s' if len(tracks) != 1 else ''}"
+            )
+    map_title = title or src.resolve().name
+    if fmt.lower() == "all":
+        base = Path(output) if output else src / "flightmap.html"
+        targets = [(f, base.with_suffix(f".{f}")) for f in ("html", "kml", "geojson")]
+    else:
+        f = fmt.lower()
+        out = Path(output) if output else src / f"flightmap.{f}"
+        targets = [(f, out)]
+    for f, out in targets:
+        try:
+            if f == "html":
+                write_flights_html(tracks, out, map_title)
+            elif f == "kml":
+                write_flights_kml(tracks, out, map_title)
+            else:
+                write_flights_geojson(tracks, out)
         except OSError as e:
             raise click.ClickException(f"Could not write {out}: {e}")
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -85,7 +85,7 @@ def main(ctx: click.Context, log_json: bool) -> None:
       embed     Embed telemetry from SRT files into MP4 videos
       validate  Validate SRT/MP4 pairs and report drift
       convert   Convert SRT telemetry to GPX or CSV formats
-      flightmap Map every flight in a folder of SRT logs on one combined map
+      flightmap Map every flight in a folder of SRT logs on one combined map (experimental)
       photomap  Map GPS-tagged still photos to an HTML/KML/GeoJSON map
       check     Analyze video files for embedded metadata
       doctor    Check system dependencies and configuration
@@ -441,6 +441,15 @@ def photomap(
     "limit) into one flight when the next file's telemetry starts within "
     "SECONDS and resumes where the previous file ended. 0 disables joining.",
 )
+@click.option(
+    "--tz-offset",
+    default="auto",
+    show_default=True,
+    metavar="OFFSET",
+    help="UTC offset of the SRT timestamps, e.g. '+05:30' or '-8'. 'auto' "
+    "detects it from each file's mtime; pass it explicitly when the files "
+    "were copied through zip/cloud transfers that rewrote the mtimes.",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
 def flightmap(
@@ -451,10 +460,11 @@ def flightmap(
     title: str | None,
     redact: str,
     join_gap: float,
+    tz_offset: str,
     verbose: bool,
     quiet: bool,
 ) -> None:
-    """Map every flight in a folder of DJI .SRT logs on one combined map.
+    """Map every flight in a folder of DJI .SRT logs on one combined map (experimental).
 
     Reads only the .SRT telemetry sidecars (fast — the videos are never
     opened) and draws each flight as its own coloured track with a summary
@@ -464,9 +474,17 @@ def flightmap(
     need 'dji-embed convert html VIDEO.MP4' per clip instead.
     """
     setup_logging(verbose, quiet)
+    try:
+        offset = parse_utc_offset(tz_offset)
+    except ValueError as e:
+        raise click.BadParameter(str(e), param_hint="--tz-offset")
     src = Path(directory)
     tracks, skipped = scan_flights(
-        src, recursive=recursive, redact=redact.lower(), join_gap=join_gap
+        src,
+        recursive=recursive,
+        redact=redact.lower(),
+        join_gap=join_gap,
+        tz_offset=offset,
     )
     total = len(tracks) + len(skipped)
     if total == 0:

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -1,6 +1,14 @@
 """Geospatial track/photo models and exporters (GeoJSON, KML, HTML, CoT)."""
 
 from .cot import convert_to_cot, track_to_cot
+from .flightmap import (
+    flights_to_geojson,
+    flights_to_kml,
+    scan_flights,
+    write_flights_geojson,
+    write_flights_kml,
+)
+from .flightmap_html import flights_to_html, write_flights_html
 from .footprint import FOV_TABLE, Footprint, build_footprints, lens_for
 from .geojson import convert_to_geojson, track_to_geojson
 from .html_viewer import convert_to_html, track_to_html
@@ -44,4 +52,11 @@ __all__ = [
     "write_photos_kml",
     "photos_to_html",
     "write_photos_html",
+    "scan_flights",
+    "flights_to_geojson",
+    "write_flights_geojson",
+    "flights_to_kml",
+    "write_flights_kml",
+    "flights_to_html",
+    "write_flights_html",
 ]

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -11,10 +11,15 @@ from __future__ import annotations
 
 import json
 import logging
+import posixpath
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from xml.sax.saxutils import escape
 
-from .track import Track, build_track
+from ..utilities import load_samples, redact_coords
+from .geometry import haversine_m
+from .track import Track, build_track_from_samples
 
 logger = logging.getLogger(__name__)
 
@@ -35,37 +40,143 @@ def _display_name(path: Path, root: Path, recursive: bool) -> str:
     return path.relative_to(root).with_suffix("").as_posix()
 
 
+# Spatial-continuity bounds for size-split joining: allow this much GPS wobble
+# even across a zero-second gap, plus travel at a generous top speed (DJI sport
+# mode peaks around 27 m/s).
+_JITTER_FLOOR_M = 50.0
+_MAX_SPEED_MS = 30.0
+
+
+@dataclass
+class _ScanEntry:
+    """A scanned track plus its raw SRT wall-clock boundaries.
+
+    ``first_dt``/``last_dt`` are the *unresolved local* datetimes straight from
+    the SRT blocks (``None`` for formats without a datetime line). Split-file
+    gaps are measured on these rather than on the resolved UTC in the track:
+    both segments share the same unknown offset, so the gap is exact even when
+    timezone auto-detection fails, and it never falls back to file mtimes,
+    which zip/cloud copies rewrite.
+    """
+
+    track: Track
+    first_dt: datetime | None
+    last_dt: datetime | None
+
+
+def _joinable(prev: _ScanEntry, nxt: _ScanEntry, max_gap_s: float) -> bool:
+    """True when *nxt* looks like the size-split continuation of *prev*."""
+    if posixpath.dirname(prev.track.name) != posixpath.dirname(nxt.track.name):
+        return False
+    if prev.last_dt is None or nxt.first_dt is None:
+        return False
+    gap = (nxt.first_dt - prev.last_dt).total_seconds()
+    # Sub-second overlap tolerated: the new file's first block can be stamped
+    # marginally before the old file's last one is flushed.
+    if not -1.0 <= gap <= max_gap_s:
+        return False
+    a, b = prev.track.points[-1], nxt.track.points[0]
+    limit = _JITTER_FLOOR_M + max(gap, 0.0) * _MAX_SPEED_MS
+    return haversine_m(a.lat, a.lon, b.lat, b.lon) <= limit
+
+
+def join_split_flights(
+    entries: list[_ScanEntry], max_gap_s: float = 15.0
+) -> list[Track]:
+    """Chain size-split recordings into single flights.
+
+    DJI closes the MP4/SRT pair when it hits the 4 GB container limit and
+    keeps recording into the next numbered file, so one flight can arrive as
+    several consecutive tracks. Segments are joined when they sit in the same
+    directory, the next file's telemetry starts within ``max_gap_s`` seconds
+    of the previous one ending, and the track resumes within the distance the
+    drone could plausibly have covered in that gap. Consecutive file numbers
+    are deliberately not required — photos share DJI's numbering counter, so
+    segment numbers can skip. A joined track keeps the first segment's name
+    and lists all sources in :attr:`Track.segments`.
+    """
+    ordered = sorted(
+        entries,
+        key=lambda e: (e.first_dt is None, e.first_dt or datetime.min, e.track.name),
+    )
+    flights: list[_ScanEntry] = []
+    for entry in ordered:
+        if flights and _joinable(flights[-1], entry, max_gap_s):
+            prev = flights[-1]
+            if prev.track.segments is None:
+                prev.track.segments = [prev.track.name]
+            prev.track.segments.append(entry.track.name)
+            # Rebase the appended segment's clock onto the previous one using
+            # the raw SRT gap. When each file's UTC was synthesized from its
+            # own mtime (timezone auto-detection failed), the segments'
+            # timelines don't line up and the joined duration would collapse
+            # to one file's length; with properly resolved offsets the shift
+            # is zero.
+            prev_end_utc = prev.track.points[-1].utc
+            first_utc = entry.track.points[0].utc
+            if prev_end_utc is not None and first_utc is not None:
+                # _joinable guaranteed both boundary datetimes exist.
+                assert prev.last_dt is not None and entry.first_dt is not None
+                shift = prev_end_utc + (entry.first_dt - prev.last_dt) - first_utc
+                if shift:
+                    for p in entry.track.points:
+                        if p.utc is not None:
+                            p.utc += shift
+            prev.track.points.extend(entry.track.points)
+            prev.last_dt = entry.last_dt
+        else:
+            flights.append(entry)
+    return [e.track for e in flights]
+
+
 def scan_flights(
-    directory: Path | str, recursive: bool = False, redact: str = "none"
+    directory: Path | str,
+    recursive: bool = False,
+    redact: str = "none",
+    join_gap: float = 15.0,
 ) -> tuple[list[Track], list[str]]:
     """Scan *directory* for ``.SRT`` files and return ``(tracks, skipped)``.
 
-    ``tracks`` holds one :class:`Track` per SRT that yielded at least one GPS
-    fix; SRTs with no usable telemetry (non-DJI subtitles, clips that never
+    ``tracks`` holds one :class:`Track` per flight: SRTs that yielded at least
+    one GPS fix, with size-split recordings chained into single flights when
+    ``join_gap`` (seconds, 0 disables) allows — see :func:`join_split_flights`.
+    SRTs with no usable telemetry (non-DJI subtitles, clips that never
     acquired a fix, unreadable files) go to ``skipped``. Both lists are sorted
     by name so output is deterministic regardless of filesystem order.
-    ``redact`` is applied per track by :func:`build_track` (``fuzz`` coarsens
-    to ~100 m).
+    ``redact`` (``fuzz`` coarsens to ~100 m) is applied *after* joining so the
+    coarsened coordinates cannot break the continuity check.
     """
     root = Path(directory)
     files: set[Path] = set()
     for pattern in _SRT_PATTERNS:
         files.update(root.rglob(pattern) if recursive else root.glob(pattern))
-    tracks: list[Track] = []
+    entries: list[_ScanEntry] = []
     skipped: list[str] = []
     for path in sorted(files):
         name = _display_name(path, root, recursive)
         try:
-            track = build_track(path, redact=redact)
+            samples = load_samples(path)
+            if not samples:
+                skipped.append(name)
+                continue
+            mtime_utc = datetime.fromtimestamp(
+                path.stat().st_mtime, tz=timezone.utc
+            ).replace(tzinfo=None)
+            track = build_track_from_samples(name, samples, mtime_utc=mtime_utc)
         except (OSError, ValueError) as exc:
             logger.warning("Skipping %s: %s", path, exc)
             skipped.append(name)
             continue
-        if not track.points:
-            skipped.append(name)
-            continue
-        track.name = name
-        tracks.append(track)
+        entries.append(_ScanEntry(track, samples[0].dt, samples[-1].dt))
+    if join_gap > 0:
+        tracks = join_split_flights(entries, max_gap_s=join_gap)
+    else:
+        tracks = [e.track for e in entries]
+    if redact == "fuzz":
+        for track in tracks:
+            coords = redact_coords([(p.lat, p.lon) for p in track.points], "fuzz")
+            for p, (lat, lon) in zip(track.points, coords):
+                p.lat, p.lon = lat, lon
     tracks.sort(key=lambda t: t.name)
     skipped.sort()
     return tracks, skipped
@@ -91,6 +202,8 @@ def _flight_properties(track: Track) -> dict:
     alts = [p.alt for p in track.points]
     props["alt_min"] = round(min(alts), 1)
     props["alt_max"] = round(max(alts), 1)
+    if track.segments:
+        props["segments"] = track.segments
     return props
 
 
@@ -152,6 +265,11 @@ def flights_to_kml(tracks: list[Track], title: str) -> str:
             desc.append(f"duration: {format_duration(props['duration_s'])}")
         desc.append(f"altitude: {props['alt_min']:g} - {props['alt_max']:g} m")
         desc.append(f"{props['points']} GPS points")
+        if track.segments:
+            desc.append(
+                f"{len(track.segments)} size-split files "
+                f"({track.segments[0]} → {track.segments[-1]})"
+            )
         if len(track.points) >= 2:
             coords = " ".join(f"{p.lon},{p.lat},{p.alt}" for p in track.points)
             geometry = (

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -1,0 +1,181 @@
+"""Multi-flight folder scan and exporters (GeoJSON, KML) for ``flightmap``.
+
+A directory of DJI ``.SRT`` sidecars is parsed straight into :class:`Track`
+objects — the videos are never opened and no external tool is needed — so
+scanning an archive of clips is fast. The resulting track list is the single
+model every flightmap writer consumes: GeoJSON and KML here, the combined
+HTML map in :mod:`.flightmap_html`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from .track import Track, build_track
+
+logger = logging.getLogger(__name__)
+
+# Both cases so case-sensitive filesystems match DJI's .SRT and renamed .srt;
+# identical paths matched twice (case-insensitive filesystems) dedupe via set.
+_SRT_PATTERNS = ("*.SRT", "*.srt")
+
+
+def _display_name(path: Path, root: Path, recursive: bool) -> str:
+    """Flight label: the SRT stem, path-qualified on recursive scans.
+
+    DJI restarts numbering per card/session, so recursive scans keep the
+    subdirectory (``session1/DJI_0001``) to stop distinct flights collapsing
+    onto one label — same rule as the photomap scanner.
+    """
+    if not recursive:
+        return path.stem
+    return path.relative_to(root).with_suffix("").as_posix()
+
+
+def scan_flights(
+    directory: Path | str, recursive: bool = False, redact: str = "none"
+) -> tuple[list[Track], list[str]]:
+    """Scan *directory* for ``.SRT`` files and return ``(tracks, skipped)``.
+
+    ``tracks`` holds one :class:`Track` per SRT that yielded at least one GPS
+    fix; SRTs with no usable telemetry (non-DJI subtitles, clips that never
+    acquired a fix, unreadable files) go to ``skipped``. Both lists are sorted
+    by name so output is deterministic regardless of filesystem order.
+    ``redact`` is applied per track by :func:`build_track` (``fuzz`` coarsens
+    to ~100 m).
+    """
+    root = Path(directory)
+    files: set[Path] = set()
+    for pattern in _SRT_PATTERNS:
+        files.update(root.rglob(pattern) if recursive else root.glob(pattern))
+    tracks: list[Track] = []
+    skipped: list[str] = []
+    for path in sorted(files):
+        name = _display_name(path, root, recursive)
+        try:
+            track = build_track(path, redact=redact)
+        except (OSError, ValueError) as exc:
+            logger.warning("Skipping %s: %s", path, exc)
+            skipped.append(name)
+            continue
+        if not track.points:
+            skipped.append(name)
+            continue
+        track.name = name
+        tracks.append(track)
+    tracks.sort(key=lambda t: t.name)
+    skipped.sort()
+    return tracks, skipped
+
+
+def format_duration(seconds: int) -> str:
+    """Format whole seconds for display: ``243`` -> ``4:03``, ``3723`` -> ``1:02:03``."""
+    h, rest = divmod(seconds, 3600)
+    m, s = divmod(rest, 60)
+    if h:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m}:{s:02d}"
+
+
+def _flight_properties(track: Track) -> dict:
+    """Per-flight summary properties shared by every writer's popups/tables."""
+    first, last = track.points[0], track.points[-1]
+    props: dict = {"name": track.name, "points": len(track.points)}
+    if first.utc is not None:
+        props["start"] = first.utc.strftime("%Y-%m-%d %H:%M:%S UTC")
+        if last.utc is not None:
+            props["duration_s"] = round((last.utc - first.utc).total_seconds())
+    alts = [p.alt for p in track.points]
+    props["alt_min"] = round(min(alts), 1)
+    props["alt_max"] = round(max(alts), 1)
+    return props
+
+
+def flights_to_geojson(tracks: list[Track]) -> dict:
+    """Return a GeoJSON ``FeatureCollection`` with one feature per flight.
+
+    Each flight is a ``LineString`` carrying name/start/duration/altitude
+    summary properties; a single-fix clip degrades to a ``Point`` because
+    RFC 7946 §3.1.4 requires two or more positions in a LineString. Unlike
+    the single-track exporter no per-sample Point features are emitted — at
+    archive scale they would swamp the map and the file.
+    """
+    features: list[dict] = []
+    for track in tracks:
+        coords = [[p.lon, p.lat, p.alt] for p in track.points]
+        if len(coords) >= 2:
+            geometry: dict = {"type": "LineString", "coordinates": coords}
+        else:
+            geometry = {"type": "Point", "coordinates": coords[0]}
+        features.append(
+            {
+                "type": "Feature",
+                "geometry": geometry,
+                "properties": _flight_properties(track),
+            }
+        )
+    return {"type": "FeatureCollection", "features": features}
+
+
+def write_flights_geojson(tracks: list[Track], output_path: Path) -> Path:
+    """Write *tracks* as GeoJSON to *output_path* and return it."""
+    output_path.write_text(
+        json.dumps(flights_to_geojson(tracks), indent=2), encoding="utf-8"
+    )
+    logger.info("GeoJSON flight map created: %s", output_path)
+    return output_path
+
+
+_KML_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>{name}</name>{placemarks}
+  </Document>
+</kml>
+"""
+
+
+def flights_to_kml(tracks: list[Track], title: str) -> str:
+    """Return a KML document with one path placemark per flight.
+
+    Google Earth and Google My Maps both render each placemark as a separate
+    line, so a whole folder of flights imports as one layered document.
+    """
+    placemarks = []
+    for track in tracks:
+        props = _flight_properties(track)
+        desc = [props.get("start")]
+        if "duration_s" in props:
+            desc.append(f"duration: {format_duration(props['duration_s'])}")
+        desc.append(f"altitude: {props['alt_min']:g} - {props['alt_max']:g} m")
+        desc.append(f"{props['points']} GPS points")
+        if len(track.points) >= 2:
+            coords = " ".join(f"{p.lon},{p.lat},{p.alt}" for p in track.points)
+            geometry = (
+                "<LineString><altitudeMode>absolute</altitudeMode>"
+                f"<coordinates>{coords}</coordinates></LineString>"
+            )
+        else:
+            p = track.points[0]
+            geometry = (
+                "<Point><altitudeMode>absolute</altitudeMode>"
+                f"<coordinates>{p.lon},{p.lat},{p.alt}</coordinates></Point>"
+            )
+        placemarks.append(
+            "\n    <Placemark>"
+            f"<name>{escape(track.name)}</name>"
+            f"<description>{escape(' · '.join(d for d in desc if d))}</description>"
+            f"{geometry}"
+            "</Placemark>"
+        )
+    return _KML_TEMPLATE.format(name=escape(title), placemarks="".join(placemarks))
+
+
+def write_flights_kml(tracks: list[Track], output_path: Path, title: str) -> Path:
+    """Write *tracks* as KML to *output_path* and return it."""
+    output_path.write_text(flights_to_kml(tracks, title), encoding="utf-8")
+    logger.info("KML flight map created: %s", output_path)
+    return output_path

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -13,10 +13,11 @@ import json
 import logging
 import posixpath
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from xml.sax.saxutils import escape
 
+from .. import utilities
 from ..utilities import load_samples, redact_coords
 from .geometry import haversine_m
 from .track import Track, build_track_from_samples
@@ -129,11 +130,35 @@ def join_split_flights(
     return [e.track for e in flights]
 
 
+class _TzWarningAggregator(logging.Filter):
+    """Collapse per-file timezone auto-detection warnings into one summary.
+
+    A folder whose mtimes were rewritten by a zip/cloud transfer would
+    otherwise repeat :func:`..utilities.estimate_utc_offset`'s warning once
+    per file — on an archive scan that is pure noise. The per-file warnings
+    are swallowed here and :func:`scan_flights` emits a single count-carrying
+    summary instead.
+    """
+
+    _PREFIX = "Timezone auto-detection failed"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.count = 0
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.getMessage().startswith(self._PREFIX):
+            self.count += 1
+            return False
+        return True
+
+
 def scan_flights(
     directory: Path | str,
     recursive: bool = False,
     redact: str = "none",
     join_gap: float = 15.0,
+    tz_offset: timedelta | None = None,
 ) -> tuple[list[Track], list[str]]:
     """Scan *directory* for ``.SRT`` files and return ``(tracks, skipped)``.
 
@@ -144,7 +169,10 @@ def scan_flights(
     acquired a fix, unreadable files) go to ``skipped``. Both lists are sorted
     by name so output is deterministic regardless of filesystem order.
     ``redact`` (``fuzz`` coarsens to ~100 m) is applied *after* joining so the
-    coarsened coordinates cannot break the continuity check.
+    coarsened coordinates cannot break the continuity check. ``tz_offset``
+    fixes the SRT-local -> UTC offset for every file; ``None`` auto-detects it
+    per file from the mtime, falling back to mtime-based start times (with one
+    aggregated warning) when the mtimes were rewritten by a transfer.
     """
     root = Path(directory)
     files: set[Path] = set()
@@ -152,22 +180,40 @@ def scan_flights(
         files.update(root.rglob(pattern) if recursive else root.glob(pattern))
     entries: list[_ScanEntry] = []
     skipped: list[str] = []
-    for path in sorted(files):
-        name = _display_name(path, root, recursive)
-        try:
-            samples = load_samples(path)
-            if not samples:
+    tz_warnings = _TzWarningAggregator()
+    util_logger = logging.getLogger(utilities.__name__)
+    util_logger.addFilter(tz_warnings)
+    try:
+        for path in sorted(files):
+            name = _display_name(path, root, recursive)
+            try:
+                samples = load_samples(path)
+                if not samples:
+                    skipped.append(name)
+                    continue
+                mtime_utc = datetime.fromtimestamp(
+                    path.stat().st_mtime, tz=timezone.utc
+                ).replace(tzinfo=None)
+                track = build_track_from_samples(
+                    name, samples, tz_offset=tz_offset, mtime_utc=mtime_utc
+                )
+            except (OSError, ValueError) as exc:
+                logger.warning("Skipping %s: %s", path, exc)
                 skipped.append(name)
                 continue
-            mtime_utc = datetime.fromtimestamp(
-                path.stat().st_mtime, tz=timezone.utc
-            ).replace(tzinfo=None)
-            track = build_track_from_samples(name, samples, mtime_utc=mtime_utc)
-        except (OSError, ValueError) as exc:
-            logger.warning("Skipping %s: %s", path, exc)
-            skipped.append(name)
-            continue
-        entries.append(_ScanEntry(track, samples[0].dt, samples[-1].dt))
+            entries.append(_ScanEntry(track, samples[0].dt, samples[-1].dt))
+    finally:
+        util_logger.removeFilter(tz_warnings)
+    if tz_warnings.count:
+        logger.warning(
+            "Timezone auto-detection failed for %d of %d SRT files: their "
+            "mtimes do not match the recording window (common after zip/cloud "
+            "transfers), so those start times fall back to the file mtime and "
+            "may be wrong. Pass --tz-offset to set the recording timezone "
+            "explicitly.",
+            tz_warnings.count,
+            len(files),
+        )
     if join_gap > 0:
         tracks = join_split_flights(entries, max_gap_s=join_gap)
     else:

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -86,7 +86,12 @@ function popupHtml(p) {
   if (p.start) html += `<br>${esc(p.start)}`;
   if (p.duration_s != null) html += `<br>duration: ${fmtDuration(p.duration_s)}`;
   if (p.alt_min != null) html += `<br>altitude: ${p.alt_min}–${p.alt_max} m`;
-  html += `<br>${p.points} GPS point${p.points === 1 ? '' : 's'}</div>`;
+  html += `<br>${p.points} GPS point${p.points === 1 ? '' : 's'}`;
+  if (p.segments) {
+    html += `<br>${p.segments.length} size-split files: ` +
+            `${esc(p.segments[0])} → ${esc(p.segments[p.segments.length - 1])}`;
+  }
+  html += '</div>';
   return html;
 }
 

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -1,0 +1,151 @@
+"""Render a multi-flight track list as a standalone, self-contained HTML map.
+
+Same contract as :mod:`.html_viewer` and :mod:`.photomap_html`: the combined
+flight GeoJSON is embedded in a ``<script type="application/json">`` block and
+a small vanilla Leaflet app renders it — one coloured polyline per flight with
+a start marker, a summary popup, and a layer control to toggle flights. Leaflet
+and the OpenStreetMap basemap load from the network; the flight data itself is
+embedded.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from html import escape
+from pathlib import Path
+
+from .flightmap import flights_to_geojson
+from .track import Track
+
+logger = logging.getLogger(__name__)
+
+# Pinned Leaflet release + Subresource Integrity hashes (same pins as
+# html_viewer.py / photomap_html.py).
+_LEAFLET_VERSION = "1.9.4"
+_LEAFLET_CSS_SRI = "sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+_LEAFLET_JS_SRI = "sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+
+_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Flight map — {title}</title>
+<!-- Leaflet + OpenStreetMap tiles load from the network; the flight data is
+     embedded below, so this file is portable but not fully offline. -->
+<link rel="stylesheet"
+      href="https://unpkg.com/leaflet@{leaflet}/dist/leaflet.css"
+      integrity="{css_sri}" crossorigin="" />
+<style>
+  html, body {{ height: 100%; margin: 0; }}
+  #map {{ height: 100%; }}
+  .flight-popup {{ font: 13px/1.5 sans-serif; }}
+</style>
+</head>
+<body>
+<div id="map"></div>
+<script type="application/json" id="flight-data">
+{data}
+</script>
+<script src="https://unpkg.com/leaflet@{leaflet}/dist/leaflet.js"
+        integrity="{js_sri}" crossorigin=""></script>
+<script>
+{app_js}
+</script>
+</body>
+</html>
+"""
+
+_APP_JS = """
+const data = JSON.parse(document.getElementById('flight-data').textContent);
+const map = L.map('map');
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+const esc = s => String(s).replace(/[&<>"']/g,
+  ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+
+// 12 visually distinct track colours, cycled when a folder has more flights.
+const PALETTE = ['#e6194b', '#3cb44b', '#4363d8', '#f58231', '#911eb4',
+                 '#42d4f4', '#f032e6', '#bfef45', '#469990', '#9a6324',
+                 '#800000', '#000075'];
+
+function fmtDuration(total) {
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const mm = h ? String(m).padStart(2, '0') : String(m);
+  return (h ? h + ':' + mm : mm) + ':' + String(s).padStart(2, '0');
+}
+
+function popupHtml(p) {
+  let html = `<div class="flight-popup"><b>${esc(p.name || '')}</b>`;
+  if (p.start) html += `<br>${esc(p.start)}`;
+  if (p.duration_s != null) html += `<br>duration: ${fmtDuration(p.duration_s)}`;
+  if (p.alt_min != null) html += `<br>altitude: ${p.alt_min}–${p.alt_max} m`;
+  html += `<br>${p.points} GPS point${p.points === 1 ? '' : 's'}</div>`;
+  return html;
+}
+
+const overlays = {};
+const allLatLngs = [];
+(data.features || []).forEach((f, i) => {
+  if (!f.geometry) return;
+  const color = PALETTE[i % PALETTE.length];
+  const p = f.properties || {};
+  const group = L.layerGroup();
+  let latlngs;
+  if (f.geometry.type === 'LineString') {
+    latlngs = f.geometry.coordinates.map(c => [c[1], c[0]]);
+    L.polyline(latlngs, { color, weight: 3 })
+      .bindPopup(popupHtml(p)).addTo(group);
+  } else {                                             // single-fix clip
+    const c = f.geometry.coordinates;
+    latlngs = [[c[1], c[0]]];
+  }
+  L.circleMarker(latlngs[0], { color, radius: 6, fillOpacity: 0.9 })
+    .bindPopup(popupHtml(p)).addTo(group);
+  group.addTo(map);
+  const label = `<span style="color:${color}">&#9632;</span> ` +
+                esc(p.name || `flight ${i + 1}`);
+  overlays[label] = group;
+  allLatLngs.push(...latlngs);
+});
+
+if (allLatLngs.length > 1) {
+  map.fitBounds(L.latLngBounds(allLatLngs).pad(0.1), { maxZoom: 17 });
+} else if (allLatLngs.length === 1) {
+  map.setView(allLatLngs[0], 16);
+} else {
+  map.setView([0, 0], 2);
+}
+if (Object.keys(overlays).length > 1) {
+  L.control.layers(null, overlays).addTo(map);
+}
+"""
+
+
+def flights_to_html(tracks: list[Track], title: str) -> str:
+    """Return a complete self-contained HTML flight map."""
+    geojson = flights_to_geojson(tracks)
+    # Escape "<" to "\\u003c" (a JSON Unicode escape) so JSON.parse round-trips
+    # it while no literal "</script>" can break out of the data block.
+    data = json.dumps(geojson).replace("<", "\\u003c")
+    return _TEMPLATE.format(
+        title=escape(title),
+        leaflet=_LEAFLET_VERSION,
+        css_sri=_LEAFLET_CSS_SRI,
+        js_sri=_LEAFLET_JS_SRI,
+        data=data,
+        app_js=_APP_JS,
+    )
+
+
+def write_flights_html(tracks: list[Track], output_path: Path, title: str) -> Path:
+    """Write *tracks* as an HTML map to *output_path* and return it."""
+    output_path.write_text(flights_to_html(tracks, title), encoding="utf-8")
+    logger.info("HTML flight map created: %s", output_path)
+    return output_path

--- a/src/dji_metadata_embedder/geo/track.py
+++ b/src/dji_metadata_embedder/geo/track.py
@@ -35,10 +35,16 @@ class TrackPoint:
 
 @dataclass
 class Track:
-    """A named ordered sequence of :class:`TrackPoint`."""
+    """A named ordered sequence of :class:`TrackPoint`.
+
+    ``segments`` lists the source file names when the track was stitched from
+    size-split recordings (see :func:`..flightmap.join_split_flights`); it is
+    ``None`` for a track built from a single file.
+    """
 
     name: str
     points: list[TrackPoint]
+    segments: list[str] | None = None
 
 
 def _cue_seconds(cue: str) -> float:

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -131,3 +131,35 @@ def test_flightmap_quiet_suppresses_stdout(tmp_path):
     res = CliRunner().invoke(main, ["flightmap", str(tmp_path), "-q"])
     assert res.exit_code == 0, res.output
     assert res.output.strip() == ""
+
+
+# Two size-split segments: B's telemetry resumes 1 s after A ends, ~1 m away.
+SPLIT_A = (
+    "1\n00:00:00,000 --> 00:00:01,000\n"
+    '<font size="28">FrameCnt: 1, DiffTime: 1000ms\n'
+    "2026-06-15 12:00:00.000\n"
+    "[latitude: 34.0] [longitude: -84.0] [rel_alt: 1.000 abs_alt: 100.0]</font>\n\n"
+    "2\n00:00:01,000 --> 00:00:02,000\n"
+    '<font size="28">FrameCnt: 2, DiffTime: 1000ms\n'
+    "2026-06-15 12:00:01.000\n"
+    "[latitude: 34.00001] [longitude: -84.0] [rel_alt: 1.000 abs_alt: 101.0]</font>\n"
+)
+SPLIT_B = SPLIT_A.replace("12:00:00", "12:00:02").replace("12:00:01", "12:00:03")
+
+
+def test_flightmap_joins_size_split_recordings(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": SPLIT_A, "DJI_0002.SRT": SPLIT_B})
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    assert "Mapped 1 flight" in res.output
+    assert "Joined 2 size-split files into 1 flight" in res.output
+    text = (tmp_path / "flightmap.html").read_text(encoding="utf-8")
+    assert '"segments": ["DJI_0001", "DJI_0002"]' in text
+
+
+def test_flightmap_join_gap_zero_disables(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": SPLIT_A, "DJI_0002.SRT": SPLIT_B})
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path), "--join-gap", "0"])
+    assert res.exit_code == 0, res.output
+    assert "Mapped 2 flights" in res.output
+    assert "Joined" not in res.output

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -1,0 +1,133 @@
+import json
+
+from click.testing import CliRunner
+
+from dji_metadata_embedder.cli import main
+
+FLIGHT_A = (
+    "1\n00:00:00,000 --> 00:00:01,000\n"
+    '<font size="28">[latitude: 10.0] [longitude: 20.0] '
+    "[rel_alt: 1.000 abs_alt: 5.0]</font>\n\n"
+    "2\n00:00:01,000 --> 00:00:02,000\n"
+    '<font size="28">[latitude: 10.001] [longitude: 20.001] '
+    "[rel_alt: 1.000 abs_alt: 6.0]</font>\n"
+)
+FLIGHT_B = FLIGHT_A.replace("10.0", "11.0").replace("20.0", "21.0")
+NOT_TELEMETRY = "1\n00:00:00,000 --> 00:00:01,000\nJust a movie subtitle\n"
+
+
+def _folder(tmp_path, files):
+    for name, content in files.items():
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+def test_flightmap_default_writes_html_into_directory(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A, "DJI_0002.SRT": FLIGHT_B})
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    out = tmp_path / "flightmap.html"
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert "leaflet@1.9.4" in text
+    assert tmp_path.resolve().name in text  # default title = directory name
+    assert "DJI_0001" in text and "DJI_0002" in text
+    assert "Mapped 2 flights" in res.output
+
+
+def test_flightmap_skips_non_telemetry_srt_with_summary(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A, "movie.srt": NOT_TELEMETRY})
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path), "-v"])
+    assert res.exit_code == 0, res.output
+    assert "Mapped 1 of 2 flights" in res.output
+    assert "movie" in res.output  # -v lists the skipped file
+
+
+def test_flightmap_all_formats_share_base_name(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    out_base = tmp_path / "trip.html"
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "-f", "all", "-o", str(out_base)]
+    )
+    assert res.exit_code == 0, res.output
+    for suffix in (".html", ".kml", ".geojson"):
+        assert out_base.with_suffix(suffix).exists(), suffix
+    data = json.loads(out_base.with_suffix(".geojson").read_text(encoding="utf-8"))
+    assert data["features"][0]["properties"]["name"] == "DJI_0001"
+
+
+def test_flightmap_recursive_scans_subdirectories(tmp_path):
+    _folder(tmp_path, {"session1/DJI_0001.SRT": FLIGHT_A,
+                       "session2/DJI_0001.SRT": FLIGHT_B})
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path)])
+    assert res.exit_code != 0  # non-recursive scan finds nothing
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path), "-r"])
+    assert res.exit_code == 0, res.output
+    text = (tmp_path / "flightmap.html").read_text(encoding="utf-8")
+    assert "session1/DJI_0001" in text and "session2/DJI_0001" in text
+
+
+def test_flightmap_kml_format_and_title(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "-f", "kml", "--title", "Lennot"]
+    )
+    assert res.exit_code == 0, res.output
+    text = (tmp_path / "flightmap.kml").read_text(encoding="utf-8")
+    assert "<kml" in text and "Lennot" in text
+
+
+def test_flightmap_redact_fuzz_coarsens_output(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A.replace("10.001", "10.123456")})
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "-f", "geojson", "--redact", "fuzz"]
+    )
+    assert res.exit_code == 0, res.output
+    data = json.loads((tmp_path / "flightmap.geojson").read_text(encoding="utf-8"))
+    coords = data["features"][0]["geometry"]["coordinates"]
+    assert coords[1][1] == 10.123  # fuzzed to 3 decimals (~100 m)
+
+
+def test_flightmap_no_srt_is_clean_error(tmp_path):
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path)])
+    assert res.exit_code != 0
+    assert "No .SRT" in res.output
+    assert res.exception is None or isinstance(res.exception, SystemExit)
+
+
+def test_flightmap_no_gps_srt_is_clean_error(tmp_path):
+    _folder(tmp_path, {"movie.srt": NOT_TELEMETRY})
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path)])
+    assert res.exit_code != 0
+    assert "GPS" in res.output
+
+
+def test_flightmap_single_format_output_honored_verbatim(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    out = tmp_path / "report.json"
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "-f", "geojson", "-o", str(out)]
+    )
+    assert res.exit_code == 0, res.output
+    assert out.exists()  # extension NOT rewritten
+    assert not (tmp_path / "report.geojson").exists()
+
+
+def test_flightmap_write_failure_is_clean_error(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main,
+        ["flightmap", str(tmp_path), "-o", str(tmp_path / "no_such_dir" / "m.html")],
+    )
+    assert res.exit_code != 0
+    assert "Could not write" in res.output
+    assert res.exception is None or isinstance(res.exception, SystemExit)
+
+
+def test_flightmap_quiet_suppresses_stdout(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path), "-q"])
+    assert res.exit_code == 0, res.output
+    assert res.output.strip() == ""

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -147,6 +147,32 @@ SPLIT_A = (
 SPLIT_B = SPLIT_A.replace("12:00:00", "12:00:02").replace("12:00:01", "12:00:03")
 
 
+def test_flightmap_tz_offset_option_sets_start_times(tmp_path):
+    import os
+
+    _folder(tmp_path, {"DJI_0001.SRT": SPLIT_A})
+    # mtime a zip transfer rewrote: auto-detection would fail without the flag
+    os.utime(tmp_path / "DJI_0001.SRT", (946684800.0, 946684800.0))
+    res = CliRunner().invoke(
+        main,
+        ["flightmap", str(tmp_path), "-f", "geojson", "--tz-offset", "+2"],
+    )
+    assert res.exit_code == 0, res.output
+    data = json.loads((tmp_path / "flightmap.geojson").read_text(encoding="utf-8"))
+    # local 2026-06-15 12:00:00 at UTC+2 -> 10:00:00 UTC
+    assert data["features"][0]["properties"]["start"] == "2026-06-15 10:00:00 UTC"
+
+
+def test_flightmap_invalid_tz_offset_is_clean_error(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "--tz-offset", "nope"]
+    )
+    assert res.exit_code != 0
+    assert "Invalid UTC offset" in res.output
+    assert res.exception is None or isinstance(res.exception, SystemExit)
+
+
 def test_flightmap_joins_size_split_recordings(tmp_path):
     _folder(tmp_path, {"DJI_0001.SRT": SPLIT_A, "DJI_0002.SRT": SPLIT_B})
     res = CliRunner().invoke(main, ["flightmap", str(tmp_path)])

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import os
 from datetime import datetime, timedelta
 
 from dji_metadata_embedder.geo.flightmap import (
@@ -243,6 +245,49 @@ def test_joined_flight_properties_carry_segments(tmp_path):
     kml = flights_to_kml(tracks, title="t")
     assert kml.count("<Placemark>") == 1
     assert "2 size-split files (DJI_0001 → DJI_0002)" in kml
+
+
+# mtime far outside any recording window (2000-01-01 UTC) so timezone
+# auto-detection is guaranteed to fail for the 2026-dated segments above.
+_BOGUS_MTIME = 946684800.0
+
+
+def test_scan_flights_explicit_tz_offset_resolves_utc(tmp_path):
+    path = _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    os.utime(path, (_BOGUS_MTIME, _BOGUS_MTIME))
+    tracks, _ = scan_flights(tmp_path, tz_offset=timedelta(hours=2))
+    # local 12:00:00 at UTC+2 -> 10:00:00 UTC
+    assert tracks[0].points[0].utc == T0 - timedelta(hours=2)
+
+
+def test_scan_flights_aggregates_tz_detection_warnings(tmp_path, caplog):
+    # Three distinct flights (hours apart, so never joined), all with mtimes
+    # a zip transfer rewrote: one summary warning, not one per file.
+    for i in range(3):
+        srt = _dt_srt(T0 + timedelta(hours=2 * i),
+                      [(10.0 + i, 20.0, 5.0), (10.001 + i, 20.0, 6.0)])
+        path = _write(tmp_path, f"DJI_000{i + 1}.SRT", srt)
+        os.utime(path, (_BOGUS_MTIME, _BOGUS_MTIME))
+    with caplog.at_level(logging.WARNING):
+        tracks, _ = scan_flights(tmp_path)
+    assert len(tracks) == 3
+    tz_warnings = [
+        r.message for r in caplog.records
+        if "Timezone auto-detection failed" in r.message
+    ]
+    assert len(tz_warnings) == 1
+    assert "3" in tz_warnings[0]
+    assert "--tz-offset" in tz_warnings[0]
+
+
+def test_scan_flights_tz_offset_silences_detection_warnings(tmp_path, caplog):
+    path = _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    os.utime(path, (_BOGUS_MTIME, _BOGUS_MTIME))
+    with caplog.at_level(logging.WARNING):
+        scan_flights(tmp_path, tz_offset=timedelta(hours=2))
+    assert not any(
+        "Timezone auto-detection failed" in r.message for r in caplog.records
+    )
 
 
 def test_writers_create_files(tmp_path):

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from dji_metadata_embedder.geo.flightmap import (
     flights_to_geojson,
@@ -121,6 +121,128 @@ def test_format_duration():
     assert format_duration(0) == "0:00"
     assert format_duration(243) == "4:03"
     assert format_duration(3723) == "1:02:03"
+
+
+def _dt_srt(start: datetime, coords: list[tuple[float, float, float]]) -> str:
+    """Datetime-carrying bracket SRT (Air 3-style), one block per second."""
+    blocks = []
+    for i, (lat, lon, alt) in enumerate(coords):
+        stamp = (start + timedelta(seconds=i)).strftime("%Y-%m-%d %H:%M:%S.000")
+        blocks.append(
+            f"{i + 1}\n00:00:{i:02d},000 --> 00:00:{i + 1:02d},000\n"
+            f'<font size="28">FrameCnt: {i + 1}, DiffTime: 1000ms\n'
+            f"{stamp}\n"
+            f"[iso: 100] [shutter: 1/500.0] [fnum: 1.8] [ev: 0] "
+            f"[focal_len: 24.00] [latitude: {lat}] [longitude: {lon}] "
+            f"[rel_alt: 1.000 abs_alt: {alt}] [ct: 5000] </font>\n"
+        )
+    return "\n".join(blocks)
+
+
+T0 = datetime(2026, 6, 15, 12, 0, 0)
+# Segment A ends at T0+2s / (34.00002, -84); B resumes 1 s later ~1 m away.
+SEG_A = _dt_srt(T0, [(34.0, -84.0, 100.0), (34.00001, -84.0, 101.0),
+                     (34.00002, -84.0, 102.0)])
+SEG_B = _dt_srt(T0 + timedelta(seconds=3),
+                [(34.00003, -84.0, 103.0), (34.00004, -84.0, 104.0)])
+SEG_C = _dt_srt(T0 + timedelta(seconds=5),
+                [(34.00005, -84.0, 105.0), (34.00006, -84.0, 106.0)])
+
+
+def test_join_chains_size_split_segments(tmp_path):
+    _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "DJI_0002.SRT", SEG_B)
+    tracks, skipped = scan_flights(tmp_path)
+    assert skipped == []
+    assert len(tracks) == 1
+    flight = tracks[0]
+    assert flight.name == "DJI_0001"
+    assert flight.segments == ["DJI_0001", "DJI_0002"]
+    assert len(flight.points) == 5
+    assert flight.points[-1].alt == 104.0  # B's points appended after A's
+
+
+def test_join_chains_three_segments(tmp_path):
+    _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "DJI_0002.SRT", SEG_B)
+    _write(tmp_path, "DJI_0003.SRT", SEG_C)
+    tracks, _ = scan_flights(tmp_path)
+    assert len(tracks) == 1
+    assert tracks[0].segments == ["DJI_0001", "DJI_0002", "DJI_0003"]
+    assert len(tracks[0].points) == 7
+
+
+def test_join_skips_nonconsecutive_file_numbers(tmp_path):
+    # Photos share DJI's numbering counter, so a split can jump 0001 -> 0003.
+    _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "DJI_0003.SRT", SEG_B)
+    tracks, _ = scan_flights(tmp_path)
+    assert len(tracks) == 1
+    assert tracks[0].segments == ["DJI_0001", "DJI_0003"]
+
+
+def test_no_join_when_time_gap_exceeds_threshold(tmp_path):
+    late = _dt_srt(T0 + timedelta(minutes=10), [(34.00003, -84.0, 103.0),
+                                                (34.00004, -84.0, 104.0)])
+    _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "DJI_0002.SRT", late)
+    tracks, _ = scan_flights(tmp_path)
+    assert [t.name for t in tracks] == ["DJI_0001", "DJI_0002"]
+    assert all(t.segments is None for t in tracks)
+
+
+def test_no_join_when_position_jumps(tmp_path):
+    far = _dt_srt(T0 + timedelta(seconds=3), [(34.1, -84.0, 103.0),
+                                              (34.10001, -84.0, 104.0)])  # ~11 km
+    _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "DJI_0002.SRT", far)
+    tracks, _ = scan_flights(tmp_path)
+    assert len(tracks) == 2
+
+
+def test_no_join_across_directories(tmp_path):
+    _write(tmp_path, "card1/DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "card2/DJI_0002.SRT", SEG_B)
+    tracks, _ = scan_flights(tmp_path, recursive=True)
+    assert len(tracks) == 2
+
+
+def test_no_join_without_srt_datetimes(tmp_path):
+    # Formats without a datetime line would leave gaps to be guessed from
+    # file mtimes, which copies rewrite — so they are never joined.
+    _write(tmp_path, "DJI_0001.SRT", FLIGHT_A)
+    _write(tmp_path, "DJI_0002.SRT", FLIGHT_A)
+    tracks, _ = scan_flights(tmp_path)
+    assert len(tracks) == 2
+
+
+def test_join_gap_zero_disables_joining(tmp_path):
+    _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "DJI_0002.SRT", SEG_B)
+    tracks, _ = scan_flights(tmp_path, join_gap=0)
+    assert len(tracks) == 2
+
+
+def test_join_applies_fuzz_after_joining(tmp_path):
+    # Fuzz rounds to ~100 m; joining first means the continuity check still
+    # sees the precise coordinates.
+    _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "DJI_0002.SRT", SEG_B)
+    tracks, _ = scan_flights(tmp_path, redact="fuzz")
+    assert len(tracks) == 1
+    assert all(p.lat == 34.0 and p.lon == -84.0 for p in tracks[0].points)
+
+
+def test_joined_flight_properties_carry_segments(tmp_path):
+    _write(tmp_path, "DJI_0001.SRT", SEG_A)
+    _write(tmp_path, "DJI_0002.SRT", SEG_B)
+    tracks, _ = scan_flights(tmp_path)
+    feature = flights_to_geojson(tracks)["features"][0]
+    assert feature["properties"]["segments"] == ["DJI_0001", "DJI_0002"]
+    assert feature["properties"]["duration_s"] == 4  # spans both segments
+    kml = flights_to_kml(tracks, title="t")
+    assert kml.count("<Placemark>") == 1
+    assert "2 size-split files (DJI_0001 → DJI_0002)" in kml
 
 
 def test_writers_create_files(tmp_path):

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -1,0 +1,131 @@
+import json
+from datetime import datetime
+
+from dji_metadata_embedder.geo.flightmap import (
+    flights_to_geojson,
+    flights_to_kml,
+    format_duration,
+    scan_flights,
+    write_flights_geojson,
+    write_flights_kml,
+)
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+
+def _bracket_srt(*coords: tuple[float, float, float]) -> str:
+    """Minimal bracket-format SRT with one block per (lat, lon, alt)."""
+    blocks = []
+    for i, (lat, lon, alt) in enumerate(coords):
+        blocks.append(
+            f"{i + 1}\n00:00:{i:02d},000 --> 00:00:{i + 1:02d},000\n"
+            f'<font size="28">[latitude: {lat}] [longitude: {lon}] '
+            f"[rel_alt: 1.000 abs_alt: {alt}]</font>\n"
+        )
+    return "\n".join(blocks)
+
+
+FLIGHT_A = _bracket_srt((10.0, 20.0, 5.0), (10.001, 20.001, 6.0))
+FLIGHT_B = _bracket_srt((11.0, 21.0, 7.0), (11.001, 21.001, 8.0))
+SINGLE_FIX = _bracket_srt((12.0, 22.0, 9.0))
+NOT_TELEMETRY = "1\n00:00:00,000 --> 00:00:01,000\nJust a movie subtitle\n"
+
+
+def _write(tmp_path, name, content):
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_scan_flights_builds_sorted_tracks_and_skips_non_telemetry(tmp_path):
+    _write(tmp_path, "DJI_0002.SRT", FLIGHT_B)
+    _write(tmp_path, "DJI_0001.SRT", FLIGHT_A)
+    _write(tmp_path, "movie.srt", NOT_TELEMETRY)
+    tracks, skipped = scan_flights(tmp_path)
+    assert [t.name for t in tracks] == ["DJI_0001", "DJI_0002"]
+    assert skipped == ["movie"]
+    assert tracks[0].points[0].lat == 10.0
+
+
+def test_scan_flights_non_recursive_ignores_subdirs(tmp_path):
+    _write(tmp_path, "sub/DJI_0001.SRT", FLIGHT_A)
+    tracks, skipped = scan_flights(tmp_path)
+    assert tracks == [] and skipped == []
+
+
+def test_scan_flights_recursive_labels_include_subdir(tmp_path):
+    _write(tmp_path, "session1/DJI_0001.SRT", FLIGHT_A)
+    _write(tmp_path, "session2/DJI_0001.SRT", FLIGHT_B)
+    tracks, _ = scan_flights(tmp_path, recursive=True)
+    assert [t.name for t in tracks] == ["session1/DJI_0001", "session2/DJI_0001"]
+
+
+def test_scan_flights_fuzz_coarsens_coordinates(tmp_path):
+    _write(tmp_path, "DJI_0001.SRT", _bracket_srt((10.123456, 20.654321, 5.0),
+                                                  (10.123999, 20.654999, 6.0)))
+    tracks, _ = scan_flights(tmp_path, redact="fuzz")
+    p = tracks[0].points[0]
+    assert (p.lat, p.lon) == (10.123, 20.654)
+
+
+def _tracks() -> list[Track]:
+    return [
+        Track(name="DJI_0001", points=[
+            TrackPoint(lat=10.0, lon=20.0, alt=5.0, timestamp="00:00:00,000",
+                       utc=datetime(2026, 6, 15, 12, 0, 0)),
+            TrackPoint(lat=10.001, lon=20.001, alt=6.5, timestamp="00:00:01,000",
+                       utc=datetime(2026, 6, 15, 12, 4, 3)),
+        ]),
+        Track(name="one_fix", points=[
+            TrackPoint(lat=12.0, lon=22.0, alt=9.0, timestamp="00:00:00,000")
+        ]),
+    ]
+
+
+def test_flights_to_geojson_one_feature_per_flight():
+    data = flights_to_geojson(_tracks())
+    assert data["type"] == "FeatureCollection"
+    line, point = data["features"]
+    assert line["geometry"]["type"] == "LineString"
+    assert line["geometry"]["coordinates"] == [[20.0, 10.0, 5.0], [20.001, 10.001, 6.5]]
+    props = line["properties"]
+    assert props["name"] == "DJI_0001"
+    assert props["start"] == "2026-06-15 12:00:00 UTC"
+    assert props["duration_s"] == 243
+    assert (props["alt_min"], props["alt_max"]) == (5.0, 6.5)
+    # RFC 7946 forbids a 1-position LineString: single-fix clips become Points.
+    assert point["geometry"] == {"type": "Point", "coordinates": [22.0, 12.0, 9.0]}
+    assert "start" not in point["properties"]  # no UTC -> no start/duration
+
+
+def test_flights_to_kml_one_placemark_per_flight():
+    kml = flights_to_kml(_tracks(), title="My flights")
+    assert kml.count("<Placemark>") == 2
+    assert "<name>My flights</name>" in kml
+    assert "<name>DJI_0001</name>" in kml
+    assert "duration: 4:03" in kml
+    assert "<LineString>" in kml and "<Point>" in kml
+    assert "20.0,10.0,5.0 20.001,10.001,6.5" in kml
+
+
+def test_flights_to_kml_escapes_names():
+    tracks = [Track(name="a<b&c", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=3.0, timestamp="00:00:00,000")])]
+    kml = flights_to_kml(tracks, title="t<&>")
+    assert "a<b&c" not in kml
+    assert "a&lt;b&amp;c" in kml
+    assert "t&lt;&amp;&gt;" in kml
+
+
+def test_format_duration():
+    assert format_duration(0) == "0:00"
+    assert format_duration(243) == "4:03"
+    assert format_duration(3723) == "1:02:03"
+
+
+def test_writers_create_files(tmp_path):
+    tracks = _tracks()
+    geo = write_flights_geojson(tracks, tmp_path / "f.geojson")
+    kml = write_flights_kml(tracks, tmp_path / "f.kml", title="t")
+    assert json.loads(geo.read_text(encoding="utf-8"))["type"] == "FeatureCollection"
+    assert "<kml" in kml.read_text(encoding="utf-8")

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -1,0 +1,90 @@
+import json
+import re
+from datetime import datetime
+
+from dji_metadata_embedder.geo.flightmap_html import flights_to_html, write_flights_html
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+TRACKS = [
+    Track(name="DJI_0001", points=[
+        TrackPoint(lat=10.0, lon=20.0, alt=5.0, timestamp="00:00:00,000",
+                   utc=datetime(2026, 6, 15, 12, 0, 0)),
+        TrackPoint(lat=10.001, lon=20.001, alt=6.5, timestamp="00:00:01,000",
+                   utc=datetime(2026, 6, 15, 12, 1, 0)),
+    ]),
+    Track(name="DJI_0002", points=[
+        TrackPoint(lat=11.0, lon=21.0, alt=7.0, timestamp="00:00:00,000"),
+        TrackPoint(lat=11.001, lon=21.001, alt=8.0, timestamp="00:00:01,000"),
+    ]),
+]
+
+_DATA_RE = re.compile(
+    r'<script type="application/json" id="flight-data">(.*?)</script>',
+    re.DOTALL,
+)
+
+
+def _embedded_geojson(html: str) -> dict:
+    match = _DATA_RE.search(html)
+    assert match, "flight-data script block not found"
+    return json.loads(match.group(1))
+
+
+def test_html_embeds_one_feature_per_flight():
+    html = flights_to_html(TRACKS, title="Summer flights")
+    data = _embedded_geojson(html)
+    names = [f["properties"]["name"] for f in data["features"]]
+    assert names == ["DJI_0001", "DJI_0002"]
+    assert all(f["geometry"]["type"] == "LineString" for f in data["features"])
+
+
+def test_html_is_self_contained_document_with_pinned_libs():
+    html = flights_to_html(TRACKS, title="Summer flights")
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    assert 'id="map"' in html
+    assert "leaflet@1.9.4" in html
+    # Both remote assets (leaflet css + js) carry SRI pins.
+    assert html.count('integrity="sha256-') == 2
+    assert "Summer flights" in html
+
+
+def test_html_escapes_script_close_in_data():
+    evil = [Track(name="x</script>y", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=3.0, timestamp="00:00:00,000")])]
+    html = flights_to_html(evil, title="t")
+    data_block = _DATA_RE.search(html).group(1)
+    assert "</script>" not in data_block.lower()
+    assert json.loads(data_block)["features"][0]["properties"]["name"] == "x</script>y"
+
+
+def test_html_popup_js_escapes_text_fields():
+    # Popup text (name/start) is inserted via the esc() helper so a hostile
+    # filename cannot inject HTML into the popup or the layer control.
+    html = flights_to_html(TRACKS, title="t")
+    for applied in ("esc(p.name", "esc(p.start"):
+        assert applied in html
+
+
+def test_html_draws_tracks_with_layer_control():
+    html = flights_to_html(TRACKS, title="t")
+    assert "L.polyline" in html
+    assert "L.control.layers" in html
+    assert "PALETTE" in html
+
+
+def test_html_empty_tracks_still_valid_document():
+    html = flights_to_html([], title="t")
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    assert _embedded_geojson(html)["features"] == []
+
+
+def test_html_title_is_escaped():
+    html = flights_to_html(TRACKS, title="<script>x")
+    assert "<script>x" not in html
+
+
+def test_write_flights_html(tmp_path):
+    out = tmp_path / "flightmap.html"
+    result = write_flights_html(TRACKS, out, title="t")
+    assert result == out
+    assert "<!DOCTYPE html>" in out.read_text(encoding="utf-8")

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -58,11 +58,21 @@ def test_html_escapes_script_close_in_data():
 
 
 def test_html_popup_js_escapes_text_fields():
-    # Popup text (name/start) is inserted via the esc() helper so a hostile
-    # filename cannot inject HTML into the popup or the layer control.
+    # Popup text (name/start/segments) is inserted via the esc() helper so a
+    # hostile filename cannot inject HTML into the popup or the layer control.
     html = flights_to_html(TRACKS, title="t")
-    for applied in ("esc(p.name", "esc(p.start"):
+    for applied in ("esc(p.name", "esc(p.start", "esc(p.segments[0]"):
         assert applied in html
+
+
+def test_html_embeds_segments_for_joined_flights():
+    joined = [Track(name="DJI_0001", segments=["DJI_0001", "DJI_0002"], points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=3.0, timestamp="00:00:00,000"),
+        TrackPoint(lat=1.001, lon=2.001, alt=4.0, timestamp="00:00:01,000"),
+    ])]
+    html = flights_to_html(joined, title="t")
+    props = _embedded_geojson(html)["features"][0]["properties"]
+    assert props["segments"] == ["DJI_0001", "DJI_0002"]
 
 
 def test_html_draws_tracks_with_layer_control():


### PR DESCRIPTION
## Summary

The photomap feature has been getting attention (mavicpilots.com), but the video side had a gap: `photomap` maps a whole folder of photos onto **one** map, while videos only got one separate HTML map per clip (`convert html --batch`). This PR closes that gap and makes the map features discoverable in the README.

### New: `dji-embed flightmap DIR`

- Scans a folder (optionally `-r` recursive) for `.SRT` telemetry sidecars **only** — the videos are never opened and no external tool is needed, so archive-scale folders map in seconds.
- Draws every flight as its own coloured track on one standalone HTML map: start marker, summary popup (start time, duration, altitude range, GPS points), and a per-flight layer toggle.
- `-f kml` → one path placemark per flight (imports into Google Earth / Google My Maps as separate lines); `-f geojson` → one `LineString` feature per flight with the same summary properties (single-fix clips degrade to `Point` per RFC 7946); `-f all` for all three.
- `--redact fuzz` coarsens every track to ~100 m for shareable maps; mirrors `photomap`'s `-o`/`-r`/`--title` UX, including relative-path flight labels on recursive scans so DJI's restarting file numbering stays distinct.
- Non-telemetry SRTs (ordinary subtitles, no-fix clips) are skipped and counted; `-v` lists them. Sidecar-less models (Air 3S, Mini 5 Pro) are documented as out of scope — `convert html VIDEO.MP4` covers those per clip.
- Same self-contained HTML contract as `html_viewer`/`photomap_html`: embedded GeoJSON data block, pinned Leaflet 1.9.4 with SRI hashes, escaped `</script>` and popup text.

### Size-split recordings are stitched back into one flight

DJI closes the MP4/SRT pair at the 4 GB file limit and keeps recording into the next numbered file, so a long flight arrives as several files. `flightmap` chains consecutive segments into one flight when they sit in the same directory, the next file's telemetry starts within `--join-gap` seconds (default 15) of the previous one ending, **and** the track resumes within plausible flying distance (50 m jitter floor + 30 m/s × gap). Design points:

- Gaps are measured on the SRT's own per-block datetimes — never file mtimes, which zip/cloud transfers rewrite. Formats without a datetime line are never joined for the same reason.
- Consecutive file numbers are deliberately not required: photos share DJI's numbering counter, so a split can legitimately jump `DJI_0010` → `DJI_0012`.
- The appended segment's clock is rebased across the join, so the combined duration stays correct even when timezone auto-detection fails (copied archives).
- Joined flights keep the first segment's name; the HTML popup, KML description, and GeoJSON `segments` property list the source files. The CLI reports `Joined N size-split files into M flights`. `--join-gap 0` disables.
- Fuzz redaction is applied *after* joining so coarsened coordinates can't break the continuity check.

### Docs

- New README **"Put Your Flights and Photos on a Map"** usage section walking through `convert html` (single clip, MP4 input, `--batch`) → `flightmap` (combined) → `photomap` (photos), plus a full `flightmap` CLI-reference entry and parallel Feature bullets.
- `docs/geospatial.md` gains a "Combined flight map" section incl. the size-split joining rules; `docs/decision-table.md` gains the flightmap rows.

### Testing

- 41 tests for the feature: scanner (sorting, recursion labels, fuzz, non-telemetry skip), split joining (2- and 3-way chains, number-skipping, time/position/directory/no-datetime rejections, `--join-gap 0`, fuzz-after-join, cross-segment duration), GeoJSON/KML writers, HTML renderer (embedded data, SRI pins, escaping), and CLI end-to-end.
- `uv run pytest -q`: 411 passed. `ruff check`: clean.
- Verified end-to-end: generated a folder where one flight spans `DJI_0010`/`DJI_0012`/`DJI_0013` (photo consumed `0011`) plus a separate flight 2 h later — the CLI joined exactly the first three (7 points, correct 8 s duration despite deliberately broken mtimes) and kept the later flight separate. Also rendered the HTML in headless Chromium: polylines, start markers, popups, and layer control all working.

## Checklist
- [x] Tests added/updated for new functionality
- [x] Documentation updated (README, geospatial.md, decision-table.md)
- [x] Cross-platform compatibility (pure-Python SRT scan, case-insensitive glob handling)
- [x] No breaking changes to existing functionality
- [x] Conventional commit format used in PR title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dTh5o3nPcia6P1QEdPD73