### PR TITLE
feat(gui): visual polish round 1 — step layout, spacing, drop-zone affordance (#292)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/DropZoneAffordanceTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/DropZoneAffordanceTests.cs
@@ -1,0 +1,71 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+using DjiEmbed.Gui.Views;
+using Xunit;
+
+namespace DjiEmbed.Gui.Tests;
+
+// #292: the drop zone needs a visible dashed outline and a drag-over
+// highlight so it's obvious a folder can be dropped.
+public class DropZoneAffordanceTests
+{
+    private static Window ShowView(Control view)
+    {
+        var window = new Window { Width = 560, Height = 520, Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        return window;
+    }
+
+    public static TheoryData<string> PickViews() => new() { "makemap", "embed" };
+
+    private static Control PickView(string kind) => kind switch
+    {
+        "makemap" => new MakeMapView
+        {
+            DataContext = new MakeMapViewModel(
+                null, new DjiEmbedRunner(), () => { }),
+        },
+        _ => new EmbedTelemetryView
+        {
+            DataContext = new EmbedTelemetryViewModel(
+                null, new DjiEmbedRunner(), () => { }),
+        },
+    };
+
+    [AvaloniaTheory]
+    [MemberData(nameof(PickViews))]
+    public void Pick_screen_drop_zone_has_a_dashed_outline(string kind)
+    {
+        var window = ShowView(PickView(kind));
+        var outlines = window.GetVisualDescendants().OfType<Rectangle>()
+            .Where(r => r.StrokeDashArray is { Count: > 0 });
+        Assert.NotEmpty(outlines);
+    }
+
+    [AvaloniaTheory]
+    [MemberData(nameof(PickViews))]
+    public void Pick_screen_names_its_drop_zone(string kind)
+    {
+        var window = ShowView(PickView(kind));
+        var zone = window.GetVisualDescendants().OfType<Border>()
+            .FirstOrDefault(b => b.Name == "DropZone");
+        Assert.NotNull(zone);
+    }
+
+    [AvaloniaFact]
+    public void Drag_over_toggles_the_dragover_class_on_the_zone()
+    {
+        var zone = new Border();
+        FolderPicking.SetDragOver(zone, true);
+        Assert.Contains("dragover", zone.Classes);
+        FolderPicking.SetDragOver(zone, false);
+        Assert.DoesNotContain("dragover", zone.Classes);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/FlowLayoutTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlowLayoutTests.cs
@@ -1,0 +1,84 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+using DjiEmbed.Gui.Views;
+using Xunit;
+
+namespace DjiEmbed.Gui.Tests;
+
+// The step panels must fill the window, not dock left at their desired
+// width (the v1.21.0 bug behind #292's "content sits awkwardly": buttons
+// and the progress bar hugged the left half of the window).
+public class FlowLayoutTests
+{
+    private const double WindowWidth = 560;
+
+    private static Window ShowView(Control view)
+    {
+        var window = new Window
+        {
+            Width = WindowWidth,
+            Height = 520,
+            Content = view,
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        return window;
+    }
+
+    private static EmbedTelemetryViewModel EmbedVm()
+        => new(null, new DjiEmbedRunner(), () => { });
+
+    private static double CentreXInWindow(Visual control, Window window) =>
+        control.TranslatePoint(
+            new Point(control.Bounds.Width / 2, 0), window)!.Value.X;
+
+    private static Button VisibleButton(Window window, string caption) =>
+        window.GetVisualDescendants().OfType<Button>()
+            .First(b => b.IsEffectivelyVisible
+                        && b.GetVisualDescendants().OfType<TextBlock>()
+                            .Any(t => t.Text == caption));
+
+    [AvaloniaFact]
+    public void Done_screen_button_is_centred_in_the_window()
+    {
+        var vm = EmbedVm();
+        vm.Step = FlowStep.Done;
+        vm.Outputs.Add(@"C:\demo\processed");
+        var window = ShowView(new EmbedTelemetryView { DataContext = vm });
+
+        var centre = CentreXInWindow(VisibleButton(window, "Done"), window);
+        Assert.InRange(centre, WindowWidth / 2 - 10, WindowWidth / 2 + 10);
+    }
+
+    [AvaloniaFact]
+    public void Running_screen_progress_bar_spans_the_content_width()
+    {
+        var vm = EmbedVm();
+        vm.Step = FlowStep.Running;
+        vm.StatusText = "Embedding your flight data…";
+        var window = ShowView(new EmbedTelemetryView { DataContext = vm });
+
+        var bar = window.GetVisualDescendants().OfType<ProgressBar>()
+            .First(p => p.IsEffectivelyVisible);
+        Assert.True(bar.Bounds.Width >= 400,
+            $"progress bar is only {bar.Bounds.Width}px wide");
+    }
+
+    [AvaloniaFact]
+    public void Failed_screen_button_is_centred_in_the_window()
+    {
+        var vm = EmbedVm();
+        vm.Step = FlowStep.Failed;
+        vm.ErrorMessage = "Something went wrong.";
+        var window = ShowView(new EmbedTelemetryView { DataContext = vm });
+
+        var centre = CentreXInWindow(VisibleButton(window, "Back"), window);
+        Assert.InRange(centre, WindowWidth / 2 - 10, WindowWidth / 2 + 10);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -1,6 +1,8 @@
+using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
+using DjiEmbed.Gui.Services;
 using DjiEmbed.Gui.ViewModels;
 using DjiEmbed.Gui.Views;
 using Xunit;
@@ -8,9 +10,8 @@ using Xunit;
 namespace DjiEmbed.Gui.Tests;
 
 /// <summary>
-/// Opt-in tooling, not a test of behaviour: renders the home screen and writes
-/// a PNG to the path in DJIEMBED_CAPTURE_PNG so visual changes can be reviewed
-/// without a Windows machine.
+/// Opt-in tooling, not a test of behaviour: renders the app's screens and
+/// writes PNGs so visual changes can be reviewed without a Windows machine.
 /// </summary>
 public class ScreenshotCaptureTests
 {
@@ -22,12 +23,92 @@ public class ScreenshotCaptureTests
             "Set DJIEMBED_CAPTURE_PNG=<path.png> to capture the home screen.");
 
         var window = new MainWindow { DataContext = new MainViewModel() };
+        Capture(window, outPath!);
+    }
+
+    /// <summary>
+    /// Renders every view in every flow step with representative fake data
+    /// and writes one PNG per screen into DJIEMBED_CAPTURE_DIR.
+    /// </summary>
+    [AvaloniaFact]
+    public void Captures_every_screen_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture all screens.");
+        Directory.CreateDirectory(dir!);
+
+        string Png(string name) => Path.Combine(dir!, name + ".png");
+        static Action NoOp() => () => { };
+
+        Capture(new MainWindow { DataContext = new MainViewModel() },
+            Png("home"));
+
+        var makeMap = new MakeMapViewModel(null, new DjiEmbedRunner(), NoOp());
+        CaptureView(new MakeMapView { DataContext = makeMap },
+            Png("makemap-pick"));
+
+        makeMap.Step = FlowStep.Done;
+        makeMap.Outputs.Add(@"C:\Users\demo\Videos\flight\photo_map.html");
+        makeMap.Outputs.Add(@"C:\Users\demo\Videos\flight\flight_map.html");
+        CaptureView(new MakeMapView { DataContext = makeMap },
+            Png("makemap-done"));
+
+        var embed = new EmbedTelemetryViewModel(
+            null, new DjiEmbedRunner(), NoOp());
+        CaptureView(new EmbedTelemetryView { DataContext = embed },
+            Png("embed-pick"));
+
+        var dragged = new EmbedTelemetryView { DataContext = embed };
+        FolderPicking.SetDragOver(dragged.FindControl<Border>("DropZone")!, true);
+        CaptureView(dragged, Png("embed-pick-dragover"));
+
+        embed.Step = FlowStep.Running;
+        embed.StatusText = "Embedding your flight data…";
+        embed.CurrentItem = "DJI_0042.MP4";
+        embed.Current = 3;
+        embed.Total = 12;
+        CaptureView(new EmbedTelemetryView { DataContext = embed },
+            Png("embed-running"));
+
+        embed.Step = FlowStep.Done;
+        embed.Outputs.Add(@"C:\Users\demo\Videos\flight\processed");
+        CaptureView(new EmbedTelemetryView { DataContext = embed },
+            Png("embed-done"));
+
+        embed.Step = FlowStep.Failed;
+        embed.ErrorMessage = "Something went wrong while embedding the "
+            + "flight data. Your original videos were not changed.";
+        embed.ErrorDetails = "Traceback (most recent call last):\n"
+            + "  File \"processor.py\", line 214, in embed\n"
+            + "RuntimeError: ffmpeg exited with code 1";
+        CaptureView(new EmbedTelemetryView { DataContext = embed },
+            Png("embed-failed"));
+
+        var setup = new CheckSetupViewModel(null, new DjiEmbedRunner(), NoOp());
+        setup.Step = FlowStep.Done;
+        setup.AllGood = true;
+        setup.Items.Add(new SetupItem(
+            "Video tools (FFmpeg)", true, "version 7.1"));
+        setup.Items.Add(new SetupItem(
+            "Photo tools (ExifTool)", true, "version 13.29"));
+        CaptureView(new CheckSetupView { DataContext = setup },
+            Png("checksetup-done"));
+    }
+
+    private static void CaptureView(Control view, string outPath) =>
+        Capture(new Window { Width = 560, Height = 520, Content = view },
+            outPath);
+
+    private static void Capture(Window window, string outPath)
+    {
         window.Show();
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();
 
         var frame = window.CaptureRenderedFrame();
         Assert.NotNull(frame);
-        frame!.Save(outPath!, new Avalonia.Media.Imaging.PngBitmapEncoderOptions());
+        frame!.Save(outPath, new Avalonia.Media.Imaging.PngBitmapEncoderOptions());
+        window.Close();
     }
 }

--- a/gui/DjiEmbed.Gui/DjiEmbed.Gui.csproj
+++ b/gui/DjiEmbed.Gui/DjiEmbed.Gui.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <Folder Include="Models\" />
     <AvaloniaResource Include="Assets\**" />
+    <InternalsVisibleTo Include="DjiEmbed.Gui.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml
+++ b/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml
@@ -11,11 +11,15 @@
         <TextBlock DockPanel.Dock="Top" Text="Check my setup"
                    FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
 
+        <!-- One step at a time; the panel keeps each one full-width. -->
+        <Panel>
+
         <!-- Running -->
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Running}}"
-                    Spacing="14" VerticalAlignment="Center">
+                    Spacing="14" MaxWidth="440"
+                    VerticalAlignment="Center" Margin="0,0,0,56">
             <TextBlock Text="Checking everything this app needs…" FontSize="16" />
             <ProgressBar IsIndeterminate="True" />
         </StackPanel>
@@ -24,7 +28,7 @@
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Done}}"
-                    Spacing="14">
+                    Spacing="16">
             <TextBlock FontSize="16"
                        IsVisible="{Binding AllGood}"
                        Text="Everything looks good — you're ready to go." />
@@ -53,7 +57,8 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+            <Button HorizontalAlignment="Center" Margin="0,10,0,0"
+                    Command="{Binding GoHomeCommand}">
                 <TextBlock Text="Back" />
             </Button>
         </StackPanel>
@@ -62,8 +67,9 @@
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Failed}}"
-                    Spacing="14" VerticalAlignment="Center">
-            <TextBlock Text="That didn't work" FontSize="18" FontWeight="SemiBold" />
+                    Spacing="16" MaxWidth="440"
+                    VerticalAlignment="Center" Margin="0,0,0,56">
+            <TextBlock Text="That didn't work" FontSize="20" FontWeight="SemiBold" />
             <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap" />
             <Expander Header="Technical details"
                       IsVisible="{Binding ErrorDetails,
@@ -71,10 +77,13 @@
                 <TextBlock Text="{Binding ErrorDetails}" TextWrapping="Wrap"
                            FontFamily="Consolas,Menlo,monospace" FontSize="12" />
             </Expander>
-            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+            <Button HorizontalAlignment="Center" Margin="0,10,0,0"
+                    Command="{Binding GoHomeCommand}">
                 <TextBlock Text="Back" />
             </Button>
         </StackPanel>
+
+        </Panel>
     </DockPanel>
 
 </UserControl>

--- a/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml
+++ b/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml
@@ -7,25 +7,43 @@
              x:Class="DjiEmbed.Gui.Views.EmbedTelemetryView"
              x:DataType="vm:EmbedTelemetryViewModel">
 
+    <UserControl.Styles>
+        <Style Selector="Border#DropZone.dragover">
+            <Setter Property="Background"
+                    Value="{DynamicResource SystemControlBackgroundBaseLowBrush}" />
+        </Style>
+        <Style Selector="Border#DropZone.dragover Rectangle.dropOutline">
+            <Setter Property="Stroke"
+                    Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+        </Style>
+    </UserControl.Styles>
+
     <DockPanel Margin="32,28">
         <TextBlock DockPanel.Dock="Top" Text="Embed telemetry"
                    FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
+
+        <!-- One step at a time; the panel keeps each one full-width. -->
+        <Panel>
 
         <!-- Pick -->
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Pick}}"
                     Spacing="16">
-            <Border DragDrop.AllowDrop="True"
-                    BorderThickness="2" CornerRadius="10" Padding="32,44"
-                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}">
-                <StackPanel Spacing="8" HorizontalAlignment="Center">
-                    <TextBlock Text="Drop a folder of drone videos here"
-                               FontSize="16" HorizontalAlignment="Center" />
-                    <TextBlock Text="MP4 videos with their .SRT flight logs — new copies get the GPS, your originals are never changed"
-                               Opacity="0.6" HorizontalAlignment="Center"
-                               TextWrapping="Wrap" TextAlignment="Center" />
-                </StackPanel>
+            <Border Name="DropZone" DragDrop.AllowDrop="True" CornerRadius="10">
+                <Panel>
+                    <Rectangle Classes="dropOutline"
+                               Stroke="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                               StrokeThickness="2" StrokeDashArray="5,3"
+                               RadiusX="10" RadiusY="10" />
+                    <StackPanel Margin="32,44" Spacing="8" HorizontalAlignment="Center">
+                        <TextBlock Text="Drop a folder of drone videos here"
+                                   FontSize="16" HorizontalAlignment="Center" />
+                        <TextBlock Text="MP4 videos with their .SRT flight logs — new copies get the GPS, your originals are never changed"
+                                   Opacity="0.6" HorizontalAlignment="Center"
+                                   TextWrapping="Wrap" TextAlignment="Center" />
+                    </StackPanel>
+                </Panel>
             </Border>
             <Button HorizontalAlignment="Center" Click="OnChooseFolderClick">
                 <TextBlock Text="Choose a folder…" />
@@ -40,7 +58,8 @@
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Running}}"
-                    Spacing="14" VerticalAlignment="Center">
+                    Spacing="14" MaxWidth="440"
+                    VerticalAlignment="Center" Margin="0,0,0,56">
             <TextBlock Text="{Binding StatusText}" FontSize="16" />
             <ProgressBar Minimum="0"
                          Maximum="{Binding Total, FallbackValue=1, TargetNullValue=1}"
@@ -48,7 +67,8 @@
                          IsIndeterminate="{Binding Total,
                              Converter={x:Static ObjectConverters.IsNull}}" />
             <TextBlock Text="{Binding CurrentItem}" Opacity="0.6" FontSize="12" />
-            <Button HorizontalAlignment="Center" Command="{Binding CancelCommand}">
+            <Button HorizontalAlignment="Center" Margin="0,10,0,0"
+                    Command="{Binding CancelCommand}">
                 <TextBlock Text="Cancel" />
             </Button>
         </StackPanel>
@@ -57,8 +77,9 @@
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Done}}"
-                    Spacing="14" VerticalAlignment="Center">
-            <TextBlock Text="All done" FontSize="18" FontWeight="SemiBold" />
+                    Spacing="16" MaxWidth="440"
+                    VerticalAlignment="Center" Margin="0,0,0,56">
+            <TextBlock Text="✅ All done" FontSize="20" FontWeight="SemiBold" />
             <TextBlock Text="New copies with the flight data embedded were written to the folder below. Your original videos were not changed."
                        TextWrapping="Wrap" />
             <ItemsControl ItemsSource="{Binding Outputs}">
@@ -76,7 +97,8 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+            <Button HorizontalAlignment="Center" Margin="0,10,0,0"
+                    Command="{Binding GoHomeCommand}">
                 <TextBlock Text="Done" />
             </Button>
         </StackPanel>
@@ -85,8 +107,9 @@
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Failed}}"
-                    Spacing="14" VerticalAlignment="Center">
-            <TextBlock Text="That didn't work" FontSize="18" FontWeight="SemiBold" />
+                    Spacing="16" MaxWidth="440"
+                    VerticalAlignment="Center" Margin="0,0,0,56">
+            <TextBlock Text="That didn't work" FontSize="20" FontWeight="SemiBold" />
             <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap" />
             <Expander Header="Technical details"
                       IsVisible="{Binding ErrorDetails,
@@ -94,10 +117,13 @@
                 <TextBlock Text="{Binding ErrorDetails}" TextWrapping="Wrap"
                            FontFamily="Consolas,Menlo,monospace" FontSize="12" />
             </Expander>
-            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+            <Button HorizontalAlignment="Center" Margin="0,10,0,0"
+                    Command="{Binding GoHomeCommand}">
                 <TextBlock Text="Back" />
             </Button>
         </StackPanel>
+
+        </Panel>
     </DockPanel>
 
 </UserControl>

--- a/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml.cs
@@ -9,7 +9,7 @@ public partial class EmbedTelemetryView : UserControl
     public EmbedTelemetryView()
     {
         InitializeComponent();
-        FolderPicking.EnableDrop(this, StartAsync);
+        FolderPicking.EnableDrop(this, StartAsync, DropZone);
     }
 
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -33,14 +33,27 @@ internal static class FolderPicking
         }
     }
 
-    internal static void EnableDrop(Control target, Func<string, Task> onFolder)
+    internal static void EnableDrop(
+        Control target, Func<string, Task> onFolder, Control? dropZone = null)
     {
         target.AddHandler(DragDrop.DragOverEvent, (_, e) =>
             e.DragEffects = e.DataTransfer.Contains(DataFormat.File)
                 ? DragDropEffects.Copy
                 : DragDropEffects.None);
+        if (dropZone is not null)
+        {
+            target.AddHandler(DragDrop.DragEnterEvent, (_, e) =>
+                SetDragOver(dropZone,
+                    e.DataTransfer.Contains(DataFormat.File)));
+            target.AddHandler(DragDrop.DragLeaveEvent, (_, _) =>
+                SetDragOver(dropZone, false));
+        }
         target.AddHandler(DragDrop.DropEvent, async (_, e) =>
         {
+            if (dropZone is not null)
+            {
+                SetDragOver(dropZone, false);
+            }
             var folder = e.DataTransfer.TryGetFiles()
                 ?.Select(f => f.TryGetLocalPath())
                 .FirstOrDefault(p =>
@@ -51,4 +64,8 @@ internal static class FolderPicking
             }
         });
     }
+
+    /// <summary>Toggles the "dragover" style class on the drop zone.</summary>
+    internal static void SetDragOver(Control zone, bool active) =>
+        zone.Classes.Set("dragover", active);
 }

--- a/gui/DjiEmbed.Gui/Views/MakeMapView.axaml
+++ b/gui/DjiEmbed.Gui/Views/MakeMapView.axaml
@@ -7,24 +7,43 @@
              x:Class="DjiEmbed.Gui.Views.MakeMapView"
              x:DataType="vm:MakeMapViewModel">
 
+    <UserControl.Styles>
+        <Style Selector="Border#DropZone.dragover">
+            <Setter Property="Background"
+                    Value="{DynamicResource SystemControlBackgroundBaseLowBrush}" />
+        </Style>
+        <Style Selector="Border#DropZone.dragover Rectangle.dropOutline">
+            <Setter Property="Stroke"
+                    Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+        </Style>
+    </UserControl.Styles>
+
     <DockPanel Margin="32,28">
         <TextBlock DockPanel.Dock="Top" Text="Make a map"
                    FontSize="24" FontWeight="SemiBold" Margin="0,0,0,24" />
+
+        <!-- One step at a time; the panel keeps each one full-width. -->
+        <Panel>
 
         <!-- Pick -->
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Pick}}"
                     Spacing="16">
-            <Border Name="DropZone" DragDrop.AllowDrop="True"
-                    BorderThickness="2" CornerRadius="10" Padding="32,44"
-                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}">
-                <StackPanel Spacing="8" HorizontalAlignment="Center">
-                    <TextBlock Text="Drop a folder of footage here"
-                               FontSize="16" HorizontalAlignment="Center" />
-                    <TextBlock Text="photos, drone videos with their .SRT flight logs, or both"
-                               Opacity="0.6" HorizontalAlignment="Center" />
-                </StackPanel>
+            <Border Name="DropZone" DragDrop.AllowDrop="True" CornerRadius="10">
+                <Panel>
+                    <Rectangle Classes="dropOutline"
+                               Stroke="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                               StrokeThickness="2" StrokeDashArray="5,3"
+                               RadiusX="10" RadiusY="10" />
+                    <StackPanel Margin="32,44" Spacing="8" HorizontalAlignment="Center">
+                        <TextBlock Text="Drop a folder of footage here"
+                                   FontSize="16" HorizontalAlignment="Center" />
+                        <TextBlock Text="photos, drone videos with their .SRT flight logs, or both"
+                                   Opacity="0.6" HorizontalAlignment="Center"
+                                   TextWrapping="Wrap" TextAlignment="Center" />
+                    </StackPanel>
+                </Panel>
             </Border>
             <Button Name="ChooseFolderButton" HorizontalAlignment="Center"
                     Click="OnChooseFolderClick">
@@ -40,7 +59,8 @@
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Running}}"
-                    Spacing="14" VerticalAlignment="Center">
+                    Spacing="14" MaxWidth="440"
+                    VerticalAlignment="Center" Margin="0,0,0,56">
             <TextBlock Text="{Binding StatusText}" FontSize="16" />
             <ProgressBar Minimum="0"
                          Maximum="{Binding Total, FallbackValue=1, TargetNullValue=1}"
@@ -48,7 +68,8 @@
                          IsIndeterminate="{Binding Total,
                              Converter={x:Static ObjectConverters.IsNull}}" />
             <TextBlock Text="{Binding CurrentItem}" Opacity="0.6" FontSize="12" />
-            <Button HorizontalAlignment="Center" Command="{Binding CancelCommand}">
+            <Button HorizontalAlignment="Center" Margin="0,10,0,0"
+                    Command="{Binding CancelCommand}">
                 <TextBlock Text="Cancel" />
             </Button>
         </StackPanel>
@@ -57,8 +78,9 @@
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Done}}"
-                    Spacing="14" VerticalAlignment="Center">
-            <TextBlock Text="Your map is ready" FontSize="18" FontWeight="SemiBold" />
+                    Spacing="16" MaxWidth="440"
+                    VerticalAlignment="Center" Margin="0,0,0,56">
+            <TextBlock Text="✅ Your map is ready" FontSize="20" FontWeight="SemiBold" />
             <ItemsControl ItemsSource="{Binding Outputs}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="x:String">
@@ -74,7 +96,8 @@
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
-            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+            <Button HorizontalAlignment="Center" Margin="0,10,0,0"
+                    Command="{Binding GoHomeCommand}">
                 <TextBlock Text="Done" />
             </Button>
         </StackPanel>
@@ -83,8 +106,9 @@
         <StackPanel IsVisible="{Binding Step,
                         Converter={x:Static ObjectConverters.Equal},
                         ConverterParameter={x:Static vm:FlowStep.Failed}}"
-                    Spacing="14" VerticalAlignment="Center">
-            <TextBlock Text="That didn't work" FontSize="18" FontWeight="SemiBold" />
+                    Spacing="16" MaxWidth="440"
+                    VerticalAlignment="Center" Margin="0,0,0,56">
+            <TextBlock Text="That didn't work" FontSize="20" FontWeight="SemiBold" />
             <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap" />
             <Expander Header="Technical details"
                       IsVisible="{Binding ErrorDetails,
@@ -92,10 +116,13 @@
                 <TextBlock Text="{Binding ErrorDetails}" TextWrapping="Wrap"
                            FontFamily="Consolas,Menlo,monospace" FontSize="12" />
             </Expander>
-            <Button HorizontalAlignment="Center" Command="{Binding GoHomeCommand}">
+            <Button HorizontalAlignment="Center" Margin="0,10,0,0"
+                    Command="{Binding GoHomeCommand}">
                 <TextBlock Text="Back" />
             </Button>
         </StackPanel>
+
+        </Panel>
     </DockPanel>
 
 </UserControl>

--- a/gui/DjiEmbed.Gui/Views/MakeMapView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/MakeMapView.axaml.cs
@@ -9,7 +9,7 @@ public partial class MakeMapView : UserControl
     public MakeMapView()
     {
         InitializeComponent();
-        FolderPicking.EnableDrop(this, StartAsync);
+        FolderPicking.EnableDrop(this, StartAsync, DropZone);
     }
 
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>


### PR DESCRIPTION
Part of #292 (visual items 1, 2 and 4; the progress-display upgrade and the functional items follow in separate PRs).

## What changed

**Step-panel layout bug (root cause of "content sits awkwardly")** — the four step panels were non-last children of a `DockPanel`, so Avalonia docked them **left at their desired width** instead of filling the window: progress bars rendered ~220 px wide and "centred" buttons hugged the left half. Each view's steps now live in a shared `Panel`, and Running/Done/Failed panels get `MaxWidth=440` + vertical centring with an optical lift.

**Drop-zone affordance** — both pick screens now draw a dashed outline (`Rectangle` + `StrokeDashArray`; Avalonia 12's `Border` has no dash support) and highlight on drag-over (accent stroke + background tint), cleared on drop/leave. `FolderPicking.EnableDrop` gained an optional drop-zone parameter and a testable `SetDragOver` helper.

**Consistency pass** — Done/Failed headings unified at 20 SemiBold with a ✅ glyph on success; button spacing unified; MakeMap's drop-zone subtitle wraps like Embed's; Check-my-setup gets the same step-panel treatment.

**Screenshot tooling** — `DJIEMBED_CAPTURE_DIR=<dir>` now renders every view in every flow step (including the drag-over state) with representative fake data, one PNG per screen. Used to produce the before/after set for this PR; reusable for README media.

## Tests

New: `FlowLayoutTests` (button centring + progress-bar width regression for the dock bug), `DropZoneAffordanceTests` (dashed outline present on both pick views, named drop zone, dragover class toggling). TDD: watched red before implementing. Full GUI suite: 63 passed, 4 skipped (env-gated).

Closes nothing on its own — #292 checkboxes tick as the round completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A