### PR TITLE
ci: attest build provenance for the EXE and installer (Sigstore)

### DIFF
--- a/.github/workflows/release-exe.yml
+++ b/.github/workflows/release-exe.yml
@@ -14,6 +14,9 @@ on:
 
 permissions:
   contents: write
+  # Sigstore build provenance for the EXE (verify with `gh attestation verify`).
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -92,6 +95,15 @@ jobs:
             $hashLines += "$($hash.Hash)  $($_.Name)"
           }
           $hashLines | Out-File -Encoding ascii dist/SHA256SUMS.txt
+      - name: Attest build provenance
+        # Sigstore-signed proof that dji-embed.exe came from this workflow.
+        # Anyone can check it:
+        #   gh attestation verify dji-embed.exe -R CallMarcus/dji-drone-metadata-embedder
+        # The wheel is not attested here - it is downloaded from PyPI, which
+        # already attests it via Trusted Publishing (PEP 740).
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/dji-embed.exe
       - name: Create or update GitHub release
         uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -24,6 +24,9 @@ on:
 
 permissions:
   contents: write
+  # Sigstore build provenance for the installer (verify with `gh attestation verify`).
+  id-token: write
+  attestations: write
 
 env:
   # Pinned FFmpeg build bundled into the installer (gyan.dev release
@@ -165,6 +168,14 @@ jobs:
           cd dist-installer
           sha256sum -- *.exe > SHA256SUMS-installer.txt
           cat SHA256SUMS-installer.txt
+
+      - name: Attest build provenance
+        # Sigstore-signed proof that the setup EXE came from this workflow.
+        # Anyone can check it:
+        #   gh attestation verify dji-metadata-embedder-setup-<ver>.exe -R CallMarcus/dji-drone-metadata-embedder
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist-installer/*.exe
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -87,6 +87,25 @@ iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedd
 
 </details>
 
+<details>
+<summary>Verify your download (optional)</summary>
+
+Every release ships `SHA256SUMS` files alongside the binaries. In addition,
+release builds (v1.23.0 onwards) carry [build provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
+— a Sigstore-signed proof that the file you downloaded was produced by this
+repository's public build workflow. With the [GitHub CLI](https://cli.github.com/):
+
+```powershell
+gh attestation verify dji-metadata-embedder-setup-<version>.exe -R CallMarcus/dji-drone-metadata-embedder
+```
+
+The same works for `dji-embed.exe`. PyPI wheels are attested separately by
+PyPI's [Trusted Publishing](https://docs.pypi.org/attestations/) — see the
+"provenance" details on each file at
+[pypi.org](https://pypi.org/project/dji-drone-metadata-embedder/#files).
+
+</details>
+
 ### macOS / Linux
 
 ```bash


### PR DESCRIPTION
## What

- `release-exe.yml` and `release-installer.yml` gain an `actions/attest-build-provenance@v4` step (+ `id-token: write` / `attestations: write` permissions): every release binary gets a Sigstore-signed, transparency-logged attestation proving it was built by this repository's public workflow.
- README gains a **Verify your download** section:
  ```powershell
  gh attestation verify dji-metadata-embedder-setup-<version>.exe -R CallMarcus/dji-drone-metadata-embedder
  ```

## Why

- Users (and winget PR reviewers) can cryptographically verify a download is the untampered CI build.
- Concrete supply-chain evidence to cite in Defender false-positive disputes and the SignPath re-application.
- PyPI wheels are already attested via Trusted Publishing (PEP 740) — verified live for the 1.22.0 wheel — so the EXE workflow deliberately does not re-attest the wheel it downloads from PyPI.

## What this does NOT do

No change to SmartScreen/Defender behaviour — that requires Authenticode (SignPath / paid cert). This is provenance, not trust-store signing.

## Notes

- Takes effect from the next release (v1.23.0); the README section says so explicitly.
- The installer workflow attests on every build (including `workflow_dispatch` test builds without upload) — harmless, and the workflow artifact stays verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNDqtnPTetRHcBfdnaP6wR