### PR TITLE
fix(photomap): touch-friendly pins — no hover tooltips, larger tap targets

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -106,6 +106,8 @@ The HTML map clusters nearby shots into an expandable numbered marker so a
 dense session doesn't turn into a wall of overlapping pins; clicking a photo
 shows its EXIF thumbnail, filename, timestamp, altitude, and camera settings,
 and hovering a marker previews the thumbnail and filename without clicking.
+On phones and tablets there is no hover, so the map skips the previews and
+gives every pin a larger tap target instead — one tap opens the photo popup.
 KML opens the same thumbnails in Google Earth Pro (Google My Maps import may
 drop the images but keeps the placemarks). GeoJSON is interchange-only — no
 thumbnails, just `name`/`timestamp`/`alt`/`camera` properties (plus

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -72,6 +72,10 @@ _TEMPLATE = """<!DOCTYPE html>
   .pin-pano  {{ background: var(--pin-pano); }}
   .pin-swatch {{ display: inline-block; vertical-align: -3px;
                 margin-right: 2px; }}
+  /* Touch tap target (issue #295): the visible dot keeps its size but sits
+     centered inside a larger transparent hit box on coarse pointers. */
+  .pin-hit {{ display: flex; width: 100%; height: 100%;
+             align-items: center; justify-content: center; }}
   /* Both cluster tints replace markercluster's default color ramp: its
      "large" (>=100) orange is nearly identical to the pano tint, which would
      contradict the orange-means-panorama legend on dense photo maps. */
@@ -191,9 +195,19 @@ const points = (data.features || []).filter(
 // colored pin and their own cluster group, so clusters stay type-pure and
 // each type can be toggled independently.
 const isPano = f => (f.properties || {}).pano === true;
+// Touch handling (issue #295): hover is a mouse concept. On touch devices the
+// first tap opened the sticky tooltip, which then covered the pin and
+// swallowed the tap meant for it ("huge image of the pin icon" on iPhone).
+// Capability check, not UA sniffing: no hover / coarse pointer → no hover
+// tooltips, and the pin's tap target grows while the dot stays the same size.
+// The click popup (whose thumbnail opens the 360 viewer) is the touch path.
+const TOUCH = window.matchMedia('(hover: none), (pointer: coarse)').matches;
+const PIN_BOX = TOUCH ? 34 : 19;
 const pinIcon = cls => L.divIcon({
-  className: '', html: `<span class="photo-pin ${cls}"></span>`,
-  iconSize: [19, 19], iconAnchor: [9, 9], popupAnchor: [0, -9]
+  className: '',
+  html: `<span class="pin-hit"><span class="photo-pin ${cls}"></span></span>`,
+  iconSize: [PIN_BOX, PIN_BOX], iconAnchor: [PIN_BOX / 2, PIN_BOX / 2],
+  popupAnchor: [0, -PIN_BOX / 2]
 });
 const photoIcon = pinIcon('pin-photo');
 const panoIcon = pinIcon('pin-pano');
@@ -252,8 +266,8 @@ function buildPopup(f) {
 
 // Hover preview (issue #273): thumbnail + filename in a sticky tooltip so a
 // map can be skimmed without clicking every pin. Thumb-less points fall back
-// to a filename-only tooltip. Desktop-only by design: touch devices have no
-// hover and the click popup already covers them.
+// to a filename-only tooltip. Bound only when the device really hovers
+// (issue #295) — on touch the tooltip hijacked the first tap and hid the pin.
 function buildTooltip(f) {
   const p = f.properties || {};
   let html = '<div class="photo-tooltip">';
@@ -268,10 +282,12 @@ for (const f of points) {
   const c = f.geometry.coordinates;                  // [lon, lat, alt]
   latlngs.push([c[1], c[0]]);
   const pano = isPano(f);
-  (pano ? panoMarkers : photoMarkers).push(
-    L.marker([c[1], c[0]], { icon: pano ? panoIcon : photoIcon })
-      .bindPopup(() => buildPopup(f), { maxWidth: 300 })
-      .bindTooltip(() => buildTooltip(f), { sticky: true, direction: 'top' }));
+  const marker = L.marker([c[1], c[0]], { icon: pano ? panoIcon : photoIcon })
+    .bindPopup(() => buildPopup(f), { maxWidth: 300 });
+  if (!TOUCH) {
+    marker.bindTooltip(() => buildTooltip(f), { sticky: true, direction: 'top' });
+  }
+  (pano ? panoMarkers : photoMarkers).push(marker);
 }
 photoCluster.addLayers(photoMarkers);
 panoCluster.addLayers(panoMarkers);

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -281,3 +281,27 @@ def test_html_pano_cluster_anchor_offset_against_occlusion():
     # underneath stays visible and clickable.
     html = photos_to_html(PANO_POINTS, title="t")
     assert "PANO_CLUSTER_ANCHOR" in html
+
+
+# Touch devices (issue #295): hover tooltips are a mouse concept — on iOS the
+# first tap opened the sticky tooltip, which then covered the pin and swallowed
+# the tap meant for it. Touch gets no tooltips and a larger tap target instead.
+
+
+def test_html_touch_devices_detected_and_skip_hover_tooltips():
+    html = photos_to_html(PANO_POINTS, title="t")
+    # Capability detection, not UA sniffing: no hover / coarse pointer.
+    assert "matchMedia" in html
+    assert "hover: none" in html
+    # Tooltip binding is gated on the touch check; popups stay unconditional.
+    assert re.search(r"if \(!TOUCH\)[\s\S]{0,120}bindTooltip\(", html)
+    assert "bindPopup(" in html
+
+
+def test_html_touch_devices_get_larger_pin_tap_target():
+    html = photos_to_html(PANO_POINTS, title="t")
+    # The divIcon box grows on touch while the visible dot keeps its size:
+    # the dot centers inside a transparent hit area.
+    assert "TOUCH ?" in html
+    assert "pin-hit" in html
+    assert ".pin-hit" in html  # centering CSS for the dot inside the hit box


### PR DESCRIPTION
Closes #295 — field-reported from mavicpilots (iPhone, v1.20.0): the hover thumbnail hid the pano pin and intercepted taps, making the 360° viewer nearly unreachable on a phone.

## Root cause

The sticky hover tooltips (#273) are a mouse concept. iOS fires hover on the first tap, so the tooltip opened, covered the pin, and — Leaflet tooltips being non-interactive — subsequent taps on the visible thumbnail fell through unpredictably.

## Fix

- **Capability detection, not UA sniffing:** `matchMedia('(hover: none), (pointer: coarse)')`.
- **Touch devices get no hover tooltips** — the click popup (whose large thumbnail already opens the 360° viewer) is the touch path, and now nothing occludes the pin.
- **Larger tap target on touch:** the divIcon hit box grows 19px → 34px while the visible dot keeps its size, centered inside a transparent `.pin-hit` flex box. Desktop rendering is pixel-identical.
- Docs: user guide notes the phone/tablet behavior.

## Testing

- TDD: two new string-contract tests (touch detection + gated `bindTooltip`; enlarged hit box + centering CSS) written first and watched fail.
- Full suite: 572 passed, 4 skipped; ruff and mypy clean.
- All existing tooltip/marker/cluster tests (#273/#283) unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A