### PR TITLE
feat(photomap): --popup-fields controls what EXIF info the map displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ dji-embed photomap /path/to/photos -r --title "Churches of Finland"   # recurse 
 dji-embed photomap /path/to/photos --link-originals                   # popups open the original photos
 dji-embed photomap /path/to/photos --link-originals --link-base ../DCIM   # originals live elsewhere
 dji-embed photomap /path/to/photos --redact fuzz                      # ~100 m coarsened pins
+dji-embed photomap /path/to/photos --popup-fields none                # popups show thumbnails only
 dji-embed photomap /path/to/photos --serve                            # serve + open browser (360° viewer works)
 ```
 
@@ -489,6 +490,9 @@ Options:
   --link-base PREFIX              Folder or URL prefix for --link-originals
                                   hrefs, for when the originals do not sit
                                   beside the HTML
+  --popup-fields LIST             Limit what HTML popups show: 'none' or a
+                                  comma list of name, timestamp, camera,
+                                  altitude (default: all of them)
   --redact [none|fuzz]            Coarsen every photo location to ~100 m
                                   before writing (default: none)
   --serve                         Serve the map on 127.0.0.1 and open the

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -239,6 +239,24 @@ download). The links are relative to the HTML file, so they only resolve
 while the map sits next to the photos — pass `--link-base` (a relative
 folder or an absolute URL) when the originals live elsewhere.
 
+### Choosing what the popups show (`--popup-fields`)
+
+A map you share shouldn't have to disclose everything your camera recorded.
+`--popup-fields` limits the popup to the details you pick — `none`, or a
+comma list of `name`, `timestamp`, `camera`, `altitude`:
+
+```bash
+dji-embed photomap ./photos --popup-fields none            # thumbnails only
+dji-embed photomap ./photos --popup-fields name,timestamp  # no camera/altitude
+```
+
+Excluded details are stripped from the HTML file entirely, not merely
+hidden — someone reading the map's source finds nothing either. Your
+original photos are untouched (their EXIF keeps everything; pair with
+`--redact fuzz` if the *locations* need coarsening too). Thumbnails, the
+360° viewer, and marker colors are unaffected, and KML/GeoJSON outputs are
+unchanged — they are data exports, not shared pages.
+
 ### 360° panoramas
 
 Stitched spherical panoramas (DJI, Insta360, Google Camera, …) carry XMP

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -108,6 +108,9 @@ shows its EXIF thumbnail, filename, timestamp, altitude, and camera settings,
 and hovering a marker previews the thumbnail and filename without clicking.
 On phones and tablets there is no hover, so the map skips the previews and
 gives every pin a larger tap target instead — one tap opens the photo popup.
+Sharing the map? `--popup-fields` chooses what the popups disclose (`none`,
+or a comma list of `name`, `timestamp`, `camera`, `altitude`); excluded
+details are left out of the HTML file entirely.
 KML opens the same thumbnails in Google Earth Pro (Google My Maps import may
 drop the images but keeps the placemarks). GeoJSON is interchange-only — no
 thumbnails, just `name`/`timestamp`/`alt`/`camera` properties (plus

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -36,6 +36,7 @@ from .geo import (
     write_flights_html,
     write_flights_kml,
     write_photos_geojson,
+    parse_popup_fields,
     write_photos_html,
     write_photos_kml,
 )
@@ -543,6 +544,13 @@ def convert(
          "https://example.com/photos/)",
 )
 @click.option(
+    "--popup-fields", default=None, metavar="LIST",
+    help="Limit what the HTML popups show: 'none' or a comma list of "
+         "name, timestamp, camera, altitude (default: all of them). "
+         "Excluded details are left out of the HTML file entirely; the "
+         "original photos are untouched. Other formats are unchanged.",
+)
+@click.option(
     "--redact",
     type=click.Choice(["none", "fuzz"], case_sensitive=False),
     default="none",
@@ -570,6 +578,7 @@ def photomap(
     title: str | None,
     link_originals: bool,
     link_base: str | None,
+    popup_fields: str | None,
     redact: str,
     serve_map: bool,
     progress_mode: str | None,
@@ -609,6 +618,20 @@ def photomap(
         link_originals = True
     if link_base is not None and not link_originals:
         raise click.UsageError("--link-base requires --link-originals")
+    # --popup-fields (issue #296): parsed up front so a typo fails before the
+    # (potentially long) ExifTool scan. None = default, popups show everything.
+    popup_field_set: frozenset[str] | None = None
+    if popup_fields is not None:
+        try:
+            popup_field_set = parse_popup_fields(popup_fields)
+        except ValueError as e:
+            raise click.BadParameter(str(e), param_hint="'--popup-fields'")
+        if fmt.lower() not in ("html", "all"):
+            click.echo(
+                "Note: --popup-fields only affects HTML output; "
+                f"{fmt.lower()} is unchanged",
+                err=True,
+            )
     if link_originals and fmt.lower() not in ("html", "all"):
         click.echo(
             "Note: --link-originals only affects HTML output; "
@@ -670,7 +693,9 @@ def photomap(
             try:
                 if f == "html":
                     write_photos_html(
-                        points, out, map_title, link_base=html_link_base
+                        points, out, map_title,
+                        link_base=html_link_base,
+                        popup_fields=popup_field_set,
                     )
                 elif f == "kml":
                     write_photos_kml(points, out, map_title)

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -24,7 +24,7 @@ from .photomap import (
     write_photos_geojson,
     write_photos_kml,
 )
-from .photomap_html import photos_to_html, write_photos_html
+from .photomap_html import parse_popup_fields, photos_to_html, write_photos_html
 from .serve import serve_directory
 from .solar import sun_position
 from .track import Track, TrackPoint, build_track
@@ -55,6 +55,7 @@ __all__ = [
     "write_photos_geojson",
     "photos_to_kml",
     "write_photos_kml",
+    "parse_popup_fields",
     "photos_to_html",
     "write_photos_html",
     "scan_flights",

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -38,6 +38,59 @@ _PANNELLUM_VERSION = "2.5.6"
 _PANNELLUM_CSS_SRI = "sha256-p/HXuG8QaPIo2S8bCu+VvUHR4uEnhVFlc62/VS7ieT0="
 _PANNELLUM_JS_SRI = "sha256-oosvezOf0KYCxnad8dymrUOvc7yMalvmcglxUonBKpo="
 
+# Popup content control (issue #296): the user-facing field names and the
+# GeoJSON properties they govern. Excluded fields are stripped from the
+# embedded data itself, not merely hidden by the popup JS — a shared map must
+# not leak in its source what it hides in its UI. thumb/link/pano always
+# survive: the thumbnail is the photo itself, the link powers the 360°
+# viewer, and pano is marker-type metadata.
+POPUP_FIELDS = ("name", "timestamp", "camera", "altitude")
+_FIELD_TO_PROP = {
+    "name": "name",
+    "timestamp": "timestamp",
+    "camera": "camera",
+    "altitude": "alt",
+}
+
+
+def parse_popup_fields(spec: str) -> frozenset[str]:
+    """Parse a ``--popup-fields`` value into a field set.
+
+    ``"none"`` selects no fields; anything else must be a comma-separated,
+    case-insensitive subset of :data:`POPUP_FIELDS`. Raises ``ValueError``
+    naming the valid fields otherwise.
+    """
+    value = spec.strip().lower()
+    if value == "none":
+        return frozenset()
+    fields = frozenset(part.strip() for part in value.split(",") if part.strip())
+    unknown = fields - frozenset(POPUP_FIELDS)
+    if unknown or not fields:
+        raise ValueError(
+            "invalid --popup-fields value"
+            + (f" ({', '.join(sorted(unknown))})" if unknown else "")
+            + f"; use 'none' or a comma list of: {', '.join(POPUP_FIELDS)}"
+        )
+    return fields
+
+
+def _apply_popup_fields(geojson: dict, fields: frozenset[str]) -> None:
+    """Strip excluded popup fields from *geojson* in place.
+
+    "altitude" also covers the coordinate's third element, so an excluded
+    altitude is absent from the HTML file entirely.
+    """
+    drop = [prop for field, prop in _FIELD_TO_PROP.items() if field not in fields]
+    for feature in geojson["features"]:
+        props = feature["properties"]
+        for prop in drop:
+            props.pop(prop, None)
+        if "altitude" not in fields:
+            coords = feature["geometry"]["coordinates"]
+            if len(coords) == 3:
+                feature["geometry"]["coordinates"] = coords[:2]
+
+
 _TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -243,7 +296,9 @@ function buildPopup(f) {
   if (p.thumb) {
     inner += `<img src="data:image/jpeg;base64,${esc(p.thumb)}" alt="">`;
   }
-  inner += `<b>${esc(p.name || '')}</b>`;
+  // Every text line is presence-guarded: --popup-fields (issue #296) strips
+  // properties from the embedded data, so nothing here may assume one exists.
+  if (p.name) inner += `<b>${esc(p.name)}</b>`;
   let html = '<div class="photo-popup">';
   if (p.link && p.pano) {
     // GPano panorama: the thumbnail/name click opens the embedded 360 viewer
@@ -260,7 +315,8 @@ function buildPopup(f) {
   if (p.link && p.pano) {
     html += `<br><a href="${esc(p.link)}" target="_blank" rel="noopener">open original</a>`;
   }
-  html += `<br>altitude: ${Number(p.alt || 0).toFixed(0)} m</div>`;
+  if (p.alt !== undefined) html += `<br>altitude: ${Number(p.alt).toFixed(0)} m`;
+  html += '</div>';
   return html;
 }
 
@@ -313,7 +369,11 @@ if (latlngs.length > 1) {
 
 
 def photos_to_html(
-    points: list[PhotoPoint], title: str, *, link_base: str | None = None
+    points: list[PhotoPoint],
+    title: str,
+    *,
+    link_base: str | None = None,
+    popup_fields: frozenset[str] | None = None,
 ) -> str:
     """Return a complete self-contained HTML photo map.
 
@@ -324,10 +384,16 @@ def photos_to_html(
     fully self-contained. GPano panoramas always render as distinct,
     toggleable orange markers (issue #283); the embedded Pannellum 360°
     viewer additionally activates when links are enabled.
+
+    ``popup_fields`` (issue #296): a set from :func:`parse_popup_fields`
+    limiting which EXIF-derived details the map carries; ``None`` (default)
+    keeps everything. Excluded fields never reach the HTML file.
     """
     geojson = photos_to_geojson(
         points, include_thumbnails=True, link_base=link_base
     )
+    if popup_fields is not None:
+        _apply_popup_fields(geojson, popup_fields)
     # Escape "<" to "\\u003c" (a JSON Unicode escape) so JSON.parse round-trips
     # it while no literal "</script>" can break out of the data block.
     data = json.dumps(geojson).replace("<", "\\u003c")
@@ -355,10 +421,14 @@ def write_photos_html(
     title: str,
     *,
     link_base: str | None = None,
+    popup_fields: frozenset[str] | None = None,
 ) -> Path:
     """Write *points* as an HTML map to *output_path* and return it."""
     output_path.write_text(
-        photos_to_html(points, title, link_base=link_base), encoding="utf-8"
+        photos_to_html(
+            points, title, link_base=link_base, popup_fields=popup_fields
+        ),
+        encoding="utf-8",
     )
     logger.info("HTML photo map created: %s", output_path)
     return output_path

--- a/tests/test_cli_photomap.py
+++ b/tests/test_cli_photomap.py
@@ -364,3 +364,48 @@ def test_photomap_no_serve_never_starts_server(monkeypatch, tmp_path):
     res = CliRunner().invoke(main, ["photomap", str(tmp_path)])
     assert res.exit_code == 0, res.output
     assert calls == {}
+
+
+# --popup-fields (issue #296): the user decides what a shared map discloses,
+# without touching the original photos' EXIF.
+
+
+def test_photomap_popup_fields_none_strips_details_from_html(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    res = CliRunner().invoke(
+        main, ["photomap", str(tmp_path), "--popup-fields", "none"])
+    assert res.exit_code == 0, res.output
+    text = (tmp_path / "photomap.html").read_text(encoding="utf-8")
+    assert "church1.jpg" not in text   # filename stripped from embedded data
+    assert "FC8482" not in text        # camera stripped
+    assert "12:30:45" not in text      # timestamp stripped
+    assert "/9j/THUMB1" in text        # the photo itself still shows
+
+
+def test_photomap_popup_fields_selective_list(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    res = CliRunner().invoke(
+        main, ["photomap", str(tmp_path), "--popup-fields", "name,altitude"])
+    assert res.exit_code == 0, res.output
+    text = (tmp_path / "photomap.html").read_text(encoding="utf-8")
+    assert "church1.jpg" in text
+    assert "FC8482" not in text
+
+
+def test_photomap_popup_fields_invalid_value_names_valid_fields(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    res = CliRunner().invoke(
+        main, ["photomap", str(tmp_path), "--popup-fields", "shutter"])
+    assert res.exit_code == 2
+    assert "shutter" in res.output
+    for valid in ("name", "timestamp", "camera", "altitude"):
+        assert valid in res.output
+
+
+def test_photomap_popup_fields_without_html_output_warns(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    res = CliRunner().invoke(
+        main,
+        ["photomap", str(tmp_path), "-f", "geojson", "--popup-fields", "none"])
+    assert res.exit_code == 0, res.output
+    assert "only affects HTML" in res.output

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -1,8 +1,14 @@
 import json
 import re
 
+import pytest
+
 from dji_metadata_embedder.geo.photomap import PhotoPoint
-from dji_metadata_embedder.geo.photomap_html import photos_to_html, write_photos_html
+from dji_metadata_embedder.geo.photomap_html import (
+    parse_popup_fields,
+    photos_to_html,
+    write_photos_html,
+)
 
 POINTS = [
     PhotoPoint(lat=60.170278, lon=24.952222, alt=95.3, name="church1.jpg",
@@ -305,3 +311,73 @@ def test_html_touch_devices_get_larger_pin_tap_target():
     assert "TOUCH ?" in html
     assert "pin-hit" in html
     assert ".pin-hit" in html  # centering CSS for the dot inside the hit box
+
+
+# Popup content control (issue #296): --popup-fields decides what the HTML
+# discloses. Excluded fields are stripped from the embedded GeoJSON itself,
+# not merely hidden by the popup JS — a shared map must not leak in its
+# source what it hides in its UI.
+
+
+def test_parse_popup_fields_none_and_comma_lists():
+    assert parse_popup_fields("none") == frozenset()
+    assert parse_popup_fields("timestamp, CAMERA") == {"timestamp", "camera"}
+    assert parse_popup_fields("name,timestamp,camera,altitude") == {
+        "name", "timestamp", "camera", "altitude"}
+
+
+def test_parse_popup_fields_rejects_unknown_and_names_valid_ones():
+    with pytest.raises(ValueError) as ei:
+        parse_popup_fields("shutter")
+    msg = str(ei.value)
+    assert "shutter" in msg
+    for valid in ("name", "timestamp", "camera", "altitude"):
+        assert valid in msg
+    with pytest.raises(ValueError):
+        parse_popup_fields("")
+
+
+def test_html_popup_fields_none_strips_exif_from_embedded_data():
+    html = photos_to_html(POINTS, title="t", popup_fields=frozenset())
+    feature = _embedded_geojson(html)["features"][0]
+    props = feature["properties"]
+    for prop in ("name", "timestamp", "camera", "alt"):
+        assert prop not in props
+    # The photo itself still shows: thumbnails survive field filtering.
+    thumbed = _embedded_geojson(html)["features"][1]["properties"]
+    assert thumbed["thumb"] == "/9j/THUMB2"
+    # Altitude leaves the coordinates too, not just the popup text.
+    assert len(feature["geometry"]["coordinates"]) == 2
+
+
+def test_html_popup_fields_selective_keeps_only_requested():
+    html = photos_to_html(
+        POINTS, title="t", popup_fields=frozenset({"timestamp"}))
+    props = _embedded_geojson(html)["features"][0]["properties"]
+    assert props["timestamp"] == "2026-06-15 12:30:45"
+    for prop in ("name", "camera", "alt"):
+        assert prop not in props
+
+
+def test_html_popup_fields_default_none_means_everything():
+    html = photos_to_html(POINTS, title="t", popup_fields=None)
+    props = _embedded_geojson(html)["features"][0]["properties"]
+    for prop in ("name", "timestamp", "camera", "alt"):
+        assert prop in props
+
+
+def test_html_popup_fields_none_keeps_pano_viewer_working():
+    html = photos_to_html(
+        PANO_POINTS, title="t", link_base="", popup_fields=frozenset())
+    data = _embedded_geojson(html)
+    pano = [f for f in data["features"] if f["properties"].get("pano")][0]
+    # pano is type metadata and link powers the viewer — never filtered.
+    assert pano["properties"]["link"]
+    assert "pannellum" in html
+
+
+def test_html_popup_js_guards_every_optional_field():
+    # With fields strippable, no popup line may assume its property exists.
+    html = photos_to_html(POINTS, title="t")
+    assert "if (p.name)" in html
+    assert re.search(r"if \([^)]*p\.alt", html)


### PR DESCRIPTION
Closes #296 — field-requested on mavicpilots: show "basically none [of the EXIF] except maybe a title or description" on a shared map, without editing every original photo.

## What

- New `photomap --popup-fields LIST` option: `none`, or a comma list of `name`, `timestamp`, `camera`, `altitude` (case-insensitive). Default is unchanged (everything shows).
- **Stripped, not hidden:** excluded fields are removed from the embedded GeoJSON at generation time, so the shared HTML file doesn't leak in its source what it hides in its UI. An excluded `altitude` also leaves the coordinates' third element.
- Always preserved: thumbnails (the photo *is* the point), `link` (powers the 360° viewer), `pano` (marker styling from #283).
- Popup JS lines are all presence-guarded now that any property can be absent.
- Typos fail fast (before the ExifTool scan) with a message naming the valid fields; non-HTML formats get a "only affects HTML" note, mirroring `--link-originals`.
- Docs: geospatial.md section (with the `--redact` pairing for location privacy), README examples + options table, user guide.

## Testing

- TDD: 7 new tests in `test_geo_photomap_html.py` (parser, none/selective/default filtering, pano-viewer survival, JS guards) + 4 CLI tests in `test_cli_photomap.py`, all watched fail first.
- Full suite: 583 passed, 4 skipped; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A