### PR TITLE
feat(photomap): thumbnail preview on marker hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,8 @@ Notes:
   distinct on the map.
 - Popup previews use the small EXIF thumbnail, falling back to a size-capped
   embedded preview for DNGs that carry no thumbnail.
+- Hovering a marker shows the thumbnail and filename in a tooltip, so a map
+  can be skimmed without clicking every pin (HTML output, desktop browsers).
 - Photos with no EXIF altitude are clamped to the ground in KML (Google Earth)
   instead of being buried at 0 m below terrain.
 - `--link-originals` makes each popup's thumbnail and filename a click-through

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -82,7 +82,8 @@ The command scans the whole directory in one pass, so even large archives
 scan quickly (ExifTool must be installed — `dji-embed doctor` checks this).
 The HTML map clusters nearby shots into an expandable numbered marker so a
 dense session doesn't turn into a wall of overlapping pins; clicking a photo
-shows its EXIF thumbnail, filename, timestamp, altitude, and camera settings.
+shows its EXIF thumbnail, filename, timestamp, altitude, and camera settings,
+and hovering a marker previews the thumbnail and filename without clicking.
 KML opens the same thumbnails in Google Earth Pro (Google My Maps import may
 drop the images but keeps the placemarks). GeoJSON is interchange-only — no
 thumbnails, just `name`/`timestamp`/`alt`/`camera` properties — for use in

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -60,6 +60,7 @@ _TEMPLATE = """<!DOCTYPE html>
   html, body {{ height: 100%; margin: 0; }}
   #map {{ height: 100%; }}
   .photo-popup img {{ max-width: 260px; display: block; margin-bottom: 4px; }}
+  .photo-tooltip img {{ max-width: 160px; display: block; margin-bottom: 2px; }}
 </style>
 </head>
 <body>
@@ -194,11 +195,27 @@ function buildPopup(f) {
   return html;
 }
 
+// Hover preview (issue #273): thumbnail + filename in a sticky tooltip so a
+// map can be skimmed without clicking every pin. Thumb-less points fall back
+// to a filename-only tooltip. Desktop-only by design: touch devices have no
+// hover and the click popup already covers them.
+function buildTooltip(f) {
+  const p = f.properties || {};
+  let html = '<div class="photo-tooltip">';
+  if (p.thumb) {
+    html += `<img src="data:image/jpeg;base64,${esc(p.thumb)}" alt="">`;
+  }
+  html += `${esc(p.name || '')}</div>`;
+  return html;
+}
+
 for (const f of points) {
   const c = f.geometry.coordinates;                  // [lon, lat, alt]
   latlngs.push([c[1], c[0]]);
   markers.push(
-    L.marker([c[1], c[0]]).bindPopup(() => buildPopup(f), { maxWidth: 300 }));
+    L.marker([c[1], c[0]])
+      .bindPopup(() => buildPopup(f), { maxWidth: 300 })
+      .bindTooltip(() => buildTooltip(f), { sticky: true, direction: 'top' }));
 }
 cluster.addLayers(markers);
 map.addLayer(cluster);

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -104,6 +104,50 @@ def test_html_popup_anchor_is_escaped_and_noopener():
     assert 'target="_blank" rel="noopener"' in html
 
 
+def _tooltip_builder(html: str) -> str:
+    match = re.search(r"function buildTooltip\(f\) \{(.*?)\n\}", html, re.DOTALL)
+    assert match, "buildTooltip function not found"
+    return match.group(1)
+
+
+def test_html_markers_bind_hover_tooltip():
+    # Hover preview (issue #273): every marker gets a sticky tooltip so the
+    # map can be skimmed without clicking each pin.
+    html = photos_to_html(POINTS, title="t")
+    assert "bindTooltip(" in html
+    assert "sticky: true" in html
+
+
+def test_html_tooltip_shows_thumbnail_and_escaped_name():
+    # The tooltip carries the EXIF thumbnail plus the filename; the filename
+    # goes through the esc() helper so hostile names cannot inject HTML.
+    body = _tooltip_builder(photos_to_html(POINTS, title="t"))
+    assert "esc(p.thumb" in body
+    assert "esc(p.name" in body
+    assert "data:image/jpeg;base64," in body
+
+
+def test_html_tooltip_degrades_without_thumbnail():
+    # Points without a thumb fall back to a filename-only tooltip: the <img>
+    # sits inside an `if (p.thumb)` guard while the name is unconditional.
+    body = _tooltip_builder(photos_to_html(POINTS, title="t"))
+    assert "if (p.thumb)" in body
+    assert "esc(p.name" in body
+
+
+def test_html_tooltip_css_limits_thumbnail_size():
+    html = photos_to_html(POINTS, title="t")
+    assert ".photo-tooltip img" in html
+    assert "max-width: 160px" in html
+
+
+def test_html_tooltip_does_not_replace_click_popup():
+    # The hover preview is additive: markers still bind the full click popup.
+    html = photos_to_html(POINTS, title="t")
+    assert "bindPopup(" in html
+    assert "bindTooltip(" in html
+
+
 PANO_POINTS = POINTS + [
     PhotoPoint(lat=60.1686, lon=24.9539, alt=12.0, name="pano.jpg",
                thumbnail_b64="/9j/PANO", is_pano=True),


### PR DESCRIPTION
Closes #273

Hovering a photomap marker now shows the EXIF thumbnail and filename in a sticky Leaflet tooltip, so a map can be skimmed without clicking every pin. Requested on the mavicpilots thread by the user who prompted #271.

## Implementation

JS-template-only change in `photomap_html.py` — no Python API or CLI changes, no extra scan cost:

- New `buildTooltip(f)` helper mirroring `buildPopup`: thumbnail `<img>` when the point carries a `thumb`, filename always — so thumb-less points degrade to a filename-only tooltip.
- Bound on the single marker-creation path via `.bindTooltip(() => buildTooltip(f), { sticky: true, direction: 'top' })`, alongside the untouched `.bindPopup(...)` — all markers including panoramas get it, click behaviour (popup / 360° viewer) unchanged.
- Filename and thumb go through the existing `esc()` helper, same path as the popup, so hostile filenames stay inert.
- Tooltip images capped at 160px (`.photo-tooltip img`), next to the existing popup CSS.
- Desktop-only by design: touch devices have no hover and the click popup already covers them.

## Testing

- 5 new tests in `tests/test_geo_photomap_html.py` (TDD: written first, confirmed failing): tooltip binding + sticky option, thumbnail/filename escaping inside `buildTooltip`, thumb-less fallback, CSS cap, popup-still-bound.
- Full gate green: `pytest` 479 passed / 4 skipped (pre-existing env-gated), `ruff` clean, `mypy` clean.
- E2E sanity: generated a real map from `samples/photos/` and confirmed the emitted HTML contains the tooltip binding and CSS.

## Checklist
- [x] Tests added/updated for new functionality
- [x] Documentation updated (README photomap notes, user guide)
- [x] Cross-platform compatibility verified (template-string change only)
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZibkZVsDF5Vg5FXZAQjR7