### PR TITLE
feat(installer): one Windows installer for GUI + CLI + bundled tools (#264 stage 3e)

### DIFF
--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,0 +1,180 @@
+---
+name: Build Windows Installer
+
+# One installer carries everything (issue #264 stage 3e): the Avalonia GUI
+# (Start menu entry), dji-embed.exe beside it, and pinned FFmpeg + ExifTool
+# in tools\ — with both directories added to the user PATH so the full CLI
+# works from any terminal with no extra steps.
+
+on:
+  workflow_run:
+    workflows: ["Release to PyPI"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., 1.21.0)'
+        required: true
+        type: string
+      upload:
+        description: 'Attach to the GitHub release (needs an existing tag)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+env:
+  # Pinned FFmpeg build bundled into the installer (gyan.dev release
+  # essentials, GPL). Upgrading the pin = bump both lines.
+  FFMPEG_VERSION: '8.1.2'
+  FFMPEG_SHA256: 'db580001caa24ac104c8cb856cd113a87b0a443f7bdf47d8c12b1d740584a2ec'
+
+jobs:
+  installer:
+    if: ${{ (github.event_name == 'workflow_dispatch') || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+      - name: Determine release version
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_UPLOAD: ${{ inputs.upload }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            ver="$INPUT_VERSION"
+            upload="$INPUT_UPLOAD"
+          else
+            ver="${HEAD_BRANCH#v}"
+            upload='true'
+          fi
+          # The version feeds shell commands and the ISCC command line:
+          # accept strict X.Y.Z only.
+          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "unexpected version: $ver" >&2
+            exit 1
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "tag=v$ver" >> "$GITHUB_OUTPUT"
+          echo "upload=$upload" >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Sync and verify project version
+        run: |
+          uv run python tools/sync_version.py ${{ steps.meta.outputs.version }}
+          uv run python tools/sync_version.py ${{ steps.meta.outputs.version }} --check
+      - name: Install dependencies
+        run: uv sync --extra build
+
+      - name: Build dji-embed.exe
+        run: uv run python tools/build_exe.py
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+      - name: Publish GUI (self-contained win-x64)
+        run: >
+          dotnet publish gui/DjiEmbed.Gui -c Release -r win-x64
+          --self-contained true
+          -p:Version=${{ steps.meta.outputs.version }}
+          -o staging/app
+
+      - name: Stage CLI
+        run: cp dist/dji-embed.exe staging/app/
+
+      - name: Stage pinned FFmpeg
+        run: |
+          url="https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-${FFMPEG_VERSION}-essentials_build.zip"
+          curl -fsSL "$url" -o ffmpeg.zip
+          echo "${FFMPEG_SHA256}  ffmpeg.zip" | sha256sum -c
+          unzip -q ffmpeg.zip -d ffmpeg-extract
+          mkdir -p staging/app/tools staging/app/licenses
+          cp ffmpeg-extract/ffmpeg-*/bin/ffmpeg.exe staging/app/tools/
+          cp ffmpeg-extract/ffmpeg-*/bin/ffprobe.exe staging/app/tools/
+          cp ffmpeg-extract/ffmpeg-*/LICENSE staging/app/licenses/FFMPEG-LICENSE.txt
+
+      - name: Stage pinned ExifTool
+        run: |
+          uv run python - <<'PY'
+          from pathlib import Path
+          from dji_metadata_embedder.utils.provision import provision_exiftool
+          exe = provision_exiftool(root=Path("exiftool-root"))
+          print(f"provisioned: {exe}")
+          PY
+          cp -r exiftool-root/exiftool-*/. staging/app/tools/
+
+      - name: Stage license notes
+        run: |
+          cp LICENSE staging/app/licenses/LICENSE.txt
+          {
+            echo "DJI Metadata Embedder bundles the following third-party tools:"
+            echo
+            echo "- FFmpeg ${FFMPEG_VERSION} (ffmpeg.exe, ffprobe.exe) - GPL build by"
+            echo "  gyan.dev (https://www.gyan.dev/ffmpeg/builds/). Source code:"
+            echo "  https://ffmpeg.org/download.html - license in FFMPEG-LICENSE.txt."
+            echo "- ExifTool by Phil Harvey (https://exiftool.org/), distributed"
+            echo "  under the Perl Artistic License / GPL - see the exiftool_files"
+            echo "  folder for its license files."
+          } > staging/app/licenses/THIRD-PARTY.txt
+
+      - name: Compile installer
+        shell: pwsh
+        run: |
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
+            /DAppVersion=${{ steps.meta.outputs.version }} `
+            /DStagingDir=..\staging\app `
+            /O..\dist-installer installer\DjiMetadataEmbedder.iss
+          Get-ChildItem dist-installer
+
+      - name: Smoke test - installer runs silently
+        shell: pwsh
+        run: |
+          $setup = Get-ChildItem dist-installer\*.exe | Select-Object -First 1
+          & $setup.FullName /VERYSILENT /SUPPRESSMSGBOXES /NORESTART | Out-Null
+          $app = "$env:LOCALAPPDATA\Programs\DJI Metadata Embedder"
+          foreach ($f in @("DjiEmbed.Gui.exe", "dji-embed.exe",
+                           "tools\ffmpeg.exe", "tools\exiftool.exe")) {
+            if (-not (Test-Path "$app\$f")) { throw "missing $f" }
+          }
+          $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+          if ($userPath -notlike "*DJI Metadata Embedder*") {
+            throw "install dir not on user PATH"
+          }
+          & "$app\dji-embed.exe" --version
+          if ($LASTEXITCODE -ne 0) { throw "bundled CLI failed" }
+
+      - name: Generate checksum
+        run: |
+          cd dist-installer
+          sha256sum -- *.exe > SHA256SUMS-installer.txt
+          cat SHA256SUMS-installer.txt
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-${{ steps.meta.outputs.version }}
+          path: dist-installer/*
+
+      - name: Attach to GitHub release
+        if: ${{ steps.meta.outputs.upload == 'true' }}
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          files: dist-installer/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ installs all of it for you.
 
 ### Windows
 
-Open PowerShell and paste:
+Download the installer (`dji-metadata-embedder-setup-<version>.exe`) from the
+[latest release](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest)
+and run it — you get the **DJI Metadata Embedder** desktop app in the Start
+menu plus the full `dji-embed` command line in any terminal, with FFmpeg and
+ExifTool bundled. No admin rights needed.
+
+Prefer a script? Open PowerShell and paste:
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedder/master/tools/bootstrap.ps1 | iex

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,11 +4,30 @@
 
 ## Easy Windows install
 
+### Windows – installer with desktop app (recommended)
+
+Download `dji-metadata-embedder-setup-<version>.exe` from the
+[latest release](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest)
+and run it. One installer carries everything:
+
+- the **DJI Metadata Embedder** desktop app (Start menu entry) for the
+  common tasks — make a map, embed telemetry, check your setup — with no
+  command line involved;
+- the full `dji-embed` command line, ready in any new terminal window
+  (the install folder is added to your user PATH);
+- pinned FFmpeg and ExifTool builds, so nothing else needs installing.
+
+No admin rights needed — it installs per-user. The uninstaller removes the
+PATH entries again.
+
+### Windows – bootstrap script
+
 ```powershell
 iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedder/master/tools/bootstrap.ps1 | iex
 ```
 
-The bootstrap script also installs FFmpeg and ExifTool.
+The bootstrap script also installs FFmpeg and ExifTool (CLI only, no
+desktop app).
 
 ### Windows – winget
 

--- a/installer/DjiMetadataEmbedder.iss
+++ b/installer/DjiMetadataEmbedder.iss
@@ -1,0 +1,153 @@
+; Inno Setup script for the DJI Metadata Embedder desktop app (issue #264
+; stage 3e). One installer carries everything: the Avalonia GUI (the Start
+; menu entry), dji-embed.exe beside it, and pinned FFmpeg/ExifTool builds in
+; tools\ — and puts both directories on the user PATH so the full CLI works
+; from any terminal with no extra steps.
+;
+; Compiled by .github/workflows/release-installer.yml:
+;   ISCC.exe /DAppVersion=1.21.0 /DStagingDir=..\staging\app installer\DjiMetadataEmbedder.iss
+; StagingDir must contain the final {app} layout (GUI publish output,
+; dji-embed.exe, tools\, licenses\).
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+#ifndef StagingDir
+  #define StagingDir "..\staging\app"
+#endif
+
+#define MyAppName "DJI Metadata Embedder"
+#define MyAppExeName "DjiEmbed.Gui.exe"
+
+[Setup]
+; Never change this AppId: it is how upgrades find the existing install.
+AppId={{A0F2FECD-3BEB-4832-9BC6-4A57B20ED947}
+AppName={#MyAppName}
+AppVersion={#AppVersion}
+AppPublisher=CallMarcus
+AppPublisherURL=https://github.com/CallMarcus/dji-drone-metadata-embedder
+AppSupportURL=https://github.com/CallMarcus/dji-drone-metadata-embedder/issues
+DefaultDirName={autopf}\{#MyAppName}
+DisableProgramGroupPage=yes
+; Per-user install: no admin prompt, and the PATH edits below stay in HKCU.
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+OutputBaseFilename=dji-metadata-embedder-setup-{#AppVersion}
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+UninstallDisplayIcon={app}\{#MyAppExeName}
+; Makes Windows broadcast WM_SETTINGCHANGE so new terminals see the PATH.
+ChangesEnvironment=yes
+
+[Files]
+Source: "{#StagingDir}\*"; DestDir: "{app}"; \
+  Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; \
+  Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; \
+  GroupDescription: "{cm:AdditionalIcons}"
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; \
+  Description: "{cm:LaunchProgram,{#MyAppName}}"; \
+  Flags: nowait postinstall skipifsilent
+
+[Code]
+// Append {app} and {app}\tools to the *user* PATH on install and remove
+// them again on uninstall. Idempotent: re-running the installer never
+// duplicates entries.
+
+const
+  UserEnvKey = 'Environment';
+
+function SplitPath(const PathValue: string; Entries: TStringList): Boolean;
+begin
+  Entries.Delimiter := ';';
+  Entries.StrictDelimiter := True;
+  Entries.DelimitedText := PathValue;
+  Result := True;
+end;
+
+function EntryIndex(Entries: TStringList; const Dir: string): Integer;
+var
+  I: Integer;
+begin
+  Result := -1;
+  for I := 0 to Entries.Count - 1 do
+    if CompareText(Trim(Entries[I]), Dir) = 0 then
+    begin
+      Result := I;
+      exit;
+    end;
+end;
+
+procedure AddDirToUserPath(const Dir: string);
+var
+  PathValue: string;
+  Entries: TStringList;
+begin
+  if not RegQueryStringValue(HKCU, UserEnvKey, 'Path', PathValue) then
+    PathValue := '';
+  Entries := TStringList.Create;
+  try
+    SplitPath(PathValue, Entries);
+    if EntryIndex(Entries, Dir) = -1 then
+    begin
+      if (PathValue <> '') and (Copy(PathValue, Length(PathValue), 1) <> ';') then
+        PathValue := PathValue + ';';
+      PathValue := PathValue + Dir;
+      RegWriteExpandStringValue(HKCU, UserEnvKey, 'Path', PathValue);
+    end;
+  finally
+    Entries.Free;
+  end;
+end;
+
+procedure RemoveDirFromUserPath(const Dir: string);
+var
+  PathValue: string;
+  Entries: TStringList;
+  I: Integer;
+begin
+  if not RegQueryStringValue(HKCU, UserEnvKey, 'Path', PathValue) then
+    exit;
+  Entries := TStringList.Create;
+  try
+    SplitPath(PathValue, Entries);
+    I := EntryIndex(Entries, Dir);
+    while I <> -1 do
+    begin
+      Entries.Delete(I);
+      I := EntryIndex(Entries, Dir);
+    end;
+    Entries.Delimiter := ';';
+    RegWriteExpandStringValue(HKCU, UserEnvKey, 'Path', Entries.DelimitedText);
+  finally
+    Entries.Free;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+  begin
+    AddDirToUserPath(ExpandConstant('{app}'));
+    AddDirToUserPath(ExpandConstant('{app}\tools'));
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usPostUninstall then
+  begin
+    RemoveDirFromUserPath(ExpandConstant('{app}'));
+    RemoveDirFromUserPath(ExpandConstant('{app}\tools'));
+  end;
+end;


### PR DESCRIPTION
## Summary

Final sub-stage of #264 stage 3, per Marcus's distribution model: **one installer installs everything — the GUI is the front door, the full CLI works from any terminal with no extra steps.**

- **`installer/DjiMetadataEmbedder.iss`** — Inno Setup: per-user install (no admin/UAC), "DJI Metadata Embedder" in Start menu / Add-Remove, optional desktop icon, launch-after-install. `{app}` and `{app}\tools` are appended to the **user PATH** (idempotent Pascal code, removed on uninstall + WM_SETTINGCHANGE broadcast), so `dji-embed`, `ffmpeg`, and `exiftool` resolve in any new terminal — which is also exactly how the CLI finds its tools, so no resolver changes were needed.
- **`.github/workflows/release-installer.yml`** — chains off "Release to PyPI" like the EXE build (same version-from-tag logic, hardened per the workflow-injection guide + strict X.Y.Z validation). Builds dji-embed.exe (PyInstaller), publishes the GUI self-contained win-x64 (no .NET prerequisite), stages **pinned FFmpeg 8.1.2** (gyan.dev essentials, sha256-verified: `db580001…84a2ec`) + the `provision.py`-pinned ExifTool, writes license files (GPL FFmpeg license + THIRD-PARTY attribution), compiles with the runner's Inno Setup 6, **smoke-tests a silent install** (files present, user PATH set, bundled CLI answers `--version`), and attaches `dji-metadata-embedder-setup-X.Y.Z.exe` + checksum to the GitHub release.
- `workflow_dispatch` with `upload=false` builds the installer as a workflow artifact only — for testing on a real machine **before** any release tag.
- Docs: README + installation.md now lead with the installer.

## Test plan

- [x] Python suite 570 pass; gui build warning-free; workflow YAML parses
- [x] The workflow's own silent-install smoke test gates every run
- [ ] **Manual E2E on a real Windows machine (Marcus)**: run `gh workflow run release-installer.yml -f version=1.20.0` on master after merge, download the artifact, install, check Start menu app + `dji-embed` in a fresh terminal + uninstall cleans PATH

Defender note: the bundled PyInstaller onefile CLI keeps its FP exposure; installer signing (SignPath?) and one-dir PyInstaller remain open follow-ups per the spec.

Closes the stage-3 staging in #264 (the issue stays open for release + follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A