### PR TITLE
feat(gui): CLI runner parsing the --progress jsonl contract (#264 stage 3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,12 @@ jobs:
       - name: Install ExifTool (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libimage-exiftool-perl
+      # Dogfoods our own pinned, checksum-verified provisioning instead of
+      # chocolatey (whose community feed outages kept breaking this leg);
+      # the shared resolver (env -> provisioned -> PATH) finds the copy.
       - name: Install ExifTool (Windows)
         if: runner.os == 'Windows'
-        run: choco install exiftool --no-progress -y
+        run: uv run dji-embed doctor --install exiftool
       - name: Pytest
         run: uv run pytest
       - name: Build package

--- a/gui/DjiEmbed.Gui.Tests/CliLocatorTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CliLocatorTests.cs
@@ -1,0 +1,74 @@
+using System.Runtime.InteropServices;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class CliLocatorTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-locator-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private static string ExeName =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "dji-embed.exe" : "dji-embed";
+
+    private string Touch(params string[] parts)
+    {
+        var path = Path.Combine([_dir, .. parts]);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "");
+        return path;
+    }
+
+    [Fact]
+    public void Env_override_wins_when_it_exists()
+    {
+        var custom = Touch("custom", "my-cli");
+        var beside = Touch("app", ExeName);
+        var found = CliLocator.Find(custom, Path.Combine(_dir, "app"), null);
+        Assert.Equal(custom, found);
+        _ = beside;
+    }
+
+    [Fact]
+    public void Nonexistent_env_override_is_ignored()
+    {
+        var beside = Touch("app", ExeName);
+        var found = CliLocator.Find(
+            Path.Combine(_dir, "missing"), Path.Combine(_dir, "app"), null);
+        Assert.Equal(beside, found);
+    }
+
+    [Fact]
+    public void Finds_cli_beside_the_gui_executable()
+    {
+        var beside = Touch("app", ExeName);
+        Assert.Equal(beside, CliLocator.Find(null, Path.Combine(_dir, "app"), null));
+    }
+
+    [Fact]
+    public void Finds_cli_in_cli_subdirectory_of_the_app()
+    {
+        // Installer layout option: keep the bundled CLI (one-dir PyInstaller)
+        // in its own subfolder next to the GUI.
+        var nested = Touch("app", "cli", ExeName);
+        Assert.Equal(nested, CliLocator.Find(null, Path.Combine(_dir, "app"), null));
+    }
+
+    [Fact]
+    public void Falls_back_to_path_directories()
+    {
+        var onPath = Touch("bin", ExeName);
+        var found = CliLocator.Find(null, Path.Combine(_dir, "app"),
+            string.Join(Path.PathSeparator, ["/nonexistent", Path.Combine(_dir, "bin")]));
+        Assert.Equal(onPath, found);
+    }
+
+    [Fact]
+    public void Returns_null_when_nothing_is_found()
+    {
+        Assert.Null(CliLocator.Find(null, Path.Combine(_dir, "app"), null));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/DjiEmbedRunnerTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/DjiEmbedRunnerTests.cs
@@ -1,0 +1,171 @@
+using System.Runtime.InteropServices;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+// The runner is tested against fake CLI scripts so no Python is needed:
+// each test writes a platform script that plays back a canned event stream.
+public class DjiEmbedRunnerTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-runner-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string WriteFakeCli(IEnumerable<string> stdoutLines,
+        int exitCode = 0, string? stderrLine = null, int sleepSeconds = 0)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var cmd = Path.Combine(_dir, "fake-cli.cmd");
+            var body = "@echo off\r\n" + string.Join("\r\n",
+                stdoutLines.Select(l => "echo " + l.Replace("\"", "\"\""))); // best effort
+            if (stderrLine is not null) body += $"\r\necho {stderrLine} 1>&2";
+            if (sleepSeconds > 0) body += $"\r\nping -n {sleepSeconds + 1} 127.0.0.1 > nul";
+            body += $"\r\nexit /b {exitCode}\r\n";
+            File.WriteAllText(cmd, body);
+            return cmd;
+        }
+        var sh = Path.Combine(_dir, "fake-cli.sh");
+        var lines = string.Join("\n",
+            stdoutLines.Select(l => "echo '" + l.Replace("'", "'\\''") + "'"));
+        if (stderrLine is not null) lines += $"\necho '{stderrLine}' >&2";
+        if (sleepSeconds > 0) lines += $"\nsleep {sleepSeconds}";
+        File.WriteAllText(sh, "#!/bin/sh\n" + lines + $"\nexit {exitCode}\n");
+        File.SetUnixFileMode(sh,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return sh;
+    }
+
+    private static readonly string[] HappyStream =
+    [
+        """{"v": 1, "event": "start", "command": "flightmap", "total": 2}""",
+        """{"v": 1, "event": "progress", "current": 1, "total": 2, "item": "a.SRT"}""",
+        """{"v": 1, "event": "progress", "current": 2, "total": 2, "item": "b.SRT"}""",
+        """{"v": 1, "event": "result", "ok": true, "outputs": ["map.html"], "summary": {"flights": 2}}""",
+    ];
+
+    [Fact]
+    public async Task Happy_path_reports_events_and_terminal_result()
+    {
+        var cli = WriteFakeCli(HappyStream);
+        var seen = new List<ProgressEvent>();
+        var result = await new DjiEmbedRunner().RunAsync(
+            cli, ["flightmap", "/some/dir"],
+            new Progress<ProgressEvent>(seen.Add));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(result.Success);
+        Assert.NotNull(result.Terminal);
+        Assert.Equal(ProgressEventKind.Result, result.Terminal!.Kind);
+        Assert.Equal(["map.html"], result.Terminal.Outputs);
+        Assert.Equal(4, result.Events.Count);
+        Assert.Empty(result.MalformedLines);
+    }
+
+    [Fact]
+    public async Task Error_terminal_with_nonzero_exit_is_not_success()
+    {
+        var cli = WriteFakeCli(
+        [
+            """{"v": 1, "event": "start", "command": "flightmap"}""",
+            """{"v": 1, "event": "error", "message": "No .SRT telemetry files found"}""",
+        ], exitCode: 1);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(result.Success);
+        Assert.Equal(ProgressEventKind.Error, result.Terminal!.Kind);
+        Assert.Equal("No .SRT telemetry files found", result.Terminal.Message);
+    }
+
+    [Fact]
+    public async Task Embed_partial_failure_exit_zero_result_not_ok_is_not_success()
+    {
+        // The contract's embed nuance: per-file failures exit 0 with
+        // result.ok == false. The UI must treat that as "attention needed".
+        var cli = WriteFakeCli(
+        [
+            """{"v": 1, "event": "start", "command": "embed", "total": 1}""",
+            """{"v": 1, "event": "result", "ok": false, "outputs": [], "summary": {"errors": ["x.mp4"]}}""",
+        ]);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["embed", "/x"]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.False(result.Success);
+        Assert.False(result.Terminal!.Ok);
+    }
+
+    [Fact]
+    public async Task Garbage_stdout_lines_are_collected_not_fatal()
+    {
+        var cli = WriteFakeCli(
+        [
+            HappyStream[0],
+            "Traceback (most recent call last):",
+            HappyStream[3],
+        ]);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+
+        Assert.True(result.Success);
+        Assert.Single(result.MalformedLines);
+        Assert.Contains("Traceback", result.MalformedLines[0]);
+    }
+
+    [Fact]
+    public async Task Missing_terminal_event_is_not_success_even_on_exit_zero()
+    {
+        // A crash after start (or a kill) can end the stream without result
+        // or error; the contract says exactly one terminal event, so its
+        // absence means the run cannot be trusted.
+        var cli = WriteFakeCli([HappyStream[0], HappyStream[1]]);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Null(result.Terminal);
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public async Task Stderr_is_captured_for_diagnostics()
+    {
+        var cli = WriteFakeCli(HappyStream, stderrLine: "some log line");
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+        Assert.Contains("some log line", result.StderrText);
+    }
+
+    [Fact]
+    public async Task Appends_the_progress_flag_so_flows_cannot_forget_it()
+    {
+        // The fake echoes its own argv on stdout as a malformed line; the
+        // runner must have added --progress jsonl after the caller's args.
+        string cli;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            cli = Path.Combine(_dir, "argv.cmd");
+            File.WriteAllText(cli, "@echo off\r\necho ARGS %*\r\nexit /b 0\r\n");
+        }
+        else
+        {
+            cli = Path.Combine(_dir, "argv.sh");
+            File.WriteAllText(cli, "#!/bin/sh\necho \"ARGS $@\"\nexit 0\n");
+            File.SetUnixFileMode(cli,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+        var argsLine = Assert.Single(result.MalformedLines);
+        Assert.Contains("flightmap", argsLine);
+        Assert.Contains("--progress jsonl", argsLine);
+    }
+
+    [Fact]
+    public async Task Cancellation_kills_the_process()
+    {
+        var cli = WriteFakeCli([HappyStream[0]], sleepSeconds: 30);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(2));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"], ct: cts.Token));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/ProgressEventTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ProgressEventTests.cs
@@ -1,0 +1,87 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+// Parsing of single --progress jsonl lines (docs/progress_jsonl.schema.json).
+public class ProgressEventTests
+{
+    [Fact]
+    public void Parses_start_event()
+    {
+        var e = ProgressEvent.Parse(
+            """{"v": 1, "event": "start", "command": "flightmap", "total": 3}""");
+        Assert.NotNull(e);
+        Assert.Equal(ProgressEventKind.Start, e!.Kind);
+        Assert.Equal("flightmap", e.Command);
+        Assert.Equal(3, e.Total);
+    }
+
+    [Fact]
+    public void Parses_progress_event()
+    {
+        var e = ProgressEvent.Parse(
+            """{"v": 1, "event": "progress", "current": 2, "total": 5, "item": "DJI_0002.SRT"}""");
+        Assert.Equal(ProgressEventKind.Progress, e!.Kind);
+        Assert.Equal(2, e.Current);
+        Assert.Equal(5, e.Total);
+        Assert.Equal("DJI_0002.SRT", e.Item);
+    }
+
+    [Fact]
+    public void Parses_warning_event()
+    {
+        var e = ProgressEvent.Parse(
+            """{"v": 1, "event": "warning", "message": "No GPS data", "item": "x.jpg"}""");
+        Assert.Equal(ProgressEventKind.Warning, e!.Kind);
+        Assert.Equal("No GPS data", e.Message);
+        Assert.Equal("x.jpg", e.Item);
+    }
+
+    [Fact]
+    public void Parses_result_event_with_outputs()
+    {
+        var e = ProgressEvent.Parse(
+            """{"v": 1, "event": "result", "ok": true, "outputs": ["a.html", "b.kml"], "summary": {"flights": 2}}""");
+        Assert.Equal(ProgressEventKind.Result, e!.Kind);
+        Assert.True(e.Ok);
+        Assert.Equal(new[] { "a.html", "b.kml" }, e.Outputs);
+    }
+
+    [Fact]
+    public void Parses_error_event()
+    {
+        var e = ProgressEvent.Parse(
+            """{"v": 1, "event": "error", "message": "No .SRT telemetry files found"}""");
+        Assert.Equal(ProgressEventKind.Error, e!.Kind);
+        Assert.Equal("No .SRT telemetry files found", e.Message);
+    }
+
+    [Fact]
+    public void Unknown_event_type_is_kept_as_unknown()
+    {
+        // Forward compatibility: the schema explicitly allows event types we
+        // do not recognise; they must flow through, not crash or vanish.
+        var e = ProgressEvent.Parse("""{"v": 1, "event": "telemetry", "foo": 1}""");
+        Assert.Equal(ProgressEventKind.Unknown, e!.Kind);
+        Assert.Equal("telemetry", e.RawEventName);
+    }
+
+    [Fact]
+    public void Unsupported_contract_version_downgrades_to_unknown()
+    {
+        // A bumped "v" means the field semantics may have changed under us:
+        // keep the line visible but do not interpret it.
+        var e = ProgressEvent.Parse("""{"v": 2, "event": "result", "ok": true}""");
+        Assert.Equal(ProgressEventKind.Unknown, e!.Kind);
+    }
+
+    [Theory]
+    [InlineData("not json at all")]
+    [InlineData("{\"v\": 1}")]
+    [InlineData("[1, 2]")]
+    [InlineData("")]
+    public void Malformed_lines_parse_to_null(string line)
+    {
+        Assert.Null(ProgressEvent.Parse(line));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/RealCliE2ETests.cs
+++ b/gui/DjiEmbed.Gui.Tests/RealCliE2ETests.cs
@@ -1,0 +1,48 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+// Opt-in end-to-end check against the real Python CLI. CI's gui job has no
+// Python environment, so this only runs when DJIEMBED_E2E_CLI points at a
+// dji-embed executable (or wrapper script) — used before releases and when
+// touching the runner.
+public class RealCliE2ETests
+{
+    private const string EnvVar = "DJIEMBED_E2E_CLI";
+
+    private const string Srt =
+        "1\n00:00:00,000 --> 00:00:01,000\n"
+        + "<font size=\"28\">FrameCnt: 1, DiffTime: 1000ms\n"
+        + "2026-06-15 12:00:00.000\n"
+        + "[latitude: 34.0] [longitude: -84.0] "
+        + "[rel_alt: 1.000 abs_alt: 100.0]</font>\n";
+
+    [Fact]
+    public async Task Flightmap_run_through_the_real_cli_succeeds()
+    {
+        var cli = Environment.GetEnvironmentVariable(EnvVar);
+        Assert.SkipWhen(string.IsNullOrEmpty(cli),
+            $"set {EnvVar} to a dji-embed executable to run this test");
+
+        var dir = Directory.CreateTempSubdirectory("djiembed-e2e").FullName;
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "DJI_0001.SRT"), Srt);
+            var seen = new List<ProgressEvent>();
+            var result = await new DjiEmbedRunner().RunAsync(
+                cli!, ["flightmap", dir],
+                new Progress<ProgressEvent>(seen.Add),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(result.Success,
+                $"exit={result.ExitCode} stderr={result.StderrText}");
+            Assert.Empty(result.MalformedLines);
+            var output = Assert.Single(result.Terminal!.Outputs!);
+            Assert.True(File.Exists(output), $"missing output {output}");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/CliLocator.cs
+++ b/gui/DjiEmbed.Gui/Services/CliLocator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// Finds the dji-embed CLI executable. Search order: the
+/// <c>DJIEMBED_CLI</c> environment override (dev/test), then beside the GUI
+/// executable and in its <c>cli/</c> subfolder (the installer layouts),
+/// then PATH (a pip/winget install).
+/// </summary>
+public static class CliLocator
+{
+    public const string EnvVar = "DJIEMBED_CLI";
+
+    private static string ExeName =>
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "dji-embed.exe" : "dji-embed";
+
+    public static string? Find() => Find(
+        Environment.GetEnvironmentVariable(EnvVar),
+        AppContext.BaseDirectory,
+        Environment.GetEnvironmentVariable("PATH"));
+
+    public static string? Find(
+        string? envOverride, string baseDirectory, string? pathVariable)
+    {
+        if (!string.IsNullOrEmpty(envOverride) && File.Exists(envOverride))
+        {
+            return envOverride;
+        }
+
+        foreach (var candidate in new[]
+                 {
+                     Path.Combine(baseDirectory, ExeName),
+                     Path.Combine(baseDirectory, "cli", ExeName),
+                 })
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        foreach (var dir in (pathVariable ?? "").Split(
+                     Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Combine(dir, ExeName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/DjiEmbedRunner.cs
+++ b/gui/DjiEmbed.Gui/Services/DjiEmbedRunner.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// Outcome of one CLI run. <see cref="Success"/> is deliberately strict:
+/// the contract promises exactly one terminal event (result XOR error), so
+/// a clean exit without a result — or a result with ok=false, the embed
+/// command's per-file-failure nuance — is not success.
+/// </summary>
+public sealed record CliRunResult(
+    int ExitCode,
+    ProgressEvent? Terminal,
+    IReadOnlyList<ProgressEvent> Events,
+    IReadOnlyList<string> MalformedLines,
+    string StderrText)
+{
+    public bool Success =>
+        ExitCode == 0 && Terminal is { Kind: ProgressEventKind.Result, Ok: true };
+}
+
+/// <summary>
+/// Spawns the dji-embed CLI with <c>--progress jsonl</c> appended and
+/// surfaces the event stream. This is the GUI's only bridge to the engine:
+/// no Python interop, just a child process and stdout (design spec
+/// docs/superpowers/specs/2026-07-14-desktop-gui-design.md).
+/// </summary>
+public sealed class DjiEmbedRunner
+{
+    public async Task<CliRunResult> RunAsync(
+        string cliPath,
+        IReadOnlyList<string> args,
+        IProgress<ProgressEvent>? progress = null,
+        CancellationToken ct = default)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = cliPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            // The contract is ASCII-safe JSON, but stderr logs may carry
+            // arbitrary text; never depend on the OEM codepage.
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+        psi.ArgumentList.Add("--progress");
+        psi.ArgumentList.Add("jsonl");
+
+        using var process = new Process { StartInfo = psi };
+        process.Start();
+
+        using var registration = ct.Register(() =>
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException)
+            {
+                // Already exited between the cancel and the kill.
+            }
+        });
+
+        var events = new List<ProgressEvent>();
+        var malformed = new List<string>();
+        ProgressEvent? terminal = null;
+
+        var stderrTask = process.StandardError.ReadToEndAsync(ct);
+        while (await process.StandardOutput.ReadLineAsync(ct) is { } line)
+        {
+            if (line.Length == 0)
+            {
+                continue;
+            }
+            var parsed = ProgressEvent.Parse(line);
+            if (parsed is null)
+            {
+                malformed.Add(line);
+                continue;
+            }
+            events.Add(parsed);
+            if (parsed.Kind is ProgressEventKind.Result or ProgressEventKind.Error)
+            {
+                terminal = parsed;
+            }
+            progress?.Report(parsed);
+        }
+
+        await process.WaitForExitAsync(ct);
+        var stderr = await stderrTask;
+        ct.ThrowIfCancellationRequested();
+
+        return new CliRunResult(process.ExitCode, terminal, events, malformed, stderr);
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/ProgressEvent.cs
+++ b/gui/DjiEmbed.Gui/Services/ProgressEvent.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace DjiEmbed.Gui.Services;
+
+public enum ProgressEventKind
+{
+    Start,
+    Progress,
+    Warning,
+    Result,
+    Error,
+
+    /// <summary>
+    /// A structurally valid event line whose type (or contract version) we
+    /// do not interpret. Kept visible for diagnostics, never acted on.
+    /// </summary>
+    Unknown,
+}
+
+/// <summary>
+/// One line of the dji-embed <c>--progress jsonl</c> stream
+/// (docs/progress_jsonl.schema.json, contract v1).
+/// </summary>
+public sealed record ProgressEvent(
+    ProgressEventKind Kind,
+    string RawEventName,
+    string? Command = null,
+    int? Current = null,
+    int? Total = null,
+    string? Item = null,
+    string? Message = null,
+    bool? Ok = null,
+    IReadOnlyList<string>? Outputs = null,
+    JsonElement? Summary = null)
+{
+    private const int SupportedVersion = 1;
+
+    /// <summary>
+    /// Parses a single stdout line. Returns null when the line is not a
+    /// JSON object with an "event" name — the caller records those as
+    /// malformed rather than failing the run.
+    /// </summary>
+    public static ProgressEvent? Parse(string line)
+    {
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(line);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object
+                || !root.TryGetProperty("event", out var eventProp)
+                || eventProp.ValueKind != JsonValueKind.String)
+            {
+                return null;
+            }
+
+            var name = eventProp.GetString()!;
+
+            // A missing or bumped "v" means the field semantics may differ
+            // from what this build understands: keep the event but do not
+            // interpret it.
+            if (!root.TryGetProperty("v", out var v)
+                || v.ValueKind != JsonValueKind.Number
+                || v.GetInt32() != SupportedVersion)
+            {
+                return new ProgressEvent(ProgressEventKind.Unknown, name);
+            }
+
+            return name switch
+            {
+                "start" => new ProgressEvent(ProgressEventKind.Start, name,
+                    Command: GetString(root, "command"),
+                    Total: GetInt(root, "total")),
+                "progress" => new ProgressEvent(ProgressEventKind.Progress, name,
+                    Current: GetInt(root, "current"),
+                    Total: GetInt(root, "total"),
+                    Item: GetString(root, "item")),
+                "warning" => new ProgressEvent(ProgressEventKind.Warning, name,
+                    Message: GetString(root, "message"),
+                    Item: GetString(root, "item")),
+                "result" => new ProgressEvent(ProgressEventKind.Result, name,
+                    Ok: GetBool(root, "ok"),
+                    Outputs: GetStringList(root, "outputs"),
+                    Summary: root.TryGetProperty("summary", out var s)
+                        ? s.Clone() : null),
+                "error" => new ProgressEvent(ProgressEventKind.Error, name,
+                    Message: GetString(root, "message"),
+                    Item: GetString(root, "item")),
+                _ => new ProgressEvent(ProgressEventKind.Unknown, name),
+            };
+        }
+    }
+
+    private static string? GetString(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String
+            ? p.GetString() : null;
+
+    private static int? GetInt(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.Number
+            ? p.GetInt32() : null;
+
+    private static bool? GetBool(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var p)
+        && p.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? p.GetBoolean() : null;
+
+    private static IReadOnlyList<string>? GetStringList(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out var p) || p.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+        var items = new List<string>();
+        foreach (var element in p.EnumerateArray())
+        {
+            if (element.ValueKind == JsonValueKind.String)
+            {
+                items.Add(element.GetString()!);
+            }
+        }
+        return items;
+    }
+}


### PR DESCRIPTION
## Summary

Stage 3b of the #264 desktop GUI: the service layer that talks to the engine. No UI changes.

- **`CliLocator`** — finds `dji-embed`: `DJIEMBED_CLI` env override → beside the GUI exe → `cli/` subfolder (installer layouts) → PATH.
- **`ProgressEvent`** — parses one JSONL line per `docs/progress_jsonl.schema.json` (contract v1); unknown event types flow through as `Unknown` (forward compat), a bumped `v` downgrades to `Unknown` instead of misinterpreting fields.
- **`DjiEmbedRunner`** — spawns the CLI with `--progress jsonl` appended (flows can't forget it), streams events via `IProgress<T>`, captures stderr for diagnostics, kills the process tree on cancellation. `CliRunResult.Success` is strict: exit 0 **and** a `result` terminal **and** `ok=true` — covering the embed per-file-failure nuance (exit 0 + ok:false) and truncated streams (no terminal event).

## Test plan

- [x] TDD; 26 new tests (30 total) against platform fake-CLI scripts — happy path, error terminal, ok:false nuance, garbage stdout lines, missing terminal, stderr capture, argv flag injection, cancellation
- [x] Opt-in E2E (`DJIEMBED_E2E_CLI`) ran the runner against the **real Python CLI**: schema-clean stream, output file verified
- [x] Build warning-free; Python suite untouched

Part of #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A