### PR TITLE
feat(gui): per-file progress counts + warning surfacing (#292)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/FlowProgressAndWarningsTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlowProgressAndWarningsTests.cs
@@ -1,0 +1,143 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+using DjiEmbed.Gui.Views;
+using Xunit;
+
+namespace DjiEmbed.Gui.Tests;
+
+// #292: long runs should feel alive ("DJI_0042.MP4 (3 of 12)") and CLI
+// warnings must reach the Done screen — a silent partial success looks
+// like a full success.
+public class FlowProgressAndWarningsTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-flowprog-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string MakeFolder()
+    {
+        var folder = Path.Combine(_dir, "footage");
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "DJI_0001.MP4"), "");
+        File.WriteAllText(Path.Combine(folder, "DJI_0001.SRT"), "");
+        return folder;
+    }
+
+    private static EmbedTelemetryViewModel Vm(string? cli) =>
+        new(cli, new DjiEmbedRunner(), () => { });
+
+    [Fact]
+    public void Progress_detail_names_the_file_and_the_count()
+    {
+        var vm = Vm(null);
+        vm.CurrentItem = "DJI_0042.MP4";
+        vm.Current = 3;
+        vm.Total = 12;
+        Assert.Equal("DJI_0042.MP4 (3 of 12)", vm.ProgressDetail);
+    }
+
+    [Fact]
+    public void Progress_detail_without_a_total_is_just_the_file()
+    {
+        var vm = Vm(null);
+        vm.CurrentItem = "DJI_0042.MP4";
+        Assert.Equal("DJI_0042.MP4", vm.ProgressDetail);
+    }
+
+    [Fact]
+    public void Progress_detail_without_an_item_is_null()
+    {
+        var vm = Vm(null);
+        vm.Current = 3;
+        vm.Total = 12;
+        Assert.Null(vm.ProgressDetail);
+    }
+
+    [Fact]
+    public async Task Warning_events_are_collected_for_the_done_screen()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+        [
+            """{"v": 1, "event": "start", "command": "embed", "total": 3}""",
+            """{"v": 1, "event": "warning", "message": "no matching SRT", "item": "DJI_0002.MP4"}""",
+            """{"v": 1, "event": "warning", "message": "2 files skipped"}""",
+            """{"v": 1, "event": "result", "ok": true, "outputs": ["/footage/processed"], "summary": {}}""",
+        ]);
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(MakeFolder());
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Equal(
+            ["DJI_0002.MP4: no matching SRT", "2 files skipped"],
+            vm.Warnings);
+    }
+
+    [Fact]
+    public async Task Warnings_do_not_leak_into_the_next_run()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+        [
+            """{"v": 1, "event": "start", "command": "embed", "total": 1}""",
+            """{"v": 1, "event": "warning", "message": "one warning"}""",
+            """{"v": 1, "event": "result", "ok": true, "outputs": [], "summary": {}}""",
+        ]);
+        var vm = Vm(cli);
+        var folder = MakeFolder();
+        await vm.StartCommand.ExecuteAsync(folder);
+        await vm.StartCommand.ExecuteAsync(folder);
+        Assert.Equal(["one warning"], vm.Warnings);
+    }
+
+    [AvaloniaFact]
+    public void Running_screen_shows_the_progress_detail()
+    {
+        var vm = Vm(null);
+        vm.Step = FlowStep.Running;
+        vm.StatusText = "Embedding your flight data…";
+        vm.CurrentItem = "DJI_0042.MP4";
+        vm.Current = 3;
+        vm.Total = 12;
+        var window = ShowView(new EmbedTelemetryView { DataContext = vm });
+        Assert.Contains(Texts(window), t => t == "DJI_0042.MP4 (3 of 12)");
+    }
+
+    [AvaloniaFact]
+    public void Embed_done_screen_shows_warnings()
+    {
+        var vm = Vm(null);
+        vm.Step = FlowStep.Done;
+        vm.Warnings.Add("DJI_0002.MP4: no matching SRT");
+        var window = ShowView(new EmbedTelemetryView { DataContext = vm });
+        Assert.Contains(Texts(window),
+            t => t?.Contains("no matching SRT") == true);
+    }
+
+    [AvaloniaFact]
+    public void Makemap_done_screen_shows_warnings()
+    {
+        var vm = new MakeMapViewModel(null, new DjiEmbedRunner(), () => { });
+        vm.Step = FlowStep.Done;
+        vm.Warnings.Add("IMG_0001.JPG: no GPS position");
+        var window = ShowView(new MakeMapView { DataContext = vm });
+        Assert.Contains(Texts(window),
+            t => t?.Contains("no GPS position") == true);
+    }
+
+    private static Window ShowView(Control view)
+    {
+        var window = new Window { Width = 560, Height = 520, Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        return window;
+    }
+
+    private static List<string?> Texts(Window window) =>
+        window.GetVisualDescendants().OfType<TextBlock>()
+            .Where(t => t.IsEffectivelyVisible)
+            .Select(t => t.Text).ToList();
+}

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -73,6 +73,7 @@ public class ScreenshotCaptureTests
 
         embed.Step = FlowStep.Done;
         embed.Outputs.Add(@"C:\Users\demo\Videos\flight\processed");
+        embed.Warnings.Add("DJI_0007.MP4: skipped — no matching .SRT flight log");
         CaptureView(new EmbedTelemetryView { DataContext = embed },
             Png("embed-done"));
 

--- a/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
@@ -49,6 +49,23 @@ public abstract partial class FlowViewModel(
 
     public ObservableCollection<string> Outputs { get; } = [];
 
+    public ObservableCollection<string> Warnings { get; } = [];
+
+    /// <summary>The Running screen's one-liner: "file (n of total)".</summary>
+    public string? ProgressDetail =>
+        CurrentItem is null ? null
+        : Total is { } total ? $"{CurrentItem} ({Current} of {total})"
+        : CurrentItem;
+
+    partial void OnCurrentItemChanged(string? value) =>
+        OnPropertyChanged(nameof(ProgressDetail));
+
+    partial void OnCurrentChanged(int value) =>
+        OnPropertyChanged(nameof(ProgressDetail));
+
+    partial void OnTotalChanged(int? value) =>
+        OnPropertyChanged(nameof(ProgressDetail));
+
     private CancellationTokenSource? _cts;
 
     /// <summary>Fails fast when the bundled CLI is missing.</summary>
@@ -70,6 +87,7 @@ public abstract partial class FlowViewModel(
     protected async Task ExecuteFlowAsync(Func<Task<bool>> body)
     {
         Outputs.Clear();
+        Warnings.Clear();
         Step = FlowStep.Running;
         _cts = new CancellationTokenSource();
         try
@@ -137,6 +155,12 @@ public abstract partial class FlowViewModel(
             Current = e.Current ?? 0;
             Total = e.Total;
             CurrentItem = e.Item;
+        }
+        else if (e.Kind == ProgressEventKind.Warning
+                 && (e.Message ?? e.Item) is { } text)
+        {
+            Warnings.Add(e.Item is null || e.Message is null
+                ? text : $"{e.Item}: {e.Message}");
         }
     }
 

--- a/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml
+++ b/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml
@@ -66,7 +66,7 @@
                          Value="{Binding Current}"
                          IsIndeterminate="{Binding Total,
                              Converter={x:Static ObjectConverters.IsNull}}" />
-            <TextBlock Text="{Binding CurrentItem}" Opacity="0.6" FontSize="12" />
+            <TextBlock Text="{Binding ProgressDetail}" Opacity="0.6" FontSize="12" />
             <Button HorizontalAlignment="Center" Margin="0,10,0,0"
                     Command="{Binding CancelCommand}">
                 <TextBlock Text="Cancel" />
@@ -94,6 +94,16 @@
                             <TextBlock Text="{Binding}" VerticalAlignment="Center"
                                        TextTrimming="CharacterEllipsis" Opacity="0.8" />
                         </DockPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <ItemsControl ItemsSource="{Binding Warnings}"
+                          IsVisible="{Binding !!Warnings.Count}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <TextBlock Text="{Binding StringFormat='⚠️ {0}'}"
+                                   TextWrapping="Wrap" Opacity="0.85"
+                                   FontSize="12" Margin="0,2" />
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>

--- a/gui/DjiEmbed.Gui/Views/MakeMapView.axaml
+++ b/gui/DjiEmbed.Gui/Views/MakeMapView.axaml
@@ -67,7 +67,7 @@
                          Value="{Binding Current}"
                          IsIndeterminate="{Binding Total,
                              Converter={x:Static ObjectConverters.IsNull}}" />
-            <TextBlock Text="{Binding CurrentItem}" Opacity="0.6" FontSize="12" />
+            <TextBlock Text="{Binding ProgressDetail}" Opacity="0.6" FontSize="12" />
             <Button HorizontalAlignment="Center" Margin="0,10,0,0"
                     Command="{Binding CancelCommand}">
                 <TextBlock Text="Cancel" />
@@ -93,6 +93,16 @@
                             <TextBlock Text="{Binding}" VerticalAlignment="Center"
                                        TextTrimming="CharacterEllipsis" Opacity="0.8" />
                         </DockPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <ItemsControl ItemsSource="{Binding Warnings}"
+                          IsVisible="{Binding !!Warnings.Count}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <TextBlock Text="{Binding StringFormat='⚠️ {0}'}"
+                                   TextWrapping="Wrap" Opacity="0.85"
+                                   FontSize="12" Margin="0,2" />
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>


### PR DESCRIPTION
Part of #292 (progress-display upgrade + surface-warning-events items). **Stacked on #301** — GitHub will retarget to master when that merges.

## What changed

- **Running screens feel alive**: new computed `FlowViewModel.ProgressDetail` renders "DJI_0042.MP4 (3 of 12)" under the progress bar (falls back to just the filename when the CLI sends no total; empty when no item). The JSONL `progress` events were already parsed — this surfaces them.
- **Warnings reach the Done screen**: `warning` events (message + optional item) accumulate in `FlowViewModel.Warnings` (cleared per run) and render as ⚠️ lines on both flows' Done screens. Silent partial successes no longer look like full successes.

## Tests

`FlowProgressAndWarningsTests`: ProgressDetail formatting (3 cases), warning collection through a FakeCli event stream, per-run reset, and view-level rendering on Running + both Done screens. TDD: watched red first. Full GUI suite: 71 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A