### PR TITLE
feat(photomap): distinct marker colors and toggles per media type

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ it's a handful of copy-paste commands. For a guided tour see
   footage and get a single interactive map with each flight as its own
   coloured track *(experimental)*.
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
-  folder of stills on one clustered map, thumbnails included, and opens 360°
-  panoramas in an interactive viewer.
+  folder of stills on one clustered map, thumbnails included; 360° panoramas
+  get their own marker color and toggle, and open in an interactive viewer.
 - **Make videos searchable by location** — `dji-embed embed` writes the GPS
   data into the video files so Windows Photos, Google Photos, and similar apps
   can find them by place. No re-encoding, no quality loss, and the full
@@ -448,7 +448,9 @@ Notes:
 
 Map GPS-tagged still photos (JPG/JPEG/DNG) as an HTML, KML, or GeoJSON map.
 Requires ExifTool (`dji-embed doctor` checks it). Photos without GPS data are
-skipped and counted in a summary; `-v` lists the skipped filenames.
+skipped and counted in a summary; `-v` lists the skipped filenames. On the
+HTML map, regular photos are blue markers and 360° panoramas orange ones,
+with a checkbox to show/hide each type when a folder mixes both.
 
 ```bash
 dji-embed photomap /path/to/photos                                    # -> photos/photomap.html

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -243,7 +243,10 @@ folder or an absolute URL) when the originals live elsewhere.
 
 Stitched spherical panoramas (DJI, Insta360, Google Camera, …) carry XMP
 GPano tags. Photomap detects `ProjectionType=equirectangular` during the
-same ExifTool scan; when `--link-originals` is set, clicking such a pin
+same ExifTool scan. Detected panoramas draw as orange markers (regular
+photos are blue), and mixed folders get a checkbox control to show or hide
+each type; the exported GeoJSON marks them with `"pano": true`. When
+`--link-originals` is set, clicking such a pin
 opens the photo in an embedded 360° viewer
 ([Pannellum](https://pannellum.org/), loaded from the CDN like Leaflet)
 instead of a flat, distorted JPEG. An "open original" link stays in the

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -104,8 +104,8 @@ shows its EXIF thumbnail, filename, timestamp, altitude, and camera settings,
 and hovering a marker previews the thumbnail and filename without clicking.
 KML opens the same thumbnails in Google Earth Pro (Google My Maps import may
 drop the images but keeps the placemarks). GeoJSON is interchange-only — no
-thumbnails, just `name`/`timestamp`/`alt`/`camera` properties — for use in
-GIS tools.
+thumbnails, just `name`/`timestamp`/`alt`/`camera` properties (plus
+`"pano": true` on 360° panoramas) — for use in GIS tools.
 
 With `--link-originals`, the HTML popups' thumbnail and filename become a
 click-through to the full-resolution original in a new browser tab (JPGs
@@ -117,7 +117,9 @@ either way. If the originals live elsewhere, point at them with
 (absolute URL).
 
 360° panoramas (GPano photos from DJI, Insta360, Google Camera, …) are
-detected automatically; with `--link-originals`, clicking one opens an
+detected automatically and drawn as orange markers (regular photos are blue);
+when a folder mixes both, a checkbox control on the map lets you show or hide
+each type independently. With `--link-originals`, clicking a panorama opens an
 embedded interactive 360° viewer instead of a flat, distorted JPEG — an
 "open original" link stays in the popup as a fallback.
 

--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -329,16 +329,17 @@ def photos_to_geojson(
     feature gains a ``link`` property pointing at the original photo file
     (``""`` = alongside the map, else a folder/URL prefix). The standalone
     GeoJSON writer never passes it — a shared map must not accumulate fragile
-    file references by default. Panoramic photos additionally get
-    ``"pano": true`` so the HTML viewer can open them in 360°.
+    file references by default. Panoramic photos always carry ``"pano": true``
+    (issue #283: it is type metadata, used for marker styling even when the
+    360° viewer itself is link-gated).
     """
     features: list[dict] = []
     for p in points:
         props: dict = {"name": p.name}
+        if p.is_pano:
+            props["pano"] = True
         if link_base is not None:
             props["link"] = _link_href(p.name, link_base)
-            if p.is_pano:
-                props["pano"] = True
         if p.timestamp:
             props["timestamp"] = p.timestamp
         # Missing altitude is omitted entirely (no property, 2D coordinate)

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -61,6 +61,17 @@ _TEMPLATE = """<!DOCTYPE html>
   #map {{ height: 100%; }}
   .photo-popup img {{ max-width: 260px; display: block; margin-bottom: 4px; }}
   .photo-tooltip img {{ max-width: 160px; display: block; margin-bottom: 2px; }}
+  /* Per-type markers (issue #283): blue dot = photo, orange dot = 360 pano.
+     The same classes render the swatches in the layer-control legend. */
+  .photo-pin {{ display: block; width: 14px; height: 14px; border-radius: 50%;
+               border: 2.5px solid #fff; box-shadow: 0 0 4px rgba(0,0,0,.5);
+               box-sizing: content-box; }}
+  .pin-photo {{ background: #2a81cb; }}
+  .pin-pano  {{ background: #f69730; }}
+  .pin-swatch {{ display: inline-block; vertical-align: -3px;
+                margin-right: 2px; }}
+  .pano-cluster {{ background-color: rgba(246, 151, 48, .4); }}
+  .pano-cluster div {{ background-color: rgba(246, 151, 48, .8); }}
 </style>
 </head>
 <body>
@@ -164,8 +175,34 @@ const esc = s => String(s).replace(/[&<>"']/g,
 
 const points = (data.features || []).filter(
   f => f.geometry && f.geometry.type === 'Point');
-const cluster = L.markerClusterGroup({ chunkedLoading: true });
-const markers = [];
+
+// Per-type markers (issue #283): photos and 360 panoramas get their own
+// colored pin and their own cluster group, so clusters stay type-pure and
+// each type can be toggled independently.
+const isPano = f => (f.properties || {}).pano === true;
+const pinIcon = cls => L.divIcon({
+  className: '', html: `<span class="photo-pin ${cls}"></span>`,
+  iconSize: [19, 19], iconAnchor: [9, 9], popupAnchor: [0, -9],
+  tooltipAnchor: [0, -11]
+});
+const photoIcon = pinIcon('pin-photo');
+const panoIcon = pinIcon('pin-pano');
+// Mirrors markercluster's default icon (count + small/medium/large sizing)
+// with a pano-tinted color scheme.
+const panoClusterIcon = c => {
+  const n = c.getChildCount();
+  const size = n < 10 ? 'small' : n < 100 ? 'medium' : 'large';
+  return L.divIcon({
+    html: `<div><span>${n}</span></div>`,
+    className: `marker-cluster marker-cluster-${size} pano-cluster`,
+    iconSize: L.point(40, 40)
+  });
+};
+const photoCluster = L.markerClusterGroup({ chunkedLoading: true });
+const panoCluster = L.markerClusterGroup({
+  chunkedLoading: true, iconCreateFunction: panoClusterIcon });
+const photoMarkers = [];
+const panoMarkers = [];
 const latlngs = [];
 
 function buildPopup(f) {
@@ -212,13 +249,25 @@ function buildTooltip(f) {
 for (const f of points) {
   const c = f.geometry.coordinates;                  // [lon, lat, alt]
   latlngs.push([c[1], c[0]]);
-  markers.push(
-    L.marker([c[1], c[0]])
+  const pano = isPano(f);
+  (pano ? panoMarkers : photoMarkers).push(
+    L.marker([c[1], c[0]], { icon: pano ? panoIcon : photoIcon })
       .bindPopup(() => buildPopup(f), { maxWidth: 300 })
       .bindTooltip(() => buildTooltip(f), { sticky: true, direction: 'top' }));
 }
-cluster.addLayers(markers);
-map.addLayer(cluster);
+photoCluster.addLayers(photoMarkers);
+panoCluster.addLayers(panoMarkers);
+if (photoMarkers.length) map.addLayer(photoCluster);
+if (panoMarkers.length) map.addLayer(panoCluster);
+if (photoMarkers.length && panoMarkers.length) {
+  // Expanded control doubles as the legend: the labels reuse the pin CSS as
+  // colored swatches. Only shown when the folder actually mixes types.
+  L.control.layers(null, {
+    '<span class="photo-pin pin-photo pin-swatch"></span>Photos': photoCluster,
+    '<span class="photo-pin pin-pano pin-swatch"></span>360° panoramas':
+      panoCluster
+  }, { collapsed: false }).addTo(map);
+}
 if (latlngs.length > 1) {
   map.fitBounds(L.latLngBounds(latlngs).pad(0.1), { maxZoom: 17 });
 } else if (latlngs.length === 1) {

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -62,16 +62,27 @@ _TEMPLATE = """<!DOCTYPE html>
   .photo-popup img {{ max-width: 260px; display: block; margin-bottom: 4px; }}
   .photo-tooltip img {{ max-width: 160px; display: block; margin-bottom: 2px; }}
   /* Per-type markers (issue #283): blue dot = photo, orange dot = 360 pano.
-     The same classes render the swatches in the layer-control legend. */
+     The same classes render the swatches in the layer-control legend, and
+     the cluster tints derive from the same two custom properties. */
+  :root {{ --pin-photo: #2a81cb; --pin-pano: #f69730; }}
   .photo-pin {{ display: block; width: 14px; height: 14px; border-radius: 50%;
                border: 2.5px solid #fff; box-shadow: 0 0 4px rgba(0,0,0,.5);
                box-sizing: content-box; }}
-  .pin-photo {{ background: #2a81cb; }}
-  .pin-pano  {{ background: #f69730; }}
+  .pin-photo {{ background: var(--pin-photo); }}
+  .pin-pano  {{ background: var(--pin-pano); }}
   .pin-swatch {{ display: inline-block; vertical-align: -3px;
                 margin-right: 2px; }}
-  .pano-cluster {{ background-color: rgba(246, 151, 48, .4); }}
-  .pano-cluster div {{ background-color: rgba(246, 151, 48, .8); }}
+  /* Both cluster tints replace markercluster's default color ramp: its
+     "large" (>=100) orange is nearly identical to the pano tint, which would
+     contradict the orange-means-panorama legend on dense photo maps. */
+  .photo-cluster {{
+    background-color: color-mix(in srgb, var(--pin-photo) 40%, transparent); }}
+  .photo-cluster div {{ color: #fff;
+    background-color: color-mix(in srgb, var(--pin-photo) 80%, transparent); }}
+  .pano-cluster {{
+    background-color: color-mix(in srgb, var(--pin-pano) 40%, transparent); }}
+  .pano-cluster div {{
+    background-color: color-mix(in srgb, var(--pin-pano) 80%, transparent); }}
 </style>
 </head>
 <body>
@@ -182,25 +193,32 @@ const points = (data.features || []).filter(
 const isPano = f => (f.properties || {}).pano === true;
 const pinIcon = cls => L.divIcon({
   className: '', html: `<span class="photo-pin ${cls}"></span>`,
-  iconSize: [19, 19], iconAnchor: [9, 9], popupAnchor: [0, -9],
-  tooltipAnchor: [0, -11]
+  iconSize: [19, 19], iconAnchor: [9, 9], popupAnchor: [0, -9]
 });
 const photoIcon = pinIcon('pin-photo');
 const panoIcon = pinIcon('pin-pano');
+// The two groups cluster independently, so a photo blob and a pano blob can
+// land on the exact same point (routine with --redact fuzz, which rounds
+// both types to the same 3-decimal grid). Anchoring the pano blob slightly
+// off-center keeps the photo blob underneath visible and clickable instead
+// of fully occluded.
+const PANO_CLUSTER_ANCHOR = L.point(31, 31);
 // Mirrors markercluster's default icon (count + small/medium/large sizing)
-// with a pano-tinted color scheme.
-const panoClusterIcon = c => {
+// with a per-type color scheme (see the .photo-cluster/.pano-cluster CSS).
+const clusterIcon = (cls, anchor) => c => {
   const n = c.getChildCount();
   const size = n < 10 ? 'small' : n < 100 ? 'medium' : 'large';
   return L.divIcon({
     html: `<div><span>${n}</span></div>`,
-    className: `marker-cluster marker-cluster-${size} pano-cluster`,
-    iconSize: L.point(40, 40)
+    className: `marker-cluster marker-cluster-${size} ${cls}`,
+    iconSize: L.point(40, 40), iconAnchor: anchor
   });
 };
-const photoCluster = L.markerClusterGroup({ chunkedLoading: true });
+const photoCluster = L.markerClusterGroup({
+  chunkedLoading: true, iconCreateFunction: clusterIcon('photo-cluster') });
 const panoCluster = L.markerClusterGroup({
-  chunkedLoading: true, iconCreateFunction: panoClusterIcon });
+  chunkedLoading: true,
+  iconCreateFunction: clusterIcon('pano-cluster', PANO_CLUSTER_ANCHOR) });
 const photoMarkers = [];
 const panoMarkers = [];
 const latlngs = [];
@@ -287,8 +305,9 @@ def photos_to_html(
     and filename to the original photo file — ``""`` means the originals sit
     beside the HTML, otherwise a folder/URL prefix. Such links only resolve
     while the originals stay reachable; the default (``None``) keeps the map
-    fully self-contained. GPano panoramas open in an embedded Pannellum 360°
-    viewer when links are enabled; without links the map is unchanged.
+    fully self-contained. GPano panoramas always render as distinct,
+    toggleable orange markers (issue #283); the embedded Pannellum 360°
+    viewer additionally activates when links are enabled.
     """
     geojson = photos_to_geojson(
         points, include_thumbnails=True, link_base=link_base

--- a/tests/test_geo_photomap.py
+++ b/tests/test_geo_photomap.py
@@ -527,10 +527,14 @@ _PANO_POINT = PhotoPoint(lat=1.0, lon=2.0, alt=None, name="pano.jpg", is_pano=Tr
 _FLAT_POINT = PhotoPoint(lat=1.0, lon=2.0, alt=None, name="flat.jpg")
 
 
-def test_geojson_pano_property_requires_link_base():
-    # Without links the viewer has nothing to load: no pano property at all.
+def test_geojson_pano_property_without_link_base():
+    # #283: the pano flag is type metadata, not viewer plumbing — emitted even
+    # without links so maps (and GIS consumers) can tell panoramas apart.
     data = photos_to_geojson([_PANO_POINT, _FLAT_POINT])
-    assert all("pano" not in f["properties"] for f in data["features"])
+    by_name = {f["properties"]["name"]: f["properties"] for f in data["features"]}
+    assert by_name["pano.jpg"]["pano"] is True
+    assert "pano" not in by_name["flat.jpg"]
+    assert all("link" not in f["properties"] for f in data["features"])
 
 
 def test_geojson_pano_property_with_link_base_only_on_panos():

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -254,9 +254,30 @@ def test_html_layer_control_gated_on_both_types():
     assert "photoMarkers.length && panoMarkers.length" in html
 
 
-def test_html_pano_clusters_tinted():
-    # Pano-only cluster blobs are tinted to match the pano pin color.
+def test_html_both_cluster_types_tinted():
+    # Both groups override markercluster's default color ramp: its "large"
+    # orange is nearly identical to the pano tint, so photo clusters are
+    # tinted blue and pano clusters orange to keep the legend truthful.
     html = photos_to_html(PANO_POINTS, title="t")
     assert "iconCreateFunction" in html
-    assert "pano-cluster" in html
+    assert ".photo-cluster div" in html
     assert ".pano-cluster div" in html
+
+
+def test_html_pin_colors_defined_once():
+    # The two type colors live in CSS custom properties; every other use
+    # (pins, cluster tints) derives from them, so a recolor is a 1-line edit.
+    html = photos_to_html(PANO_POINTS, title="t")
+    assert "--pin-photo:" in html
+    assert "--pin-pano:" in html
+    assert "color-mix(" in html
+    assert "rgba(246" not in html  # no parallel hand-converted copy
+
+
+def test_html_pano_cluster_anchor_offset_against_occlusion():
+    # Coincident photo and pano clusters (routine under --redact fuzz, which
+    # rounds both types to the same 3-decimal grid) must not fully occlude
+    # each other: the pano blob anchors slightly off-center so the photo blob
+    # underneath stays visible and clickable.
+    html = photos_to_html(PANO_POINTS, title="t")
+    assert "PANO_CLUSTER_ANCHOR" in html

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -161,11 +161,16 @@ def test_html_no_pannellum_without_panos():
 
 
 def test_html_no_pannellum_without_links():
-    # A pano without --link-originals has nothing the viewer could load.
+    # A pano without --link-originals has nothing the viewer could load, but
+    # the pano flag itself is still embedded for marker styling (#283).
     html = photos_to_html(PANO_POINTS, title="t")
     assert "pannellum" not in html
-    data = _embedded_geojson(html)
-    assert all("pano" not in f["properties"] for f in data["features"])
+    by_name = {
+        f["properties"]["name"]: f["properties"]
+        for f in _embedded_geojson(html)["features"]
+    }
+    assert by_name["pano.jpg"]["pano"] is True
+    assert all("link" not in p for p in by_name.values())
 
 
 def test_html_pano_with_links_embeds_pinned_viewer():

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -63,7 +63,8 @@ def test_html_popup_js_escapes_text_fields():
 def test_html_uses_cluster_bulk_path():
     html = photos_to_html(POINTS, title="t")
     assert "chunkedLoading: true" in html
-    assert "cluster.addLayers(markers)" in html
+    assert "photoCluster.addLayers(photoMarkers)" in html
+    assert "panoCluster.addLayers(panoMarkers)" in html
 
 
 def test_html_empty_points_still_valid_document():
@@ -220,3 +221,42 @@ def test_html_file_protocol_help_absent_without_panos():
     html = photos_to_html(POINTS, title="t", link_base="")
     assert "pano-blocked" not in html
     assert "location.protocol" not in html
+
+
+# Per-type markers (issue #283): photos and 360° panoramas get distinct,
+# individually toggleable markers so mixed folders stay readable.
+
+
+def test_html_markers_use_type_colored_divicons():
+    html = photos_to_html(PANO_POINTS, title="t")
+    assert "L.divIcon" in html
+    # Shared dot CSS plus one color class per type; the JS picks the icon
+    # from the feature's pano property.
+    assert ".photo-pin" in html
+    assert "pin-photo" in html and "pin-pano" in html
+
+
+def test_html_type_pure_cluster_groups():
+    # One markerClusterGroup per type, so cluster blobs never mix types and
+    # each type can be toggled as a whole.
+    html = photos_to_html(PANO_POINTS, title="t")
+    assert "photoCluster.addLayers(photoMarkers)" in html
+    assert "panoCluster.addLayers(panoMarkers)" in html
+
+
+def test_html_layer_control_gated_on_both_types():
+    # The expanded layer control doubles as the legend; it only appears when
+    # the folder actually mixes types (runtime check on the embedded data).
+    html = photos_to_html(PANO_POINTS, title="t")
+    assert "L.control.layers" in html
+    assert "collapsed: false" in html
+    assert "Photos" in html and "panoramas" in html
+    assert "photoMarkers.length && panoMarkers.length" in html
+
+
+def test_html_pano_clusters_tinted():
+    # Pano-only cluster blobs are tinted to match the pano pin color.
+    html = photos_to_html(PANO_POINTS, title="t")
+    assert "iconCreateFunction" in html
+    assert "pano-cluster" in html
+    assert ".pano-cluster div" in html


### PR DESCRIPTION
## Summary

Stage 1 of #283 (community request from EyesWideShut): photos and 360° panoramas are now visually distinct and individually toggleable on the photomap.

- `photos_to_geojson` always emits `"pano": true` on panoramas (previously gated behind `link_base`) — it is type metadata, not viewer plumbing. GeoJSON exports gain the flag as a side benefit; the 360° viewer remains link-gated.
- The Leaflet template splits markers into two type-pure `markerClusterGroup`s rendered as colored `divIcon` dots — blue photos, orange panoramas — with both cluster tints derived from two CSS custom properties.
- Mixed folders get an expanded `L.control.layers` with pin-colored swatch labels (doubles as the legend); single-type folders see no control.
- Pano cluster blobs anchor slightly off-center so a coincident photo cluster (routine under `--redact fuzz`) is never fully occluded.
- No new dependencies: Leaflet core + the already-pinned markercluster only.

Multi-angle review (4 finders + verification) ran on the branch; all 5 confirmed findings fixed (occlusion of coincident clusters, default large-cluster color colliding with the pano tint, stale docstring, dead `tooltipAnchor`, color triplication).

Part of #283 — stages 2 (camera-model grouping / SVG glyphs) and 3 (video markers) stay open in the issue.

## Test plan

- [x] TDD throughout; 565 tests pass, ruff + mypy clean
- [x] Generated JS syntax-checked with `node --check` (link and no-link variants)
- [x] E2E: real CLI run over `samples/photos/` classifies `pano.jpg` correctly; map carries pins, control, tints
- [x] Docs: README, user_guide, geospatial.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A