### PR TITLE
feat(logging): route all logs to stderr unconditionally

### DIFF
--- a/docs/PROGRESS_JSONL.md
+++ b/docs/PROGRESS_JSONL.md
@@ -97,6 +97,6 @@ field, never by arrival order.
 `--log-json` (env `DJIEMBED_LOG_JSON`) is an older, separate feature: it
 formats *log lines* as JSON for the commands that read it (e.g. `doctor`)
 and is independent of this event stream. The four progress-wired commands
-do not change their logging format based on it; under `--progress jsonl`
-their logs are human-readable text on stderr. Parse stdout events, treat
-stderr as free-form diagnostics.
+do not change their logging format based on it; logs are human-readable
+text on stderr for every command, with or without `--progress jsonl`.
+Parse stdout events, treat stderr as free-form diagnostics.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -69,6 +69,10 @@ which switches stdout to machine-readable progress events (one JSON object
 per line) for scripts and GUI frontends. The event contract is documented
 in [Progress Events (JSONL)](PROGRESS_JSONL.md).
 
+Log messages always go to stderr, so redirecting stdout (`dji-embed convert
+gpx flight.SRT > out.gpx` style pipelines) captures only real output, never
+log lines.
+
 ### Sidecar-less footage (MP4 with embedded telemetry)
 
 Newer DJI models record telemetry inside the MP4 instead of a `.SRT`. Pass the

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -297,7 +297,7 @@ def embed(
     progress = make_progress(progress_mode)
     if progress.active:
         quiet = True  # stdout belongs to the JSONL events
-    setup_logging(verbose, quiet, stderr=progress.active)
+    setup_logging(verbose, quiet)
     with _jsonl_terminal(progress, "embed"):
         deps_ok, missing = check_dependencies()
         if not deps_ok:
@@ -355,7 +355,7 @@ def check(
     progress = make_progress(progress_mode)
     if progress.active:
         quiet = True  # stdout belongs to the JSONL events
-    setup_logging(verbose, quiet, stderr=progress.active)
+    setup_logging(verbose, quiet)
     with _jsonl_terminal(progress, "check", total=len(paths)):
         if not paths:
             raise click.ClickException("No file or directory specified")
@@ -594,7 +594,7 @@ def photomap(
                 "--serve cannot be combined with --progress jsonl (serving "
                 "blocks; open the written HTML yourself instead)"
             )
-    setup_logging(verbose, quiet, stderr=progress.active)
+    setup_logging(verbose, quiet)
     if serve_map:
         if fmt.lower() not in ("html", "all"):
             raise click.UsageError(
@@ -760,7 +760,7 @@ def flightmap(
     progress = make_progress(progress_mode)
     if progress.active:
         quiet = True  # stdout belongs to the JSONL events
-    setup_logging(verbose, quiet, stderr=progress.active)
+    setup_logging(verbose, quiet)
     with _jsonl_terminal(progress, "flightmap"):
         try:
             offset = parse_utc_offset(tz_offset)

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -356,13 +356,14 @@ def setup_logging(
     verbose: bool = False,
     quiet: bool = False,
     json_logs: bool = False,
-    stderr: bool = False,
 ) -> None:
     """Configure application wide logging.
 
-    ``stderr`` routes the pretty Rich output to stderr instead of stdout —
-    required whenever stdout carries machine-readable data (--progress
-    jsonl). The json_logs branch already logs to stderr (logging's default).
+    All log output goes to stderr (issue #282): stdout is reserved for real
+    command output — summaries, exported data, ``--progress jsonl`` events.
+    The json_logs branch already logs to stderr (logging's default); the
+    Rich branch needs an explicit stderr console because RichHandler's
+    default console writes to stdout.
     """
     level = logging.INFO
     if verbose:
@@ -386,7 +387,7 @@ def setup_logging(
             handlers=[
                 RichHandler(
                     rich_tracebacks=True,
-                    console=Console(stderr=True) if stderr else None,
+                    console=Console(stderr=True),
                 )
             ],
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,8 +41,8 @@ if "rich" not in sys.modules:
             # Honours an explicit console's stream; without one it defaults
             # to stderr (StreamHandler's default). NOTE: the real RichHandler
             # defaults to STDOUT, so in-process tests cannot catch logging
-            # polluting jsonl stdout — that guarantee is covered by the
-            # subprocess test in test_progress_jsonl.py.
+            # polluting stdout — stream routing is covered by subprocess
+            # tests in test_progress_jsonl.py and test_cli_logging.py.
             super().__init__(console.file if console is not None else None)
 
     setattr(progress, "Progress", _StubProgress)

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,0 +1,54 @@
+"""Logs go to stderr unconditionally (issue #282).
+
+stdout is reserved for real command output — summaries, exported data,
+``--progress jsonl`` events — so ``dji-embed <cmd> > file`` never captures
+log lines. These tests must run the CLI in a real subprocess: under pytest
+the logging plugin already owns the root logger (setup_logging's basicConfig
+no-ops) and the conftest rich stub defaults to stderr anyway, so an
+in-process test would pass vacuously either way.
+"""
+
+import subprocess
+import sys
+
+_SRT = (
+    "1\n00:00:00,000 --> 00:00:01,000\n"
+    '<font size="28">FrameCnt: 1, DiffTime: 1000ms\n'
+    "2026-06-15 12:00:00.000\n"
+    "[latitude: 34.0] [longitude: -84.0] "
+    "[rel_alt: 1.000 abs_alt: 100.0]</font>\n"
+)
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", "from dji_metadata_embedder.cli import main; main()", *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_info_logs_go_to_stderr_without_progress(tmp_path):
+    (tmp_path / "DJI_0001.SRT").write_text(_SRT, encoding="utf-8")
+    proc = _run_cli("flightmap", str(tmp_path))
+    assert proc.returncode == 0, proc.stderr
+    # The RichHandler INFO line ("HTML flight map created: ...") must not
+    # interleave with stdout output.
+    assert "flight map created" not in proc.stdout.lower()
+    assert "flight map created" in proc.stderr.lower()
+
+
+def test_warning_logs_go_to_stderr_without_progress(tmp_path):
+    import os
+
+    # An SRT with absolute datetimes plus a rewritten mtime triggers the
+    # aggregated timezone logger.warning in scan_flights (same recipe as the
+    # jsonl purity test).
+    path = tmp_path / "DJI_0001.SRT"
+    path.write_text(_SRT, encoding="utf-8")
+    os.utime(path, (946684800.0, 946684800.0))
+    proc = _run_cli("flightmap", str(tmp_path))
+    assert proc.returncode == 0, proc.stderr
+    assert "Timezone auto-detection" not in proc.stdout
+    assert "Timezone auto-detection" in proc.stderr


### PR DESCRIPTION
## Summary

Closes #282 (follow-up from the #264 stage-2 review, decided before the stage-3 GUI hardcodes stream expectations).

- `setup_logging` always hands RichHandler a `Console(stderr=True)`; the `stderr=` flag from #281 is deleted along with the four per-command routing decisions in cli.py.
- stdout is now reserved for real command output everywhere: `dji-embed convert gpx flight.SRT > out.gpx`-style redirects no longer capture log lines like "GPX file created".
- Verified the one risky spot: the Click `check` command prints its per-file results via `click.echo` (stdout, unaffected); the `logger.info` result line in `metadata_check.py` is only the legacy argparse entry point. `convert`'s "file created" lines moving to stderr is the intended fix.
- Docs: PROGRESS_JSONL.md and user_guide.md now state logs are on stderr for every command.

**Behavior change** for scripts that grew to parse logs from stdout — should ride a minor release; the conventional-commit `feat` gives it a changelog entry.

## Test plan

- [x] TDD: two new real-subprocess tests (in-process tests are vacuous here — pytest owns the root logger and the conftest rich stub defaults to stderr) covering INFO and aggregated-warning routing
- [x] 567 tests pass, ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A