### PR TITLE
feat(photomap): --serve local map server; clear error for file:// pano viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ dji-embed photomap /path/to/photos -r --title "Churches of Finland"   # recurse 
 dji-embed photomap /path/to/photos --link-originals                   # popups open the original photos
 dji-embed photomap /path/to/photos --link-originals --link-base ../DCIM   # originals live elsewhere
 dji-embed photomap /path/to/photos --redact fuzz                      # ~100 m coarsened pins
+dji-embed photomap /path/to/photos --serve                            # serve + open browser (360° viewer works)
 ```
 
 <details>
@@ -469,6 +470,8 @@ Options:
                                   beside the HTML
   --redact [none|fuzz]            Coarsen every photo location to ~100 m
                                   before writing (default: none)
+  --serve                         Serve the map on 127.0.0.1 and open the
+                                  browser (implies --link-originals)
   -v, --verbose                   Verbose output
   -q, --quiet                     Suppress info output
 ```
@@ -491,8 +494,10 @@ Notes:
   (a relative folder like `../DCIM`, or an absolute URL). Browsers download
   rather than display DNG files; JPGs open in a new tab.
 - 360° panoramas (DJI, Insta360, Google Camera, …) are detected during the
-  same scan; with `--link-originals`, clicking one opens an embedded
-  interactive viewer instead of a flat, distorted JPEG.
+  same scan; clicking one opens an embedded interactive viewer instead of a
+  flat, distorted JPEG when the map is served with `--serve` (or opened over
+  HTTP with `--link-originals`) — browsers block the viewer on maps opened
+  straight from disk.
 - `--redact fuzz` coarsens every pin to ~100 m before the map is written —
   use it for maps you plan to share. Combined with `--link-originals`, the
   linked originals still carry exact GPS in their EXIF, so share those

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -253,10 +253,26 @@ popup as a fallback.
 dji-embed photomap /path/to/panoramas --link-originals
 ```
 
+The simplest way to use the viewer is `--serve` (it implies
+`--link-originals`):
+
+```bash
+dji-embed photomap /path/to/panoramas --serve
+```
+
+This writes the map, serves its folder at a private local address
+(`http://127.0.0.1:<port>` — reachable only from your own computer), and
+opens it in your browser. Press Ctrl+C in the terminal to stop.
+
 Notes:
 
-- Without `--link-originals` the map is unchanged — the viewer needs the
-  original files to be reachable from the HTML.
+- Opened straight from disk (double-clicking `photomap.html`), the 360°
+  viewer is blocked by the browser — `file://` pages may not feed local
+  images to WebGL. The map shows a short explanation instead; use `--serve`
+  and the viewer works. The "open original" link works either way.
+- Without `--link-originals` (or `--serve`, which implies it) the map is
+  unchanged — the viewer needs the original files to be reachable from the
+  HTML.
 - Very large panoramas can exceed a device's WebGL texture size (phones are
   often limited to 8192 px wide); the viewer shows an error in that case and
   the "open original" link still works.

--- a/docs/superpowers/specs/2026-07-14-photomap-serve-design.md
+++ b/docs/superpowers/specs/2026-07-14-photomap-serve-design.md
@@ -1,0 +1,129 @@
+# Photomap `--serve` + friendly `file://` pano error — design
+
+**Date:** 2026-07-14
+**Issue:** [#274](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/274)
+**Status:** Approved
+
+## Problem
+
+The #271 panorama viewer (PR #272, unreleased) fails when `photomap.html` is
+opened directly from disk — the default double-click workflow. Browsers give
+every `file://` document an opaque origin, so WebGL is refused pixel access
+to the linked panorama and Pannellum shows a raw "The file ... could not be
+accessed" error. The "open original" fallback works (plain navigation is
+allowed; only WebGL texture reads are blocked).
+
+Verified with a real 12000×6000 equirectangular JPEG: the identical map fails
+from `file://` and works over `http://localhost`. The wiring is correct; the
+protocol is the problem.
+
+## Scope
+
+Two parts, one PR:
+
+1. A clear in-page message when a pano is clicked from `file://`.
+2. A `--serve` flag on `photomap` that serves the map over local HTTP and
+   opens the browser — making `dji-embed photomap <folder> --serve` the
+   complete one-liner for the pano-viewer experience.
+
+Out of scope: `flightmap` (no linked assets — unaffected by `file://`),
+serving directories other than the output folder, daemon/background mode,
+port selection flags (YAGNI until someone asks).
+
+## Design
+
+### 1. Friendly `file://` message — `geo/photomap_html.py`
+
+In `_PANO_JS`'s `openPano(src)`, before creating the viewer:
+
+- If `location.protocol === 'file:'`, do **not** call `pannellum.viewer`.
+  Instead show the overlay with a styled message in the `#pano-viewer`
+  container (static text, no user data — no escaping concerns):
+
+  > 360° view is blocked by the browser for maps opened straight from disk.
+  > Use the "open original" link in the popup, or rebuild the map with:
+  > `dji-embed photomap <your folder> --serve`
+
+- Close button and Escape already tear the overlay down; `closePano()` must
+  clear the injected message so a later HTTP-served viewer isn't mixed with
+  stale text (simplest: `openPano` sets the container's content each time —
+  message text on the `file:` branch, empty before `pannellum.viewer()` on
+  the normal branch; Pannellum owns the container from there).
+- Emitted only inside `_PANO_JS`, which is already gated on
+  `link_base is not None and any(p.is_pano)` — maps without panos are
+  byte-for-byte unchanged.
+
+### 2. `--serve` — `cli.py` + new `geo/serve.py`
+
+New module `src/dji_metadata_embedder/geo/serve.py`:
+
+```python
+def serve_directory(directory: Path, filename: str, *, quiet: bool = False,
+                    log_requests: bool = False, open_browser: bool = True) -> None
+```
+
+- `ThreadingHTTPServer` + `SimpleHTTPRequestHandler` via
+  `functools.partial(SimpleHTTPRequestHandler, directory=str(directory))`.
+- Binds `("127.0.0.1", 0)` — **loopback only**, OS-assigned free port.
+  Never `0.0.0.0`.
+- Prints `Serving map at http://127.0.0.1:<port>/<filename> — press Ctrl+C
+  to stop`. The URL line is printed even under `--quiet` (it is the product
+  of the command); only the closing "Stopped." note honours quiet.
+- Opens `webbrowser.open(url)` unless `open_browser=False` (tests).
+- `serve_forever()` until `KeyboardInterrupt`, then clean shutdown and a
+  short "Stopped." note (suppressed by `--quiet`).
+- Request logging: subclass the handler to silence `log_message` unless
+  verbose logging is enabled (pass a `log_requests: bool`).
+
+CLI wiring in the `photomap` command:
+
+- New flag after `--redact`: `--serve` / `is_flag=True`, help: "After
+  writing the map, serve its folder on localhost and open the browser
+  (implies --link-originals; needed for the 360° viewer when opening the
+  map from disk would be blocked)".
+- `--serve` sets `link_originals = True` (silently — it's documented
+  behaviour, not a surprise).
+- Guard: `--serve` with `-f kml` or `-f geojson` → `click.UsageError`
+  ("--serve requires the HTML map (use -f html or -f all)").
+- Warn (stderr, non-fatal) when `--serve` is combined with `--link-base`:
+  the links then point away from the served folder and may not resolve
+  through the local server.
+- Serve directory = the parent of the written HTML output (`out.parent` /
+  `base.parent`), filename = the HTML file's name — correct for both the
+  default (`<dir>/photomap.html`) and `-o elsewhere/map.html`. With `-o`
+  outside the photo folder and no `--link-base`, relative links break
+  exactly as they do without `--serve`; existing docs already cover it.
+- Runs after all formats are written (`-f all` writes kml/geojson first,
+  then serves).
+
+### 3. Docs
+
+- `docs/geospatial.md` (360° section): rewrite the caveat list around the
+  local-file case — "opened straight from disk, the 360° viewer is blocked
+  by the browser; run with `--serve`" — keep the texture-limit and CORS
+  (`--link-base` URL) notes.
+- README + `docs/user_guide.md`: add `--serve` to the photomap option
+  table/examples; the EyesWideShut-shaped example is
+  `dji-embed photomap C:\photos --serve`.
+
+## Testing
+
+- `tests/test_geo_serve.py` (real server, no mocks): start on port 0 against
+  a tmp dir with an html + jpg; GET both → 200 and correct bytes; assert the
+  bound address is `127.0.0.1`; `open_browser=False`; shutdown cleanly from
+  the test thread.
+- CLI tests (`tests/test_cli_photomap.py`, `serve_directory` +
+  `webbrowser` mocked): `--serve` implies links (`"link"` present in the
+  written HTML's GeoJSON); `--serve -f kml` fails with the usage error;
+  `--serve --link-base x` warns; `serve_directory` called with the HTML's
+  parent dir and filename.
+- HTML tests (`tests/test_geo_photomap_html.py`): the emitted pano JS
+  contains the `file:` protocol branch and the message text; still absent
+  entirely when there are no panos or no links.
+
+## E2E verification (manual, done during design)
+
+Local reproduction is already the proof: `python3 -m http.server` over
+`C:\TEMP\PanoTest` renders the 12000×6000 pano in the viewer; the same map
+from `file://` shows Pannellum's raw error. After implementation, repeat
+with `dji-embed photomap /mnt/c/TEMP/PanoTest --serve`.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -102,6 +102,14 @@ detected automatically; with `--link-originals`, clicking one opens an
 embedded interactive 360° viewer instead of a flat, distorted JPEG — an
 "open original" link stays in the popup as a fallback.
 
+```bash
+dji-embed photomap /path/to/photos --serve
+```
+
+Writes the map, then serves it at a private local address and opens your
+browser — required for the built-in 360° panorama viewer, which browsers
+block when the map is opened straight from disk.
+
 Photos without GPS coordinates are skipped and counted in a summary, e.g.
 `Mapped 412 of 430 photos; 18 had no GPS data (use -v to list them)`; add
 `-v` to list the skipped filenames.

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -26,6 +26,7 @@ from .geo import (
     redact_photo_points,
     scan_flights,
     scan_photos,
+    serve_directory,
     write_flights_geojson,
     write_flights_html,
     write_flights_kml,
@@ -365,6 +366,14 @@ def convert(
     "before writing (all formats). Linked/attached original files still "
     "carry exact GPS in their EXIF.",
 )
+@click.option(
+    "--serve", "serve_map", is_flag=True,
+    help="After writing the map, serve its folder at a private local address "
+         "(http://127.0.0.1, this computer only) and open the browser. "
+         "Implies --link-originals. Needed for the 360° viewer, which "
+         "browsers block when the map is opened straight from disk. "
+         "With -v, each HTTP request is logged.",
+)
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
 def photomap(
@@ -376,6 +385,7 @@ def photomap(
     link_originals: bool,
     link_base: str | None,
     redact: str,
+    serve_map: bool,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -385,9 +395,23 @@ def photomap(
     each photo's EXIF thumbnail in the html/kml popups. The html map clusters
     nearby pins and loads Leaflet and OpenStreetMap tiles from the internet.
     Requires ExifTool (see 'dji-embed doctor'). GPano 360° panoramas open in
-    an embedded viewer when --link-originals is set.
+    an embedded viewer when --link-originals is set. Use --serve to view the
+    map over local HTTP — required for the 360° viewer, which browsers block
+    on maps opened straight from disk.
     """
     setup_logging(verbose, quiet)
+    if serve_map:
+        if fmt.lower() not in ("html", "all"):
+            raise click.UsageError(
+                "--serve requires the HTML map (use -f html or -f all)"
+            )
+        if link_base is not None:
+            click.echo(
+                "Note: --serve serves the map's own folder; --link-base "
+                "links may not resolve through it",
+                err=True,
+            )
+        link_originals = True
     if link_base is not None and not link_originals:
         raise click.UsageError("--link-base requires --link-originals")
     if link_originals and fmt.lower() not in ("html", "all"):
@@ -453,6 +477,14 @@ def photomap(
                 write_photos_geojson(points, out)
         except OSError as e:
             raise click.ClickException(f"Could not write {out}: {e}")
+    if serve_map:
+        html_out = next(out for f, out in targets if f == "html")
+        serve_directory(
+            html_out.parent,
+            html_out.name,
+            quiet=quiet,
+            log_requests=verbose,
+        )
 
 
 @main.command()

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -24,6 +24,7 @@ from .photomap import (
     write_photos_kml,
 )
 from .photomap_html import photos_to_html, write_photos_html
+from .serve import serve_directory
 from .solar import sun_position
 from .track import Track, TrackPoint, build_track
 
@@ -61,4 +62,5 @@ __all__ = [
     "write_flights_kml",
     "flights_to_html",
     "write_flights_html",
+    "serve_directory",
 ]

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -91,6 +91,9 @@ _PANO_HEAD = (
     "  #pano-close { position: absolute; top: 8px; right: 16px; z-index: 2001;\n"
     "                font-size: 28px; line-height: 1; color: #fff;\n"
     "                background: none; border: none; cursor: pointer; }\n"
+    "  #pano-viewer .pano-blocked { color: #fff; max-width: 32em;\n"
+    "    margin: 20vh auto 0; padding: 0 1em; text-align: center;\n"
+    "    font: 16px/1.6 system-ui, sans-serif; }\n"
     "</style>"
 )
 
@@ -111,9 +114,22 @@ _PANO_SCRIPT = (
 _PANO_JS = """
 let panoViewer = null;
 const panoOverlay = document.getElementById('pano-overlay');
+const panoContainer = document.getElementById('pano-viewer');
 function openPano(src) {
-  if (panoViewer) { panoViewer.destroy(); }
+  if (panoViewer) { panoViewer.destroy(); panoViewer = null; }
   panoOverlay.style.display = 'block';
+  if (location.protocol === 'file:') {
+    // Browsers refuse WebGL pixel access to images on file:// pages, so the
+    // viewer cannot work for maps opened straight from disk.
+    panoContainer.innerHTML = '<div class="pano-blocked">' +
+      '360\\u00b0 view is blocked by the browser for maps opened straight ' +
+      'from disk.<br>Use the "open original" link in the popup, or rebuild ' +
+      'the map with:<br><code>dji-embed photomap &lt;your folder&gt; ' +
+      '--serve</code></div>';
+    return;
+  }
+  // Reset so a previous file:// message (or dead viewer DOM) never lingers.
+  panoContainer.innerHTML = '';
   // Lazy: the original file is only fetched here, on first click. Pannellum
   // renders its own error text in the container if the load fails (missing
   // file, WebGL texture limit); the popup's plain link remains the fallback.

--- a/src/dji_metadata_embedder/geo/serve.py
+++ b/src/dji_metadata_embedder/geo/serve.py
@@ -1,0 +1,59 @@
+"""Serve a generated map folder over local HTTP.
+
+Browsers refuse WebGL pixel access to images on ``file://`` pages, so the
+photomap 360-degree viewer only works when the map is served over HTTP.
+This module is the loopback-only server behind ``dji-embed photomap --serve``.
+"""
+
+from __future__ import annotations
+
+import webbrowser
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import click
+
+
+class _QuietHandler(SimpleHTTPRequestHandler):
+    """SimpleHTTPRequestHandler without per-request stderr logging."""
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def _make_server(directory: Path, *, log_requests: bool = False) -> ThreadingHTTPServer:
+    """Build a threading HTTP server for *directory* on a free loopback port.
+
+    Binds 127.0.0.1 only — the map must never be exposed beyond this machine.
+    """
+    handler_cls = SimpleHTTPRequestHandler if log_requests else _QuietHandler
+    handler = partial(handler_cls, directory=str(directory))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    # Don't let an in-flight transfer keep the process alive after Ctrl+C.
+    server.daemon_threads = True
+    return server
+
+
+def serve_directory(
+    directory: Path,
+    filename: str,
+    *,
+    quiet: bool = False,
+    log_requests: bool = False,
+    open_browser: bool = True,
+) -> None:
+    """Serve *directory* until Ctrl+C, opening *filename* in the browser."""
+    with _make_server(directory, log_requests=log_requests) as httpd:
+        port = httpd.server_address[1]
+        url = f"http://127.0.0.1:{port}/{filename}"
+        # The URL is the product of the command: printed even under --quiet.
+        click.echo(f"Serving map at {url} — press Ctrl+C to stop")
+        if open_browser:
+            webbrowser.open(url)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            pass
+    if not quiet:
+        click.echo("Stopped.")

--- a/tests/test_cli_photomap.py
+++ b/tests/test_cli_photomap.py
@@ -286,3 +286,81 @@ def test_photomap_redact_default_none_keeps_exact_coords(monkeypatch, tmp_path):
     assert res.exit_code == 0, res.output
     html = (tmp_path / "photomap.html").read_text(encoding="utf-8")
     assert "60.170278" in html
+
+
+def _mock_serve(monkeypatch):
+    calls = {}
+
+    def fake(directory, filename, **kwargs):
+        calls["directory"] = Path(directory)
+        calls["filename"] = filename
+        calls["kwargs"] = kwargs
+
+    monkeypatch.setattr("dji_metadata_embedder.cli.serve_directory", fake)
+    return calls
+
+
+def test_photomap_serve_implies_links_and_serves_html_folder(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    calls = _mock_serve(monkeypatch)
+    res = CliRunner().invoke(main, ["photomap", str(tmp_path), "--serve"])
+    assert res.exit_code == 0, res.output
+    assert _html_link_props(tmp_path / "photomap.html") == ["church1.jpg"]
+    assert calls["directory"] == tmp_path
+    assert calls["filename"] == "photomap.html"
+    assert calls["kwargs"]["quiet"] is False
+    assert calls["kwargs"]["log_requests"] is False
+
+
+def test_photomap_serve_requires_html_format(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    calls = _mock_serve(monkeypatch)
+    res = CliRunner().invoke(main, ["photomap", str(tmp_path), "--serve", "-f", "kml"])
+    assert res.exit_code != 0
+    assert "--serve requires the HTML map" in res.output
+    assert calls == {}
+
+
+def test_photomap_serve_format_all_serves_the_html_output(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    calls = _mock_serve(monkeypatch)
+    res = CliRunner().invoke(main, ["photomap", str(tmp_path), "--serve", "-f", "all"])
+    assert res.exit_code == 0, res.output
+    assert calls["filename"] == "photomap.html"
+
+
+def test_photomap_serve_with_link_base_warns(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    _mock_serve(monkeypatch)
+    res = CliRunner().invoke(
+        main,
+        ["photomap", str(tmp_path), "--serve", "--link-base", "https://example.com/p/"],
+    )
+    assert res.exit_code == 0, res.output
+    assert "--link-base" in res.output and "may not resolve" in res.output
+
+
+def test_photomap_serve_verbose_enables_request_logging(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    calls = _mock_serve(monkeypatch)
+    res = CliRunner().invoke(main, ["photomap", str(tmp_path), "--serve", "-v"])
+    assert res.exit_code == 0, res.output
+    assert calls["kwargs"]["log_requests"] is True
+
+
+def test_photomap_serve_with_redact_fuzz_still_warns_about_exif(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    _mock_serve(monkeypatch)
+    res = CliRunner().invoke(
+        main, ["photomap", str(tmp_path), "--serve", "--redact", "fuzz"]
+    )
+    assert res.exit_code == 0, res.output
+    assert "still carry exact GPS" in res.output
+
+
+def test_photomap_no_serve_never_starts_server(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    calls = _mock_serve(monkeypatch)
+    res = CliRunner().invoke(main, ["photomap", str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    assert calls == {}

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -148,3 +148,26 @@ def test_html_pano_popup_keeps_plain_fallback_link():
     assert "open original" in html
     assert "pannellum.viewer(" in html
     assert "panoViewer.destroy()" in html
+
+
+def test_html_pano_file_protocol_shows_help_instead_of_viewer():
+    html = photos_to_html(PANO_POINTS, title="t", link_base="")
+    # Maps opened from disk cannot feed WebGL: openPano branches on the
+    # protocol and shows guidance instead of launching Pannellum.
+    assert "location.protocol === 'file:'" in html
+    assert "pano-blocked" in html
+    assert "--serve" in html
+    assert "open original" in html
+
+
+def test_html_pano_container_reset_on_every_open():
+    html = photos_to_html(PANO_POINTS, title="t", link_base="")
+    # The container's content is set on each open so a stale file:// message
+    # can never linger under a later Pannellum instance.
+    assert "panoContainer.innerHTML = ''" in html
+
+
+def test_html_file_protocol_help_absent_without_panos():
+    html = photos_to_html(POINTS, title="t", link_base="")
+    assert "pano-blocked" not in html
+    assert "location.protocol" not in html

--- a/tests/test_geo_serve.py
+++ b/tests/test_geo_serve.py
@@ -1,0 +1,109 @@
+import threading
+import urllib.request
+import webbrowser
+from http.server import ThreadingHTTPServer
+
+from dji_metadata_embedder.geo.serve import _make_server, serve_directory
+
+
+def _fixture_dir(tmp_path):
+    (tmp_path / "photomap.html").write_text("<!DOCTYPE html><p>map</p>", encoding="utf-8")
+    (tmp_path / "pano.jpg").write_bytes(b"\xff\xd8\xff\xdbJPEGDATA")
+    return tmp_path
+
+
+def test_make_server_binds_loopback_free_port_and_serves_files(tmp_path):
+    served = _fixture_dir(tmp_path)
+    server = _make_server(served)
+    thread = None
+    try:
+        host, port = server.server_address[0], server.server_address[1]
+        assert host == "127.0.0.1"
+        assert port != 0  # OS assigned a real free port
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base = f"http://127.0.0.1:{port}"
+        with urllib.request.urlopen(f"{base}/photomap.html", timeout=5) as resp:
+            assert resp.status == 200
+            assert b"map" in resp.read()
+        with urllib.request.urlopen(f"{base}/pano.jpg", timeout=5) as resp:
+            assert resp.status == 200
+            assert resp.read() == (served / "pano.jpg").read_bytes()
+    finally:
+        server.shutdown()
+        server.server_close()
+        if thread is not None:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+
+def test_make_server_is_quiet_by_default(tmp_path, capsys):
+    # Request logging (BaseHTTPRequestHandler.log_message -> stderr) is
+    # silenced unless log_requests=True.
+    server = _make_server(_fixture_dir(tmp_path))
+    thread = None
+    try:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        port = server.server_address[1]
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/photomap.html", timeout=5).read()
+    finally:
+        server.shutdown()
+        server.server_close()
+        if thread is not None:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+    assert "GET /photomap.html" not in capsys.readouterr().err
+
+
+def test_make_server_logs_requests_when_enabled(tmp_path, capsys):
+    server = _make_server(_fixture_dir(tmp_path), log_requests=True)
+    thread = None
+    try:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        port = server.server_address[1]
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/photomap.html", timeout=5).read()
+    finally:
+        server.shutdown()
+        server.server_close()
+        if thread is not None:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+    assert "GET /photomap.html" in capsys.readouterr().err
+
+
+def test_serve_directory_prints_url_opens_browser_and_stops_on_interrupt(
+    tmp_path, monkeypatch, capsys
+):
+    served = _fixture_dir(tmp_path)
+    opened = []
+    monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url) or True)
+
+    def fake_serve_forever(self, poll_interval=0.5):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(ThreadingHTTPServer, "serve_forever", fake_serve_forever)
+    serve_directory(served, "photomap.html")
+    out = capsys.readouterr().out
+    assert "http://127.0.0.1:" in out
+    assert "photomap.html" in out
+    assert "Ctrl+C" in out
+    assert "Stopped." in out
+    assert opened and opened[0].endswith("/photomap.html")
+
+
+def test_serve_directory_open_browser_false_and_quiet(tmp_path, monkeypatch, capsys):
+    opened = []
+    monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url) or True)
+
+    def fake_serve_forever(self, poll_interval=0.5):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(ThreadingHTTPServer, "serve_forever", fake_serve_forever)
+    serve_directory(_fixture_dir(tmp_path), "photomap.html", quiet=True, open_browser=False)
+    out = capsys.readouterr().out
+    # The URL is the product of the command: printed even under quiet.
+    assert "http://127.0.0.1:" in out
+    assert "Stopped." not in out
+    assert opened == []


### PR DESCRIPTION
Closes #274

The #271/#272 360° panorama viewer fails when `photomap.html` is opened straight from disk: browsers give `file://` documents an opaque origin, so WebGL is refused pixel access to the linked panorama and Pannellum shows a raw "could not be accessed" error. Verified with a real 12000×6000 equirectangular JPEG — the identical map works over `http://localhost`.

## Changes

- **`geo/serve.py`** — loopback-only map server: `ThreadingHTTPServer` bound to `127.0.0.1` on an OS-assigned free port, daemon threads (Ctrl+C never hangs on an in-flight transfer), request logging opt-in, opens the default browser.
- **`photomap --serve`** — the one-liner for the viewer: implies `--link-originals`, writes the map(s), serves the HTML's folder, prints the URL (even under `-q`), runs until Ctrl+C. Errors on `-f kml/geojson`; warns when combined with `--link-base`; `-v` also logs HTTP requests.
- **Friendly `file://` message** — clicking a pano on a map opened from disk now shows a short explanation (use "open original", or rebuild with `--serve`) instead of Pannellum's raw error. Emitted only when the pano viewer is emitted; maps without panoramas are byte-identical.
- **Docs** — geospatial.md 360° section rewritten around the local-file case; README + user_guide examples.

## Testing

- 12 new tests: real-socket server tests (bind address, byte-exact GET of html+jpg, quiet/verbose logging, Ctrl+C lifecycle), CLI interaction matrix (implied links, format guard, `--link-base` warning, `--redact fuzz` ordering, `-f all`, never-serve-on-error), `file:` branch gating in the HTML.
- Full gate: `ruff` clean, `mypy` clean, `pytest` 474 passed (4 pre-existing skips).
- E2E: `dji-embed photomap <folder> --serve` against a real 12000×6000 GPano panorama — map and 10.7 MB original both served 200 on the printed loopback URL; viewer confirmed working over HTTP in a desktop browser.

Spec: `docs/superpowers/specs/2026-07-14-photomap-serve-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjW82kiEhTdyWwz4xmNQt5