### PR TITLE
ci: sign Windows binaries with Certum SimplySign (Authenticode)

### DIFF
--- a/.github/actions/certum-sign/action.yml
+++ b/.github/actions/certum-sign/action.yml
@@ -1,0 +1,242 @@
+name: Certum SimplySign Authenticode signing
+description: |
+  Authenticode-sign Windows executables with a Certum "Code Signing in the
+  Cloud" (SimplySign) certificate, headlessly.
+
+  Certum SimplySign has no headless signing API: the cloud key is reachable
+  only through the SimplySign Desktop GUI, which exposes it as a PKCS#11
+  token. This action runs that GUI headlessly (Xvfb + xdotool), logs in with
+  the TOTP derived from the otpauth URI, signs each file with jsign over
+  PKCS#11 (RFC3161-timestamped), and verifies the result with osslsigncode.
+
+  MUST run inside the certum-signer image (see docker/certum-signer), which
+  bakes in SimplySign Desktop, jsign, osslsigncode and the X11/PKCS#11 stack
+  and exports $SS_DIST / $JSIGN_JAR. Credentials are read from the
+  environment - composite actions cannot declare secret-typed inputs - so map
+  these secrets into env on the calling job:
+    CERTUM_USER_ID            SimplySign login id
+    CERTUM_OTP_URI            otpauth:// URI for the SimplySign TOTP
+    CERTUM_CERT_FINGERPRINT   (optional) SHA-256 fingerprint the signing
+                              certificate chain must contain
+
+  Adapted from reactiveui/actions-common certum-sign (MIT); their NuGet
+  signing is swapped for .exe Authenticode, and the login step avoids bash
+  xtrace so the one-time password never reaches the public job log.
+
+inputs:
+  files-glob:
+    description: 'Glob of files to sign (relative to the working directory).'
+    required: false
+    default: 'dist/*.exe'
+  timestamp-url:
+    description: 'RFC3161 timestamp authority URL.'
+    required: false
+    default: 'http://time.certum.pl'
+  display-name:
+    description: 'Program name embedded in the signature (shown in UAC).'
+    required: false
+    default: 'DJI Metadata Embedder'
+  display-url:
+    description: 'Program URL embedded in the signature.'
+    required: false
+    default: 'https://github.com/CallMarcus/dji-drone-metadata-embedder'
+  launch-seconds:
+    description: 'Seconds to wait after launching SimplySign before driving the UI.'
+    required: false
+    default: '20'
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve SimplySign paths
+      shell: bash
+      run: |
+        set -euxo pipefail
+        # The signer image sets SS_DIST and JSIGN_JAR (Dockerfile ENV). Derive
+        # the exe/wrapper/PKCS#11 paths and export them for the later steps.
+        : "${SS_DIST:?must run inside the certum-signer image (SS_DIST unset)}"
+        {
+          echo "SS_DIST=$SS_DIST"
+          echo "SS_START=$(find "$SS_DIST/" -name 'SimplySignDesktop_start' -type f | head -1)"
+          echo "SS_EXE=$(find "$SS_DIST/" -name 'SimplySignDesktop' -type f | head -1)"
+          echo "SS_PKCS11=$(find "$SS_DIST/" -name 'SimplySignPKCS*.so' | head -1)"
+        } >> "$GITHUB_ENV"
+
+    - name: Start headless display
+      shell: bash
+      run: |
+        set -euxo pipefail
+        Xvfb :99 -screen 0 1280x1024x24 >"$RUNNER_TEMP/xvfb.log" 2>&1 &
+        sleep 3
+        # Stop fluxbox running fbsetbg (missing default wallpaper -> an
+        # xmessage that steals focus from the login form).
+        mkdir -p "$HOME/.fluxbox"
+        printf 'session.screen0.rootCommand: /bin/true\n' > "$HOME/.fluxbox/init"
+        DISPLAY=:99 fluxbox >"$RUNNER_TEMP/fluxbox.log" 2>&1 &
+        sleep 2
+        DISPLAY=:99 xdpyinfo >/dev/null && echo "X display :99 up"
+
+    - name: Connect SimplySign (headless login)
+      shell: bash
+      env:
+        DISPLAY: ':99'
+      run: |
+        # No xtrace in this step: it would print the computed OTP (and every
+        # xdotool keystroke) into the public job log. The OTP is only valid
+        # for ~30 s, but the log is forever.
+        set -euo pipefail
+        : "${CERTUM_USER_ID:?map the CERTUM_USER_ID secret into the job env}"
+        : "${CERTUM_OTP_URI:?map the CERTUM_OTP_URI secret into the job env}"
+
+        # SimplySignDesktop reads $USER at startup and segfaults (NULL deref
+        # in its bundled OpenSSL) when unset. The image bakes USER=root, but
+        # default it here too in case the runner scrubs it.
+        export USER="${USER:-root}"
+
+        # SimplySign needs its config near $HOME + the logon-dialog
+        # preference, otherwise it shows a "Critical error" on launch.
+        cp "$SS_DIST/SimplySignDesktop.xml" "$HOME/" 2>/dev/null || true
+        mkdir -p "$HOME/.config"
+        { echo "[General]"
+          echo "CacheUserIdAtLogon=Yes"
+          echo "ShowLogonDialogAfterApplicationStartup=Yes"
+          echo "ShowLogonDialogWhenAnyAppRequestsAccess=Yes"
+        } > "$HOME/.config/Unknown Organization.conf"
+
+        # Launch via the *_start wrapper (sets LD_LIBRARY_PATH for bundled Qt).
+        export LD_LIBRARY_PATH="$SS_DIST:${LD_LIBRARY_PATH:-}"
+        if [ -n "${SS_START:-}" ]; then "$SS_START" >"$RUNNER_TEMP/simplysign.log" 2>&1 &
+        else "$SS_EXE" >"$RUNNER_TEMP/simplysign.log" 2>&1 & fi
+        echo "SimplySign launched; waiting ${{ inputs.launch-seconds }}s"
+        sleep "${{ inputs.launch-seconds }}"
+
+        # Current OTP from the otpauth URI (honours algorithm/digits/period).
+        OTP="$(python3 - <<'PY'
+        import os,hmac,hashlib,base64,struct,time
+        from urllib.parse import urlparse,parse_qs
+        q=parse_qs(urlparse(os.environ["CERTUM_OTP_URI"]).query)
+        s=q["secret"][0]
+        digits=int(q.get("digits",["6"])[0]); period=int(q.get("period",["30"])[0])
+        algo={"SHA1":hashlib.sha1,"SHA256":hashlib.sha256,"SHA512":hashlib.sha512}[q.get("algorithm",["SHA1"])[0].upper()]
+        key=base64.b32decode(s+"="*((8-len(s)%8)%8))
+        h=hmac.new(key,struct.pack(">Q",int(time.time()//period)),algo).digest(); o=h[-1]&0xF
+        print(str((int.from_bytes(h[o:o+4],"big")&0x7fffffff)%(10**digits)).zfill(digits))
+        PY
+        )"
+        echo "::add-mask::$OTP"
+
+        # Find the login form: enumerate windows, match getwindowname
+        # (_NET_WM_NAME); `search --name PATTERN` matches the empty legacy
+        # WM_NAME for this app. Retry-wait: the dialog can lag the launch.
+        WID=""; BX=0; BY=0; BW=0; BH=0
+        for attempt in $(seq 1 30); do
+          best=0; WID=""
+          for w in $(xdotool search --name '' 2>/dev/null); do
+            nm="$(xdotool getwindowname "$w" 2>/dev/null || true)"
+            case "$nm" in *implySign*) ;; *) continue ;; esac
+            eval "$(xdotool getwindowgeometry --shell "$w" 2>/dev/null)"
+            area=$(( ${WIDTH:-0} * ${HEIGHT:-0} ))
+            if [ "$area" -gt "$best" ]; then best=$area; WID=$w; BX=${X:-0}; BY=${Y:-0}; BW=${WIDTH:-0}; BH=${HEIGHT:-0}; fi
+          done
+          [ "${BW:-0}" -ge 400 ] && [ "${BH:-0}" -ge 300 ] && { echo "login window $WID ${BW}x${BH} (attempt $attempt)"; break; }
+          WID=""; sleep 2
+        done
+        [ -z "$WID" ] && { echo "::error::SimplySign login window did not appear"; cat "$RUNNER_TEMP/simplysign.log" || true; exit 1; }
+
+        xdotool windowactivate --sync "$WID" || xdotool windowactivate "$WID" || true
+        xdotool windowraise "$WID" || true
+        sleep 1
+        # Click the E-MAIL field, type id; Tab; type OTP; click Login.
+        xdotool mousemove $((BX + BW/2)) $((BY + BH*39/100)) click 1; sleep 1
+        xdotool type --clearmodifiers --delay 50 "$CERTUM_USER_ID"
+        xdotool key Tab; sleep 1
+        xdotool type --clearmodifiers --delay 50 "$OTP"
+        xdotool mousemove $((BX + BW/2)) $((BY + BH*76/100)) click 1
+        sleep 8
+
+        # "Logon successful" dialog: the token does NOT activate until its
+        # Close button (bottom-centre) is clicked. Re-find the window (its
+        # content changed).
+        best=0
+        for w in $(xdotool search --name '' 2>/dev/null); do
+          nm="$(xdotool getwindowname "$w" 2>/dev/null || true)"
+          case "$nm" in *implySign*) ;; *) continue ;; esac
+          eval "$(xdotool getwindowgeometry --shell "$w" 2>/dev/null)"
+          area=$(( ${WIDTH:-0} * ${HEIGHT:-0} ))
+          if [ "$area" -gt "$best" ]; then best=$area; WID=$w; BX=${X:-0}; BY=${Y:-0}; BW=${WIDTH:-0}; BH=${HEIGHT:-0}; fi
+        done
+        xdotool windowactivate --sync "$WID" || true
+        xdotool mousemove $((BX + BW/2)) $((BY + BH*94/100)) click 1
+        sleep 3
+
+        # Confirm the token is active (fails fast if login didn't take).
+        timeout 60 pkcs11-tool --module "$SS_PKCS11" -L
+
+    - name: Sign with jsign + verify
+      shell: bash
+      env:
+        TS_URL: ${{ inputs.timestamp-url }}
+        FILES_GLOB: ${{ inputs.files-glob }}
+        SIGN_NAME: ${{ inputs.display-name }}
+        SIGN_URL: ${{ inputs.display-url }}
+      run: |
+        set -euxo pipefail
+        : "${JSIGN_JAR:?must run inside the certum-signer image (JSIGN_JAR unset)}"
+        CONF="$RUNNER_TEMP/sunpkcs11.conf"
+        { echo "name = SimplySign"; echo "library = $SS_PKCS11"; echo "slotListIndex = 0"; } > "$CONF"
+
+        shopt -s nullglob
+        files=( $FILES_GLOB )
+        [ "${#files[@]}" -gt 0 ] || { echo "::error::no files matched: $FILES_GLOB"; exit 1; }
+
+        for f in "${files[@]}"; do
+          echo "::group::sign $f"
+          # Single call: the token has one key (jsign auto-selects it).
+          # RFC3161 timestamp so the signature outlives the cert.
+          java -jar "$JSIGN_JAR" --storetype PKCS11 --keystore "$CONF" --storepass "" \
+            --alg SHA-256 --tsmode RFC3161 --tsaurl "$TS_URL" --replace \
+            --name "$SIGN_NAME" --url "$SIGN_URL" "$f"
+          # Structural + chain verification (Certum roots ship in
+          # ca-certificates on the signer image).
+          osslsigncode verify \
+            -CAfile /etc/ssl/certs/ca-certificates.crt \
+            -TSA-CAfile /etc/ssl/certs/ca-certificates.crt \
+            -in "$f"
+          echo "::endgroup::"
+        done
+
+    - name: Check certificate fingerprint pin
+      shell: bash
+      env:
+        FILES_GLOB: ${{ inputs.files-glob }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        files=( $FILES_GLOB )
+        first="${files[0]}"
+        osslsigncode extract-signature -in "$first" -out "$RUNNER_TEMP/sig.der" >/dev/null
+        openssl pkcs7 -inform DER -in "$RUNNER_TEMP/sig.der" -print_certs > "$RUNNER_TEMP/certs.pem"
+        # List every certificate in the signature (leaf + chain) with its
+        # SHA-256 fingerprint - and, when CERTUM_CERT_FINGERPRINT is set,
+        # require the pinned one to be present. This guards against signing
+        # with an unexpected certificate if the token ever carries several.
+        python3 - "$RUNNER_TEMP/certs.pem" <<'PY'
+        import hashlib, os, re, subprocess, sys
+        pem = open(sys.argv[1]).read()
+        blocks = re.findall(r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----", pem, re.S)
+        pin = re.sub(r"[^0-9A-Fa-f]", "", os.environ.get("CERTUM_CERT_FINGERPRINT", "")).upper()
+        found = False
+        for b in blocks:
+            der = subprocess.run(["openssl", "x509", "-outform", "DER"],
+                                 input=b.encode(), capture_output=True, check=True).stdout
+            fp = hashlib.sha256(der).hexdigest().upper()
+            subj = subprocess.run(["openssl", "x509", "-noout", "-subject"],
+                                  input=b.encode(), capture_output=True, check=True).stdout.decode().strip()
+            print(f"{fp}  {subj}")
+            found = found or (pin and fp == pin)
+        if pin and not found:
+            print("::error::pinned CERTUM_CERT_FINGERPRINT not found in the signature chain")
+            sys.exit(1)
+        print("fingerprint pin OK" if pin else
+              "CERTUM_CERT_FINGERPRINT not set - skipping pin check (fingerprints above)")
+        PY

--- a/.github/actions/certum-sign/action.yml
+++ b/.github/actions/certum-sign/action.yml
@@ -80,6 +80,7 @@ runs:
       shell: bash
       env:
         DISPLAY: ':99'
+        LAUNCH_SECONDS: ${{ inputs.launch-seconds }}
       run: |
         # No xtrace in this step: it would print the computed OTP (and every
         # xdotool keystroke) into the public job log. The OTP is only valid
@@ -107,23 +108,8 @@ runs:
         export LD_LIBRARY_PATH="$SS_DIST:${LD_LIBRARY_PATH:-}"
         if [ -n "${SS_START:-}" ]; then "$SS_START" >"$RUNNER_TEMP/simplysign.log" 2>&1 &
         else "$SS_EXE" >"$RUNNER_TEMP/simplysign.log" 2>&1 & fi
-        echo "SimplySign launched; waiting ${{ inputs.launch-seconds }}s"
-        sleep "${{ inputs.launch-seconds }}"
-
-        # Current OTP from the otpauth URI (honours algorithm/digits/period).
-        OTP="$(python3 - <<'PY'
-        import os,hmac,hashlib,base64,struct,time
-        from urllib.parse import urlparse,parse_qs
-        q=parse_qs(urlparse(os.environ["CERTUM_OTP_URI"]).query)
-        s=q["secret"][0]
-        digits=int(q.get("digits",["6"])[0]); period=int(q.get("period",["30"])[0])
-        algo={"SHA1":hashlib.sha1,"SHA256":hashlib.sha256,"SHA512":hashlib.sha512}[q.get("algorithm",["SHA1"])[0].upper()]
-        key=base64.b32decode(s+"="*((8-len(s)%8)%8))
-        h=hmac.new(key,struct.pack(">Q",int(time.time()//period)),algo).digest(); o=h[-1]&0xF
-        print(str((int.from_bytes(h[o:o+4],"big")&0x7fffffff)%(10**digits)).zfill(digits))
-        PY
-        )"
-        echo "::add-mask::$OTP"
+        echo "SimplySign launched; waiting ${LAUNCH_SECONDS}s"
+        sleep "$LAUNCH_SECONDS"
 
         # Find the login form: enumerate windows, match getwindowname
         # (_NET_WM_NAME); `search --name PATTERN` matches the empty legacy
@@ -150,6 +136,27 @@ runs:
         xdotool mousemove $((BX + BW/2)) $((BY + BH*39/100)) click 1; sleep 1
         xdotool type --clearmodifiers --delay 50 "$CERTUM_USER_ID"
         xdotool key Tab; sleep 1
+
+        # Compute the OTP only now, right before typing it - the window
+        # discovery loop above can take up to a minute, which would let an
+        # early-computed code roll over. If the current period has <5s left,
+        # wait for the next one so the code stays valid while it is typed
+        # and submitted. Honours the URI's algorithm/digits/period params.
+        OTP="$(python3 - <<'PY'
+        import os,hmac,hashlib,base64,struct,time
+        from urllib.parse import urlparse,parse_qs
+        q=parse_qs(urlparse(os.environ["CERTUM_OTP_URI"]).query)
+        s=q["secret"][0]
+        digits=int(q.get("digits",["6"])[0]); period=int(q.get("period",["30"])[0])
+        algo={"SHA1":hashlib.sha1,"SHA256":hashlib.sha256,"SHA512":hashlib.sha512}[q.get("algorithm",["SHA1"])[0].upper()]
+        key=base64.b32decode(s+"="*((8-len(s)%8)%8))
+        remaining=period-(time.time()%period)
+        if remaining<5: time.sleep(remaining+0.5)
+        h=hmac.new(key,struct.pack(">Q",int(time.time()//period)),algo).digest(); o=h[-1]&0xF
+        print(str((int.from_bytes(h[o:o+4],"big")&0x7fffffff)%(10**digits)).zfill(digits))
+        PY
+        )"
+        echo "::add-mask::$OTP"
         xdotool type --clearmodifiers --delay 50 "$OTP"
         xdotool mousemove $((BX + BW/2)) $((BY + BH*76/100)) click 1
         sleep 8
@@ -212,15 +219,16 @@ runs:
       run: |
         set -euo pipefail
         shopt -s nullglob
-        files=( $FILES_GLOB )
-        first="${files[0]}"
-        osslsigncode extract-signature -in "$first" -out "$RUNNER_TEMP/sig.der" >/dev/null
-        openssl pkcs7 -inform DER -in "$RUNNER_TEMP/sig.der" -print_certs > "$RUNNER_TEMP/certs.pem"
-        # List every certificate in the signature (leaf + chain) with its
-        # SHA-256 fingerprint - and, when CERTUM_CERT_FINGERPRINT is set,
-        # require the pinned one to be present. This guards against signing
-        # with an unexpected certificate if the token ever carries several.
-        python3 - "$RUNNER_TEMP/certs.pem" <<'PY'
+        # List every certificate in each file's signature (leaf + chain) with
+        # its SHA-256 fingerprint - and, when CERTUM_CERT_FINGERPRINT is set,
+        # require the pinned one to be present in EVERY signed file. This
+        # guards against signing with an unexpected certificate if the token
+        # ever carries several.
+        for f in $FILES_GLOB; do
+          echo "--- $f"
+          osslsigncode extract-signature -in "$f" -out "$RUNNER_TEMP/sig.der" >/dev/null
+          openssl pkcs7 -inform DER -in "$RUNNER_TEMP/sig.der" -print_certs > "$RUNNER_TEMP/certs.pem"
+          python3 - "$RUNNER_TEMP/certs.pem" <<'PY'
         import hashlib, os, re, subprocess, sys
         pem = open(sys.argv[1]).read()
         blocks = re.findall(r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----", pem, re.S)
@@ -240,3 +248,4 @@ runs:
         print("fingerprint pin OK" if pin else
               "CERTUM_CERT_FINGERPRINT not set - skipping pin check (fingerprints above)")
         PY
+        done

--- a/.github/workflows/certum-sign.yml
+++ b/.github/workflows/certum-sign.yml
@@ -1,0 +1,62 @@
+---
+name: Certum sign (reusable)
+
+# Reusable signing job: downloads an artifact, Authenticode-signs the files
+# matching the glob inside the certum-signer container, and re-uploads the
+# whole tree as a new artifact. Owns the container reference and the secret
+# plumbing so callers (release-exe.yml, release-installer.yml twice,
+# sign-test.yml) don't repeat them - call with `secrets: inherit`.
+
+on:
+  workflow_call:
+    inputs:
+      artifact:
+        description: 'Artifact containing the files to sign'
+        required: true
+        type: string
+      signed-artifact:
+        description: 'Artifact name for the signed result (whole tree)'
+        required: true
+        type: string
+      files-glob:
+        description: 'Glob of files to sign, relative to the artifact root'
+        required: false
+        type: string
+        default: '*.exe'
+
+permissions:
+  contents: read
+  # Pull the certum-signer container image from GHCR.
+  packages: read
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    container:
+      # Version-coded tag: bump alongside the ARGs in
+      # docker/certum-signer/Dockerfile and the IMAGE env in signer-image.yml
+      # (the only other place this tag appears).
+      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
+      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
+      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact }}
+          path: work
+      - name: Sign and verify
+        uses: ./.github/actions/certum-sign
+        with:
+          files-glob: work/${{ inputs.files-glob }}
+      - name: Upload signed artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.signed-artifact }}
+          path: work/*
+          if-no-files-found: error

--- a/.github/workflows/release-exe.yml
+++ b/.github/workflows/release-exe.yml
@@ -1,6 +1,11 @@
 ---
 name: Build Windows EXE
 
+# build (windows) -> sign (linux, Certum SimplySign container) -> publish.
+# Checksums and the Sigstore attestation are generated AFTER signing:
+# Authenticode signing changes the file hash, so they would not match the
+# released binary otherwise.
+
 on:
   workflow_run:
     workflows: ["Release to PyPI"]
@@ -17,11 +22,16 @@ permissions:
   # Sigstore build provenance for the EXE (verify with `gh attestation verify`).
   id-token: write
   attestations: write
+  # Pull the certum-signer container image from GHCR.
+  packages: read
 
 jobs:
   build:
     if: ${{ (github.event_name == 'workflow_dispatch') || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     runs-on: windows-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -86,15 +96,55 @@ jobs:
           }
           Write-Error "Wheel for $ver not on PyPI after $max attempts (~6 min)."
           exit 1
+      - name: Upload unsigned dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: unsigned-dist
+          path: dist/*
+          if-no-files-found: error
+
+  sign:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
+      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
+      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: unsigned-dist
+          path: dist
+      - name: Sign dji-embed.exe
+        uses: ./.github/actions/certum-sign
+        with:
+          files-glob: 'dist/*.exe'
+      - name: Upload signed dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: signed-dist
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    needs: [build, sign]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: signed-dist
+          path: dist
       - name: Generate SHA256SUMS.txt
-        shell: pwsh
         run: |
-          $hashLines = @()
-          Get-ChildItem dist -File | ForEach-Object {
-            $hash = Get-FileHash $_.FullName -Algorithm SHA256
-            $hashLines += "$($hash.Hash)  $($_.Name)"
-          }
-          $hashLines | Out-File -Encoding ascii dist/SHA256SUMS.txt
+          cd dist
+          sha256sum -- * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
       - name: Attest build provenance
         # Sigstore-signed proof that dji-embed.exe came from this workflow.
         # Anyone can check it:
@@ -107,13 +157,13 @@ jobs:
       - name: Create or update GitHub release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: ${{ steps.meta.outputs.tag }}
+          tag_name: ${{ needs.build.outputs.tag }}
+          name: ${{ needs.build.outputs.tag }}
           files: dist/*
           generate_release_notes: true
           fail_on_unmatched_files: true
       - name: Summary
-        shell: pwsh
+        env:
+          TAG: ${{ needs.build.outputs.tag }}
         run: |
-          $tag = '${{ steps.meta.outputs.tag }}'
-          echo "Windows binaries attached to [release $tag](https://github.com/${{ github.repository }}/releases/tag/$tag)" >> $env:GITHUB_STEP_SUMMARY
+          echo "Signed Windows binaries attached to [release $TAG](https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-exe.yml
+++ b/.github/workflows/release-exe.yml
@@ -105,32 +105,11 @@ jobs:
 
   sign:
     needs: build
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
-      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
-      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
-        with:
-          name: unsigned-dist
-          path: dist
-      - name: Sign dji-embed.exe
-        uses: ./.github/actions/certum-sign
-        with:
-          files-glob: 'dist/*.exe'
-      - name: Upload signed dist
-        uses: actions/upload-artifact@v7
-        with:
-          name: signed-dist
-          path: dist/*
-          if-no-files-found: error
+    uses: ./.github/workflows/certum-sign.yml
+    with:
+      artifact: unsigned-dist
+      signed-artifact: signed-dist
+    secrets: inherit
 
   publish:
     needs: [build, sign]

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -5,6 +5,15 @@ name: Build Windows Installer
 # (Start menu entry), dji-embed.exe beside it, and pinned FFmpeg + ExifTool
 # in tools\ — with both directories added to the user PATH so the full CLI
 # works from any terminal with no extra steps.
+#
+# Signing (Certum SimplySign, Linux container) happens in two rounds:
+#   build (windows)  -> sign-app (dji-embed.exe + DjiEmbed.Gui.exe)
+#   -> assemble (windows: ISCC + smoke test over the SIGNED binaries)
+#   -> sign-installer (the setup EXE) -> publish
+# Checksums + the Sigstore attestation run AFTER signing - signing changes
+# the hashes. The Inno-generated uninstaller is knowingly NOT signed: it can
+# only be signed at ISCC compile time on Windows (SignTool= directive), which
+# the Linux signing route cannot reach. Revisit if it ever matters.
 
 on:
   workflow_run:
@@ -27,6 +36,8 @@ permissions:
   # Sigstore build provenance for the installer (verify with `gh attestation verify`).
   id-token: write
   attestations: write
+  # Pull the certum-signer container image from GHCR.
+  packages: read
 
 env:
   # Pinned FFmpeg build bundled into the installer (gyan.dev release
@@ -35,12 +46,16 @@ env:
   FFMPEG_SHA256: 'db580001caa24ac104c8cb856cd113a87b0a443f7bdf47d8c12b1d740584a2ec'
 
 jobs:
-  installer:
+  build:
     if: ${{ (github.event_name == 'workflow_dispatch') || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     runs-on: windows-latest
     defaults:
       run:
         shell: bash
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      upload: ${{ steps.meta.outputs.upload }}
     steps:
       - uses: actions/checkout@v7
       - name: Determine release version
@@ -134,13 +149,81 @@ jobs:
             echo "  folder for its license files."
           } > staging/app/licenses/THIRD-PARTY.txt
 
+      - name: Upload staging tree
+        uses: actions/upload-artifact@v7
+        with:
+          name: staging
+          path: staging/app/**
+          if-no-files-found: error
+      - name: Upload binaries to sign
+        # Uploaded separately so the sign job moves ~2 exes instead of the
+        # whole ~200 MB staging tree. Artifact root is their common parent
+        # (staging/app), so they download flat.
+        uses: actions/upload-artifact@v7
+        with:
+          name: to-sign
+          path: |
+            staging/app/dji-embed.exe
+            staging/app/DjiEmbed.Gui.exe
+          if-no-files-found: error
+
+  sign-app:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
+      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
+      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: to-sign
+          path: tosign
+      - name: Sign app binaries
+        uses: ./.github/actions/certum-sign
+        with:
+          files-glob: 'tosign/*.exe'
+      - name: Upload signed app binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: signed-app
+          path: tosign/*.exe
+          if-no-files-found: error
+
+  assemble:
+    needs: [build, sign-app]
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: staging
+          path: staging/app
+      - uses: actions/download-artifact@v8
+        with:
+          name: signed-app
+          path: signed
+      - name: Swap in signed binaries
+        run: |
+          cp -f signed/dji-embed.exe signed/DjiEmbed.Gui.exe staging/app/
+          rm -rf signed
+
       - name: Compile installer
         shell: pwsh
         run: |
           # ISCC resolves relative paths against the .iss file's directory,
           # so the output dir must be absolute to land in the workspace.
           & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
-            /DAppVersion=${{ steps.meta.outputs.version }} `
+            /DAppVersion=${{ needs.build.outputs.version }} `
             /DStagingDir=..\staging\app `
             "/O$env:GITHUB_WORKSPACE\dist-installer" `
             installer\DjiMetadataEmbedder.iss
@@ -162,7 +245,55 @@ jobs:
           }
           & "$app\dji-embed.exe" --version
           if ($LASTEXITCODE -ne 0) { throw "bundled CLI failed" }
+          # The staged CLI is Authenticode-signed at this point; make sure
+          # the signature survived staging + install intact.
+          $sig = Get-AuthenticodeSignature "$app\dji-embed.exe"
+          if ($sig.Status -ne 'Valid') { throw "dji-embed.exe signature: $($sig.Status)" }
 
+      - name: Upload unsigned installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: unsigned-installer
+          path: dist-installer/*
+          if-no-files-found: error
+
+  sign-installer:
+    needs: [build, assemble]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
+      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
+      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: unsigned-installer
+          path: dist-installer
+      - name: Sign installer
+        uses: ./.github/actions/certum-sign
+        with:
+          files-glob: 'dist-installer/*.exe'
+      - name: Upload signed installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: signed-installer
+          path: dist-installer/*
+          if-no-files-found: error
+
+  publish:
+    needs: [build, sign-installer]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: signed-installer
+          path: dist-installer
       - name: Generate checksum
         run: |
           cd dist-installer
@@ -180,15 +311,15 @@ jobs:
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v7
         with:
-          name: installer-${{ steps.meta.outputs.version }}
+          name: installer-${{ needs.build.outputs.version }}
           path: dist-installer/*
 
       - name: Attach to GitHub release
-        if: ${{ steps.meta.outputs.upload == 'true' }}
+        if: ${{ needs.build.outputs.upload == 'true' }}
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: ${{ steps.meta.outputs.tag }}
+          tag_name: ${{ needs.build.outputs.tag }}
+          name: ${{ needs.build.outputs.tag }}
           files: dist-installer/*
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -150,10 +150,16 @@ jobs:
           } > staging/app/licenses/THIRD-PARTY.txt
 
       - name: Upload staging tree
+        # The two app exes are excluded: they always arrive via the signed-app
+        # artifact instead, so shipping the unsigned copies here would only
+        # waste transfer and risk an unsigned binary sneaking into staging.
         uses: actions/upload-artifact@v7
         with:
           name: staging
-          path: staging/app/**
+          path: |
+            staging/app/**
+            !staging/app/dji-embed.exe
+            !staging/app/DjiEmbed.Gui.exe
           if-no-files-found: error
       - name: Upload binaries to sign
         # Uploaded separately so the sign job moves ~2 exes instead of the
@@ -169,32 +175,11 @@ jobs:
 
   sign-app:
     needs: build
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
-      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
-      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
-        with:
-          name: to-sign
-          path: tosign
-      - name: Sign app binaries
-        uses: ./.github/actions/certum-sign
-        with:
-          files-glob: 'tosign/*.exe'
-      - name: Upload signed app binaries
-        uses: actions/upload-artifact@v7
-        with:
-          name: signed-app
-          path: tosign/*.exe
-          if-no-files-found: error
+    uses: ./.github/workflows/certum-sign.yml
+    with:
+      artifact: to-sign
+      signed-artifact: signed-app
+    secrets: inherit
 
   assemble:
     needs: [build, sign-app]
@@ -245,10 +230,16 @@ jobs:
           }
           & "$app\dji-embed.exe" --version
           if ($LASTEXITCODE -ne 0) { throw "bundled CLI failed" }
-          # The staged CLI is Authenticode-signed at this point; make sure
-          # the signature survived staging + install intact.
-          $sig = Get-AuthenticodeSignature "$app\dji-embed.exe"
-          if ($sig.Status -ne 'Valid') { throw "dji-embed.exe signature: $($sig.Status)" }
+          # ExifTool's Perl lib tree (hundreds of nested files) round-tripped
+          # through the staging artifact; running it proves the tree survived.
+          & "$app\tools\exiftool.exe" -ver
+          if ($LASTEXITCODE -ne 0) { throw "bundled ExifTool failed" }
+          # Both staged exes are Authenticode-signed at this point; make sure
+          # the signatures survived staging + install intact.
+          foreach ($exe in @("dji-embed.exe", "DjiEmbed.Gui.exe")) {
+            $sig = Get-AuthenticodeSignature "$app\$exe"
+            if ($sig.Status -ne 'Valid') { throw "${exe} signature: $($sig.Status)" }
+          }
 
       - name: Upload unsigned installer
         uses: actions/upload-artifact@v7
@@ -258,33 +249,12 @@ jobs:
           if-no-files-found: error
 
   sign-installer:
-    needs: [build, assemble]
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
-      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
-      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
-        with:
-          name: unsigned-installer
-          path: dist-installer
-      - name: Sign installer
-        uses: ./.github/actions/certum-sign
-        with:
-          files-glob: 'dist-installer/*.exe'
-      - name: Upload signed installer
-        uses: actions/upload-artifact@v7
-        with:
-          name: signed-installer
-          path: dist-installer/*
-          if-no-files-found: error
+    needs: assemble
+    uses: ./.github/workflows/certum-sign.yml
+    with:
+      artifact: unsigned-installer
+      signed-artifact: signed-installer
+    secrets: inherit
 
   publish:
     needs: [build, sign-installer]

--- a/.github/workflows/sign-test.yml
+++ b/.github/workflows/sign-test.yml
@@ -3,11 +3,12 @@ name: Sign test
 
 # Manual end-to-end test of the Certum SimplySign signing path WITHOUT
 # cutting a release: downloads dji-embed.exe from an existing GitHub release,
-# signs it in the certum-signer container, verifies the signature, and prints
-# the signing certificate's SHA-256 fingerprint (use the leaf - the "Open
-# Source Developer" subject - as the CERTUM_CERT_FINGERPRINT secret).
-# The signed exe is uploaded as a workflow artifact so it can be inspected on
-# a real Windows machine (Properties -> Digital Signatures).
+# signs it via the reusable certum-sign workflow, and verifies the signature.
+# The sign job's log prints the signing certificate's SHA-256 fingerprints -
+# use the leaf (the "Open Source Developer" subject) as the
+# CERTUM_CERT_FINGERPRINT secret. The signed exe is uploaded as a workflow
+# artifact so it can be inspected on a real Windows machine
+# (Properties -> Digital Signatures).
 #
 # Run this after: building the signer image (signer-image.yml), changing the
 # certum-sign action, or bumping the pinned SimplySign version.
@@ -26,19 +27,9 @@ permissions:
   packages: read
 
 jobs:
-  sign-test:
+  fetch:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
-      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
-      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
     steps:
-      - uses: actions/checkout@v7
       - name: Download dji-embed.exe from a release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,17 +41,31 @@ jobs:
           else
             api="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest"
           fi
-          url="$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" "$api" \
-                 | python3 -c 'import json,sys; a=[x["browser_download_url"] for x in json.load(sys.stdin)["assets"] if x["name"]=="dji-embed.exe"]; print(a[0])')"
+          curl -fsSL -H "Authorization: Bearer $GH_TOKEN" "$api" -o release.json
+          url="$(python3 - <<'PY'
+          import json, sys
+          rel = json.load(open("release.json"))
+          urls = [a["browser_download_url"] for a in rel["assets"] if a["name"] == "dji-embed.exe"]
+          if not urls:
+              sys.stderr.write("::error::release %s has no dji-embed.exe asset\n" % rel.get("tag_name"))
+              raise SystemExit(1)
+          print(urls[0])
+          PY
+          )"
           mkdir -p dist
           curl -fsSL -o dist/dji-embed.exe "$url"
           ls -l dist/
-      - name: Sign and verify
-        uses: ./.github/actions/certum-sign
-        with:
-          files-glob: 'dist/*.exe'
-      - name: Upload signed exe
+      - name: Upload exe to sign
         uses: actions/upload-artifact@v7
         with:
-          name: signed-dji-embed
+          name: sign-test-input
           path: dist/dji-embed.exe
+          if-no-files-found: error
+
+  sign:
+    needs: fetch
+    uses: ./.github/workflows/certum-sign.yml
+    with:
+      artifact: sign-test-input
+      signed-artifact: signed-dji-embed
+    secrets: inherit

--- a/.github/workflows/sign-test.yml
+++ b/.github/workflows/sign-test.yml
@@ -1,0 +1,66 @@
+---
+name: Sign test
+
+# Manual end-to-end test of the Certum SimplySign signing path WITHOUT
+# cutting a release: downloads dji-embed.exe from an existing GitHub release,
+# signs it in the certum-signer container, verifies the signature, and prints
+# the signing certificate's SHA-256 fingerprint (use the leaf - the "Open
+# Source Developer" subject - as the CERTUM_CERT_FINGERPRINT secret).
+# The signed exe is uploaded as a workflow artifact so it can be inspected on
+# a real Windows machine (Properties -> Digital Signatures).
+#
+# Run this after: building the signer image (signer-image.yml), changing the
+# certum-sign action, or bumping the pinned SimplySign version.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: 'Release tag to take dji-embed.exe from (empty = latest)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  sign-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
+      CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
+      CERTUM_CERT_FINGERPRINT: ${{ secrets.CERTUM_CERT_FINGERPRINT }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download dji-embed.exe from a release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.release-tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "$TAG" ]; then
+            api="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
+          else
+            api="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest"
+          fi
+          url="$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" "$api" \
+                 | python3 -c 'import json,sys; a=[x["browser_download_url"] for x in json.load(sys.stdin)["assets"] if x["name"]=="dji-embed.exe"]; print(a[0])')"
+          mkdir -p dist
+          curl -fsSL -o dist/dji-embed.exe "$url"
+          ls -l dist/
+      - name: Sign and verify
+        uses: ./.github/actions/certum-sign
+        with:
+          files-glob: 'dist/*.exe'
+      - name: Upload signed exe
+        uses: actions/upload-artifact@v7
+        with:
+          name: signed-dji-embed
+          path: dist/dji-embed.exe

--- a/.github/workflows/signer-image.yml
+++ b/.github/workflows/signer-image.yml
@@ -1,0 +1,40 @@
+---
+name: Build signer image
+
+# Builds and pushes the Certum SimplySign signing container used by the
+# release sign jobs (see docker/certum-signer/Dockerfile). Run manually after
+# changing the Dockerfile or bumping the pinned SimplySign/jsign versions,
+# then re-run sign-test.yml to confirm the headless login still works.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  # Version-coded tag: bump alongside the ARGs in the Dockerfile, and update
+  # the image references in release-exe.yml / release-installer.yml /
+  # sign-test.yml to match.
+  IMAGE: ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer:2.9.14-jsign7.5
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/certum-signer
+          push: true
+          tags: ${{ env.IMAGE }}
+      - name: Summary
+        run: echo "Pushed \`$IMAGE\`" >> "$GITHUB_STEP_SUMMARY"

--- a/HELP.md
+++ b/HELP.md
@@ -42,7 +42,7 @@ Two ways to use it — same engine:
 
 | Situation | Do this |
 | --- | --- |
-| **Windows, simplest** | Download `dji-metadata-embedder-setup-<version>.exe` from the GitHub Releases page. One installer = app + CLI + FFmpeg + ExifTool, nothing else needed. Windows shows an "Unknown publisher" SmartScreen warning (the project is unsigned so far): click **More info → Run anyway**. |
+| **Windows, simplest** | Download `dji-metadata-embedder-setup-<version>.exe` from the GitHub Releases page. One installer = app + CLI + FFmpeg + ExifTool, nothing else needed. Installers from v1.23.0 onwards are code-signed (publisher: "Open Source Developer, Marcus Westermark"); SmartScreen may still warn while the certificate builds reputation — click **More info → Run anyway**. Older releases are unsigned. |
 | Windows, CLI only | `winget install CallMarcus.DJIMetadataEmbedder` (portable exe), or `pip install dji-drone-metadata-embedder` with Python 3.10–3.12. |
 | macOS | `brew install pipx ffmpeg exiftool` then `pipx install dji-drone-metadata-embedder` (plain `pip3` is blocked on Homebrew Python). |
 | Linux | `pip install dji-drone-metadata-embedder` (or pipx) + `ffmpeg`/`exiftool` from your package manager. |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedd
 <details>
 <summary>Verify your download (optional)</summary>
 
-Every release ships `SHA256SUMS` files alongside the binaries. In addition,
+Windows binaries and the installer are Authenticode code-signed from v1.23.0
+onwards — right-click the file → **Properties → Digital Signatures** and you
+should see "Open Source Developer, Marcus Westermark" (issued by Certum).
+
+Every release also ships `SHA256SUMS` files alongside the binaries, and
 release builds (v1.23.0 onwards) carry [build provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
 — a Sigstore-signed proof that the file you downloaded was produced by this
 repository's public build workflow. With the [GitHub CLI](https://cli.github.com/):

--- a/docker/certum-signer/Dockerfile
+++ b/docker/certum-signer/Dockerfile
@@ -23,8 +23,13 @@ FROM ubuntu:24.04
 # for Certum's file host, so bump this manually when Certum ships a new
 # version - and re-run sign-test.yml after any bump: a SimplySign UI change
 # can break the xdotool login scripting in the certum-sign action.
+# Checksum-verified pins, matching the repo convention for bundled tooling
+# (FFmpeg in release-installer.yml, ExifTool in utils/provision.py):
+# bumps change the pin AND the checksum, nothing else.
 ARG SIMPLYSIGN_BIN_URL=https://files.certum.eu/software/SimplySignDesktop/Linux-Ubuntu/2.9.14-9.4.3.0/SimplySignDesktop-2.9.14-9.4.3.0-x86_64-prod-ubuntu.bin
+ARG SIMPLYSIGN_SHA256=e462dc83679f9987d4e8419c9b4db30e11884bffd875e85e142ac77aad7233e8
 ARG JSIGN_VERSION=7.5
+ARG JSIGN_SHA256=602a51c3545a6dc4fb99bd2ea7152b26d1345916d0c93ddfbd5936cb735af91c
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -52,6 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # there (mirrors hpvb/certum-container). Extract to a temp dir, then move the
 # dist into place and drop the installer + temp to keep the layer smaller.
 RUN curl -fsSL -o /tmp/ss.bin "$SIMPLYSIGN_BIN_URL" \
+    && echo "$SIMPLYSIGN_SHA256  /tmp/ss.bin" | sha256sum -c \
     && mkdir -p /tmp/ss-extract \
     && (yes yes | sh /tmp/ss.bin --target /tmp/ss-extract || true) \
     && mv "$(find /tmp/ss-extract -maxdepth 1 -type d -name 'SSD-*-dist' | head -1)" /opt/SimplySignDesktop \
@@ -59,7 +65,8 @@ RUN curl -fsSL -o /tmp/ss.bin "$SIMPLYSIGN_BIN_URL" \
     && test -x /opt/SimplySignDesktop/SimplySignDesktop
 
 # jsign (Authenticode signing over PKCS#11).
-RUN curl -fsSL -o /opt/jsign.jar "https://repo1.maven.org/maven2/net/jsign/jsign/${JSIGN_VERSION}/jsign-${JSIGN_VERSION}.jar"
+RUN curl -fsSL -o /opt/jsign.jar "https://repo1.maven.org/maven2/net/jsign/jsign/${JSIGN_VERSION}/jsign-${JSIGN_VERSION}.jar" \
+    && echo "$JSIGN_SHA256  /opt/jsign.jar" | sha256sum -c
 
 # Contract consumed by the certum-sign action.
 #

--- a/docker/certum-signer/Dockerfile
+++ b/docker/certum-signer/Dockerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1
+#
+# Certum SimplySign signing image for the release workflows.
+#
+# SimplySign (Certum's cloud HSM) has no headless signing API: the private key
+# is only reachable through the SimplySign Desktop GUI, which exposes it as a
+# PKCS#11 token. This image bakes in everything the sign jobs need to run that
+# GUI headlessly - SimplySign Desktop (~313 MB installer from Certum's slow EU
+# host), the X/Qt/PKCS#11 runtime stack, jsign (Authenticode signing) and
+# osslsigncode (signature verification) - so a sign run pulls one image
+# instead of re-downloading and apt-installing everything every release.
+#
+# Adapted from reactiveui/actions-common (docker/certum-signer, MIT) and
+# hpvb/certum-container. Their .NET SDK base is dropped: we sign .exe files
+# with jsign, not NuGet packages.
+#
+# Build & push via .github/workflows/signer-image.yml (manual dispatch).
+# Consumed by .github/actions/certum-sign via the SS_DIST/JSIGN_JAR contract.
+
+FROM ubuntu:24.04
+
+# SimplySign Desktop Linux (Ubuntu) installer. No Renovate datasource exists
+# for Certum's file host, so bump this manually when Certum ships a new
+# version - and re-run sign-test.yml after any bump: a SimplySign UI change
+# can break the xdotool login scripting in the certum-sign action.
+ARG SIMPLYSIGN_BIN_URL=https://files.certum.eu/software/SimplySignDesktop/Linux-Ubuntu/2.9.14-9.4.3.0/SimplySignDesktop-2.9.14-9.4.3.0-x86_64-prod-ubuntu.bin
+ARG JSIGN_VERSION=7.5
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Headless X (Xvfb + fluxbox), UI automation (xdotool/wmctrl), PKCS#11
+# tooling, Java for jsign, osslsigncode for verification, git for
+# actions/checkout, and the Qt5/WebKit + misc system libs SimplySign needs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      xvfb x11-utils xdotool wmctrl fluxbox \
+      opensc opensc-pkcs11 default-jre-headless osslsigncode \
+      unzip openssl ca-certificates curl python3 git procps \
+      libx11-6 libxext6 libxcomposite1 libxi6 libice6 libsm6 libxrender1 \
+      libxcb1 libxau6 libpcsclite1 libglx-mesa0 libgl1 libxslt1.1 \
+      libxkbcommon0 libxcb-xinerama0 libfontconfig1 libdbus-1-3 \
+      libpulse-mainloop-glib0 libpulse0 libasound2t64 \
+      libqt5webkit5 libqt5multimedia5 libqt5multimediawidgets5 libqt5quick5 \
+      libqt5printsupport5 libqt5positioning5 libqt5sensors5 libqt5opengl5 \
+      libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 \
+      libwoff1 libharfbuzz0b libhyphen0 libwebp7 libwebpdemux2 \
+      libnss3 libxtst6 libxss1 libxrandr2 libxdamage1 libxfixes3 libxcursor1 \
+      libegl1 libgbm1 libxkbcommon-x11-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install SimplySign Desktop. The bundled SimplySignDesktop_start wrapper
+# hardcodes /opt/SimplySignDesktop/SimplySignDesktop, so the dist MUST live
+# there (mirrors hpvb/certum-container). Extract to a temp dir, then move the
+# dist into place and drop the installer + temp to keep the layer smaller.
+RUN curl -fsSL -o /tmp/ss.bin "$SIMPLYSIGN_BIN_URL" \
+    && mkdir -p /tmp/ss-extract \
+    && (yes yes | sh /tmp/ss.bin --target /tmp/ss-extract || true) \
+    && mv "$(find /tmp/ss-extract -maxdepth 1 -type d -name 'SSD-*-dist' | head -1)" /opt/SimplySignDesktop \
+    && rm -rf /tmp/ss.bin /tmp/ss-extract \
+    && test -x /opt/SimplySignDesktop/SimplySignDesktop
+
+# jsign (Authenticode signing over PKCS#11).
+RUN curl -fsSL -o /opt/jsign.jar "https://repo1.maven.org/maven2/net/jsign/jsign/${JSIGN_VERSION}/jsign-${JSIGN_VERSION}.jar"
+
+# Contract consumed by the certum-sign action.
+#
+# USER=root: SimplySignDesktop reads $USER at startup and segfaults (NULL
+# deref in its bundled OpenSSL) when it is unset. Container jobs don't set
+# $USER, so bake a default in - without it the login window never appears.
+ENV USER=root \
+    SS_DIST=/opt/SimplySignDesktop \
+    JSIGN_JAR=/opt/jsign.jar \
+    LD_LIBRARY_PATH=/opt/SimplySignDesktop
+
+LABEL org.opencontainers.image.title="Certum SimplySign signer" \
+      org.opencontainers.image.description="SimplySign Desktop + jsign + osslsigncode for headless Authenticode signing on Linux" \
+      org.opencontainers.image.source="https://github.com/CallMarcus/dji-drone-metadata-embedder"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,9 +16,36 @@ and changelog workflows; the winget submission is a separate manual step.
 6. Generate `SHA256SUMS.txt` for verification
 
 ### 2. Windows EXE Build (`release-exe.yml`)
-1. Build a standalone `dji-embed.exe` using PyInstaller
-2. Sign the executable and upload to GitHub Releases
-3. Update release assets with the Windows executable
+Three jobs: `build` → `sign` → `publish`.
+1. Build a standalone `dji-embed.exe` using PyInstaller and download the
+   just-published wheel from PyPI (windows runner)
+2. Authenticode-sign the exe via the reusable `certum-sign.yml` workflow
+   (see "Code signing" below)
+3. Generate `SHA256SUMS.txt`, attest build provenance (Sigstore), and attach
+   everything to the GitHub release — both happen **after** signing because
+   signing changes the file hashes
+
+### 2b. Windows Installer (`release-installer.yml`)
+Five jobs: `build` → `sign-app` → `assemble` → `sign-installer` → `publish`.
+1. Build `dji-embed.exe`, publish the Avalonia GUI, stage pinned
+   FFmpeg/ExifTool + licenses (windows runner)
+2. Sign `dji-embed.exe` and `DjiEmbed.Gui.exe`
+3. Compile the Inno Setup installer over the signed binaries and smoke-test
+   a silent install (also asserts both signatures are valid); the
+   Inno-generated uninstaller is knowingly unsigned (compile-time-only)
+4. Sign the setup EXE
+5. Checksums + attestation + release upload
+
+### Code signing (Certum SimplySign)
+Signing runs headlessly on Linux inside the pinned
+`ghcr.io/callmarcus/dji-drone-metadata-embedder/certum-signer` container
+(built by `signer-image.yml`, sources in `docker/certum-signer/`), driven by
+the `.github/actions/certum-sign` composite action through the reusable
+`certum-sign.yml` workflow. Repository secrets: `CERTUM_USER_ID`,
+`CERTUM_OTP_URI`, and optionally `CERTUM_CERT_FINGERPRINT` (SHA-256 pin).
+After changing any signing piece or bumping the pinned SimplySign version,
+run the manual **Sign test** workflow (`sign-test.yml`) — it signs an
+existing release exe end-to-end without cutting a release.
 
 ### 3. Winget Submission (`release-winget.yml`) — manual
 This workflow is **not** triggered by the release tag. It only runs via

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -182,10 +182,13 @@ sudo chmod -R 755 /path/to/output/directory
 
 ### My antivirus blocked the EXE
 
-Some security tools may flag downloaded executables. Verify the
-download source and allow the file if you trust it, or contact your
-administrator. A code-signed release is planned for a future version
-to reduce these warnings.
+Some security tools may flag downloaded executables. Releases from
+v1.23.0 onwards are Authenticode code-signed (publisher: "Open Source
+Developer, Marcus Westermark" — check the file's **Properties → Digital
+Signatures** tab), which reduces these warnings over time as the
+certificate accrues reputation. Verify the download source and allow
+the file if you trust it, or contact your administrator. Releases
+before v1.23.0 are unsigned.
 
 ---
 


### PR DESCRIPTION
Closes the biggest novice-adoption blocker: the "Unknown publisher" warning on `dji-embed.exe`, `DjiEmbed.Gui.exe` and the installer. Binaries are now Authenticode-signed with the Certum "Code Signing in the Cloud" (SimplySign) OV certificate, headlessly, on ordinary hosted runners — adapted from the production recipe in [reactiveui/actions-common](https://github.com/reactiveui/actions-common) (SimplySign Desktop under Xvfb, TOTP login via xdotool, PKCS#11 signing with [jsign](https://github.com/ebourg/jsign)).

## What's in here

- **`docker/certum-signer/`** — pinned signer image (SimplySign Desktop 2.9.14, jsign 7.5, osslsigncode) we build and own, pushed to GHCR via the new `signer-image.yml` (manual dispatch). Owning the image avoids trusting a third-party container with the signing credentials; the SimplySign version is pinned because a UI update can break the scripted login.
- **`.github/actions/certum-sign/`** — composite action: headless SimplySign login, jsign signing with RFC3161 timestamp (`time.certum.pl`), `osslsigncode` verification, optional SHA-256 certificate-fingerprint pin. The login step deliberately runs without bash xtrace so the one-time password never appears in the public job log (an improvement over the upstream recipe).
- **`sign-test.yml`** — manual E2E test: signs an existing release `dji-embed.exe` without cutting a release, prints the signing-certificate fingerprints (source for the `CERTUM_CERT_FINGERPRINT` secret), and uploads the signed exe for inspection on a real Windows machine.
- **`release-exe.yml`** — split into `build` (windows) → `sign` (linux container) → `publish`. `SHA256SUMS.txt` and the Sigstore attestation moved after signing, since signing changes the hashes.
- **`release-installer.yml`** — two signing rounds: app binaries are signed *before* ISCC so the installer ships signed exes, the setup EXE is signed after. The smoke test now also asserts `Get-AuthenticodeSignature` validity on the installed CLI. The Inno-generated **uninstaller is knowingly left unsigned** — it can only be signed at ISCC compile time on Windows, which the Linux signing route can't reach; deferred.

## Secrets

`CERTUM_OTP_URI` (set), `CERTUM_USER_ID` (**still needed**), `CERTUM_CERT_FINGERPRINT` (optional pin, obtainable from the first sign-test run).

## Rollout order

1. Merge
2. Run **Build signer image** (`signer-image.yml`)
3. Set `CERTUM_USER_ID`
4. Run **Sign test** (`sign-test.yml`) — iterate here if the login scripting needs tuning
5. Set `CERTUM_CERT_FINGERPRINT` from the sign-test output
6. Next release (v1.23.0) ships signed

Notes: OV reputation with SmartScreen starts at zero and accrues per-certificate across releases; this fixes the publisher identity immediately, not the SmartScreen prompt on day one. Signing adds ~1–2 min per sign job. If SignPath Foundation approves later, both can coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnWu4rkYn3gx1FefG1sLH5