### PR TITLE
feat(gui): Make a map flow wired to the CLI runner (#264 stage 3c)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/DjiEmbedRunnerTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/DjiEmbedRunnerTests.cs
@@ -13,29 +13,8 @@ public class DjiEmbedRunnerTests : IDisposable
     public void Dispose() => Directory.Delete(_dir, recursive: true);
 
     private string WriteFakeCli(IEnumerable<string> stdoutLines,
-        int exitCode = 0, string? stderrLine = null, int sleepSeconds = 0)
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            var cmd = Path.Combine(_dir, "fake-cli.cmd");
-            var body = "@echo off\r\n" + string.Join("\r\n",
-                stdoutLines.Select(l => "echo " + l.Replace("\"", "\"\""))); // best effort
-            if (stderrLine is not null) body += $"\r\necho {stderrLine} 1>&2";
-            if (sleepSeconds > 0) body += $"\r\nping -n {sleepSeconds + 1} 127.0.0.1 > nul";
-            body += $"\r\nexit /b {exitCode}\r\n";
-            File.WriteAllText(cmd, body);
-            return cmd;
-        }
-        var sh = Path.Combine(_dir, "fake-cli.sh");
-        var lines = string.Join("\n",
-            stdoutLines.Select(l => "echo '" + l.Replace("'", "'\\''") + "'"));
-        if (stderrLine is not null) lines += $"\necho '{stderrLine}' >&2";
-        if (sleepSeconds > 0) lines += $"\nsleep {sleepSeconds}";
-        File.WriteAllText(sh, "#!/bin/sh\n" + lines + $"\nexit {exitCode}\n");
-        File.SetUnixFileMode(sh,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        return sh;
-    }
+        int exitCode = 0, string? stderrLine = null, int sleepSeconds = 0) =>
+        FakeCli.WriteEventStream(_dir, stdoutLines, exitCode, stderrLine, sleepSeconds);
 
     private static readonly string[] HappyStream =
     [
@@ -52,7 +31,8 @@ public class DjiEmbedRunnerTests : IDisposable
         var seen = new List<ProgressEvent>();
         var result = await new DjiEmbedRunner().RunAsync(
             cli, ["flightmap", "/some/dir"],
-            new Progress<ProgressEvent>(seen.Add));
+            new Progress<ProgressEvent>(seen.Add),
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(0, result.ExitCode);
         Assert.True(result.Success);
@@ -71,7 +51,7 @@ public class DjiEmbedRunnerTests : IDisposable
             """{"v": 1, "event": "start", "command": "flightmap"}""",
             """{"v": 1, "event": "error", "message": "No .SRT telemetry files found"}""",
         ], exitCode: 1);
-        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"], ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(1, result.ExitCode);
         Assert.False(result.Success);
@@ -89,7 +69,7 @@ public class DjiEmbedRunnerTests : IDisposable
             """{"v": 1, "event": "start", "command": "embed", "total": 1}""",
             """{"v": 1, "event": "result", "ok": false, "outputs": [], "summary": {"errors": ["x.mp4"]}}""",
         ]);
-        var result = await new DjiEmbedRunner().RunAsync(cli, ["embed", "/x"]);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["embed", "/x"], ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(0, result.ExitCode);
         Assert.False(result.Success);
@@ -105,7 +85,7 @@ public class DjiEmbedRunnerTests : IDisposable
             "Traceback (most recent call last):",
             HappyStream[3],
         ]);
-        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"], ct: TestContext.Current.CancellationToken);
 
         Assert.True(result.Success);
         Assert.Single(result.MalformedLines);
@@ -119,7 +99,7 @@ public class DjiEmbedRunnerTests : IDisposable
         // or error; the contract says exactly one terminal event, so its
         // absence means the run cannot be trusted.
         var cli = WriteFakeCli([HappyStream[0], HappyStream[1]]);
-        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"], ct: TestContext.Current.CancellationToken);
 
         Assert.Equal(0, result.ExitCode);
         Assert.Null(result.Terminal);
@@ -130,7 +110,7 @@ public class DjiEmbedRunnerTests : IDisposable
     public async Task Stderr_is_captured_for_diagnostics()
     {
         var cli = WriteFakeCli(HappyStream, stderrLine: "some log line");
-        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"], ct: TestContext.Current.CancellationToken);
         Assert.Contains("some log line", result.StderrText);
     }
 
@@ -139,20 +119,10 @@ public class DjiEmbedRunnerTests : IDisposable
     {
         // The fake echoes its own argv on stdout as a malformed line; the
         // runner must have added --progress jsonl after the caller's args.
-        string cli;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            cli = Path.Combine(_dir, "argv.cmd");
-            File.WriteAllText(cli, "@echo off\r\necho ARGS %*\r\nexit /b 0\r\n");
-        }
-        else
-        {
-            cli = Path.Combine(_dir, "argv.sh");
-            File.WriteAllText(cli, "#!/bin/sh\necho \"ARGS $@\"\nexit 0\n");
-            File.SetUnixFileMode(cli,
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        }
-        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"]);
+        var cli = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? FakeCli.WriteScript(_dir, "@echo off\r\necho ARGS %*\r\nexit /b 0\r\n")
+            : FakeCli.WriteScript(_dir, "#!/bin/sh\necho \"ARGS $@\"\nexit 0\n");
+        var result = await new DjiEmbedRunner().RunAsync(cli, ["flightmap", "/x"], ct: TestContext.Current.CancellationToken);
         var argsLine = Assert.Single(result.MalformedLines);
         Assert.Contains("flightmap", argsLine);
         Assert.Contains("--progress jsonl", argsLine);

--- a/gui/DjiEmbed.Gui.Tests/FakeCli.cs
+++ b/gui/DjiEmbed.Gui.Tests/FakeCli.cs
@@ -1,0 +1,80 @@
+namespace DjiEmbed.Gui.Tests;
+
+/// <summary>
+/// Writes platform fake-CLI scripts that play back canned --progress jsonl
+/// streams, so runner/flow tests need no Python.
+/// </summary>
+internal static class FakeCli
+{
+    private static bool IsWindows => OperatingSystem.IsWindows();
+
+    internal static string WriteEventStream(string dir,
+        IEnumerable<string> stdoutLines, int exitCode = 0,
+        string? stderrLine = null, int sleepSeconds = 0)
+    {
+        if (IsWindows)
+        {
+            var body = EchoLinesCmd(stdoutLines);
+            if (stderrLine is not null) body += $"echo {stderrLine} 1>&2\r\n";
+            if (sleepSeconds > 0) body += $"ping -n {sleepSeconds + 1} 127.0.0.1 > nul\r\n";
+            body += $"exit /b {exitCode}\r\n";
+            return WriteScript(dir, "@echo off\r\n" + body);
+        }
+        var sh = EchoLinesSh(stdoutLines);
+        if (stderrLine is not null) sh += $"echo '{stderrLine}' >&2\n";
+        if (sleepSeconds > 0) sh += $"sleep {sleepSeconds}\n";
+        sh += $"exit {exitCode}\n";
+        return WriteScript(dir, "#!/bin/sh\n" + sh);
+    }
+
+    /// <summary>
+    /// A fake CLI that branches on its first argument (the subcommand), so
+    /// one script can answer both the flightmap and photomap invocation.
+    /// </summary>
+    internal static string WritePerCommand(string dir,
+        IReadOnlyDictionary<string, (string[] Lines, int ExitCode)> commands)
+    {
+        if (IsWindows)
+        {
+            var body = "@echo off\r\n";
+            foreach (var (cmd, spec) in commands)
+            {
+                body += $"if \"%1\"==\"{cmd}\" (\r\n"
+                    + EchoLinesCmd(spec.Lines)
+                    + $"exit /b {spec.ExitCode}\r\n)\r\n";
+            }
+            body += "exit /b 99\r\n";
+            return WriteScript(dir, body);
+        }
+        var sh = "#!/bin/sh\ncase \"$1\" in\n";
+        foreach (var (cmd, spec) in commands)
+        {
+            sh += $"{cmd})\n" + EchoLinesSh(spec.Lines) + $"exit {spec.ExitCode}\n;;\n";
+        }
+        sh += "esac\nexit 99\n";
+        return WriteScript(dir, sh);
+    }
+
+    private static string EchoLinesCmd(IEnumerable<string> lines) =>
+        string.Concat(lines.Select(l =>
+            "echo " + l.Replace("\"", "\"\"") + "\r\n"));
+
+    private static string EchoLinesSh(IEnumerable<string> lines) =>
+        string.Concat(lines.Select(l =>
+            "echo '" + l.Replace("'", "'\\''") + "'\n"));
+
+    internal static string WriteScript(string dir, string body)
+    {
+        var path = Path.Combine(dir,
+            "fake-cli-" + Guid.NewGuid().ToString("N")[..8]
+            + (IsWindows ? ".cmd" : ".sh"));
+        File.WriteAllText(path, body);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite
+                | UnixFileMode.UserExecute);
+        }
+        return path;
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
@@ -1,0 +1,57 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class FolderInspectorTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-inspector-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private void Touch(params string[] parts)
+    {
+        var path = Path.Combine([_dir, .. parts]);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "");
+    }
+
+    [Fact]
+    public void Detects_flight_logs_only()
+    {
+        Touch("DJI_0001.SRT");
+        var c = FolderInspector.Inspect(_dir);
+        Assert.True(c.HasFlightLogs);
+        Assert.False(c.HasPhotos);
+    }
+
+    [Fact]
+    public void Detects_photos_only_case_insensitive_and_nested()
+    {
+        Touch("sub", "IMG_1.JPG");
+        Touch("sub", "deeper", "raw.dng");
+        var c = FolderInspector.Inspect(_dir);
+        Assert.False(c.HasFlightLogs);
+        Assert.True(c.HasPhotos);
+    }
+
+    [Fact]
+    public void Detects_mixed_content()
+    {
+        Touch("DJI_0001.srt");
+        Touch("photos", "a.jpeg");
+        var c = FolderInspector.Inspect(_dir);
+        Assert.True(c.HasFlightLogs);
+        Assert.True(c.HasPhotos);
+    }
+
+    [Fact]
+    public void Empty_or_unrelated_folder_detects_nothing()
+    {
+        Touch("video.mp4");
+        Touch("notes.txt");
+        var c = FolderInspector.Inspect(_dir);
+        Assert.False(c.HasFlightLogs);
+        Assert.False(c.HasPhotos);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/MakeMapViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/MakeMapViewModelTests.cs
@@ -1,0 +1,143 @@
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class MakeMapViewModelTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-makemap-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string MakeFolder(bool srt = false, bool photos = false)
+    {
+        var folder = Path.Combine(_dir, "footage");
+        Directory.CreateDirectory(folder);
+        if (srt) File.WriteAllText(Path.Combine(folder, "DJI_0001.SRT"), "");
+        if (photos) File.WriteAllText(Path.Combine(folder, "IMG_1.JPG"), "");
+        return folder;
+    }
+
+    private static readonly string[] FlightmapStream =
+    [
+        """{"v": 1, "event": "start", "command": "flightmap", "total": 1}""",
+        """{"v": 1, "event": "progress", "current": 1, "total": 1, "item": "DJI_0001.SRT"}""",
+        """{"v": 1, "event": "result", "ok": true, "outputs": ["flightmap.html"], "summary": {}}""",
+    ];
+
+    private static readonly string[] PhotomapStream =
+    [
+        """{"v": 1, "event": "start", "command": "photomap", "total": 1}""",
+        """{"v": 1, "event": "result", "ok": true, "outputs": ["photomap.html"], "summary": {}}""",
+    ];
+
+    private static MakeMapViewModel Vm(string? cli, bool wentHome = false) =>
+        new(cli, new DjiEmbedRunner(), () => { });
+
+    [Fact]
+    public void Starts_on_the_pick_step()
+    {
+        Assert.Equal(MakeMapStep.Pick, Vm("unused").Step);
+    }
+
+    [Fact]
+    public async Task Missing_cli_fails_with_novice_wording()
+    {
+        var vm = Vm(null);
+        await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
+        Assert.Equal(MakeMapStep.Failed, vm.Step);
+        Assert.Contains("engine", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Folder_without_footage_fails_before_launching_anything()
+    {
+        // A CLI path that would explode if executed proves nothing ran.
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.StartCommand.ExecuteAsync(MakeFolder());
+        Assert.Equal(MakeMapStep.Failed, vm.Step);
+        Assert.Contains("folder", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Flight_logs_only_runs_flightmap_and_reports_done()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
+        Assert.Equal(MakeMapStep.Done, vm.Step);
+        Assert.Equal(["flightmap.html"], vm.Outputs);
+    }
+
+    [Fact]
+    public async Task Mixed_folder_runs_both_commands_and_collects_all_outputs()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+            ["photomap"] = (PhotomapStream, 0),
+        });
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true, photos: true));
+        Assert.Equal(MakeMapStep.Done, vm.Step);
+        Assert.Equal(["flightmap.html", "photomap.html"], vm.Outputs);
+    }
+
+    [Fact]
+    public async Task Cli_error_shows_its_message_and_stderr_details()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+        [
+            """{"v": 1, "event": "start", "command": "flightmap"}""",
+            """{"v": 1, "event": "error", "message": "None of the 3 SRT files contain GPS telemetry"}""",
+        ], exitCode: 1, stderrLine: "detail line");
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
+        Assert.Equal(MakeMapStep.Failed, vm.Step);
+        Assert.Contains("GPS telemetry", vm.ErrorMessage);
+        Assert.Contains("detail line", vm.ErrorDetails);
+    }
+
+    [Fact]
+    public async Task Progress_events_update_the_running_state()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var vm = Vm(cli);
+        var sawRunning = false;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(vm.CurrentItem) && vm.CurrentItem is not null)
+            {
+                sawRunning = vm.Step == MakeMapStep.Running;
+            }
+        };
+        await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
+        Assert.True(sawRunning, "expected a progress item while running");
+        Assert.Equal(1, vm.Current);
+        Assert.Equal(1, vm.Total);
+    }
+
+    [Fact]
+    public async Task Cancel_returns_to_the_pick_step()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+            ["""{"v": 1, "event": "start", "command": "flightmap"}"""],
+            sleepSeconds: 30);
+        var vm = Vm(cli);
+        var run = vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
+        while (vm.Step != MakeMapStep.Running)
+        {
+            await Task.Delay(20, TestContext.Current.CancellationToken);
+        }
+        vm.CancelCommand.Execute(null);
+        await run;
+        Assert.Equal(MakeMapStep.Pick, vm.Step);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.VisualTree;
+using DjiEmbed.Gui.ViewModels;
+using DjiEmbed.Gui.Views;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class NavigationTests
+{
+    [AvaloniaFact]
+    public void Make_a_map_card_navigates_to_the_map_flow()
+    {
+        var window = new MainWindow { DataContext = new MainViewModel() };
+        window.Show();
+
+        var makeMap = window.GetVisualDescendants().OfType<Button>()
+            .First(b => b.GetVisualDescendants().OfType<TextBlock>()
+                .Any(t => t.Text == "Make a map"));
+        makeMap.Focus();
+        window.KeyPressQwerty(Avalonia.Input.PhysicalKey.Enter,
+            Avalonia.Input.RawInputModifiers.None);
+
+        Assert.NotNull(window.GetVisualDescendants()
+            .OfType<MakeMapView>().FirstOrDefault());
+    }
+
+    [AvaloniaFact]
+    public void Map_flow_back_button_returns_home()
+    {
+        var main = new MainViewModel();
+        var window = new MainWindow { DataContext = main };
+        window.Show();
+        main.StartTask(TaskKind.MakeMap);
+
+        var vm = Assert.IsType<MakeMapViewModel>(main.CurrentPage);
+        vm.GoHomeCommand.Execute(null);
+        Assert.IsType<HomeViewModel>(main.CurrentPage);
+    }
+
+    [AvaloniaFact]
+    public void Map_flow_pick_step_offers_drop_and_browse()
+    {
+        var main = new MainViewModel();
+        var window = new MainWindow { DataContext = main };
+        window.Show();
+        main.StartTask(TaskKind.MakeMap);
+        // Give the ContentControl a layout pass so the new page's visual
+        // tree exists before we inspect it.
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var texts = window.GetVisualDescendants()
+            .OfType<TextBlock>().Select(t => t.Text ?? "").ToList();
+        Assert.Contains(texts, t => t.Contains("Drop a folder"));
+        Assert.Contains(texts, t => t.Contains("Choose a folder"));
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/FolderInspector.cs
+++ b/gui/DjiEmbed.Gui/Services/FolderInspector.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+
+namespace DjiEmbed.Gui.Services;
+
+public sealed record FolderContents(bool HasFlightLogs, bool HasPhotos);
+
+/// <summary>
+/// Decides which map commands apply to a dropped folder. Extension-only and
+/// recursive, mirroring the CLI dragdrop semantics: the CLI itself is the
+/// authority on whether files actually contain telemetry/GPS.
+/// </summary>
+public static class FolderInspector
+{
+    public static FolderContents Inspect(string directory)
+    {
+        var hasFlightLogs = false;
+        var hasPhotos = false;
+        foreach (var file in Directory.EnumerateFiles(
+                     directory, "*", SearchOption.AllDirectories))
+        {
+            var ext = Path.GetExtension(file);
+            if (ext.Equals(".srt", StringComparison.OrdinalIgnoreCase))
+            {
+                hasFlightLogs = true;
+            }
+            else if (ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+                     || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+                     || ext.Equals(".dng", StringComparison.OrdinalIgnoreCase))
+            {
+                hasPhotos = true;
+            }
+            if (hasFlightLogs && hasPhotos)
+            {
+                break;
+            }
+        }
+        return new FolderContents(hasFlightLogs, hasPhotos);
+    }
+}

--- a/gui/DjiEmbed.Gui/ViewModels/HomeViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/HomeViewModel.cs
@@ -1,0 +1,31 @@
+using System;
+using CommunityToolkit.Mvvm.Input;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+public enum TaskKind
+{
+    MakeMap,
+    EmbedTelemetry,
+    CheckSetup,
+}
+
+/// <summary>
+/// The home screen: one question, exactly three task cards, a CLI escape
+/// hatch in the footer. The anti-bloat rules in the design spec
+/// (docs/superpowers/specs/2026-07-14-desktop-gui-design.md) are binding:
+/// no menu bar, no tabs, no settings dialog.
+/// </summary>
+public partial class HomeViewModel(Action<TaskKind> onChoose) : ViewModelBase
+{
+    [RelayCommand]
+    private void MakeMap() => onChoose(TaskKind.MakeMap);
+
+    // The embed and check flows land in stage 3d; the cards are already
+    // real buttons so the home contract stays testable.
+    [RelayCommand]
+    private void EmbedTelemetry() => onChoose(TaskKind.EmbedTelemetry);
+
+    [RelayCommand]
+    private void CheckSetup() => onChoose(TaskKind.CheckSetup);
+}

--- a/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
@@ -1,29 +1,32 @@
-using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DjiEmbed.Gui.Services;
 
 namespace DjiEmbed.Gui.ViewModels;
 
 /// <summary>
-/// The home screen: one question, exactly three task cards, a CLI escape
-/// hatch in the footer. The anti-bloat rules in the design spec
-/// (docs/superpowers/specs/2026-07-14-desktop-gui-design.md) are binding:
-/// no menu bar, no tabs, no settings dialog.
+/// Window shell: swaps the current page. Every task is one linear flow
+/// that ends back at the home screen.
 /// </summary>
 public partial class MainViewModel : ViewModelBase
 {
-    // The task flows land in later sub-stages of issue #264 stage 3; the
-    // commands exist now so the cards are real buttons from day one.
-    [RelayCommand]
-    private void MakeMap()
+    [ObservableProperty]
+    public partial ViewModelBase CurrentPage { get; set; }
+
+    public MainViewModel()
     {
+        CurrentPage = new HomeViewModel(StartTask);
     }
 
-    [RelayCommand]
-    private void EmbedTelemetry()
+    public void StartTask(TaskKind kind)
     {
+        CurrentPage = kind switch
+        {
+            TaskKind.MakeMap => new MakeMapViewModel(
+                CliLocator.Find(), new DjiEmbedRunner(), GoHome),
+            // Embed and check flows arrive in stage 3d.
+            _ => CurrentPage,
+        };
     }
 
-    [RelayCommand]
-    private void CheckSetup()
-    {
-    }
+    private void GoHome() => CurrentPage = new HomeViewModel(StartTask);
 }

--- a/gui/DjiEmbed.Gui/ViewModels/MakeMapViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MakeMapViewModel.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+public enum MakeMapStep
+{
+    Pick,
+    Running,
+    Done,
+    Failed,
+}
+
+/// <summary>
+/// The "Make a map" flow: folder in → progress → one result screen. Runs
+/// flightmap and/or photomap (decided by <see cref="FolderInspector"/>)
+/// through the bundled CLI and collects the map files it names.
+/// </summary>
+public partial class MakeMapViewModel(
+    string? cliPath, DjiEmbedRunner runner, Action goHome) : ViewModelBase
+{
+    [ObservableProperty]
+    public partial MakeMapStep Step { get; set; } = MakeMapStep.Pick;
+
+    [ObservableProperty]
+    public partial string StatusText { get; set; } = "";
+
+    [ObservableProperty]
+    public partial string? CurrentItem { get; set; }
+
+    [ObservableProperty]
+    public partial int Current { get; set; }
+
+    [ObservableProperty]
+    public partial int? Total { get; set; }
+
+    [ObservableProperty]
+    public partial string? ErrorMessage { get; set; }
+
+    [ObservableProperty]
+    public partial string? ErrorDetails { get; set; }
+
+    public ObservableCollection<string> Outputs { get; } = [];
+
+    private CancellationTokenSource? _cts;
+
+    [RelayCommand]
+    private async Task StartAsync(string folder)
+    {
+        if (cliPath is null)
+        {
+            Fail("The dji-embed engine could not be found next to this app. "
+                 + "Reinstalling the application should fix this.");
+            return;
+        }
+
+        var contents = FolderInspector.Inspect(folder);
+        if (contents is { HasFlightLogs: false, HasPhotos: false })
+        {
+            Fail("No drone flight logs (.SRT) or photos were found in that "
+                 + "folder. Pick the folder that contains your footage — "
+                 + "subfolders are included automatically.");
+            return;
+        }
+
+        Outputs.Clear();
+        Step = MakeMapStep.Running;
+        _cts = new CancellationTokenSource();
+        try
+        {
+            if (contents.HasFlightLogs
+                && !await RunOneAsync("flightmap", "Mapping your flights…", folder))
+            {
+                return;
+            }
+            if (contents.HasPhotos
+                && !await RunOneAsync("photomap", "Mapping your photos…", folder))
+            {
+                return;
+            }
+            Step = MakeMapStep.Done;
+        }
+        catch (OperationCanceledException)
+        {
+            Step = MakeMapStep.Pick;
+        }
+        catch (Exception e)
+        {
+            Fail("Something went wrong while making the map.", e.Message);
+        }
+        finally
+        {
+            _cts.Dispose();
+            _cts = null;
+        }
+    }
+
+    private async Task<bool> RunOneAsync(string command, string status, string folder)
+    {
+        StatusText = status;
+        CurrentItem = null;
+        Current = 0;
+        Total = null;
+
+        var result = await runner.RunAsync(
+            cliPath!, [command, folder, "-r"],
+            new DirectProgress<ProgressEvent>(OnEvent), _cts!.Token);
+
+        if (!result.Success)
+        {
+            Fail(result.Terminal?.Message
+                 ?? "Something went wrong while making the map.",
+                string.IsNullOrWhiteSpace(result.StderrText)
+                    ? null : result.StderrText);
+            return false;
+        }
+        foreach (var output in result.Terminal!.Outputs ?? [])
+        {
+            Outputs.Add(output);
+        }
+        return true;
+    }
+
+    private void OnEvent(ProgressEvent e)
+    {
+        if (e.Kind == ProgressEventKind.Progress)
+        {
+            Current = e.Current ?? 0;
+            Total = e.Total;
+            CurrentItem = e.Item;
+        }
+    }
+
+    private void Fail(string message, string? details = null)
+    {
+        ErrorMessage = message;
+        ErrorDetails = details;
+        Step = MakeMapStep.Failed;
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    [RelayCommand]
+    private void OpenOutput(string path) =>
+        Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+
+    [RelayCommand]
+    private void GoHome() => goHome();
+
+    /// <summary>
+    /// Reports inline on the runner's read loop. Started from the UI
+    /// thread, the runner's awaits hop back via the Avalonia sync context,
+    /// so property updates land on the UI thread without a dispatcher.
+    /// </summary>
+    private sealed class DirectProgress<T>(Action<T> action) : IProgress<T>
+    {
+        public void Report(T value) => action(value);
+    }
+}

--- a/gui/DjiEmbed.Gui/Views/HomeView.axaml
+++ b/gui/DjiEmbed.Gui/Views/HomeView.axaml
@@ -1,0 +1,65 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DjiEmbed.Gui.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="520"
+             x:Class="DjiEmbed.Gui.Views.HomeView"
+             x:DataType="vm:HomeViewModel">
+
+    <UserControl.Styles>
+        <Style Selector="Button.card">
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Padding" Value="20,16" />
+            <Setter Property="CornerRadius" Value="8" />
+        </Style>
+        <Style Selector="TextBlock.cardTitle">
+            <Setter Property="FontSize" Value="17" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+        <Style Selector="TextBlock.cardSubtitle">
+            <Setter Property="Opacity" Value="0.7" />
+            <Setter Property="Margin" Value="0,4,0,0" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+    </UserControl.Styles>
+
+    <DockPanel Margin="32,28">
+        <TextBlock DockPanel.Dock="Top"
+                   Text="What do you want to do?"
+                   FontSize="24" FontWeight="SemiBold"
+                   Margin="0,0,0,24" />
+
+        <!-- The escape hatch is a sentence, not a pane. -->
+        <TextBlock DockPanel.Dock="Bottom"
+                   Text="Need more control? The dji-embed command line has every option."
+                   Opacity="0.6" FontSize="12"
+                   Margin="0,20,0,0" TextWrapping="Wrap" />
+
+        <StackPanel Spacing="14" VerticalAlignment="Top">
+            <Button Classes="card" Command="{Binding MakeMapCommand}">
+                <StackPanel>
+                    <TextBlock Classes="cardTitle" Text="Make a map" />
+                    <TextBlock Classes="cardSubtitle"
+                               Text="See a whole folder of photos or drone flights on one map. Everything stays on this computer." />
+                </StackPanel>
+            </Button>
+            <Button Classes="card" Command="{Binding EmbedTelemetryCommand}">
+                <StackPanel>
+                    <TextBlock Classes="cardTitle" Text="Embed telemetry" />
+                    <TextBlock Classes="cardSubtitle"
+                               Text="Write GPS from your drone's flight logs into the video files, so photo apps can sort them by place. Your originals are never changed." />
+                </StackPanel>
+            </Button>
+            <Button Classes="card" Command="{Binding CheckSetupCommand}">
+                <StackPanel>
+                    <TextBlock Classes="cardTitle" Text="Check my setup" />
+                    <TextBlock Classes="cardSubtitle"
+                               Text="Make sure everything this app needs is present and working." />
+                </StackPanel>
+            </Button>
+        </StackPanel>
+    </DockPanel>
+
+</UserControl>

--- a/gui/DjiEmbed.Gui/Views/HomeView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/HomeView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DjiEmbed.Gui.Views;
+
+public partial class HomeView : UserControl
+{
+    public HomeView()
+    {
+        InitializeComponent();
+    }
+}

--- a/gui/DjiEmbed.Gui/Views/MainWindow.axaml
+++ b/gui/DjiEmbed.Gui/Views/MainWindow.axaml
@@ -14,59 +14,7 @@
         <vm:MainViewModel />
     </Design.DataContext>
 
-    <Window.Styles>
-        <Style Selector="Button.card">
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
-            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-            <Setter Property="Padding" Value="20,16" />
-            <Setter Property="CornerRadius" Value="8" />
-        </Style>
-        <Style Selector="TextBlock.cardTitle">
-            <Setter Property="FontSize" Value="17" />
-            <Setter Property="FontWeight" Value="SemiBold" />
-        </Style>
-        <Style Selector="TextBlock.cardSubtitle">
-            <Setter Property="Opacity" Value="0.7" />
-            <Setter Property="Margin" Value="0,4,0,0" />
-            <Setter Property="TextWrapping" Value="Wrap" />
-        </Style>
-    </Window.Styles>
-
-    <DockPanel Margin="32,28">
-        <TextBlock DockPanel.Dock="Top"
-                   Text="What do you want to do?"
-                   FontSize="24" FontWeight="SemiBold"
-                   Margin="0,0,0,24" />
-
-        <!-- The escape hatch is a sentence, not a pane. -->
-        <TextBlock DockPanel.Dock="Bottom"
-                   Text="Need more control? The dji-embed command line has every option."
-                   Opacity="0.6" FontSize="12"
-                   Margin="0,20,0,0" TextWrapping="Wrap" />
-
-        <StackPanel Spacing="14" VerticalAlignment="Top">
-            <Button Classes="card" Command="{Binding MakeMapCommand}">
-                <StackPanel>
-                    <TextBlock Classes="cardTitle" Text="Make a map" />
-                    <TextBlock Classes="cardSubtitle"
-                               Text="See a whole folder of photos or drone flights on one map. Everything stays on this computer." />
-                </StackPanel>
-            </Button>
-            <Button Classes="card" Command="{Binding EmbedTelemetryCommand}">
-                <StackPanel>
-                    <TextBlock Classes="cardTitle" Text="Embed telemetry" />
-                    <TextBlock Classes="cardSubtitle"
-                               Text="Write GPS from your drone's flight logs into the video files, so photo apps can sort them by place. Your originals are never changed." />
-                </StackPanel>
-            </Button>
-            <Button Classes="card" Command="{Binding CheckSetupCommand}">
-                <StackPanel>
-                    <TextBlock Classes="cardTitle" Text="Check my setup" />
-                    <TextBlock Classes="cardSubtitle"
-                               Text="Make sure everything this app needs is present and working." />
-                </StackPanel>
-            </Button>
-        </StackPanel>
-    </DockPanel>
+    <!-- One page at a time; the ViewLocator resolves the matching view. -->
+    <ContentControl Content="{Binding CurrentPage}" />
 
 </Window>

--- a/gui/DjiEmbed.Gui/Views/MakeMapView.axaml
+++ b/gui/DjiEmbed.Gui/Views/MakeMapView.axaml
@@ -1,0 +1,101 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DjiEmbed.Gui.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="520"
+             x:Class="DjiEmbed.Gui.Views.MakeMapView"
+             x:DataType="vm:MakeMapViewModel">
+
+    <DockPanel Margin="32,28">
+        <TextBlock DockPanel.Dock="Top" Text="Make a map"
+                   FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
+
+        <!-- Pick -->
+        <StackPanel IsVisible="{Binding Step,
+                        Converter={x:Static ObjectConverters.Equal},
+                        ConverterParameter={x:Static vm:MakeMapStep.Pick}}"
+                    Spacing="16">
+            <Border Name="DropZone" DragDrop.AllowDrop="True"
+                    BorderThickness="2" CornerRadius="10" Padding="32,44"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}">
+                <StackPanel Spacing="8" HorizontalAlignment="Center">
+                    <TextBlock Text="Drop a folder of footage here"
+                               FontSize="16" HorizontalAlignment="Center" />
+                    <TextBlock Text="photos, drone videos with their .SRT flight logs, or both"
+                               Opacity="0.6" HorizontalAlignment="Center" />
+                </StackPanel>
+            </Border>
+            <Button Name="ChooseFolderButton" HorizontalAlignment="Center"
+                    Click="OnChooseFolderClick">
+                <TextBlock Text="Choose a folder…" />
+            </Button>
+            <Button HorizontalAlignment="Center" Theme="{DynamicResource TransparentButton}"
+                    Command="{Binding GoHomeCommand}">
+                <TextBlock Text="Back" Opacity="0.7" />
+            </Button>
+        </StackPanel>
+
+        <!-- Running -->
+        <StackPanel IsVisible="{Binding Step,
+                        Converter={x:Static ObjectConverters.Equal},
+                        ConverterParameter={x:Static vm:MakeMapStep.Running}}"
+                    Spacing="14" VerticalAlignment="Center">
+            <TextBlock Text="{Binding StatusText}" FontSize="16" />
+            <ProgressBar Minimum="0"
+                         Maximum="{Binding Total, FallbackValue=1, TargetNullValue=1}"
+                         Value="{Binding Current}"
+                         IsIndeterminate="{Binding Total,
+                             Converter={x:Static ObjectConverters.IsNull}}" />
+            <TextBlock Text="{Binding CurrentItem}" Opacity="0.6" FontSize="12" />
+            <Button HorizontalAlignment="Center" Command="{Binding CancelCommand}">
+                <TextBlock Text="Cancel" />
+            </Button>
+        </StackPanel>
+
+        <!-- Done -->
+        <StackPanel IsVisible="{Binding Step,
+                        Converter={x:Static ObjectConverters.Equal},
+                        ConverterParameter={x:Static vm:MakeMapStep.Done}}"
+                    Spacing="14" VerticalAlignment="Center">
+            <TextBlock Text="Your map is ready" FontSize="18" FontWeight="SemiBold" />
+            <ItemsControl ItemsSource="{Binding Outputs}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <DockPanel Margin="0,4">
+                            <Button DockPanel.Dock="Right" Margin="12,0,0,0"
+                                    Command="{Binding $parent[ItemsControl].((vm:MakeMapViewModel)DataContext).OpenOutputCommand}"
+                                    CommandParameter="{Binding}">
+                                <TextBlock Text="Open map" />
+                            </Button>
+                            <TextBlock Text="{Binding}" VerticalAlignment="Center"
+                                       TextTrimming="CharacterEllipsis" Opacity="0.8" />
+                        </DockPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+                <TextBlock Text="Done" />
+            </Button>
+        </StackPanel>
+
+        <!-- Failed -->
+        <StackPanel IsVisible="{Binding Step,
+                        Converter={x:Static ObjectConverters.Equal},
+                        ConverterParameter={x:Static vm:MakeMapStep.Failed}}"
+                    Spacing="14" VerticalAlignment="Center">
+            <TextBlock Text="That didn't work" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap" />
+            <Expander Header="Technical details"
+                      IsVisible="{Binding ErrorDetails,
+                          Converter={x:Static ObjectConverters.IsNotNull}}">
+                <TextBlock Text="{Binding ErrorDetails}" TextWrapping="Wrap"
+                           FontFamily="Consolas,Menlo,monospace" FontSize="12" />
+            </Expander>
+            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+                <TextBlock Text="Back" />
+            </Button>
+        </StackPanel>
+    </DockPanel>
+
+</UserControl>

--- a/gui/DjiEmbed.Gui/Views/MakeMapView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/MakeMapView.axaml.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Views;
+
+public partial class MakeMapView : UserControl
+{
+    public MakeMapView()
+    {
+        InitializeComponent();
+        AddHandler(DragDrop.DragOverEvent, OnDragOver);
+        AddHandler(DragDrop.DropEvent, OnDrop);
+    }
+
+    private async void OnChooseFolderClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MakeMapViewModel vm
+            || TopLevel.GetTopLevel(this) is not { } top)
+        {
+            return;
+        }
+        var folders = await top.StorageProvider.OpenFolderPickerAsync(
+            new FolderPickerOpenOptions
+            {
+                AllowMultiple = false,
+                Title = "Choose the folder with your footage",
+            });
+        var path = folders.FirstOrDefault()?.TryGetLocalPath();
+        if (path is not null)
+        {
+            await vm.StartCommand.ExecuteAsync(path);
+        }
+    }
+
+    private void OnDragOver(object? sender, DragEventArgs e)
+    {
+        e.DragEffects = e.DataTransfer.Contains(DataFormat.File)
+            ? DragDropEffects.Copy
+            : DragDropEffects.None;
+    }
+
+    private async void OnDrop(object? sender, DragEventArgs e)
+    {
+        if (DataContext is not MakeMapViewModel vm)
+        {
+            return;
+        }
+        var folder = e.DataTransfer.TryGetFiles()
+            ?.Select(f => f.TryGetLocalPath())
+            .FirstOrDefault(p => p is not null && System.IO.Directory.Exists(p));
+        if (folder is not null)
+        {
+            await vm.StartCommand.ExecuteAsync(folder);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Stage 3c: the first real task flow, scope per the mockup.

- **Pick** — drop a folder onto the drop zone or use the folder picker; `FolderInspector` (recursive, extension-only — the CLI stays the authority on content) decides whether to run `flightmap`, `photomap`, or both.
- **Running** — live status + progress bar fed by the JSONL event stream (indeterminate until a total arrives), current filename, working Cancel (kills the process tree, returns to pick).
- **Done** — plain-words result screen listing each produced map with an "Open map" button (default browser via shell-execute).
- **Failed** — the CLI's own error message in novice wording, stderr behind a "Technical details" expander; distinct copy for engine-missing and nothing-to-map cases (the latter never launches a process).
- MainWindow became a page shell (`ContentControl` + ViewLocator); the home screen moved to `HomeView` with its locked contract intact. Avalonia 12's new DataTransfer drag-drop API used for the drop zone.

## Test plan

- [x] TDD; 15 new tests (45 total): folder detection, all flow states incl. both-commands aggregation, error/stderr surfacing, cancellation, headless navigation (card click → flow view → back)
- [x] Opt-in real-CLI E2E green (45/45 with `DJIEMBED_E2E_CLI` set)
- [x] Build warning-free

Part of #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A