### PR TITLE
feat(gui): failure screen stderr tail + Copy details (#292)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/FailureDetailsTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FailureDetailsTests.cs
@@ -1,0 +1,107 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input.Platform;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+using DjiEmbed.Gui.Views;
+using Xunit;
+
+namespace DjiEmbed.Gui.Tests;
+
+// #292: the failure screen should show the tail of the captured stderr
+// (not a wall of text) and offer "Copy details" so bug reports arrive
+// with the full error output.
+public class FailureDetailsTests
+{
+    private static EmbedTelemetryViewModel FailedVm(string details)
+    {
+        var vm = new EmbedTelemetryViewModel(
+            null, new DjiEmbedRunner(), () => { });
+        vm.Step = FlowStep.Failed;
+        vm.ErrorMessage = "Something went wrong.";
+        vm.ErrorDetails = details;
+        return vm;
+    }
+
+    private static Window ShowView(Control view)
+    {
+        var window = new Window { Width = 560, Height = 520, Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        // The details live inside the collapsed expander; open it the way
+        // a user would before looking at them.
+        foreach (var expander in
+                 window.GetVisualDescendants().OfType<Expander>().ToList())
+        {
+            expander.IsExpanded = true;
+        }
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        return window;
+    }
+
+    [Fact]
+    public void Short_details_are_shown_whole()
+    {
+        var vm = FailedVm("line one\nline two");
+        Assert.Equal("line one\nline two", vm.ErrorDetailsTail);
+    }
+
+    [Fact]
+    public void Long_details_are_cut_to_the_last_lines()
+    {
+        var lines = Enumerable.Range(1, 40).Select(i => $"line {i}");
+        var vm = FailedVm(string.Join('\n', lines));
+        var tail = vm.ErrorDetailsTail!;
+        Assert.Contains("line 40", tail);
+        Assert.DoesNotContain("line 1\n", tail);
+        // The cut is announced, so nobody thinks this is everything.
+        Assert.Contains("omitted", tail);
+    }
+
+    [Fact]
+    public void No_details_means_no_tail()
+    {
+        var vm = new EmbedTelemetryViewModel(
+            null, new DjiEmbedRunner(), () => { });
+        Assert.Null(vm.ErrorDetailsTail);
+    }
+
+    [AvaloniaFact]
+    public void Failed_screen_shows_the_tail_not_the_full_dump()
+    {
+        var lines = Enumerable.Range(1, 40).Select(i => $"line {i}");
+        var vm = FailedVm(string.Join('\n', lines));
+        var window = ShowView(new EmbedTelemetryView { DataContext = vm });
+        var texts = window.GetVisualDescendants().OfType<TextBlock>()
+            .Select(t => t.Text ?? "").ToList();
+        Assert.Contains(texts, t => t.Contains("line 40"));
+        Assert.DoesNotContain(texts, t => t.Contains("line 1\n"));
+    }
+
+    [AvaloniaFact]
+    public async Task Copy_details_puts_the_full_output_on_the_clipboard()
+    {
+        var lines = Enumerable.Range(1, 40).Select(i => $"line {i}");
+        var vm = FailedVm(string.Join('\n', lines));
+        var window = ShowView(new EmbedTelemetryView { DataContext = vm });
+
+        var copy = window.GetVisualDescendants().OfType<Button>()
+            .First(b => b.GetVisualDescendants().OfType<TextBlock>()
+                .Any(t => t.Text == "Copy details"));
+        copy.Command?.Execute(copy.CommandParameter);
+        if (copy.Command is null)
+        {
+            copy.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(
+                Button.ClickEvent));
+        }
+        Dispatcher.UIThread.RunJobs();
+
+        var copied = await window.Clipboard!.TryGetTextAsync();
+        Assert.Contains("line 1", copied);
+        Assert.Contains("line 40", copied);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using DjiEmbed.Gui.Services;
 using DjiEmbed.Gui.ViewModels;
 using DjiEmbed.Gui.Views;
@@ -80,11 +81,27 @@ public class ScreenshotCaptureTests
         embed.Step = FlowStep.Failed;
         embed.ErrorMessage = "Something went wrong while embedding the "
             + "flight data. Your original videos were not changed.";
-        embed.ErrorDetails = "Traceback (most recent call last):\n"
+        embed.ErrorDetails = string.Join('\n',
+            Enumerable.Range(1, 30).Select(i => $"ffmpeg: pass {i} …"))
+            + "\nTraceback (most recent call last):\n"
             + "  File \"processor.py\", line 214, in embed\n"
             + "RuntimeError: ffmpeg exited with code 1";
         CaptureView(new EmbedTelemetryView { DataContext = embed },
             Png("embed-failed"));
+
+        var failedOpen = new EmbedTelemetryView { DataContext = embed };
+        var failedWindow = new Window
+        {
+            Width = 560, Height = 520, Content = failedOpen,
+        };
+        failedWindow.Show();
+        Dispatcher.UIThread.RunJobs();
+        foreach (var expander in failedWindow.GetVisualDescendants()
+                     .OfType<Expander>().ToList())
+        {
+            expander.IsExpanded = true;
+        }
+        Capture(failedWindow, Png("embed-failed-details"));
 
         var setup = new CheckSetupViewModel(null, new DjiEmbedRunner(), NoOp());
         setup.Step = FlowStep.Done;

--- a/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
@@ -57,6 +57,31 @@ public abstract partial class FlowViewModel(
         : Total is { } total ? $"{CurrentItem} ({Current} of {total})"
         : CurrentItem;
 
+    private const int DetailTailLines = 15;
+
+    /// <summary>
+    /// Failure details cut to the last lines for on-screen display;
+    /// "Copy details" always gets the full text.
+    /// </summary>
+    public string? ErrorDetailsTail
+    {
+        get
+        {
+            if (ErrorDetails is null)
+            {
+                return null;
+            }
+            var lines = ErrorDetails.Split('\n');
+            return lines.Length <= DetailTailLines
+                ? ErrorDetails
+                : "… (earlier output omitted — Copy details includes everything)\n"
+                  + string.Join('\n', lines[^DetailTailLines..]);
+        }
+    }
+
+    partial void OnErrorDetailsChanged(string? value) =>
+        OnPropertyChanged(nameof(ErrorDetailsTail));
+
     partial void OnCurrentItemChanged(string? value) =>
         OnPropertyChanged(nameof(ProgressDetail));
 

--- a/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml
+++ b/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml
@@ -74,8 +74,16 @@
             <Expander Header="Technical details"
                       IsVisible="{Binding ErrorDetails,
                           Converter={x:Static ObjectConverters.IsNotNull}}">
-                <TextBlock Text="{Binding ErrorDetails}" TextWrapping="Wrap"
-                           FontFamily="Consolas,Menlo,monospace" FontSize="12" />
+                <StackPanel Spacing="10">
+                    <ScrollViewer MaxHeight="140"
+                                  VerticalScrollBarVisibility="Auto">
+                        <TextBlock Text="{Binding ErrorDetailsTail}" TextWrapping="Wrap"
+                                   FontFamily="Consolas,Menlo,monospace" FontSize="12" />
+                    </ScrollViewer>
+                    <Button HorizontalAlignment="Left" Click="OnCopyDetailsClick">
+                        <TextBlock Text="Copy details" FontSize="12" />
+                    </Button>
+                </StackPanel>
             </Expander>
             <Button HorizontalAlignment="Center" Margin="0,10,0,0"
                     Command="{Binding GoHomeCommand}">

--- a/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/CheckSetupView.axaml.cs
@@ -21,4 +21,12 @@ public partial class CheckSetupView : UserControl
             await vm.StartCommand.ExecuteAsync(null);
         }
     }
+
+    private async void OnCopyDetailsClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is FlowViewModel vm)
+        {
+            await ClipboardCopy.CopyAsync(this, vm.ErrorDetails);
+        }
+    }
 }

--- a/gui/DjiEmbed.Gui/Views/ClipboardCopy.cs
+++ b/gui/DjiEmbed.Gui/Views/ClipboardCopy.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input.Platform;
+
+namespace DjiEmbed.Gui.Views;
+
+/// <summary>Puts text on the clipboard from any control in a window.</summary>
+internal static class ClipboardCopy
+{
+    internal static Task CopyAsync(Control anchor, string? text) =>
+        text is not null
+        && TopLevel.GetTopLevel(anchor)?.Clipboard is { } clipboard
+            ? clipboard.SetTextAsync(text)
+            : Task.CompletedTask;
+}

--- a/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml
+++ b/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml
@@ -124,8 +124,16 @@
             <Expander Header="Technical details"
                       IsVisible="{Binding ErrorDetails,
                           Converter={x:Static ObjectConverters.IsNotNull}}">
-                <TextBlock Text="{Binding ErrorDetails}" TextWrapping="Wrap"
-                           FontFamily="Consolas,Menlo,monospace" FontSize="12" />
+                <StackPanel Spacing="10">
+                    <ScrollViewer MaxHeight="140"
+                                  VerticalScrollBarVisibility="Auto">
+                        <TextBlock Text="{Binding ErrorDetailsTail}" TextWrapping="Wrap"
+                                   FontFamily="Consolas,Menlo,monospace" FontSize="12" />
+                    </ScrollViewer>
+                    <Button HorizontalAlignment="Left" Click="OnCopyDetailsClick">
+                        <TextBlock Text="Copy details" FontSize="12" />
+                    </Button>
+                </StackPanel>
             </Expander>
             <Button HorizontalAlignment="Center" Margin="0,10,0,0"
                     Command="{Binding GoHomeCommand}">

--- a/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/EmbedTelemetryView.axaml.cs
@@ -15,6 +15,14 @@ public partial class EmbedTelemetryView : UserControl
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>
         await FolderPicking.ChooseAsync(this, StartAsync);
 
+    private async void OnCopyDetailsClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is FlowViewModel vm)
+        {
+            await ClipboardCopy.CopyAsync(this, vm.ErrorDetails);
+        }
+    }
+
     private System.Threading.Tasks.Task StartAsync(string folder) =>
         DataContext is EmbedTelemetryViewModel vm
             ? vm.StartCommand.ExecuteAsync(folder)

--- a/gui/DjiEmbed.Gui/Views/MakeMapView.axaml
+++ b/gui/DjiEmbed.Gui/Views/MakeMapView.axaml
@@ -123,8 +123,16 @@
             <Expander Header="Technical details"
                       IsVisible="{Binding ErrorDetails,
                           Converter={x:Static ObjectConverters.IsNotNull}}">
-                <TextBlock Text="{Binding ErrorDetails}" TextWrapping="Wrap"
-                           FontFamily="Consolas,Menlo,monospace" FontSize="12" />
+                <StackPanel Spacing="10">
+                    <ScrollViewer MaxHeight="140"
+                                  VerticalScrollBarVisibility="Auto">
+                        <TextBlock Text="{Binding ErrorDetailsTail}" TextWrapping="Wrap"
+                                   FontFamily="Consolas,Menlo,monospace" FontSize="12" />
+                    </ScrollViewer>
+                    <Button HorizontalAlignment="Left" Click="OnCopyDetailsClick">
+                        <TextBlock Text="Copy details" FontSize="12" />
+                    </Button>
+                </StackPanel>
             </Expander>
             <Button HorizontalAlignment="Center" Margin="0,10,0,0"
                     Command="{Binding GoHomeCommand}">

--- a/gui/DjiEmbed.Gui/Views/MakeMapView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/MakeMapView.axaml.cs
@@ -15,6 +15,14 @@ public partial class MakeMapView : UserControl
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>
         await FolderPicking.ChooseAsync(this, StartAsync);
 
+    private async void OnCopyDetailsClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is FlowViewModel vm)
+        {
+            await ClipboardCopy.CopyAsync(this, vm.ErrorDetails);
+        }
+    }
+
     private System.Threading.Tasks.Task StartAsync(string folder) =>
         DataContext is MakeMapViewModel vm
             ? vm.StartCommand.ExecuteAsync(folder)


### PR DESCRIPTION
Part of #292 (better-failure-screen item). **Stacked on #302** (which stacks on #301) — GitHub retargets as the stack merges.

## What changed

- **`FlowViewModel.ErrorDetailsTail`** — the Technical-details expander now shows the last 15 lines of captured stderr, prefixed with "… (earlier output omitted — Copy details includes everything)" when cut. Short output passes through unchanged.
- **Copy details button** on all three views' failure screens copies the **full** `ErrorDetails` to the clipboard (shared `ClipboardCopy` helper), so bug reports arrive with the real error text.
- Details render inside a `ScrollViewer` (MaxHeight 140) so an opened expander can't push the Back button out of the 520-px window.

## Tests

`FailureDetailsTests`: tail formatting (short/long/null), the Failed view showing the tail not the dump, and an end-to-end clipboard assertion through Avalonia's headless clipboard (click Copy details → read text back). TDD: watched red first. Full GUI suite: 76 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ybg4oprasKj2y1j7zu4A