### PR TITLE
feat(gui): embed-telemetry and check-my-setup flows (#264 stage 3d)

### DIFF
--- a/docs/PROGRESS_JSONL.md
+++ b/docs/PROGRESS_JSONL.md
@@ -1,6 +1,7 @@
 # `--progress jsonl` — machine-readable progress events
 
-`photomap`, `flightmap`, `embed`, and `check` accept `--progress jsonl`. In
+`photomap`, `flightmap`, `embed`, `check`, and `doctor` accept
+`--progress jsonl`. In
 this mode a command writes **one JSON object per line to stdout** and nothing
 else — human/informational output is suppressed, and warnings and log
 messages go to stderr. A non-zero exit code always means the run failed;
@@ -92,11 +93,22 @@ field, never by arrival order.
   `warning` event (`"Not found or unreadable"`) — the run still ends in
   `result` with `"ok": true`.
 
+### `doctor`
+- No `progress` events. One `warning` per missing tool (`item` = tool
+  name). `outputs` is empty. `summary`: `{"ok": bool, "tools":
+  {"ffmpeg": {"present": bool}, "exiftool": {"present": bool, "version",
+  "source", "path", "decode"}}, "system": {...}}` — the exiftool extras
+  appear only when it is present and its version is readable.
+- Missing dependencies are a report, not a crash: `"ok": false` with exit
+  code 0 (same reading rule as `embed`).
+- The opt-in online update check **never** runs under `--progress jsonl`;
+  consent for going online stays interactive-only.
+
 ## Relation to `--log-json`
 
 `--log-json` (env `DJIEMBED_LOG_JSON`) is an older, separate feature: it
 formats *log lines* as JSON for the commands that read it (e.g. `doctor`)
-and is independent of this event stream. The four progress-wired commands
+and is independent of this event stream. The progress-wired commands
 do not change their logging format based on it; logs are human-readable
 text on stderr for every command, with or without `--progress jsonl`.
 Parse stdout events, treat stderr as free-form diagnostics.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -64,7 +64,7 @@ For detailed how-to guides such as creating Windows bundles or redacting locatio
 
 ## Scripting and frontends
 
-`photomap`, `flightmap`, `embed`, and `check` accept `--progress jsonl`,
+`photomap`, `flightmap`, `embed`, `check`, and `doctor` accept `--progress jsonl`,
 which switches stdout to machine-readable progress events (one JSON object
 per line) for scripts and GUI frontends. The event contract is documented
 in [Progress Events (JSONL)](PROGRESS_JSONL.md).

--- a/gui/DjiEmbed.Gui.Tests/CheckSetupViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CheckSetupViewModelTests.cs
@@ -1,0 +1,76 @@
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class CheckSetupViewModelTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-checkvm-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private static CheckSetupViewModel Vm(string? cli) =>
+        new(cli, new DjiEmbedRunner(), () => { });
+
+    private const string AllGoodResult =
+        """{"v": 1, "event": "result", "ok": true, "outputs": [], "summary": {"ok": true, "tools": {"ffmpeg": {"present": true}, "exiftool": {"present": true, "version": "13.30"}}, "system": {}}}""";
+
+    [Fact]
+    public async Task All_tools_present_shows_green_checklist()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+        [
+            """{"v": 1, "event": "start", "command": "doctor"}""",
+            AllGoodResult,
+        ]);
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.True(vm.AllGood);
+        Assert.Equal(2, vm.Items.Count);
+        var exif = Assert.Single(vm.Items, i => i.Label.Contains("ExifTool"));
+        Assert.True(exif.Present);
+        Assert.Contains("13.30", exif.Detail);
+    }
+
+    [Fact]
+    public async Task Missing_tool_still_lands_on_done_with_a_red_item()
+    {
+        // Missing dependencies are a report, not a crash (mirrors the CLI's
+        // ok=false + exit 0 rule) — the checklist is the result screen.
+        var cli = FakeCli.WriteEventStream(_dir,
+        [
+            """{"v": 1, "event": "start", "command": "doctor"}""",
+            """{"v": 1, "event": "warning", "message": "Not found", "item": "ffmpeg"}""",
+            """{"v": 1, "event": "result", "ok": false, "outputs": [], "summary": {"ok": false, "tools": {"ffmpeg": {"present": false}, "exiftool": {"present": true}}, "system": {}}}""",
+        ]);
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.False(vm.AllGood);
+        var ffmpeg = Assert.Single(vm.Items, i => i.Label.Contains("FFmpeg"));
+        Assert.False(ffmpeg.Present);
+    }
+
+    [Fact]
+    public async Task Missing_cli_fails_with_novice_wording()
+    {
+        var vm = Vm(null);
+        await vm.StartCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Contains("engine", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Crashed_doctor_lands_on_failed()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+            ["""{"v": 1, "event": "start", "command": "doctor"}"""],
+            exitCode: 3, stderrLine: "Traceback");
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Contains("Traceback", vm.ErrorDetails);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/EmbedTelemetryViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/EmbedTelemetryViewModelTests.cs
@@ -1,0 +1,62 @@
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class EmbedTelemetryViewModelTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-embedvm-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string MakeFolder(bool videos = false, bool srt = false)
+    {
+        var folder = Path.Combine(_dir, "footage");
+        Directory.CreateDirectory(folder);
+        if (videos) File.WriteAllText(Path.Combine(folder, "DJI_0001.MP4"), "");
+        if (srt) File.WriteAllText(Path.Combine(folder, "DJI_0001.SRT"), "");
+        return folder;
+    }
+
+    private static EmbedTelemetryViewModel Vm(string? cli) =>
+        new(cli, new DjiEmbedRunner(), () => { });
+
+    [Fact]
+    public async Task Folder_without_videos_fails_before_launching_anything()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Contains("video", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Happy_embed_reports_done_with_output_folder()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+        [
+            """{"v": 1, "event": "start", "command": "embed", "total": 1}""",
+            """{"v": 1, "event": "progress", "current": 1, "total": 1, "item": "DJI_0001.MP4"}""",
+            """{"v": 1, "event": "result", "ok": true, "outputs": ["/footage/processed"], "summary": {"processed": 1}}""",
+        ]);
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(MakeFolder(videos: true, srt: true));
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Equal(["/footage/processed"], vm.Outputs);
+    }
+
+    [Fact]
+    public async Task Partial_failure_ok_false_lands_on_failed_with_details()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+        [
+            """{"v": 1, "event": "start", "command": "embed", "total": 2}""",
+            """{"v": 1, "event": "result", "ok": false, "outputs": ["/footage/processed"], "summary": {"errors": ["DJI_0002.MP4"]}}""",
+        ], stderrLine: "ffmpeg exploded");
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(MakeFolder(videos: true, srt: true));
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Contains("ffmpeg exploded", vm.ErrorDetails);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
@@ -48,10 +48,20 @@ public class FolderInspectorTests : IDisposable
     [Fact]
     public void Empty_or_unrelated_folder_detects_nothing()
     {
-        Touch("video.mp4");
         Touch("notes.txt");
         var c = FolderInspector.Inspect(_dir);
         Assert.False(c.HasFlightLogs);
+        Assert.False(c.HasPhotos);
+        Assert.False(c.HasVideos);
+    }
+
+    [Fact]
+    public void Detects_videos_for_the_embed_flow()
+    {
+        Touch("clips", "DJI_0001.MP4");
+        Touch("clips", "extra.mov");
+        var c = FolderInspector.Inspect(_dir);
+        Assert.True(c.HasVideos);
         Assert.False(c.HasPhotos);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/MakeMapViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/MakeMapViewModelTests.cs
@@ -38,7 +38,7 @@ public class MakeMapViewModelTests : IDisposable
     [Fact]
     public void Starts_on_the_pick_step()
     {
-        Assert.Equal(MakeMapStep.Pick, Vm("unused").Step);
+        Assert.Equal(FlowStep.Pick, Vm("unused").Step);
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class MakeMapViewModelTests : IDisposable
     {
         var vm = Vm(null);
         await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
-        Assert.Equal(MakeMapStep.Failed, vm.Step);
+        Assert.Equal(FlowStep.Failed, vm.Step);
         Assert.Contains("engine", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -56,7 +56,7 @@ public class MakeMapViewModelTests : IDisposable
         // A CLI path that would explode if executed proves nothing ran.
         var vm = Vm(Path.Combine(_dir, "does-not-exist"));
         await vm.StartCommand.ExecuteAsync(MakeFolder());
-        Assert.Equal(MakeMapStep.Failed, vm.Step);
+        Assert.Equal(FlowStep.Failed, vm.Step);
         Assert.Contains("folder", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -69,7 +69,7 @@ public class MakeMapViewModelTests : IDisposable
         });
         var vm = Vm(cli);
         await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
-        Assert.Equal(MakeMapStep.Done, vm.Step);
+        Assert.Equal(FlowStep.Done, vm.Step);
         Assert.Equal(["flightmap.html"], vm.Outputs);
     }
 
@@ -83,7 +83,7 @@ public class MakeMapViewModelTests : IDisposable
         });
         var vm = Vm(cli);
         await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true, photos: true));
-        Assert.Equal(MakeMapStep.Done, vm.Step);
+        Assert.Equal(FlowStep.Done, vm.Step);
         Assert.Equal(["flightmap.html", "photomap.html"], vm.Outputs);
     }
 
@@ -97,7 +97,7 @@ public class MakeMapViewModelTests : IDisposable
         ], exitCode: 1, stderrLine: "detail line");
         var vm = Vm(cli);
         await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
-        Assert.Equal(MakeMapStep.Failed, vm.Step);
+        Assert.Equal(FlowStep.Failed, vm.Step);
         Assert.Contains("GPS telemetry", vm.ErrorMessage);
         Assert.Contains("detail line", vm.ErrorDetails);
     }
@@ -115,7 +115,7 @@ public class MakeMapViewModelTests : IDisposable
         {
             if (e.PropertyName == nameof(vm.CurrentItem) && vm.CurrentItem is not null)
             {
-                sawRunning = vm.Step == MakeMapStep.Running;
+                sawRunning = vm.Step == FlowStep.Running;
             }
         };
         await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
@@ -132,12 +132,12 @@ public class MakeMapViewModelTests : IDisposable
             sleepSeconds: 30);
         var vm = Vm(cli);
         var run = vm.StartCommand.ExecuteAsync(MakeFolder(srt: true));
-        while (vm.Step != MakeMapStep.Running)
+        while (vm.Step != FlowStep.Running)
         {
             await Task.Delay(20, TestContext.Current.CancellationToken);
         }
         vm.CancelCommand.Execute(null);
         await run;
-        Assert.Equal(MakeMapStep.Pick, vm.Step);
+        Assert.Equal(FlowStep.Pick, vm.Step);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
@@ -28,6 +28,39 @@ public class NavigationTests
     }
 
     [AvaloniaFact]
+    public void Embed_card_navigates_to_the_embed_flow()
+    {
+        var main = new MainViewModel();
+        var window = new MainWindow { DataContext = main };
+        window.Show();
+        main.StartTask(TaskKind.EmbedTelemetry);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        Assert.IsType<EmbedTelemetryViewModel>(main.CurrentPage);
+        Assert.NotNull(window.GetVisualDescendants()
+            .OfType<EmbedTelemetryView>().FirstOrDefault());
+    }
+
+    [AvaloniaFact]
+    public void Check_setup_view_resolves_and_autostarts()
+    {
+        // A null CLI path makes autostart fail fast without spawning
+        // anything — proving the Loaded wiring fired.
+        var vm = new CheckSetupViewModel(
+            null, new Services.DjiEmbedRunner(), () => { });
+        var window = new MainWindow { DataContext = new MainViewModel() };
+        window.Show();
+        ((MainViewModel)window.DataContext!).CurrentPage = vm;
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        Assert.NotNull(window.GetVisualDescendants()
+            .OfType<CheckSetupView>().FirstOrDefault());
+        Assert.Equal(FlowStep.Failed, vm.Step);
+    }
+
+    [AvaloniaFact]
     public void Map_flow_back_button_returns_home()
     {
         var main = new MainViewModel();

--- a/gui/DjiEmbed.Gui.Tests/RealCliE2ETests.cs
+++ b/gui/DjiEmbed.Gui.Tests/RealCliE2ETests.cs
@@ -18,6 +18,25 @@ public class RealCliE2ETests
         + "[rel_alt: 1.000 abs_alt: 100.0]</font>\n";
 
     [Fact]
+    public async Task Doctor_run_through_the_real_cli_yields_a_tools_summary()
+    {
+        var cli = Environment.GetEnvironmentVariable(EnvVar);
+        Assert.SkipWhen(string.IsNullOrEmpty(cli),
+            $"set {EnvVar} to a dji-embed executable to run this test");
+
+        var result = await new DjiEmbedRunner().RunAsync(
+            cli!, ["doctor"], ct: TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.MalformedLines);
+        Assert.NotNull(result.Terminal);
+        Assert.Equal(ProgressEventKind.Result, result.Terminal!.Kind);
+        Assert.True(result.Terminal.Summary!.Value
+            .GetProperty("tools").GetProperty("exiftool")
+            .TryGetProperty("present", out _));
+    }
+
+    [Fact]
     public async Task Flightmap_run_through_the_real_cli_succeeds()
     {
         var cli = Environment.GetEnvironmentVariable(EnvVar);

--- a/gui/DjiEmbed.Gui/Services/FolderInspector.cs
+++ b/gui/DjiEmbed.Gui/Services/FolderInspector.cs
@@ -3,10 +3,11 @@ using System.IO;
 
 namespace DjiEmbed.Gui.Services;
 
-public sealed record FolderContents(bool HasFlightLogs, bool HasPhotos);
+public sealed record FolderContents(
+    bool HasFlightLogs, bool HasPhotos, bool HasVideos);
 
 /// <summary>
-/// Decides which map commands apply to a dropped folder. Extension-only and
+/// Decides which commands apply to a dropped folder. Extension-only and
 /// recursive, mirroring the CLI dragdrop semantics: the CLI itself is the
 /// authority on whether files actually contain telemetry/GPS.
 /// </summary>
@@ -16,6 +17,7 @@ public static class FolderInspector
     {
         var hasFlightLogs = false;
         var hasPhotos = false;
+        var hasVideos = false;
         foreach (var file in Directory.EnumerateFiles(
                      directory, "*", SearchOption.AllDirectories))
         {
@@ -30,11 +32,16 @@ public static class FolderInspector
             {
                 hasPhotos = true;
             }
-            if (hasFlightLogs && hasPhotos)
+            else if (ext.Equals(".mp4", StringComparison.OrdinalIgnoreCase)
+                     || ext.Equals(".mov", StringComparison.OrdinalIgnoreCase))
+            {
+                hasVideos = true;
+            }
+            if (hasFlightLogs && hasPhotos && hasVideos)
             {
                 break;
             }
         }
-        return new FolderContents(hasFlightLogs, hasPhotos);
+        return new FolderContents(hasFlightLogs, hasPhotos, hasVideos);
     }
 }

--- a/gui/DjiEmbed.Gui/ViewModels/CheckSetupViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/CheckSetupViewModel.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>One row of the setup checklist.</summary>
+public sealed record SetupItem(string Label, bool Present, string? Detail);
+
+/// <summary>
+/// "Check my setup": doctor as a novice-worded checklist. Missing tools
+/// are a report (red row + hint), not a failure screen; only a crashed or
+/// missing engine fails. Auto-started by the view.
+/// </summary>
+public partial class CheckSetupViewModel(
+    string? cliPath, DjiEmbedRunner runner, Action goHome)
+    : FlowViewModel(cliPath, runner, goHome)
+{
+    protected override string GenericFailureMessage =>
+        "The setup check could not be completed.";
+
+    [ObservableProperty]
+    public partial bool AllGood { get; set; }
+
+    public ObservableCollection<SetupItem> Items { get; } = [];
+
+    [RelayCommand]
+    private async Task StartAsync()
+    {
+        if (!EnsureCli())
+        {
+            return;
+        }
+        await ExecuteFlowAsync(async () =>
+        {
+            var result = await RunCliAsync("Checking…", ["doctor"]);
+            if (result.ExitCode != 0
+                || result.Terminal is not { Kind: ProgressEventKind.Result } t)
+            {
+                Fail(result.Terminal?.Message ?? GenericFailureMessage,
+                    string.IsNullOrWhiteSpace(result.StderrText)
+                        ? null : result.StderrText);
+                return false;
+            }
+            Items.Clear();
+            ParseTools(t.Summary);
+            AllGood = t.Ok == true;
+            return true;
+        });
+    }
+
+    private void ParseTools(JsonElement? summary)
+    {
+        if (summary is not { ValueKind: JsonValueKind.Object } s
+            || !s.TryGetProperty("tools", out var tools)
+            || tools.ValueKind != JsonValueKind.Object)
+        {
+            return;
+        }
+        foreach (var tool in tools.EnumerateObject())
+        {
+            var present = tool.Value.TryGetProperty("present", out var p)
+                          && p.ValueKind == JsonValueKind.True;
+            var detail = present
+                ? tool.Value.TryGetProperty("version", out var v)
+                  && v.ValueKind == JsonValueKind.String
+                    ? $"version {v.GetString()}" : null
+                : "Reinstalling the application should restore this.";
+            Items.Add(new SetupItem(FriendlyName(tool.Name), present, detail));
+        }
+    }
+
+    private static string FriendlyName(string tool) => tool switch
+    {
+        "ffmpeg" => "Video tools (FFmpeg)",
+        "exiftool" => "Photo tools (ExifTool)",
+        _ => tool,
+    };
+}

--- a/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryViewModel.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>
+/// The "Embed telemetry" flow: a folder of MP4+SRT in, new GPS-tagged
+/// copies out. Originals are never modified — the done screen says so.
+/// </summary>
+public partial class EmbedTelemetryViewModel(
+    string? cliPath, DjiEmbedRunner runner, Action goHome)
+    : FlowViewModel(cliPath, runner, goHome)
+{
+    protected override string GenericFailureMessage =>
+        "Something went wrong while embedding the flight data.";
+
+    [RelayCommand]
+    private async Task StartAsync(string folder)
+    {
+        if (!EnsureCli())
+        {
+            return;
+        }
+        if (!FolderInspector.Inspect(folder).HasVideos)
+        {
+            Fail("No videos (.MP4) were found in that folder. Pick the "
+                 + "folder that holds the drone videos together with their "
+                 + ".SRT flight logs.");
+            return;
+        }
+        await ExecuteFlowAsync(() => RunStepAsync(
+            "Embedding flight data into new copies…", ["embed", folder]));
+    }
+}

--- a/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+public enum FlowStep
+{
+    Pick,
+    Running,
+    Done,
+    Failed,
+}
+
+/// <summary>
+/// Shared machinery for the task flows: one linear Pick → Running →
+/// Done/Failed shape, live progress from the CLI event stream, and the
+/// novice-first failure copy. Subclasses provide the actual commands.
+/// </summary>
+public abstract partial class FlowViewModel(
+    string? cliPath, DjiEmbedRunner runner, Action goHome) : ViewModelBase
+{
+    [ObservableProperty]
+    public partial FlowStep Step { get; set; } = FlowStep.Pick;
+
+    [ObservableProperty]
+    public partial string StatusText { get; set; } = "";
+
+    [ObservableProperty]
+    public partial string? CurrentItem { get; set; }
+
+    [ObservableProperty]
+    public partial int Current { get; set; }
+
+    [ObservableProperty]
+    public partial int? Total { get; set; }
+
+    [ObservableProperty]
+    public partial string? ErrorMessage { get; set; }
+
+    [ObservableProperty]
+    public partial string? ErrorDetails { get; set; }
+
+    public ObservableCollection<string> Outputs { get; } = [];
+
+    private CancellationTokenSource? _cts;
+
+    /// <summary>Fails fast when the bundled CLI is missing.</summary>
+    protected bool EnsureCli()
+    {
+        if (cliPath is not null)
+        {
+            return true;
+        }
+        Fail("The dji-embed engine could not be found next to this app. "
+             + "Reinstalling the application should fix this.");
+        return false;
+    }
+
+    /// <summary>
+    /// Runs <paramref name="body"/> with the shared Running/Done/Failed
+    /// bookkeeping; cancel returns to Pick.
+    /// </summary>
+    protected async Task ExecuteFlowAsync(Func<Task<bool>> body)
+    {
+        Outputs.Clear();
+        Step = FlowStep.Running;
+        _cts = new CancellationTokenSource();
+        try
+        {
+            if (await body())
+            {
+                Step = FlowStep.Done;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            Step = FlowStep.Pick;
+        }
+        catch (Exception e)
+        {
+            Fail(GenericFailureMessage, e.Message);
+        }
+        finally
+        {
+            _cts.Dispose();
+            _cts = null;
+        }
+    }
+
+    protected abstract string GenericFailureMessage { get; }
+
+    /// <summary>Runs one CLI command, streaming progress into the flow.</summary>
+    protected Task<CliRunResult> RunCliAsync(
+        string status, IReadOnlyList<string> args)
+    {
+        StatusText = status;
+        CurrentItem = null;
+        Current = 0;
+        Total = null;
+        return runner.RunAsync(cliPath!, args,
+            new DirectProgress<ProgressEvent>(OnEvent), _cts!.Token);
+    }
+
+    /// <summary>
+    /// Runs one CLI command and requires contract success, collecting the
+    /// outputs it names; failure fills the error state.
+    /// </summary>
+    protected async Task<bool> RunStepAsync(
+        string status, IReadOnlyList<string> args)
+    {
+        var result = await RunCliAsync(status, args);
+        if (!result.Success)
+        {
+            Fail(result.Terminal?.Message ?? GenericFailureMessage,
+                string.IsNullOrWhiteSpace(result.StderrText)
+                    ? null : result.StderrText);
+            return false;
+        }
+        foreach (var output in result.Terminal!.Outputs ?? [])
+        {
+            Outputs.Add(output);
+        }
+        return true;
+    }
+
+    private void OnEvent(ProgressEvent e)
+    {
+        if (e.Kind == ProgressEventKind.Progress)
+        {
+            Current = e.Current ?? 0;
+            Total = e.Total;
+            CurrentItem = e.Item;
+        }
+    }
+
+    protected void Fail(string message, string? details = null)
+    {
+        ErrorMessage = message;
+        ErrorDetails = details;
+        Step = FlowStep.Failed;
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cts?.Cancel();
+
+    [RelayCommand]
+    private void OpenOutput(string path) =>
+        Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+
+    [RelayCommand]
+    private void GoHome() => goHome();
+
+    /// <summary>
+    /// Reports inline on the runner's read loop. Started from the UI
+    /// thread, the runner's awaits hop back via the Avalonia sync context,
+    /// so property updates land on the UI thread without a dispatcher.
+    /// </summary>
+    private sealed class DirectProgress<T>(Action<T> action) : IProgress<T>
+    {
+        public void Report(T value) => action(value);
+    }
+}

--- a/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
@@ -23,7 +23,10 @@ public partial class MainViewModel : ViewModelBase
         {
             TaskKind.MakeMap => new MakeMapViewModel(
                 CliLocator.Find(), new DjiEmbedRunner(), GoHome),
-            // Embed and check flows arrive in stage 3d.
+            TaskKind.EmbedTelemetry => new EmbedTelemetryViewModel(
+                CliLocator.Find(), new DjiEmbedRunner(), GoHome),
+            TaskKind.CheckSetup => new CheckSetupViewModel(
+                CliLocator.Find(), new DjiEmbedRunner(), GoHome),
             _ => CurrentPage,
         };
     }

--- a/gui/DjiEmbed.Gui/ViewModels/MakeMapViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MakeMapViewModel.cs
@@ -1,21 +1,9 @@
 using System;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
-using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DjiEmbed.Gui.Services;
 
 namespace DjiEmbed.Gui.ViewModels;
-
-public enum MakeMapStep
-{
-    Pick,
-    Running,
-    Done,
-    Failed,
-}
 
 /// <summary>
 /// The "Make a map" flow: folder in → progress → one result screen. Runs
@@ -23,43 +11,19 @@ public enum MakeMapStep
 /// through the bundled CLI and collects the map files it names.
 /// </summary>
 public partial class MakeMapViewModel(
-    string? cliPath, DjiEmbedRunner runner, Action goHome) : ViewModelBase
+    string? cliPath, DjiEmbedRunner runner, Action goHome)
+    : FlowViewModel(cliPath, runner, goHome)
 {
-    [ObservableProperty]
-    public partial MakeMapStep Step { get; set; } = MakeMapStep.Pick;
-
-    [ObservableProperty]
-    public partial string StatusText { get; set; } = "";
-
-    [ObservableProperty]
-    public partial string? CurrentItem { get; set; }
-
-    [ObservableProperty]
-    public partial int Current { get; set; }
-
-    [ObservableProperty]
-    public partial int? Total { get; set; }
-
-    [ObservableProperty]
-    public partial string? ErrorMessage { get; set; }
-
-    [ObservableProperty]
-    public partial string? ErrorDetails { get; set; }
-
-    public ObservableCollection<string> Outputs { get; } = [];
-
-    private CancellationTokenSource? _cts;
+    protected override string GenericFailureMessage =>
+        "Something went wrong while making the map.";
 
     [RelayCommand]
     private async Task StartAsync(string folder)
     {
-        if (cliPath is null)
+        if (!EnsureCli())
         {
-            Fail("The dji-embed engine could not be found next to this app. "
-                 + "Reinstalling the application should fix this.");
             return;
         }
-
         var contents = FolderInspector.Inspect(folder);
         if (contents is { HasFlightLogs: false, HasPhotos: false })
         {
@@ -68,99 +32,19 @@ public partial class MakeMapViewModel(
                  + "subfolders are included automatically.");
             return;
         }
-
-        Outputs.Clear();
-        Step = MakeMapStep.Running;
-        _cts = new CancellationTokenSource();
-        try
+        await ExecuteFlowAsync(async () =>
         {
-            if (contents.HasFlightLogs
-                && !await RunOneAsync("flightmap", "Mapping your flights…", folder))
+            if (contents.HasFlightLogs && !await RunStepAsync(
+                    "Mapping your flights…", ["flightmap", folder, "-r"]))
             {
-                return;
+                return false;
             }
-            if (contents.HasPhotos
-                && !await RunOneAsync("photomap", "Mapping your photos…", folder))
+            if (contents.HasPhotos && !await RunStepAsync(
+                    "Mapping your photos…", ["photomap", folder, "-r"]))
             {
-                return;
+                return false;
             }
-            Step = MakeMapStep.Done;
-        }
-        catch (OperationCanceledException)
-        {
-            Step = MakeMapStep.Pick;
-        }
-        catch (Exception e)
-        {
-            Fail("Something went wrong while making the map.", e.Message);
-        }
-        finally
-        {
-            _cts.Dispose();
-            _cts = null;
-        }
-    }
-
-    private async Task<bool> RunOneAsync(string command, string status, string folder)
-    {
-        StatusText = status;
-        CurrentItem = null;
-        Current = 0;
-        Total = null;
-
-        var result = await runner.RunAsync(
-            cliPath!, [command, folder, "-r"],
-            new DirectProgress<ProgressEvent>(OnEvent), _cts!.Token);
-
-        if (!result.Success)
-        {
-            Fail(result.Terminal?.Message
-                 ?? "Something went wrong while making the map.",
-                string.IsNullOrWhiteSpace(result.StderrText)
-                    ? null : result.StderrText);
-            return false;
-        }
-        foreach (var output in result.Terminal!.Outputs ?? [])
-        {
-            Outputs.Add(output);
-        }
-        return true;
-    }
-
-    private void OnEvent(ProgressEvent e)
-    {
-        if (e.Kind == ProgressEventKind.Progress)
-        {
-            Current = e.Current ?? 0;
-            Total = e.Total;
-            CurrentItem = e.Item;
-        }
-    }
-
-    private void Fail(string message, string? details = null)
-    {
-        ErrorMessage = message;
-        ErrorDetails = details;
-        Step = MakeMapStep.Failed;
-    }
-
-    [RelayCommand]
-    private void Cancel() => _cts?.Cancel();
-
-    [RelayCommand]
-    private void OpenOutput(string path) =>
-        Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
-
-    [RelayCommand]
-    private void GoHome() => goHome();
-
-    /// <summary>
-    /// Reports inline on the runner's read loop. Started from the UI
-    /// thread, the runner's awaits hop back via the Avalonia sync context,
-    /// so property updates land on the UI thread without a dispatcher.
-    /// </summary>
-    private sealed class DirectProgress<T>(Action<T> action) : IProgress<T>
-    {
-        public void Report(T value) => action(value);
+            return true;
+        });
     }
 }

--- a/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml
+++ b/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml
@@ -1,0 +1,80 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DjiEmbed.Gui.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="520"
+             x:Class="DjiEmbed.Gui.Views.CheckSetupView"
+             x:DataType="vm:CheckSetupViewModel">
+
+    <DockPanel Margin="32,28">
+        <TextBlock DockPanel.Dock="Top" Text="Check my setup"
+                   FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
+
+        <!-- Running -->
+        <StackPanel IsVisible="{Binding Step,
+                        Converter={x:Static ObjectConverters.Equal},
+                        ConverterParameter={x:Static vm:FlowStep.Running}}"
+                    Spacing="14" VerticalAlignment="Center">
+            <TextBlock Text="Checking everything this app needs…" FontSize="16" />
+            <ProgressBar IsIndeterminate="True" />
+        </StackPanel>
+
+        <!-- Done: the checklist -->
+        <StackPanel IsVisible="{Binding Step,
+                        Converter={x:Static ObjectConverters.Equal},
+                        ConverterParameter={x:Static vm:FlowStep.Done}}"
+                    Spacing="14">
+            <TextBlock FontSize="16"
+                       IsVisible="{Binding AllGood}"
+                       Text="Everything looks good — you're ready to go." />
+            <TextBlock FontSize="16" TextWrapping="Wrap"
+                       IsVisible="{Binding !AllGood}"
+                       Text="Something is missing — see the list below." />
+            <ItemsControl ItemsSource="{Binding Items}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:SetupItem">
+                        <DockPanel Margin="0,6">
+                            <Panel DockPanel.Dock="Left" Width="28"
+                                   VerticalAlignment="Top">
+                                <TextBlock FontSize="16" Text="✅"
+                                           IsVisible="{Binding Present}" />
+                                <TextBlock FontSize="16" Text="❌"
+                                           IsVisible="{Binding !Present}" />
+                            </Panel>
+                            <StackPanel>
+                                <TextBlock Text="{Binding Label}" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding Detail}" Opacity="0.7"
+                                           FontSize="12" TextWrapping="Wrap"
+                                           IsVisible="{Binding Detail,
+                                               Converter={x:Static ObjectConverters.IsNotNull}}" />
+                            </StackPanel>
+                        </DockPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+                <TextBlock Text="Back" />
+            </Button>
+        </StackPanel>
+
+        <!-- Failed -->
+        <StackPanel IsVisible="{Binding Step,
+                        Converter={x:Static ObjectConverters.Equal},
+                        ConverterParameter={x:Static vm:FlowStep.Failed}}"
+                    Spacing="14" VerticalAlignment="Center">
+            <TextBlock Text="That didn't work" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap" />
+            <Expander Header="Technical details"
+                      IsVisible="{Binding ErrorDetails,
+                          Converter={x:Static ObjectConverters.IsNotNull}}">
+                <TextBlock Text="{Binding ErrorDetails}" TextWrapping="Wrap"
+                           FontFamily="Consolas,Menlo,monospace" FontSize="12" />
+            </Expander>
+            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+                <TextBlock Text="Back" />
+            </Button>
+        </StackPanel>
+    </DockPanel>
+
+</UserControl>

--- a/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml.cs
@@ -1,0 +1,24 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Views;
+
+public partial class CheckSetupView : UserControl
+{
+    public CheckSetupView()
+    {
+        InitializeComponent();
+        // The checklist is the whole point of the screen: start the check
+        // as soon as the view appears, no button to find.
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is CheckSetupViewModel { Step: FlowStep.Pick } vm)
+        {
+            await vm.StartCommand.ExecuteAsync(null);
+        }
+    }
+}

--- a/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml
+++ b/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml
@@ -4,11 +4,11 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="520"
-             x:Class="DjiEmbed.Gui.Views.MakeMapView"
-             x:DataType="vm:MakeMapViewModel">
+             x:Class="DjiEmbed.Gui.Views.EmbedTelemetryView"
+             x:DataType="vm:EmbedTelemetryViewModel">
 
     <DockPanel Margin="32,28">
-        <TextBlock DockPanel.Dock="Top" Text="Make a map"
+        <TextBlock DockPanel.Dock="Top" Text="Embed telemetry"
                    FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
 
         <!-- Pick -->
@@ -16,18 +16,18 @@
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Pick}}"
                     Spacing="16">
-            <Border Name="DropZone" DragDrop.AllowDrop="True"
+            <Border DragDrop.AllowDrop="True"
                     BorderThickness="2" CornerRadius="10" Padding="32,44"
                     BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}">
                 <StackPanel Spacing="8" HorizontalAlignment="Center">
-                    <TextBlock Text="Drop a folder of footage here"
+                    <TextBlock Text="Drop a folder of drone videos here"
                                FontSize="16" HorizontalAlignment="Center" />
-                    <TextBlock Text="photos, drone videos with their .SRT flight logs, or both"
-                               Opacity="0.6" HorizontalAlignment="Center" />
+                    <TextBlock Text="MP4 videos with their .SRT flight logs — new copies get the GPS, your originals are never changed"
+                               Opacity="0.6" HorizontalAlignment="Center"
+                               TextWrapping="Wrap" TextAlignment="Center" />
                 </StackPanel>
             </Border>
-            <Button Name="ChooseFolderButton" HorizontalAlignment="Center"
-                    Click="OnChooseFolderClick">
+            <Button HorizontalAlignment="Center" Click="OnChooseFolderClick">
                 <TextBlock Text="Choose a folder…" />
             </Button>
             <Button HorizontalAlignment="Center" Theme="{DynamicResource TransparentButton}"
@@ -58,15 +58,17 @@
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Done}}"
                     Spacing="14" VerticalAlignment="Center">
-            <TextBlock Text="Your map is ready" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Text="All done" FontSize="18" FontWeight="SemiBold" />
+            <TextBlock Text="New copies with the flight data embedded were written to the folder below. Your original videos were not changed."
+                       TextWrapping="Wrap" />
             <ItemsControl ItemsSource="{Binding Outputs}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="x:String">
                         <DockPanel Margin="0,4">
                             <Button DockPanel.Dock="Right" Margin="12,0,0,0"
-                                    Command="{Binding $parent[ItemsControl].((vm:MakeMapViewModel)DataContext).OpenOutputCommand}"
+                                    Command="{Binding $parent[ItemsControl].((vm:EmbedTelemetryViewModel)DataContext).OpenOutputCommand}"
                                     CommandParameter="{Binding}">
-                                <TextBlock Text="Open map" />
+                                <TextBlock Text="Open folder" />
                             </Button>
                             <TextBlock Text="{Binding}" VerticalAlignment="Center"
                                        TextTrimming="CharacterEllipsis" Opacity="0.8" />

--- a/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml.cs
@@ -4,9 +4,9 @@ using DjiEmbed.Gui.ViewModels;
 
 namespace DjiEmbed.Gui.Views;
 
-public partial class MakeMapView : UserControl
+public partial class EmbedTelemetryView : UserControl
 {
-    public MakeMapView()
+    public EmbedTelemetryView()
     {
         InitializeComponent();
         FolderPicking.EnableDrop(this, StartAsync);
@@ -16,7 +16,7 @@ public partial class MakeMapView : UserControl
         await FolderPicking.ChooseAsync(this, StartAsync);
 
     private System.Threading.Tasks.Task StartAsync(string folder) =>
-        DataContext is MakeMapViewModel vm
+        DataContext is EmbedTelemetryViewModel vm
             ? vm.StartCommand.ExecuteAsync(folder)
             : System.Threading.Tasks.Task.CompletedTask;
 }

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+
+namespace DjiEmbed.Gui.Views;
+
+/// <summary>
+/// Shared pick-a-folder plumbing for the flow views: the system folder
+/// picker and window drag-drop, both funnelling into one callback.
+/// </summary>
+internal static class FolderPicking
+{
+    internal static async Task ChooseAsync(
+        Control anchor, Func<string, Task> onFolder)
+    {
+        if (TopLevel.GetTopLevel(anchor) is not { } top)
+        {
+            return;
+        }
+        var folders = await top.StorageProvider.OpenFolderPickerAsync(
+            new FolderPickerOpenOptions
+            {
+                AllowMultiple = false,
+                Title = "Choose the folder with your footage",
+            });
+        var path = folders.FirstOrDefault()?.TryGetLocalPath();
+        if (path is not null)
+        {
+            await onFolder(path);
+        }
+    }
+
+    internal static void EnableDrop(Control target, Func<string, Task> onFolder)
+    {
+        target.AddHandler(DragDrop.DragOverEvent, (_, e) =>
+            e.DragEffects = e.DataTransfer.Contains(DataFormat.File)
+                ? DragDropEffects.Copy
+                : DragDropEffects.None);
+        target.AddHandler(DragDrop.DropEvent, async (_, e) =>
+        {
+            var folder = e.DataTransfer.TryGetFiles()
+                ?.Select(f => f.TryGetLocalPath())
+                .FirstOrDefault(p =>
+                    p is not null && System.IO.Directory.Exists(p));
+            if (folder is not null)
+            {
+                await onFolder(folder);
+            }
+        });
+    }
+}

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -901,6 +901,28 @@ def dragdrop(ctx: click.Context, paths: tuple[str, ...]) -> None:
         sys.exit(ExitCode.GENERAL_ERROR)
 
 
+def _doctor_summary() -> dict:
+    """Structured equivalent of run_doctor's report for --progress jsonl."""
+    from .utils import exiftool as exiftool_utils
+    from .utils.system_info import get_system_summary
+
+    deps_ok, missing = check_dependencies()
+    tools: dict = {
+        "ffmpeg": {"present": "ffmpeg" not in missing},
+        "exiftool": {"present": "exiftool" not in missing},
+    }
+    if tools["exiftool"]["present"]:
+        version = exiftool_utils.exiftool_version()
+        if version:
+            tools["exiftool"].update(
+                version=version,
+                source=exiftool_utils.exiftool_source(),
+                path=str(exiftool_utils.exiftool_exe()),
+                decode=exiftool_utils.describe_decode_capability(version),
+            )
+    return {"ok": deps_ok, "tools": tools, "system": get_system_summary()}
+
+
 @main.command()
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
@@ -924,6 +946,7 @@ def dragdrop(ctx: click.Context, paths: tuple[str, ...]) -> None:
     "this run and remember the choice. Default: remembered choice, asked "
     "once on interactive terminals. DJIEMBED_NO_UPDATE_CHECK=1 hard-disables.",
 )
+@_progress_option
 @click.pass_context
 def doctor(
     ctx: click.Context,
@@ -932,10 +955,31 @@ def doctor(
     install_tool: str | None,
     force: bool,
     online: bool | None,
+    progress_mode: str | None,
 ) -> None:
     """Show system information and verify dependencies."""
     log_json = ctx.obj.get('log_json', False)
+    progress = make_progress(progress_mode)
+    if progress.active:
+        quiet = True  # stdout belongs to the JSONL events
     setup_logging(verbose, quiet, log_json)
+
+    if progress.active:
+        # Machine consumers get a structured report. The online update
+        # check never runs here: consent is interactive-only, and a GUI or
+        # script must not trigger the network path as a side effect.
+        with _jsonl_terminal(progress, "doctor"):
+            if install_tool == "exiftool":
+                exe = provision_exiftool(force=force)
+                click.echo(
+                    f"ExifTool {EXIFTOOL_VERSION} installed: {exe}", err=True
+                )
+            summary = _doctor_summary()
+            for tool, info in summary["tools"].items():
+                if not info["present"]:
+                    progress.warning("Not found", item=tool)
+            progress.result(ok=summary["ok"], outputs=[], summary=summary)
+        sys.exit(ExitCode.SUCCESS)
 
     try:
         if install_tool == "exiftool":

--- a/tests/test_progress_jsonl.py
+++ b/tests/test_progress_jsonl.py
@@ -385,3 +385,70 @@ def test_flightmap_jsonl_all_formats_lists_every_output(tmp_path):
     events = _events(res.stdout)
     outputs = events[-1]["outputs"]
     assert [Path(o).suffix for o in outputs] == [".html", ".kml", ".geojson"]
+
+
+# --- doctor (issue #264 stage 3d: the GUI's "Check my setup" screen) ------
+
+
+def _patch_doctor_env(monkeypatch, *, ffmpeg=True, exiftool=True):
+    from dji_metadata_embedder import cli
+    from dji_metadata_embedder.utils import exiftool as exiftool_utils
+
+    missing = [
+        t for t, ok in (("ffmpeg", ffmpeg), ("exiftool", exiftool)) if not ok
+    ]
+    monkeypatch.setattr(cli, "check_dependencies", lambda: (not missing, missing))
+    if exiftool:
+        monkeypatch.setattr(exiftool_utils, "exiftool_version", lambda: "13.30")
+        monkeypatch.setattr(exiftool_utils, "exiftool_source", lambda: "path")
+        monkeypatch.setattr(
+            exiftool_utils, "exiftool_exe", lambda: "/usr/bin/exiftool"
+        )
+        monkeypatch.setattr(
+            exiftool_utils, "describe_decode_capability", lambda v: "full"
+        )
+
+
+def test_doctor_jsonl_all_present(monkeypatch):
+    _patch_doctor_env(monkeypatch)
+    res = CliRunner().invoke(main, ["doctor", "--progress", "jsonl"])
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert events[0]["event"] == "start"
+    assert events[0]["command"] == "doctor"
+    result = events[-1]
+    assert result["event"] == "result"
+    assert result["ok"] is True
+    tools = result["summary"]["tools"]
+    assert tools["ffmpeg"]["present"] is True
+    assert tools["exiftool"]["present"] is True
+    assert tools["exiftool"]["version"] == "13.30"
+
+
+def test_doctor_jsonl_missing_tool_warns_but_exits_zero(monkeypatch):
+    # Missing dependencies are a report, not a crash: ok=false + exit 0,
+    # mirroring embed's per-file-failure nuance.
+    _patch_doctor_env(monkeypatch, ffmpeg=False)
+    res = CliRunner().invoke(main, ["doctor", "--progress", "jsonl"])
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    warnings = [e for e in events if e["event"] == "warning"]
+    assert [w["item"] for w in warnings] == ["ffmpeg"]
+    result = events[-1]
+    assert result["ok"] is False
+    assert result["summary"]["tools"]["ffmpeg"]["present"] is False
+
+
+def test_doctor_jsonl_never_runs_the_online_update_check(monkeypatch):
+    # Consent for going online is interactive-only; a machine consumer of
+    # the event stream must never trigger the network path.
+    _patch_doctor_env(monkeypatch)
+    from dji_metadata_embedder.utils import update_check
+
+    def _boom(*a, **k):
+        raise AssertionError("update check must not run under --progress jsonl")
+
+    monkeypatch.setattr(update_check, "update_report", _boom)
+    res = CliRunner().invoke(main, ["doctor", "--progress", "jsonl", "--online"])
+    assert res.exit_code == 0, res.output
+    assert _events(res.stdout)[-1]["event"] == "result"


### PR DESCRIPTION
## Summary

Stage 3d completes all three task flows from the design spec. Two commits:

**Python — `doctor` joins the JSONL contract** (needed by the check screen): structured `tools`/`system` summary in the result event, one warning per missing tool, ok=false + exit 0 for missing deps (embed's reading rule), and the opt-in online update check **never** runs in this mode — consent stays interactive-only. Docs updated (PROGRESS_JSONL.md, user_guide).

**C# — the two remaining flows:**
- Shared `FlowViewModel` base extracted (Pick/Running/Done/Failed, live progress, cancel-to-pick, novice failure copy); MakeMap refactored onto it.
- **Embed telemetry**: folder of MP4+SRT in; done screen names the output folder and explicitly says the originals were never changed; embed's ok=false nuance lands on the failure screen with stderr details.
- **Check my setup**: auto-starts when the screen opens, renders the doctor summary as a checklist with novice wording ("Video tools (FFmpeg)", "Photo tools (ExifTool) — version 13.30"); missing tools are red rows with a reinstall hint — a report, not a failure screen.
- `FolderInspector` learns video detection; folder pick/drop plumbing shared across flow views.

## Test plan

- [x] TDD both halves; Python 570 pass + ruff + mypy; gui suite 56/56 including **two real-CLI E2Es** (flightmap + the new doctor contract driven from C#)
- [x] Build warning-free

Part of #264 — 3e (installer + bundling) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A