### PR TITLE
feat(doctor): opt-in online update check with environment-aware upgrade hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,25 @@ dji-embed doctor
 ExifTool into your user directory — useful where system packages are too old
 for MP4 timed metadata (most Linux distros).
 
+**Opt-in update check.** Normal commands never touch the network. `doctor`
+is the only command that may go online for version info, and it asks first:
+the first interactive run prompts once (`Check online for newer versions
+(PyPI + ExifTool)? [y/N]`, default No) and remembers your answer. When
+enabled, doctor compares your dji-embed against PyPI and your ExifTool
+against the bundled pin, and prints an upgrade command matched to how you
+installed (winget/EXE, pipx, or the exact `python -m pip` for your
+interpreter). Network failures degrade silently to the offline report.
+
+```bash
+dji-embed doctor --online     # enable for this run and remember it
+dji-embed doctor --offline    # disable for this run and remember it
+```
+
+Set `DJIEMBED_NO_UPDATE_CHECK=1` to hard-disable the check regardless of the
+remembered choice. Non-interactive runs (no terminal, or `CI` set) never
+prompt and never check. The ExifTool-vs-pin comparison needs no network and
+is always shown when your ExifTool is older than the pinned release.
+
 ### `dji-embed ui` - Local Web UI
 
 Launch the local web UI in your browser (requires the `[ui]` extra). It runs

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -123,6 +123,13 @@ to one interpreter, while plain `pip` belongs to another. `pip install
 dji-drone-metadata-embedder` then reports "requirement already satisfied"
 in the wrong environment — and without `--upgrade` it never updates anyway.
 
+**Shortcut:** `dji-embed doctor --online` checks PyPI for the latest release
+and prints the exact upgrade command for the interpreter that owns *your*
+`dji-embed` (the literal `python.exe -m pip ...` path, `pipx upgrade`, or
+the winget/EXE route) — no PATH archaeology needed. The check is opt-in and
+only ever runs from `doctor`; see the README for details and the
+`DJIEMBED_NO_UPDATE_CHECK=1` opt-out.
+
 **Diagnose** — find which interpreter owns the `dji-embed` that runs:
 
 ```powershell

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -627,9 +627,22 @@ def flightmap(
     is_flag=True,
     help="With --install: reinstall even when already provisioned.",
 )
+@click.option(
+    "--online/--offline",
+    "online",
+    default=None,
+    help="Enable/disable the online update check (PyPI + ExifTool pin) for "
+    "this run and remember the choice. Default: remembered choice, asked "
+    "once on interactive terminals. DJIEMBED_NO_UPDATE_CHECK=1 hard-disables.",
+)
 @click.pass_context
 def doctor(
-    ctx: click.Context, verbose: bool, quiet: bool, install_tool: str | None, force: bool
+    ctx: click.Context,
+    verbose: bool,
+    quiet: bool,
+    install_tool: str | None,
+    force: bool,
+    online: bool | None,
 ) -> None:
     """Show system information and verify dependencies."""
     log_json = ctx.obj.get('log_json', False)
@@ -639,7 +652,7 @@ def doctor(
         if install_tool == "exiftool":
             exe = provision_exiftool(force=force)
             click.echo(f"ExifTool {EXIFTOOL_VERSION} installed: {exe}")
-        run_doctor()
+        run_doctor(online=online)
         if log_json:
             click.echo(json.dumps({"status": "success"}))
         sys.exit(ExitCode.SUCCESS)

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -790,8 +790,13 @@ class DJIMetadataEmbedder:
         return result
 
 
-def run_doctor() -> None:
-    """Print system and dependency information."""
+def run_doctor(online: bool | None = None) -> None:
+    """Print system and dependency information.
+
+    ``online`` forces the opt-in update check on/off for this run (and
+    persists the choice); ``None`` uses the remembered consent, prompting
+    once on interactive terminals.
+    """
     from .utilities import check_dependencies
 
     # System information
@@ -829,6 +834,12 @@ def run_doctor() -> None:
         logger.info("All dependencies verified.")
     else:
         logger.warning("Some dependencies are missing or not functional.")
+
+    # Opt-in update check (doctor is the only command that may go online).
+    from .utils import update_check
+
+    for line in update_check.update_report(online):
+        logger.info("%s", line)
 
 
 def main():

--- a/src/dji_metadata_embedder/utils/update_check.py
+++ b/src/dji_metadata_embedder/utils/update_check.py
@@ -1,0 +1,257 @@
+"""Opt-in online update check for ``dji-embed doctor``.
+
+Principle: normal commands never touch the network. ``doctor`` is the only
+command that may go online for version info, and it asks first. The user's
+answer is remembered in the per-user config dir (the parent of the provisioned
+ExifTool tools dir — see :func:`provision.tools_dir`), so the prompt appears
+only once. ``DJIEMBED_NO_UPDATE_CHECK=1`` hard-disables regardless of stored
+consent, and any network failure degrades silently to the offline report.
+
+The ExifTool-vs-pin comparison in :func:`exiftool_pin_lines` needs no network
+at all: the pin ships with the package.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+from .provision import EXIFTOOL_VERSION, tools_dir
+
+logger = logging.getLogger(__name__)
+
+PYPI_PROJECT = "dji-drone-metadata-embedder"
+PYPI_URL = f"https://pypi.org/pypi/{PYPI_PROJECT}/json"
+RELEASES_URL = "https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest"
+WINGET_ID = "CallMarcus.DJIMetadataEmbedder"
+NO_UPDATE_CHECK_ENV = "DJIEMBED_NO_UPDATE_CHECK"
+
+# Hard latency bound for the one optional network call (issue #277: ~3 s).
+HTTP_TIMEOUT = 3.0
+
+_PROMPT = "Check online for newer versions (PyPI + ExifTool)? [y/N] "
+
+
+# ---------------------------------------------------------------------------
+# Consent persistence
+# ---------------------------------------------------------------------------
+
+
+def consent_path() -> Path:
+    """Consent file in the per-user config dir (parent of the tools dir)."""
+    return tools_dir().parent / "update_check.json"
+
+
+def load_consent() -> bool | None:
+    """The remembered opt-in choice, or ``None`` when never answered."""
+    try:
+        data = json.loads(consent_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    value = data.get("online_check") if isinstance(data, dict) else None
+    return value if isinstance(value, bool) else None
+
+
+def save_consent(enabled: bool) -> None:
+    """Persist the opt-in choice; failures are non-fatal (read-only homes)."""
+    path = consent_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"online_check": enabled}) + "\n", encoding="utf-8"
+        )
+    except OSError:
+        logger.debug("Could not persist update-check consent to %s", path)
+
+
+# ---------------------------------------------------------------------------
+# Consent resolution
+# ---------------------------------------------------------------------------
+
+
+def hard_disabled() -> bool:
+    """True when ``DJIEMBED_NO_UPDATE_CHECK`` is set to a truthy value."""
+    value = os.environ.get(NO_UPDATE_CHECK_ENV, "").strip().lower()
+    return value not in ("", "0", "false", "no")
+
+
+def is_interactive() -> bool:
+    """A real terminal on both ends and not a CI environment."""
+    if os.environ.get("CI"):
+        return False
+    try:
+        return sys.stdin.isatty() and sys.stdout.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _prompt_consent() -> bool:
+    """One-time interactive prompt; plain Enter (or EOF) means No."""
+    try:
+        answer = input(_PROMPT)
+    except EOFError:
+        return False
+    return answer.strip().lower() in ("y", "yes")
+
+
+def _status(enabled: bool) -> str:
+    if enabled:
+        return "online check: enabled (change with doctor --offline)"
+    return "online check: disabled (enable with doctor --online)"
+
+
+def resolve_online(cli_choice: bool | None = None) -> tuple[bool, str]:
+    """Decide whether this doctor run may go online.
+
+    Precedence: kill-switch env var > ``--online``/``--offline`` flag (which
+    also persists) > remembered choice > one-time interactive prompt (which
+    also persists) > off. Non-interactive runs never prompt and never check.
+    """
+    if hard_disabled():
+        return False, f"online check: disabled ({NO_UPDATE_CHECK_ENV}=1)"
+    if cli_choice is not None:
+        save_consent(cli_choice)
+        return cli_choice, _status(cli_choice)
+    stored = load_consent()
+    if stored is not None:
+        return stored, _status(stored)
+    if not is_interactive():
+        return False, _status(False)
+    choice = _prompt_consent()
+    save_consent(choice)
+    return choice, _status(choice)
+
+
+# ---------------------------------------------------------------------------
+# Check 1: dji-embed version via the PyPI JSON API
+# ---------------------------------------------------------------------------
+
+
+def latest_pypi_version(timeout: float = HTTP_TIMEOUT) -> str | None:
+    """Latest released version on PyPI, or ``None`` on any failure (silent)."""
+    req = Request(PYPI_URL, headers={"User-Agent": "dji-embed"})
+    try:
+        with urlopen(req, timeout=timeout) as response:
+            data = json.load(response)
+        version = data["info"]["version"]
+    except Exception:  # offline, timeout, PyPI down, bad JSON — never an error
+        return None
+    return str(version) if version else None
+
+
+def parse_version(version: str) -> tuple[int, ...]:
+    """Leading numeric components of a dotted version ("1.18.0" -> (1, 18, 0))."""
+    parts: list[int] = []
+    for chunk in version.strip().split("."):
+        digits = re.match(r"\d+", chunk)  # stop at the first non-numeric chunk
+        if digits is None:
+            break
+        parts.append(int(digits.group()))
+    return tuple(parts) or (0,)
+
+
+def is_newer(candidate: str, current: str) -> bool:
+    """True when ``candidate`` is a strictly newer version than ``current``."""
+    return parse_version(candidate) > parse_version(current)
+
+
+def _norm_parts(path: str) -> list[str]:
+    """Case-folded path components, tolerating both / and \\ separators."""
+    return [part.lower() for part in re.split(r"[\\/]+", path) if part]
+
+
+def detect_install_environment(executable: str | None = None) -> str:
+    """How dji-embed was installed: ``frozen``, ``pipx``, or ``pip``."""
+    if getattr(sys, "frozen", False):  # PyInstaller EXE
+        return "frozen"
+    exe = executable or sys.executable
+    exe_parts = _norm_parts(exe)
+    pipx_home = os.environ.get("PIPX_HOME")
+    if pipx_home:
+        home_parts = _norm_parts(pipx_home)
+        if exe_parts[: len(home_parts)] == home_parts:
+            return "pipx"
+    # Default pipx layouts keep a literal "pipx" path component:
+    # ~/.local/pipx/venvs/... and %LOCALAPPDATA%\pipx\venvs\...
+    if "pipx" in exe_parts:
+        return "pipx"
+    return "pip"
+
+
+def upgrade_hint(env: str | None = None) -> str:
+    """Environment-aware upgrade command for an outdated dji-embed."""
+    env = env or detect_install_environment()
+    if env == "frozen":
+        return (
+            f"download the new EXE from {RELEASES_URL} "
+            f"or run: winget upgrade {WINGET_ID}"
+        )
+    if env == "pipx":
+        return f"pipx upgrade {PYPI_PROJECT}"
+    # Literal interpreter path defeats the multi-Python trap: bare `pip`
+    # often belongs to a different Python than the dji-embed on PATH.
+    return f'"{sys.executable}" -m pip install --upgrade {PYPI_PROJECT}'
+
+
+def _pypi_lines() -> list[str]:
+    from .. import __version__
+
+    latest = latest_pypi_version()
+    if latest is None:  # network failure: degrade silently to offline report
+        return []
+    if not is_newer(latest, __version__):
+        return [f"dji-embed {__version__} is up to date"]
+    return [
+        f"dji-embed {__version__} -> {latest} available",
+        f"  update: {upgrade_hint()}",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Check 2: resolved ExifTool vs the shipped pin (fully offline)
+# ---------------------------------------------------------------------------
+
+
+def exiftool_pin_lines() -> list[str]:
+    """Hint when the resolved ExifTool is older than the pinned release."""
+    from . import exiftool as exiftool_utils
+
+    ver = exiftool_utils.exiftool_version()
+    if ver is None:  # missing entirely — doctor already reports that
+        return []
+    if exiftool_utils.version_key(ver) >= exiftool_utils.version_key(
+        EXIFTOOL_VERSION
+    ):
+        return []
+    lagging = [
+        model
+        for model, floor in exiftool_utils.EXIFTOOL_FLOORS.values()
+        if exiftool_utils.version_key(ver) < exiftool_utils.version_key(floor)
+    ]
+    detail = f"decodes {' / '.join(lagging)}" if lagging else "available"
+    return [
+        f"exiftool {ver} ({exiftool_utils.exiftool_source()}) "
+        f"-> pinned {EXIFTOOL_VERSION} {detail}",
+        "  update: dji-embed doctor --install exiftool",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Doctor report
+# ---------------------------------------------------------------------------
+
+
+def update_report(cli_choice: bool | None = None) -> list[str]:
+    """All update-check lines for doctor output (may prompt interactively)."""
+    online, status = resolve_online(cli_choice)
+    lines: list[str] = []
+    if online:
+        lines.extend(_pypi_lines())
+    lines.extend(exiftool_pin_lines())
+    lines.append(status)
+    return lines

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -85,3 +85,71 @@ def test_doctor_install_rejects_unknown_tool():
     runner = CliRunner()
     result = runner.invoke(cli_mod.main, ["doctor", "--install", "ffmpeg"])
     assert result.exit_code != 0  # click.Choice rejects it
+
+
+def test_doctor_ci_env_no_prompt_no_network(monkeypatch, tmp_path):
+    """Non-interactive doctor must neither prompt nor touch the network."""
+    from dji_metadata_embedder.utils import update_check as uc
+
+    monkeypatch.setenv("DJIEMBED_TOOLS_DIR", str(tmp_path / "dji-embed" / "tools"))
+
+    monkeypatch.delenv("DJIEMBED_NO_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: (_ for _ in ()).throw(AssertionError("prompted"))
+    )
+
+    def no_net(*a, **k):
+        raise AssertionError("network touched")
+
+    monkeypatch.setattr(uc, "urlopen", no_net)
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.main, ["doctor", "-q"], env={"CI": "1"})
+    assert result.exit_code == 0
+
+
+def test_doctor_online_flag_respects_kill_switch(monkeypatch, tmp_path):
+    """DJIEMBED_NO_UPDATE_CHECK=1 hard-disables even doctor --online."""
+    from dji_metadata_embedder.utils import update_check as uc
+
+    monkeypatch.setenv("DJIEMBED_TOOLS_DIR", str(tmp_path / "dji-embed" / "tools"))
+
+    def no_net(*a, **k):
+        raise AssertionError("network touched despite kill switch")
+
+    monkeypatch.setattr(uc, "urlopen", no_net)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.main,
+        ["doctor", "--online"],
+        env={"DJIEMBED_NO_UPDATE_CHECK": "1"},
+    )
+    assert result.exit_code == 0
+    assert uc.load_consent() is None  # kill switch also blocks persisting
+
+
+def test_doctor_offline_flag_persists_choice(monkeypatch, tmp_path):
+    from dji_metadata_embedder.utils import update_check as uc
+
+    monkeypatch.setenv("DJIEMBED_TOOLS_DIR", str(tmp_path / "dji-embed" / "tools"))
+
+    monkeypatch.delenv("DJIEMBED_NO_UPDATE_CHECK", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.main, ["doctor", "--offline", "-q"])
+    assert result.exit_code == 0
+    assert uc.load_consent() is False
+
+
+def test_doctor_online_flag_checks_and_persists(monkeypatch, caplog, tmp_path):
+    from dji_metadata_embedder.utils import update_check as uc
+
+    monkeypatch.setenv("DJIEMBED_TOOLS_DIR", str(tmp_path / "dji-embed" / "tools"))
+
+    monkeypatch.delenv("DJIEMBED_NO_UPDATE_CHECK", raising=False)
+    monkeypatch.setattr(uc, "latest_pypi_version", lambda **k: "99.0.0")
+    runner = CliRunner()
+    with caplog.at_level(logging.INFO):
+        result = runner.invoke(cli_mod.main, ["doctor", "--online"])
+    assert result.exit_code == 0
+    assert uc.load_consent() is True
+    assert "99.0.0 available" in caplog.text
+    assert "online check: enabled" in caplog.text

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,321 @@
+"""Opt-in doctor update check: consent persistence, env detection, silent failure.
+
+All HTTP is mocked — these tests never touch the network. The autouse
+``_isolate_tools_dir`` fixture in conftest.py redirects the per-user config
+dir (and thus the consent file) into a temp directory.
+"""
+
+import io
+import json
+from urllib.error import URLError
+
+import pytest
+
+from dji_metadata_embedder import __version__
+from dji_metadata_embedder.utils import update_check as uc
+from dji_metadata_embedder.utils.provision import EXIFTOOL_VERSION
+
+
+@pytest.fixture(autouse=True)
+def _no_hard_disable(monkeypatch, tmp_path):
+    """Tests control the kill switch explicitly; consent file is per-test."""
+    monkeypatch.delenv("DJIEMBED_NO_UPDATE_CHECK", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    # A nested tools dir gives each test its own config dir (its parent),
+    # unlike conftest's flat tools0/tools1/... which share a parent.
+    monkeypatch.setenv("DJIEMBED_TOOLS_DIR", str(tmp_path / "dji-embed" / "tools"))
+
+
+# ---------------------------------------------------------------------------
+# Consent persistence
+# ---------------------------------------------------------------------------
+
+
+def test_consent_round_trip():
+    assert uc.load_consent() is None
+    uc.save_consent(True)
+    assert uc.load_consent() is True
+    uc.save_consent(False)
+    assert uc.load_consent() is False
+
+
+def test_consent_file_lives_next_to_tools_dir():
+    from dji_metadata_embedder.utils.provision import tools_dir
+
+    uc.save_consent(True)
+    assert uc.consent_path().parent == tools_dir().parent
+    data = json.loads(uc.consent_path().read_text(encoding="utf-8"))
+    assert data == {"online_check": True}
+
+
+def test_corrupt_consent_file_reads_as_unset():
+    uc.consent_path().parent.mkdir(parents=True, exist_ok=True)
+    uc.consent_path().write_text("not json{", encoding="utf-8")
+    assert uc.load_consent() is None
+
+
+# ---------------------------------------------------------------------------
+# Consent resolution (prompt / flags / kill switch)
+# ---------------------------------------------------------------------------
+
+
+def test_hard_disable_beats_flag_and_stored_consent(monkeypatch):
+    uc.save_consent(True)
+    monkeypatch.setenv("DJIEMBED_NO_UPDATE_CHECK", "1")
+    online, status = uc.resolve_online(True)
+    assert online is False
+    assert "DJIEMBED_NO_UPDATE_CHECK" in status
+    # the stored choice is left untouched
+    assert uc.load_consent() is True
+
+
+def test_cli_flag_overrides_and_persists(monkeypatch):
+    uc.save_consent(False)
+    online, status = uc.resolve_online(True)
+    assert online is True
+    assert uc.load_consent() is True
+    online, status = uc.resolve_online(False)
+    assert online is False
+    assert uc.load_consent() is False
+    assert "doctor --online" in status
+
+
+def test_stored_consent_used_without_prompt(monkeypatch):
+    uc.save_consent(True)
+    monkeypatch.setattr(uc, "is_interactive", lambda: True)
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: pytest.fail("must not prompt when stored")
+    )
+    online, status = uc.resolve_online(None)
+    assert online is True
+    assert "enabled" in status
+
+
+def test_non_interactive_never_prompts_never_persists(monkeypatch):
+    monkeypatch.setattr(uc, "is_interactive", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: pytest.fail("must not prompt non-interactively")
+    )
+    online, status = uc.resolve_online(None)
+    assert online is False
+    assert uc.load_consent() is None
+    assert "doctor --online" in status
+
+
+def test_ci_env_var_means_non_interactive(monkeypatch):
+    monkeypatch.setenv("CI", "true")
+    monkeypatch.setattr(uc.sys, "stdin", io.StringIO())
+    assert uc.is_interactive() is False
+
+
+def test_interactive_prompt_default_is_no(monkeypatch):
+    monkeypatch.setattr(uc, "is_interactive", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *a: "")  # plain Enter
+    online, _ = uc.resolve_online(None)
+    assert online is False
+    assert uc.load_consent() is False  # remembered
+
+
+def test_interactive_prompt_yes_enables_and_persists(monkeypatch):
+    monkeypatch.setattr(uc, "is_interactive", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda *a: "y")
+    online, _ = uc.resolve_online(None)
+    assert online is True
+    assert uc.load_consent() is True
+
+
+def test_prompt_eof_degrades_to_no(monkeypatch):
+    def _eof(*a):
+        raise EOFError
+
+    monkeypatch.setattr(uc, "is_interactive", lambda: True)
+    monkeypatch.setattr("builtins.input", _eof)
+    online, _ = uc.resolve_online(None)
+    assert online is False
+
+
+# ---------------------------------------------------------------------------
+# PyPI version check (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _fake_urlopen(payload: bytes):
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            self.close()
+
+    def opener(req, timeout=None):
+        assert timeout is not None and timeout <= 5, "timeout must be bounded"
+        return _Resp(payload)
+
+    return opener
+
+
+def test_latest_pypi_version_parses_json(monkeypatch):
+    body = json.dumps({"info": {"version": "9.9.9"}}).encode()
+    monkeypatch.setattr(uc, "urlopen", _fake_urlopen(body))
+    assert uc.latest_pypi_version() == "9.9.9"
+
+
+def test_latest_pypi_version_network_error_is_silent(monkeypatch):
+    def boom(req, timeout=None):
+        raise URLError("offline")
+
+    monkeypatch.setattr(uc, "urlopen", boom)
+    assert uc.latest_pypi_version() is None
+
+
+def test_latest_pypi_version_garbage_json_is_silent(monkeypatch):
+    monkeypatch.setattr(uc, "urlopen", _fake_urlopen(b"<html>PyPI down</html>"))
+    assert uc.latest_pypi_version() is None
+
+
+def test_version_comparison():
+    assert uc.is_newer("1.19.0", "1.18.0")
+    assert not uc.is_newer("1.18.0", "1.18.0")
+    assert not uc.is_newer("1.17.9", "1.18.0")
+    assert uc.is_newer("2.0", "1.99.99")
+    # non-numeric junk never raises
+    assert not uc.is_newer("banana", "1.18.0")
+
+
+# ---------------------------------------------------------------------------
+# Install-environment detection matrix
+# ---------------------------------------------------------------------------
+
+
+def test_detect_frozen(monkeypatch):
+    monkeypatch.setattr(uc.sys, "frozen", True, raising=False)
+    assert uc.detect_install_environment() == "frozen"
+
+
+def test_detect_pipx_posix_path(monkeypatch):
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    exe = "/home/u/.local/pipx/venvs/dji-drone-metadata-embedder/bin/python"
+    assert uc.detect_install_environment(exe) == "pipx"
+
+
+def test_detect_pipx_windows_path(monkeypatch):
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    exe = r"C:\Users\u\AppData\Local\pipx\venvs\dji\Scripts\python.exe"
+    assert uc.detect_install_environment(exe) == "pipx"
+
+
+def test_detect_pipx_home_env(monkeypatch):
+    monkeypatch.setenv("PIPX_HOME", "/opt/isolated-apps")
+    exe = "/opt/isolated-apps/venvs/dji/bin/python"
+    assert uc.detect_install_environment(exe) == "pipx"
+
+
+def test_detect_plain_pip(monkeypatch):
+    monkeypatch.delenv("PIPX_HOME", raising=False)
+    exe = "/usr/local/bin/python3"
+    assert uc.detect_install_environment(exe) == "pip"
+
+
+def test_upgrade_hint_pip_uses_literal_sys_executable():
+    hint = uc.upgrade_hint("pip")
+    assert uc.sys.executable in hint
+    assert "-m pip install --upgrade dji-drone-metadata-embedder" in hint
+    assert hint.startswith('"')  # quoted for paths with spaces
+
+
+def test_upgrade_hint_pipx():
+    assert uc.upgrade_hint("pipx") == "pipx upgrade dji-drone-metadata-embedder"
+
+
+def test_upgrade_hint_frozen_mentions_winget_and_releases():
+    hint = uc.upgrade_hint("frozen")
+    assert "winget upgrade CallMarcus.DJIMetadataEmbedder" in hint
+    assert "releases" in hint
+
+
+# ---------------------------------------------------------------------------
+# ExifTool-vs-pin (offline)
+# ---------------------------------------------------------------------------
+
+
+def test_exiftool_older_than_pin_hints_doctor_install(monkeypatch):
+    monkeypatch.setattr(
+        "dji_metadata_embedder.utils.exiftool.exiftool_version", lambda: "12.76"
+    )
+    monkeypatch.setattr(
+        "dji_metadata_embedder.utils.exiftool.exiftool_source", lambda: "PATH"
+    )
+    lines = uc.exiftool_pin_lines()
+    text = "\n".join(lines)
+    assert "12.76" in text
+    assert "PATH" in text
+    assert EXIFTOOL_VERSION in text
+    assert "dji-embed doctor --install exiftool" in text
+
+
+def test_exiftool_at_pin_is_quiet(monkeypatch):
+    monkeypatch.setattr(
+        "dji_metadata_embedder.utils.exiftool.exiftool_version",
+        lambda: EXIFTOOL_VERSION,
+    )
+    assert uc.exiftool_pin_lines() == []
+
+
+def test_exiftool_missing_is_quiet(monkeypatch):
+    monkeypatch.setattr(
+        "dji_metadata_embedder.utils.exiftool.exiftool_version", lambda: None
+    )
+    assert uc.exiftool_pin_lines() == []
+
+
+# ---------------------------------------------------------------------------
+# Full report
+# ---------------------------------------------------------------------------
+
+
+def test_report_offline_no_network(monkeypatch):
+    monkeypatch.setattr(uc, "is_interactive", lambda: False)
+    monkeypatch.setattr(
+        uc, "latest_pypi_version", lambda **k: pytest.fail("no network when offline")
+    )
+    monkeypatch.setattr(
+        "dji_metadata_embedder.utils.exiftool.exiftool_version",
+        lambda: EXIFTOOL_VERSION,
+    )
+    lines = uc.update_report(None)
+    assert lines == ["online check: disabled (enable with doctor --online)"]
+
+
+def test_report_online_outdated(monkeypatch):
+    uc.save_consent(True)
+    monkeypatch.setattr(uc, "latest_pypi_version", lambda **k: "99.0.0")
+    monkeypatch.setattr(
+        "dji_metadata_embedder.utils.exiftool.exiftool_version",
+        lambda: EXIFTOOL_VERSION,
+    )
+    text = "\n".join(uc.update_report(None))
+    assert f"dji-embed {__version__} -> 99.0.0 available" in text
+    assert "update:" in text
+    assert "online check: enabled (change with doctor --offline)" in text
+
+
+def test_report_online_up_to_date(monkeypatch):
+    uc.save_consent(True)
+    monkeypatch.setattr(uc, "latest_pypi_version", lambda **k: __version__)
+    monkeypatch.setattr(
+        "dji_metadata_embedder.utils.exiftool.exiftool_version",
+        lambda: EXIFTOOL_VERSION,
+    )
+    text = "\n".join(uc.update_report(None))
+    assert "up to date" in text
+
+
+def test_report_online_network_failure_degrades_silently(monkeypatch):
+    uc.save_consent(True)
+    monkeypatch.setattr(uc, "latest_pypi_version", lambda **k: None)
+    monkeypatch.setattr(
+        "dji_metadata_embedder.utils.exiftool.exiftool_version",
+        lambda: EXIFTOOL_VERSION,
+    )
+    lines = uc.update_report(None)
+    assert lines == ["online check: enabled (change with doctor --offline)"]


### PR DESCRIPTION
Closes #277

Implements the design from the issue: **normal commands never touch the network — `doctor` is the only command that may go online for version info, and it asks first.**

## What's in it

**Consent flow** (`utils/update_check.py`, new):
- One-time prompt on interactive doctor runs (`[y/N]`, plain Enter/EOF = No), persisted as `update_check.json` in the per-user config dir (parent of the provisioned-ExifTool tools dir, so `DJIEMBED_TOOLS_DIR` relocates it too).
- `doctor --online` / `--offline` force this run and persist; the current setting is always shown in doctor output for discoverability.
- Precedence: `DJIEMBED_NO_UPDATE_CHECK` kill-switch > CLI flag > stored consent > one-time prompt > off. Non-TTY or `CI` set: never prompts, never checks.
- Any network failure degrades silently to the offline report (3 s timeout, stdlib `urllib`, no new dependencies).

**Check 1 — dji-embed vs PyPI**: when outdated, the hint is environment-aware — frozen EXE → GitHub release / `winget upgrade`, pipx → `pipx upgrade`, otherwise the literal `"<sys.executable>" -m pip install --upgrade ...`, which is what defeats the multi-Python trap from the 2026-07-14 support case.

**Check 2 — ExifTool vs the pin** (fully offline): when the resolved ExifTool trails the pinned release, the hint names the DJI models the pin unlocks and points at `dji-embed doctor --install exiftool`.

**Docs**: README documents the opt-in check and the opt-out; the troubleshooting entry for "I updated but `--version` shows the old version" now cross-links `doctor --online`.

## Testing

- 33 new tests (29 in `tests/test_update_check.py`, 4 CLI-level): consent persistence + corrupt-file handling, precedence order, env-detection matrix (frozen/pipx incl. `PIPX_HOME` and Windows layouts/pip), version comparison, silent-failure path with mocked HTTP.
- Full gate green: `pytest` 508 passed / 4 skipped (pre-existing env-gated), `ruff` clean, `mypy` clean.
- Manual smoke: `CI=1 doctor` → no prompt, no network; `DJIEMBED_NO_UPDATE_CHECK=1 doctor --online` → neither checks nor persists; real `doctor --online` hit PyPI and the real apt ExifTool 12.76 produced the pin hint exactly as in the issue's example.

## Checklist
- [x] Tests added/updated for new functionality
- [x] Documentation updated (README, troubleshooting)
- [x] Cross-platform compatibility verified (explicit UTF-8 I/O, path handling tolerant of both separators)
- [x] No breaking changes (normal commands untouched; `run_doctor()` default unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZibkZVsDF5Vg5FXZAQjR7