### PR TITLE
feat(cli): drag a folder onto dji-embed to open its maps (#264 stage 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ Open the resulting `.html` file in any browser — done. The maps embed your
 data but load the background map tiles from the internet, so they need a
 connection to render.
 
+**No terminal at all?** On Windows, drag your footage folder onto
+`dji-embed.exe` — it maps every flight log (and geotagged photos) in the
+folder, including subfolders, and opens the result in your browser. The same
+works in a terminal by passing just a folder: `dji-embed /path/to/footage`.
+
 **Prefer a browser over the terminal?** There's an optional local web UI that
 wraps the main commands:
 

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -16,6 +16,7 @@ This guide helps you choose the right command and approach for your specific use
 | **Drive it from a browser** | `dji-embed ui` | You prefer a GUI; requires the `[ui]` extra |
 | **Map a whole folder of flights** | `dji-embed flightmap` | You want every flight's track on one combined map (experimental) |
 | **Map your still photos** | `dji-embed photomap` | You shot geotagged photos and want them on a map |
+| **No terminal at all** | drag the folder onto `dji-embed.exe` | Maps the folder's flight logs and photos, then opens the result in your browser (same as `dji-embed <folder>`) |
 
 ---
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -7,10 +7,21 @@ This guide shows the basics of processing DJI footage with `dji-embed`.
 Process a directory of videos and matching SRT files:
 
 ```bash
-dji-embed /path/to/footage
+dji-embed embed /path/to/footage
 ```
 
 A `processed` folder will be created containing new videos with embedded metadata and telemetry summary files.
+
+## Just want a map? Drag and drop
+
+Passing a bare folder — no command — maps it instead: every `.SRT` flight
+log (and geotagged photos, subfolders included) is drawn and the map opens
+in your browser. On Windows this means you can simply **drag your footage
+folder onto `dji-embed.exe`**:
+
+```bash
+dji-embed /path/to/footage    # -> flightmap.html (and photomap.html) open in the browser
+```
 
 ## Common options
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import sys
+import webbrowser
 import click
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 from . import __version__
 from .embedder import DJIMetadataEmbedder, run_doctor
@@ -34,6 +37,7 @@ from .geo import (
     write_photos_html,
     write_photos_kml,
 )
+from .geo.photomap import _PHOTO_EXTS
 from .mp4_telemetry import Mp4TelemetryError
 from .utilities import check_dependencies, setup_logging, get_tool_versions
 
@@ -64,7 +68,70 @@ def _print_version(ctx: click.Context, param: click.Parameter, value: bool) -> N
     ctx.exit(ExitCode.SUCCESS)
 
 
-@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def _dragdrop_pause() -> None:
+    """Hold the console open on a frozen EXE so the message stays readable.
+
+    Double-clicking (or dragging onto) dji-embed.exe opens a console window
+    that vanishes the instant the process exits.
+    """
+    if getattr(sys, "frozen", False) and sys.stdin is not None and sys.stdin.isatty():
+        click.echo()
+        click.pause("Press any key to close this window ...")
+
+
+def _echo_dragdrop_hint() -> None:
+    """Friendly double-click message instead of the full CLI help dump."""
+    click.echo(f"dji-embed {__version__}")
+    click.echo()
+    click.echo(
+        "To make a map of your drone footage: drag the folder that holds\n"
+        "your videos or photos onto dji-embed.exe, and the map will open\n"
+        "in your browser."
+    )
+    click.echo()
+    click.echo("For everything else, open a terminal and run: dji-embed --help")
+    _dragdrop_pause()
+
+
+class DragDropGroup(click.Group):
+    """Click group that also accepts a bare directory argument.
+
+    Windows Explorer passes a dragged folder as ``argv[1]`` with no
+    subcommand; routing that to the hidden ``dragdrop`` command is the whole
+    no-command-line story of issue #264 stage 1.
+    """
+
+    def main(
+        self, args: Sequence[str] | None = None, *pargs: Any, **extra: Any
+    ) -> Any:
+        argv = list(sys.argv[1:]) if args is None else [str(a) for a in args]
+        if not argv and getattr(sys, "frozen", False):
+            _echo_dragdrop_hint()
+            return None
+        return super().main(argv, *pargs, **extra)
+
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str, click.Command, list[str]]:
+        try:
+            return super().resolve_command(ctx, args)
+        except click.UsageError:
+            if all(Path(a).is_dir() for a in args):
+                cmd = self.get_command(ctx, "dragdrop")
+                assert cmd is not None  # registered below in this module
+                return "dragdrop", cmd, args
+            if Path(args[0]).is_file():
+                raise click.UsageError(
+                    f"'{args[0]}' is a file. To make a map, drag the folder "
+                    "that contains your footage instead."
+                )
+            raise
+
+
+@click.group(
+    cls=DragDropGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.option(
     "--version",
     is_flag=True,
@@ -610,6 +677,61 @@ def flightmap(
                 write_flights_geojson(tracks, out)
         except OSError as e:
             raise click.ClickException(f"Could not write {out}: {e}")
+
+
+def _contains_photos(src: Path) -> bool:
+    """Cheap suffix check so a folder with no stills never runs ExifTool."""
+    photo_suffixes = {f".{ext}" for ext in _PHOTO_EXTS}
+    return any(
+        p.suffix.lower() in photo_suffixes
+        for p in src.rglob("*")
+        if p.is_file()
+    )
+
+
+@main.command(hidden=True)
+@click.argument(
+    "directories",
+    nargs=-1,
+    required=True,
+    type=click.Path(exists=True, file_okay=False),
+)
+@click.pass_context
+def dragdrop(ctx: click.Context, directories: tuple[str, ...]) -> None:
+    """Map folders dropped onto the EXE and open the results in the browser.
+
+    This runs when dji-embed is invoked with bare directory arguments (the
+    shape Windows Explorer produces for drag-and-drop): flightmap over the
+    .SRT logs and, when the folder holds stills, photomap too — both
+    recursive — then every written HTML map opens in the default browser.
+    """
+    setup_logging(verbose=False, quiet=False)
+    opened_any = False
+    for directory in directories:
+        src = Path(directory)
+        maps: list[Path] = []
+        try:
+            ctx.invoke(flightmap, directory=directory, recursive=True)
+            maps.append(src / "flightmap.html")
+        except click.ClickException as e:
+            click.echo(f"No flight map for {src}: {e.message}", err=True)
+        if _contains_photos(src):
+            try:
+                ctx.invoke(photomap, directory=directory, recursive=True)
+                maps.append(src / "photomap.html")
+            except click.ClickException as e:
+                click.echo(f"No photo map for {src}: {e.message}", err=True)
+        for out in maps:
+            webbrowser.open(out.resolve().as_uri())
+            opened_any = True
+    if not opened_any:
+        click.echo(
+            "Nothing to map: no DJI .SRT flight logs or geotagged photos "
+            f"found in {', '.join(directories)}",
+            err=True,
+        )
+        _dragdrop_pause()
+        sys.exit(ExitCode.GENERAL_ERROR)
 
 
 @main.command()

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -26,6 +26,7 @@ from .geo import (
     convert_to_html,
     convert_to_cot,
     PhotomapError,
+    folder_has_photos,
     redact_photo_points,
     scan_flights,
     scan_photos,
@@ -37,7 +38,6 @@ from .geo import (
     write_photos_html,
     write_photos_kml,
 )
-from .geo.photomap import _PHOTO_EXTS
 from .mp4_telemetry import Mp4TelemetryError
 from .utilities import check_dependencies, setup_logging, get_tool_versions
 
@@ -68,13 +68,29 @@ def _print_version(ctx: click.Context, param: click.Parameter, value: bool) -> N
     ctx.exit(ExitCode.SUCCESS)
 
 
-def _dragdrop_pause() -> None:
-    """Hold the console open on a frozen EXE so the message stays readable.
+def _launched_from_explorer() -> bool:
+    """True when this process is the sole owner of its console window.
 
-    Double-clicking (or dragging onto) dji-embed.exe opens a console window
-    that vanishes the instant the process exits.
+    That is the double-click / drag-and-drop launch shape on Windows:
+    Explorer spawns a fresh console holding only this process, and it
+    vanishes the instant the process exits. Started from cmd/PowerShell,
+    the shell also owns the console, so the count is >= 2.
     """
-    if getattr(sys, "frozen", False) and sys.stdin is not None and sys.stdin.isatty():
+    if sys.platform != "win32":
+        return False
+    try:
+        import ctypes
+
+        process_ids = (ctypes.c_uint32 * 2)()
+        count = ctypes.windll.kernel32.GetConsoleProcessList(process_ids, 2)
+        return count <= 1
+    except Exception:  # no console at all, or a non-standard runtime
+        return False
+
+
+def _dragdrop_pause() -> None:
+    """Hold an Explorer-spawned console open so the message stays readable."""
+    if getattr(sys, "frozen", False) and _launched_from_explorer():
         click.echo()
         click.pause("Press any key to close this window ...")
 
@@ -90,7 +106,6 @@ def _echo_dragdrop_hint() -> None:
     )
     click.echo()
     click.echo("For everything else, open a terminal and run: dji-embed --help")
-    _dragdrop_pause()
 
 
 class DragDropGroup(click.Group):
@@ -104,11 +119,23 @@ class DragDropGroup(click.Group):
     def main(
         self, args: Sequence[str] | None = None, *pargs: Any, **extra: Any
     ) -> Any:
-        argv = list(sys.argv[1:]) if args is None else [str(a) for a in args]
-        if not argv and getattr(sys, "frozen", False):
+        # args must be passed through untouched: click only applies its
+        # Windows glob/~/env expansion when it receives args=None.
+        argv = sys.argv[1:] if args is None else args
+        if not argv and getattr(sys, "frozen", False) and _launched_from_explorer():
             _echo_dragdrop_hint()
+            _dragdrop_pause()
             return None
-        return super().main(argv, *pargs, **extra)
+        try:
+            return super().main(
+                None if args is None else list(args), *pargs, **extra
+            )
+        except SystemExit as e:
+            if e.code not in (0, None):
+                # Errors on a double-click launch print into a console that
+                # closes instantly; hold it open (no-op elsewhere).
+                _dragdrop_pause()
+            raise
 
     def resolve_command(
         self, ctx: click.Context, args: list[str]
@@ -116,14 +143,22 @@ class DragDropGroup(click.Group):
         try:
             return super().resolve_command(ctx, args)
         except click.UsageError:
-            if all(Path(a).is_dir() for a in args):
-                cmd = self.get_command(ctx, "dragdrop")
-                assert cmd is not None  # registered below in this module
-                return "dragdrop", cmd, args
-            if Path(args[0]).is_file():
+            paths = [Path(a) for a in args]
+            if all(p.exists() for p in paths):
+                if any(p.is_dir() for p in paths):
+                    cmd = self.get_command(ctx, "dragdrop")
+                    assert cmd is not None  # registered below in this module
+                    return "dragdrop", cmd, args
                 raise click.UsageError(
                     f"'{args[0]}' is a file. To make a map, drag the folder "
                     "that contains your footage instead."
+                )
+            if paths and paths[0].is_dir():
+                raise click.UsageError(
+                    f"'{args[0]}' is a folder, and bare-folder mapping takes "
+                    "no other arguments. For options, name the command: "
+                    f"dji-embed flightmap {args[0]} ... or "
+                    f"dji-embed photomap {args[0]} ..."
                 )
             raise
 
@@ -679,58 +714,67 @@ def flightmap(
             raise click.ClickException(f"Could not write {out}: {e}")
 
 
-def _contains_photos(src: Path) -> bool:
-    """Cheap suffix check so a folder with no stills never runs ExifTool."""
-    photo_suffixes = {f".{ext}" for ext in _PHOTO_EXTS}
-    return any(
-        p.suffix.lower() in photo_suffixes
-        for p in src.rglob("*")
-        if p.is_file()
-    )
-
-
 @main.command(hidden=True)
 @click.argument(
-    "directories",
+    "paths",
     nargs=-1,
     required=True,
-    type=click.Path(exists=True, file_okay=False),
+    type=click.Path(exists=True),
 )
 @click.pass_context
-def dragdrop(ctx: click.Context, directories: tuple[str, ...]) -> None:
+def dragdrop(ctx: click.Context, paths: tuple[str, ...]) -> None:
     """Map folders dropped onto the EXE and open the results in the browser.
 
-    This runs when dji-embed is invoked with bare directory arguments (the
-    shape Windows Explorer produces for drag-and-drop): flightmap over the
-    .SRT logs and, when the folder holds stills, photomap too — both
-    recursive — then every written HTML map opens in the default browser.
+    This runs when dji-embed is invoked with bare path arguments (the shape
+    Windows Explorer produces for drag-and-drop): flightmap over each
+    folder's .SRT logs and, when the folder holds stills, photomap too —
+    both recursive — then every written HTML map opens in the default
+    browser. Files in the selection are skipped with a note.
     """
     setup_logging(verbose=False, quiet=False)
-    opened_any = False
-    for directory in directories:
-        src = Path(directory)
+    unmapped: list[str] = []
+    for target in paths:
+        src = Path(target)
+        if not src.is_dir():
+            click.echo(
+                f"Skipping {src.name}: drag folders to map, not single files",
+                err=True,
+            )
+            continue
         maps: list[Path] = []
+        flight_out = src / "flightmap.html"
         try:
-            ctx.invoke(flightmap, directory=directory, recursive=True)
-            maps.append(src / "flightmap.html")
+            ctx.invoke(
+                flightmap,
+                directory=target,
+                recursive=True,
+                output=str(flight_out),
+            )
+            maps.append(flight_out)
         except click.ClickException as e:
             click.echo(f"No flight map for {src}: {e.message}", err=True)
-        if _contains_photos(src):
+        if folder_has_photos(src):
+            photo_out = src / "photomap.html"
             try:
-                ctx.invoke(photomap, directory=directory, recursive=True)
-                maps.append(src / "photomap.html")
+                ctx.invoke(
+                    photomap,
+                    directory=target,
+                    recursive=True,
+                    output=str(photo_out),
+                )
+                maps.append(photo_out)
             except click.ClickException as e:
                 click.echo(f"No photo map for {src}: {e.message}", err=True)
         for out in maps:
             webbrowser.open(out.resolve().as_uri())
-            opened_any = True
-    if not opened_any:
+        if not maps:
+            unmapped.append(str(src))
+    if unmapped:
         click.echo(
             "Nothing to map: no DJI .SRT flight logs or geotagged photos "
-            f"found in {', '.join(directories)}",
+            f"found in {', '.join(unmapped)}",
             err=True,
         )
-        _dragdrop_pause()
         sys.exit(ExitCode.GENERAL_ERROR)
 
 

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -16,6 +16,7 @@ from .kml import convert_to_kml, track_to_kml
 from .photomap import (
     PhotomapError,
     PhotoPoint,
+    folder_has_photos,
     photos_to_geojson,
     photos_to_kml,
     redact_photo_points,
@@ -31,6 +32,7 @@ from .track import Track, TrackPoint, build_track
 __all__ = [
     "Track",
     "TrackPoint",
+    "folder_has_photos",
     "build_track",
     "sun_position",
     "track_to_cot",

--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import subprocess
 from dataclasses import dataclass, replace
@@ -258,6 +259,20 @@ def _run_exiftool_scan(directory: Path, recursive: bool) -> list[dict]:
     if not isinstance(data, list):
         raise PhotomapError("Unexpected ExifTool JSON shape (expected a list)")
     return data
+
+
+def folder_has_photos(directory: Path | str) -> bool:
+    """Cheap recursive suffix check: does the tree hold any photo files?
+
+    Lets callers skip the ExifTool scan entirely for photo-less folders;
+    os.walk avoids a stat call per entry and short-circuits on the first hit.
+    """
+    suffixes = {f".{ext}" for ext in _PHOTO_EXTS}
+    for _root, _dirs, filenames in os.walk(directory):
+        for name in filenames:
+            if os.path.splitext(name)[1].lower() in suffixes:
+                return True
+    return False
 
 
 def scan_photos(

--- a/tests/test_cli_dragdrop.py
+++ b/tests/test_cli_dragdrop.py
@@ -159,14 +159,116 @@ def test_dragged_file_hints_at_dragging_the_folder(tmp_path):
     assert "No such command" not in res.output
 
 
-def test_frozen_no_args_shows_drag_hint_not_help(monkeypatch):
+def test_mixed_drop_maps_the_folder_and_skips_the_file(monkeypatch, tmp_path):
+    opened = _capture_browser(monkeypatch)
+    trip = tmp_path / "trip"
+    trip.mkdir()
+    (trip / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    stray = tmp_path / "DJI_0002.MP4"
+    stray.write_bytes(b"fake")
+    res = CliRunner().invoke(main, [str(trip), str(stray)])
+    assert res.exit_code == 0, res.output
+    assert (trip / "flightmap.html").exists()
+    assert len(opened) == 1
+    assert "Skipping" in res.output and "DJI_0002.MP4" in res.output
+
+
+def test_multiple_dragged_files_get_the_folder_hint(tmp_path):
+    files = []
+    for name in ("DJI_0001.MP4", "DJI_0002.MP4"):
+        f = tmp_path / name
+        f.write_bytes(b"fake")
+        files.append(str(f))
+    res = CliRunner().invoke(main, files)
+    assert res.exit_code != 0
+    assert "folder" in res.output.lower()
+    assert "No such command" not in res.output
+
+
+def test_directory_with_options_gets_guidance(tmp_path):
+    (tmp_path / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    res = CliRunner().invoke(main, [str(tmp_path), "-v"])
+    assert res.exit_code != 0
+    assert "flightmap" in res.output
+    assert "No such command" not in res.output
+
+
+def test_partial_failure_exits_nonzero_but_still_opens_good_map(
+    monkeypatch, tmp_path
+):
+    opened = _capture_browser(monkeypatch)
+    good = tmp_path / "good"
+    good.mkdir()
+    (good / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    res = CliRunner().invoke(main, [str(good), str(empty)])
+    assert res.exit_code != 0
+    assert (good / "flightmap.html").exists()
+    assert len(opened) == 1
+    assert "Nothing to map" in res.output and "empty" in res.output
+
+
+def test_frozen_no_args_double_click_shows_drag_hint_not_help(monkeypatch):
     monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(cli, "_launched_from_explorer", lambda: True)
     res = CliRunner().invoke(main, [])
     assert res.exit_code == 0, res.output
     assert "drag" in res.output.lower()
     assert "Commands:" not in res.output  # not the click help dump
 
 
+def test_frozen_no_args_in_terminal_still_shows_help(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(cli, "_launched_from_explorer", lambda: False)
+    res = CliRunner().invoke(main, [])
+    assert "Usage:" in res.output
+
+
 def test_unfrozen_no_args_still_shows_help():
     res = CliRunner().invoke(main, [])
     assert "Usage:" in res.output
+
+
+def test_frozen_double_click_error_pauses_before_window_closes(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(cli, "_launched_from_explorer", lambda: True)
+    paused = []
+    monkeypatch.setattr("click.pause", lambda info: paused.append(info))
+    video = tmp_path / "DJI_0001.MP4"
+    video.write_bytes(b"fake")
+    res = CliRunner().invoke(main, [str(video)])
+    assert res.exit_code != 0
+    assert "folder" in res.output.lower()
+    assert len(paused) == 1
+
+
+def test_terminal_error_does_not_pause(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(cli, "_launched_from_explorer", lambda: False)
+    paused = []
+    monkeypatch.setattr("click.pause", lambda info: paused.append(info))
+    video = tmp_path / "DJI_0001.MP4"
+    video.write_bytes(b"fake")
+    res = CliRunner().invoke(main, [str(video)])
+    assert res.exit_code != 0
+    assert paused == []
+
+
+def test_group_passes_none_args_through_for_windows_expansion(monkeypatch):
+    """Click only glob-expands on Windows when main() receives args=None."""
+    received = []
+
+    def spy_main(self, args=None, *pargs, **extra):
+        received.append(args)
+        raise SystemExit(0)
+
+    monkeypatch.setattr("click.Group.main", spy_main)
+    monkeypatch.setattr(sys, "argv", ["dji-embed", "--help"])
+    try:
+        main()
+    except SystemExit:
+        pass
+    assert received == [None]

--- a/tests/test_cli_dragdrop.py
+++ b/tests/test_cli_dragdrop.py
@@ -1,0 +1,172 @@
+"""Drag-a-folder-onto-the-EXE flow (#264 stage 1).
+
+Windows passes a dragged folder as a bare argv[1]; the CLI maps it and
+opens the result in the default browser. These tests drive the same path
+through CliRunner with a bare directory argument.
+"""
+
+import sys
+
+from click.testing import CliRunner
+
+from dji_metadata_embedder import cli
+from dji_metadata_embedder.cli import main
+from dji_metadata_embedder.geo import photomap as pm
+from dji_metadata_embedder.geo.photomap import PhotomapError
+
+FLIGHT_A = (
+    "1\n00:00:00,000 --> 00:00:01,000\n"
+    '<font size="28">[latitude: 10.0] [longitude: 20.0] '
+    "[rel_alt: 1.000 abs_alt: 5.0]</font>\n\n"
+    "2\n00:00:01,000 --> 00:00:02,000\n"
+    '<font size="28">[latitude: 10.001] [longitude: 20.001] '
+    "[rel_alt: 1.000 abs_alt: 6.0]</font>\n"
+)
+
+GEOTAGGED = [
+    {
+        "SourceFile": "photos/church1.jpg",
+        "GPSLatitude": 60.170278,
+        "GPSLongitude": 24.952222,
+        "GPSAltitude": 95.3,
+    },
+]
+
+
+def _capture_browser(monkeypatch):
+    opened = []
+    monkeypatch.setattr(cli.webbrowser, "open", lambda url: opened.append(url))
+    return opened
+
+
+def _mock_photo_scan(monkeypatch, data=None, error=None):
+    def fake(directory, recursive):
+        if error is not None:
+            raise error
+        return data
+
+    monkeypatch.setattr(pm, "_run_exiftool_scan", fake)
+
+
+def test_bare_directory_maps_flights_and_opens_browser(monkeypatch, tmp_path):
+    opened = _capture_browser(monkeypatch)
+    (tmp_path / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    res = CliRunner().invoke(main, [str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    out = tmp_path / "flightmap.html"
+    assert out.exists()
+    assert opened == [out.resolve().as_uri()]
+
+
+def test_bare_directory_scans_subdirectories(monkeypatch, tmp_path):
+    opened = _capture_browser(monkeypatch)
+    sub = tmp_path / "DCIM" / "100MEDIA"
+    sub.mkdir(parents=True)
+    (sub / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    res = CliRunner().invoke(main, [str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    assert (tmp_path / "flightmap.html").exists()
+    assert len(opened) == 1
+
+
+def test_bare_directory_with_photos_writes_photomap_too(monkeypatch, tmp_path):
+    opened = _capture_browser(monkeypatch)
+    _mock_photo_scan(monkeypatch, data=GEOTAGGED)
+    (tmp_path / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    (tmp_path / "church1.jpg").write_bytes(b"\xff\xd8fake")
+    res = CliRunner().invoke(main, [str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    assert (tmp_path / "flightmap.html").exists()
+    assert (tmp_path / "photomap.html").exists()
+    assert len(opened) == 2
+
+
+def test_bare_directory_photos_only(monkeypatch, tmp_path):
+    opened = _capture_browser(monkeypatch)
+    _mock_photo_scan(monkeypatch, data=GEOTAGGED)
+    (tmp_path / "church1.jpg").write_bytes(b"\xff\xd8fake")
+    res = CliRunner().invoke(main, [str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    assert not (tmp_path / "flightmap.html").exists()
+    out = tmp_path / "photomap.html"
+    assert out.exists()
+    assert opened == [out.resolve().as_uri()]
+
+
+def test_bare_directory_photomap_failure_still_opens_flightmap(
+    monkeypatch, tmp_path
+):
+    opened = _capture_browser(monkeypatch)
+    _mock_photo_scan(monkeypatch, error=PhotomapError("exiftool not found"))
+    (tmp_path / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    (tmp_path / "church1.jpg").write_bytes(b"\xff\xd8fake")
+    res = CliRunner().invoke(main, [str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    out = tmp_path / "flightmap.html"
+    assert opened == [out.resolve().as_uri()]
+    assert "exiftool not found" in res.output
+
+
+def test_bare_directory_without_photos_never_runs_exiftool(
+    monkeypatch, tmp_path
+):
+    _capture_browser(monkeypatch)
+    _mock_photo_scan(monkeypatch, error=AssertionError("must not be called"))
+    (tmp_path / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    res = CliRunner().invoke(main, [str(tmp_path)])
+    assert res.exit_code == 0, res.output
+
+
+def test_bare_directory_with_nothing_mappable_is_clean_error(
+    monkeypatch, tmp_path
+):
+    opened = _capture_browser(monkeypatch)
+    res = CliRunner().invoke(main, [str(tmp_path)])
+    assert res.exit_code != 0
+    assert res.exception is None or isinstance(res.exception, SystemExit)
+    assert "Nothing to map" in res.output
+    assert opened == []
+
+
+def test_multiple_dragged_directories_each_get_a_map(monkeypatch, tmp_path):
+    opened = _capture_browser(monkeypatch)
+    for name in ("trip1", "trip2"):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    res = CliRunner().invoke(
+        main, [str(tmp_path / "trip1"), str(tmp_path / "trip2")]
+    )
+    assert res.exit_code == 0, res.output
+    assert (tmp_path / "trip1" / "flightmap.html").exists()
+    assert (tmp_path / "trip2" / "flightmap.html").exists()
+    assert len(opened) == 2
+
+
+def test_unknown_command_error_unchanged(tmp_path):
+    res = CliRunner().invoke(main, ["definitely-not-a-command"])
+    assert res.exit_code != 0
+    assert "No such command" in res.output
+
+
+def test_dragged_file_hints_at_dragging_the_folder(tmp_path):
+    video = tmp_path / "DJI_0001.MP4"
+    video.write_bytes(b"fake")
+    res = CliRunner().invoke(main, [str(video)])
+    assert res.exit_code != 0
+    assert res.exception is None or isinstance(res.exception, SystemExit)
+    assert "folder" in res.output.lower()
+    assert "No such command" not in res.output
+
+
+def test_frozen_no_args_shows_drag_hint_not_help(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    res = CliRunner().invoke(main, [])
+    assert res.exit_code == 0, res.output
+    assert "drag" in res.output.lower()
+    assert "Commands:" not in res.output  # not the click help dump
+
+
+def test_unfrozen_no_args_still_shows_help():
+    res = CliRunner().invoke(main, [])
+    assert "Usage:" in res.output


### PR DESCRIPTION
## Summary

Stage 1 of #264 (no-command-line path): invoking `dji-embed` with a **bare directory argument** — exactly what Windows Explorer passes when a folder is dragged onto `dji-embed.exe` — now maps the folder and opens the result in the default browser. Zero commands for the Reddit novice audience; ships in a patch release.

### Behavior

- `dji-embed <folder>` (or drag-and-drop): runs **flightmap** over the `.SRT` logs and, when the folder contains stills, **photomap** too — both recursive (novices drag their whole `DCIM` tree) — then opens every written HTML map via `webbrowser.open()`. Maps land in the dragged folder, same as the commands' defaults.
- Multiple folders dragged at once: each gets its own map.
- One map failing (e.g. no ExifTool for photomap) doesn't stop the other; nothing mappable at all is a clean, friendly error.
- Dragging a **file** gets *"drag the folder that contains your footage instead"*, not `No such command`.
- **Frozen EXE double-clicked with no args**: short drag-and-drop hint with a keypress pause (the console window used to flash the full help dump and vanish). Terminal `dji-embed` with no args still prints help; all existing commands and errors are untouched.

### Implementation

- `DragDropGroup(click.Group)`: falls back to a hidden `dragdrop` command when command resolution fails and every argument is an existing directory; frozen no-args hint lives in `main()` override.
- Photo presence is a cheap suffix scan (from `_PHOTO_EXTS`) so folders without stills never start ExifTool.
- Docs: README "Your first map", user guide (also fixes the stale pre-Click `dji-embed /path/to/footage` quick start that claimed bare-directory *embeds*), decision table.

## Testing

- 12 new tests in `tests/test_cli_dragdrop.py` (TDD; written first, watched fail): happy path incl. recursion + browser-open capture, photos-only, both-maps, partial failure, no-ExifTool-invocation guard, clean nothing-to-map error, multi-folder, dragged-file hint, frozen/unfrozen no-args, unknown-command unchanged.
- Full suite: 525 passed; ruff + mypy clean.
- E2E through the real CLI (WSL, `BROWSER` shim): bare folder with nested `DCIM/*.SRT` → `flightmap.html` written into the folder, browser opened with the file URI; empty-folder and dragged-file error paths verified.

Refs #264 (stage 1 of 3 — stages 2–3 are the JSONL progress contract and the Avalonia app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A