### PR TITLE
fix(flightmap): popup accuracy, 1 Hz display thinning, truncated-block guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,9 @@ Notes:
   position) where the previous one ended — measured on the SRT's own
   timestamps, so it survives copied files with rewritten mtimes. The popup
   lists the joined files; tune or disable with `--join-gap`.
+- Tracks are thinned to ~1 GPS point per second for the map (DJI logs ~30
+  per second) — visually identical but far smaller files; use
+  `dji-embed convert` on a single flight when you need every sample.
 - Popup start times are converted to UTC using each file's mtime. On archives
   whose mtimes were rewritten (zip/cloud transfers) the tool warns once and
   falls back to the mtime; pass `--tz-offset` with your recording timezone to

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -169,6 +169,12 @@ summary properties (no per-sample points — at archive scale they would swamp
 the file); the KML is one path placemark per flight, which Google Earth and
 Google My Maps import as separate lines.
 
+DJI logs one GPS point per video frame (~30 Hz), so `flightmap` thins every
+track to about one point per second (always keeping the exact first and last
+fix) — visually identical, but a 400-file archive drops from ~70 MB to a few
+MB of HTML. Your SRT files are untouched; for full-rate output of a single
+flight use `dji-embed convert` instead.
+
 SRT files without GPS telemetry (ordinary subtitles, clips that never got a
 fix) are skipped and counted; `-v` lists them. With `-r`, flights are labelled
 by their path relative to the scanned folder so per-session directories that

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -513,7 +513,7 @@ def flightmap(
         if joined:
             files_joined = sum(len(t.segments or []) for t in joined)
             click.echo(
-                f"Joined {files_joined} size-split files into "
+                f"Joined {files_joined} files into "
                 f"{len(joined)} flight{'s' if len(joined) != 1 else ''}"
             )
     map_title = title or src.resolve().name

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -20,7 +20,7 @@ from xml.sax.saxutils import escape
 from .. import utilities
 from ..utilities import load_samples, redact_coords
 from .geometry import haversine_m
-from .track import Track, build_track_from_samples
+from .track import Track, TrackPoint, build_track_from_samples
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +130,35 @@ def join_split_flights(
     return [e.track for e in flights]
 
 
+# DJI logs one GPS point per video frame (~30 Hz); at archive scale that
+# balloons the combined map (398 files -> 72 MB HTML) with detail the eye
+# cannot see. Display output keeps ~1 point per second.
+_DISPLAY_INTERVAL_S = 1.0
+
+
+def _decimate_points(
+    points: list[TrackPoint], interval_s: float = _DISPLAY_INTERVAL_S
+) -> list[TrackPoint]:
+    """Thin *points* to at most one per *interval_s*, keeping first and last.
+
+    Timing comes from each point's resolved UTC; points without one are kept
+    (no basis for thinning). Must run *after* split-joining — the continuity
+    check needs the raw boundary fixes.
+    """
+    if len(points) <= 2:
+        return points
+    kept = [points[0]]
+    for p in points[1:-1]:
+        if (
+            p.utc is None
+            or kept[-1].utc is None
+            or (p.utc - kept[-1].utc).total_seconds() >= interval_s
+        ):
+            kept.append(p)
+    kept.append(points[-1])
+    return kept
+
+
 class _TzWarningAggregator(logging.Filter):
     """Collapse per-file timezone auto-detection warnings into one summary.
 
@@ -218,6 +247,8 @@ def scan_flights(
         tracks = join_split_flights(entries, max_gap_s=join_gap)
     else:
         tracks = [e.track for e in entries]
+    for track in tracks:
+        track.points = _decimate_points(track.points)
     if redact == "fuzz":
         for track in tracks:
             coords = redact_coords([(p.lat, p.lon) for p in track.points], "fuzz")
@@ -328,7 +359,7 @@ def flights_to_kml(tracks: list[Track], title: str) -> str:
         desc.append(f"{props['points']} GPS points")
         if track.segments:
             desc.append(
-                f"{len(track.segments)} size-split files "
+                f"recorded across {len(track.segments)} files "
                 f"({track.segments[0]} → {track.segments[-1]})"
             )
         if len(track.points) >= 2:

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -248,6 +248,12 @@ def _flight_properties(track: Track) -> dict:
     alts = [p.alt for p in track.points]
     props["alt_min"] = round(min(alts), 1)
     props["alt_max"] = round(max(alts), 1)
+    # DJI's abs_alt reference varies by model and can sit far below sea level,
+    # so popups prefer height above takeoff whenever the format carries it.
+    rels = [p.rel_alt for p in track.points if p.rel_alt is not None]
+    if rels:
+        props["height_min"] = round(min(rels), 1)
+        props["height_max"] = round(max(rels), 1)
     if track.segments:
         props["segments"] = track.segments
     return props
@@ -309,7 +315,16 @@ def flights_to_kml(tracks: list[Track], title: str) -> str:
         desc = [props.get("start")]
         if "duration_s" in props:
             desc.append(f"duration: {format_duration(props['duration_s'])}")
-        desc.append(f"altitude: {props['alt_min']:g} - {props['alt_max']:g} m")
+        if "height_min" in props:
+            desc.append(
+                f"height: {props['height_min']:g} to "
+                f"{props['height_max']:g} m above takeoff"
+            )
+        else:
+            desc.append(
+                f"altitude: {props['alt_min']:g} to "
+                f"{props['alt_max']:g} m (as logged)"
+            )
         desc.append(f"{props['points']} GPS points")
         if track.segments:
             desc.append(

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -92,7 +92,7 @@ function popupHtml(p) {
   }
   html += `<br>${p.points} GPS point${p.points === 1 ? '' : 's'}`;
   if (p.segments) {
-    html += `<br>${p.segments.length} size-split files: ` +
+    html += `<br>recorded across ${p.segments.length} files: ` +
             `${esc(p.segments[0])} → ${esc(p.segments[p.segments.length - 1])}`;
   }
   html += '</div>';

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -85,7 +85,11 @@ function popupHtml(p) {
   let html = `<div class="flight-popup"><b>${esc(p.name || '')}</b>`;
   if (p.start) html += `<br>${esc(p.start)}`;
   if (p.duration_s != null) html += `<br>duration: ${fmtDuration(p.duration_s)}`;
-  if (p.alt_min != null) html += `<br>altitude: ${p.alt_min}–${p.alt_max} m`;
+  if (p.height_min != null) {
+    html += `<br>height: ${p.height_min} to ${p.height_max} m above takeoff`;
+  } else if (p.alt_min != null) {
+    html += `<br>altitude: ${p.alt_min} to ${p.alt_max} m (as logged)`;
+  }
   html += `<br>${p.points} GPS point${p.points === 1 ? '' : 's'}`;
   if (p.segments) {
     html += `<br>${p.segments.length} size-split files: ` +

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -202,6 +202,13 @@ def parse_telemetry_samples(srt_path: Path) -> List[TelemetrySample]:
         lat_match = re.search(r"\[latitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
         lon_match = re.search(r"\[longitude:\s*([+-]?\d+\.?\d*)\]", tele_line)
         alt_match = re.search(r"abs_alt:\s*([+-]?\d+\.?\d*)\]", tele_line)
+        if lat_match and lon_match and alt_match is None:
+            # Every documented bracket format carries abs_alt right after the
+            # coordinates, so its absence means the block was cut mid-write
+            # (drone powered off while flushing the final block). Drop the
+            # sample rather than fabricate alt=0.0. The GPS(...) compact form
+            # (no abs_alt token at all) takes the branch below instead.
+            continue
         if not (lat_match and lon_match):
             # Tolerate optional altitude unit suffix (M300 ``0.0M``) and an
             # optional space before ``(`` used by the P4 RTK compact format.

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -178,7 +178,7 @@ def test_flightmap_joins_size_split_recordings(tmp_path):
     res = CliRunner().invoke(main, ["flightmap", str(tmp_path)])
     assert res.exit_code == 0, res.output
     assert "Mapped 1 flight" in res.output
-    assert "Joined 2 size-split files into 1 flight" in res.output
+    assert "Joined 2 files into 1 flight" in res.output
     text = (tmp_path / "flightmap.html").read_text(encoding="utf-8")
     assert '"segments": ["DJI_0001", "DJI_0002"]' in text
 

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -119,6 +119,48 @@ def test_flights_to_kml_escapes_names():
     assert "t&lt;&amp;&gt;" in kml
 
 
+def test_flight_properties_prefer_relative_height():
+    # DJI's abs_alt reference is unreliable (can sit far below sea level), so
+    # when the format carries rel_alt the popup fields use height-above-takeoff.
+    track = Track(name="f", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=-125.6, timestamp="00:00:00,000",
+                   rel_alt=1.2),
+        TrackPoint(lat=1.001, lon=2.001, alt=-66.8, timestamp="00:00:01,000",
+                   rel_alt=96.4),
+    ])
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert (props["height_min"], props["height_max"]) == (1.2, 96.4)
+    # abs alt stays available for GeoJSON consumers
+    assert (props["alt_min"], props["alt_max"]) == (-125.6, -66.8)
+
+
+def test_flight_properties_without_rel_alt_have_no_height():
+    props = flights_to_geojson(_tracks())["features"][0]["properties"]
+    assert "height_min" not in props
+
+
+def test_kml_relative_height_preferred_and_readable():
+    track = Track(name="f", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=-125.6, timestamp="00:00:00,000",
+                   rel_alt=1.2),
+        TrackPoint(lat=1.001, lon=2.001, alt=-66.8, timestamp="00:00:01,000",
+                   rel_alt=96.4),
+    ])
+    kml = flights_to_kml([track], title="t")
+    assert "height: 1.2 to 96.4 m above takeoff" in kml
+
+
+def test_kml_negative_altitude_range_readable():
+    # Without rel_alt the abs range must not render as "-125.6--66.8 m".
+    track = Track(name="f", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=-125.6, timestamp="00:00:00,000"),
+        TrackPoint(lat=1.001, lon=2.001, alt=-66.8, timestamp="00:00:01,000"),
+    ])
+    kml = flights_to_kml([track], title="t")
+    assert "altitude: -125.6 to -66.8 m (as logged)" in kml
+    assert "--" not in kml.split("<description>")[1].split("</description>")[0]
+
+
 def test_format_duration():
     assert format_duration(0) == "0:00"
     assert format_duration(243) == "4:03"

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -286,7 +286,50 @@ def test_joined_flight_properties_carry_segments(tmp_path):
     assert feature["properties"]["duration_s"] == 4  # spans both segments
     kml = flights_to_kml(tracks, title="t")
     assert kml.count("<Placemark>") == 1
-    assert "2 size-split files (DJI_0001 → DJI_0002)" in kml
+    # Neutral wording: joins also catch quick stop/start re-records, so the
+    # description must not claim the files were size-splits.
+    assert "recorded across 2 files (DJI_0001 → DJI_0002)" in kml
+    assert "size-split" not in kml
+
+
+def _hz30_srt(start: datetime, seconds: float, lat0: float = 34.0) -> str:
+    """30 Hz datetime-carrying SRT: one block per video frame, drifting north."""
+    blocks = []
+    n = int(seconds * 30)
+    for i in range(n):
+        t = start + timedelta(seconds=i / 30)
+        stamp = t.strftime("%Y-%m-%d %H:%M:%S.") + f"{t.microsecond // 1000:03d}"
+        cue_s, cue_ms = divmod(int(i * 1000 / 30), 1000)
+        blocks.append(
+            f"{i + 1}\n00:00:{cue_s:02d},{cue_ms:03d} --> 00:00:{cue_s:02d},{cue_ms + 33:03d}\n"
+            f'<font size="28">FrameCnt: {i + 1}, DiffTime: 33ms\n'
+            f"{stamp}\n"
+            f"[latitude: {lat0 + i * 1e-6:.6f}] [longitude: -84.0] "
+            f"[rel_alt: 1.000 abs_alt: 100.0]</font>\n"
+        )
+    return "\n".join(blocks)
+
+
+def test_scan_flights_decimates_to_one_point_per_second(tmp_path):
+    # 5 s of 30 Hz telemetry = 150 raw points; the map keeps ~1 Hz plus the
+    # exact first and last fix so archive-scale HTML stays small.
+    _write(tmp_path, "DJI_0001.SRT", _hz30_srt(T0, 5.0))
+    tracks, _ = scan_flights(tmp_path)
+    pts = tracks[0].points
+    assert len(pts) <= 7
+    assert pts[0].lat == 34.0                       # first fix kept verbatim
+    assert pts[-1].lat == 34.0 + 149 * 1e-6         # last fix kept verbatim
+
+
+def test_decimation_does_not_break_split_joining(tmp_path):
+    # Continuity is checked on raw boundary points before decimation.
+    _write(tmp_path, "DJI_0001.SRT", _hz30_srt(T0, 2.0))
+    _write(tmp_path, "DJI_0002.SRT",
+           _hz30_srt(T0 + timedelta(seconds=2), 2.0, lat0=34.0 + 60 * 1e-6))
+    tracks, _ = scan_flights(tmp_path)
+    assert len(tracks) == 1
+    assert tracks[0].segments == ["DJI_0001", "DJI_0002"]
+    assert len(tracks[0].points) <= 8               # ~4 s at 1 Hz + endpoints
 
 
 # mtime far outside any recording window (2000-01-01 UTC) so timezone

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -75,6 +75,28 @@ def test_html_embeds_segments_for_joined_flights():
     assert props["segments"] == ["DJI_0001", "DJI_0002"]
 
 
+def test_html_popup_prefers_relative_height_and_readable_ranges():
+    # The popup JS must show rel-alt height when present and join ranges with
+    # " to " so negative abs altitudes don't render as "-125.6--66.8 m".
+    html = flights_to_html(TRACKS, title="t")
+    assert "p.height_min" in html
+    assert "m above takeoff" in html
+    assert "}–${" not in html  # old en-dash range join
+
+
+def test_html_embeds_height_properties_from_rel_alt():
+    tracks = [Track(name="f", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=-125.6, timestamp="00:00:00,000",
+                   rel_alt=1.2),
+        TrackPoint(lat=1.001, lon=2.001, alt=-66.8, timestamp="00:00:01,000",
+                   rel_alt=96.4),
+    ])]
+    props = _embedded_geojson(flights_to_html(tracks, title="t"))["features"][0][
+        "properties"
+    ]
+    assert (props["height_min"], props["height_max"]) == (1.2, 96.4)
+
+
 def test_html_draws_tracks_with_layer_control():
     html = flights_to_html(TRACKS, title="t")
     assert "L.polyline" in html

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -75,6 +75,14 @@ def test_html_embeds_segments_for_joined_flights():
     assert props["segments"] == ["DJI_0001", "DJI_0002"]
 
 
+def test_html_popup_neutral_join_wording():
+    # Joins also catch quick stop/start re-records, so the popup must not
+    # claim the files were size-splits.
+    html = flights_to_html(TRACKS, title="t")
+    assert "recorded across" in html
+    assert "size-split" not in html
+
+
 def test_html_popup_prefers_relative_height_and_readable_ranges():
     # The popup JS must show rel-alt height when present and join ranges with
     # " to " so negative abs altitudes don't render as "-125.6--66.8 m".

--- a/tests/test_parse_samples.py
+++ b/tests/test_parse_samples.py
@@ -38,6 +38,35 @@ def test_samples_datetime_none_when_absent(tmp_path):
     assert all(s.dt is None for s in samples)
 
 
+def test_truncated_final_block_is_dropped(tmp_path):
+    # A drone powered off mid-write leaves the last block cut inside the
+    # altitude tokens. Real case: DJI_0209 ends "...[latitude: X] [longitude:
+    # Y] [rel_". The sample must be dropped, not given a fabricated alt=0.0.
+    truncated = NODT_SRT + (
+        "\n3\n00:00:02,000 --> 00:00:03,000\n"
+        '<font size="28">[latitude: 12.0] [longitude: 22.0] [rel_'
+    )
+    srt = tmp_path / "cut.SRT"
+    srt.write_text(truncated, encoding="utf-8")
+    samples = parse_telemetry_samples(srt)
+    assert len(samples) == 2
+    assert all(s.alt != 0.0 for s in samples)
+
+
+def test_gps_compact_form_without_abs_alt_still_parses(tmp_path):
+    # Avata 2-style GPS(lat,lon,alt) has no abs_alt token; the altitude comes
+    # from the GPS() group and must survive the truncated-block guard.
+    srt = tmp_path / "avata.SRT"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:00,033\n"
+        "GPS(39.906217,116.391305,69.800) BAROMETER(91.2)\n",
+        encoding="utf-8",
+    )
+    samples = parse_telemetry_samples(srt)
+    assert len(samples) == 1
+    assert samples[0].alt == 69.8
+
+
 def test_parse_telemetry_points_is_unchanged_wrapper():
     # The legacy 4-tuple API must be byte-for-byte the same as before.
     pts = parse_telemetry_points(CLIP)


### PR DESCRIPTION
## Summary

Popup fixes plus archive-scale follow-ups, all validated against a real 398-file / 90-photo archive.

**Popup accuracy** (first commit):
- Unreadable negative ranges (`altitude: -125.6--66.8 m`) → ranges join with ` to `.
- When the SRT carries `rel_alt`, popups/KML show `height: -8.6 to 49.7 m above takeoff` instead of DJI's unreliably-referenced `abs_alt`; abs stays in GeoJSON properties and as the labelled fallback. New additive properties `height_min`/`height_max`.

**Archive-scale polish** (second commit):
- **~1 point/second display thinning** (exact first/last fix kept): DJI logs ~30 GPS points/s, which ballooned the combined HTML to 72 MB on a 398-file archive — now 2.5 MB, visually identical. Runs after split-joining so continuity checks see raw fixes.
- **Neutral join wording** (`recorded across N files`): measuring 136 real joins showed 115 true sub-half-second 4 GB splits but 13 quick stop/start re-records — the old "size-split files" label overstated.
- **Truncated-block guard**: a real archive contained a file cut mid-write (`...[longitude: Y] [rel_` then EOF); the parser now drops that sample instead of fabricating `alt=0.0`. Avata 2's `GPS(...)` form (no abs_alt token) is regression-tested.

## Testing

- 11 new tests across parser, scanner, writers, HTML, CLI; `uv run pytest -q`: 430 passed. mypy + ruff clean.
- E2E on the real archive: 260 flights, identical joins before/after thinning, 72 MB → 2.5 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzdmWshjLXZadKs8CpS5bo