### PR TITLE
feat(photomap): pano initial view from GPano tags + EXIF attribution line

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -230,8 +230,10 @@ Where `flightmap` plots video flight tracks, `photomap` plots individual
 GPS-tagged still photos (JPG/JPEG/DNG). ExifTool scans the whole directory in
 one pass (`dji-embed doctor` checks it's installed); the HTML map clusters
 nearby shots into an expandable marker, and clicking a pin shows the EXIF
-thumbnail, filename, timestamp, altitude, and camera settings. Photos with no
-GPS are skipped and counted in a summary; `-v` lists them.
+thumbnail, filename, timestamp, altitude, and camera settings — plus an
+attribution line when the photo carries `Artist`/`Copyright` metadata (see
+below). Photos with no GPS are skipped and counted in a summary; `-v` lists
+them.
 
 With `--link-originals`, a popup's thumbnail and filename become a
 click-through to the full-resolution original (JPGs open inline, DNGs
@@ -243,7 +245,7 @@ folder or an absolute URL) when the originals live elsewhere.
 
 A map you share shouldn't have to disclose everything your camera recorded.
 `--popup-fields` limits the popup to the details you pick — `none`, or a
-comma list of `name`, `timestamp`, `camera`, `altitude`:
+comma list of `name`, `timestamp`, `camera`, `altitude`, `credit`:
 
 ```bash
 dji-embed photomap ./photos --popup-fields none            # thumbnails only
@@ -273,6 +275,27 @@ popup as a fallback.
 ```bash
 dji-embed photomap /path/to/panoramas --link-originals
 ```
+
+The viewer honors the standard GPano *initial view* tags, so you can choose
+each panorama's opening direction and zoom once, in the photo itself, with
+ExifTool:
+
+```bash
+exiftool -XMP-GPano:InitialViewHeadingDegrees=210 \
+         -XMP-GPano:InitialHorizontalFOVDegrees=90 pano.jpg
+```
+
+The heading is compass degrees (`PoseHeadingDegrees`, written by the
+stitcher, records where the image center points; without it the center is
+assumed to face North). `InitialViewPitchDegrees` tilts the opening view
+above/below the horizon.
+
+Photos that carry `Artist`/`Copyright` EXIF (or the XMP Dublin Core
+equivalents) get an attribution line in their popup, and the 360° viewer
+shows it as a byline — add it once with
+`exiftool -Artist="Name" -Copyright="© 2026 Name" -overwrite_original DIR`
+and every map you generate credits you. Drop it from a particular map with
+`--popup-fields` if you prefer.
 
 The simplest way to use the viewer is `--serve` (it implies
 `--link-originals`):

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -546,7 +546,7 @@ def convert(
 @click.option(
     "--popup-fields", default=None, metavar="LIST",
     help="Limit what the HTML popups show: 'none' or a comma list of "
-         "name, timestamp, camera, altitude (default: all of them). "
+         "name, timestamp, camera, altitude, credit (default: all of them). "
          "Excluded details are left out of the HTML file entirely; the "
          "original photos are untouched. Other formats are unchanged.",
 )

--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -53,6 +53,20 @@ _SCAN_TAGS = [
     # XMP GPano marks stitched panoramas (DJI, Insta360, Google Camera, ...).
     # equirectangular => the HTML map can open the photo in a 360 viewer.
     "-XMP-GPano:ProjectionType",
+    # Initial view (#309): the author's chosen opening direction/zoom for the
+    # 360 viewer. Headings are compass degrees; PoseHeadingDegrees (the
+    # heading of the image center, written by the stitcher) anchors them to
+    # the image frame.
+    "-XMP-GPano:PoseHeadingDegrees",
+    "-XMP-GPano:InitialViewHeadingDegrees",
+    "-XMP-GPano:InitialViewPitchDegrees",
+    "-XMP-GPano:InitialHorizontalFOVDegrees",
+    # Attribution (#310): shown as a credit line in popups and the 360
+    # viewer. EXIF first; XMP Dublin Core is the per-field fallback.
+    "-EXIF:Artist",
+    "-EXIF:Copyright",
+    "-XMP-dc:Creator",
+    "-XMP-dc:Rights",
 ]
 _PHOTO_EXTS = ("jpg", "jpeg", "dng")
 
@@ -73,7 +87,10 @@ class PhotoPoint:
     has no ``GPSAltitude``), source filename, and optional capture metadata for
     popups. ``None`` altitude is kept distinct from a real 0 m fix so writers
     can clamp such placemarks to the ground rather than burying them.
-    ``is_pano`` marks GPano equirectangular panoramas (360 viewer candidates)."""
+    ``is_pano`` marks GPano equirectangular panoramas (360 viewer candidates);
+    ``pano_yaw``/``pano_pitch``/``pano_hfov`` are their viewer-ready initial
+    view (#309). ``credit`` is the authorship line from Artist/Copyright
+    metadata (#310)."""
 
     lat: float
     lon: float
@@ -86,6 +103,10 @@ class PhotoPoint:
     fnum: float | None = None
     thumbnail_b64: str | None = None
     is_pano: bool = False
+    pano_yaw: float | None = None
+    pano_pitch: float | None = None
+    pano_hfov: float | None = None
+    credit: str | None = None
 
 
 def _display_datetime(value: object) -> str | None:
@@ -112,6 +133,48 @@ def _maybe_float(value: object) -> float | None:
 
 def _maybe_str(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _credit_line(entry: dict) -> str | None:
+    """Combine authorship tags into one display line (#310).
+
+    EXIF ``Artist``/``Copyright`` win; XMP Dublin Core (``Creator``, a list,
+    and ``Rights``) is the per-field fallback. When the copyright text
+    already names the artist, the artist is not repeated.
+    """
+    creator = entry.get("Creator")
+    if isinstance(creator, list):
+        creator = ", ".join(s for c in creator if (s := str(c).strip()))
+    artist = _maybe_str(entry.get("Artist")) or _maybe_str(creator)
+    rights = _maybe_str(entry.get("Copyright")) or _maybe_str(entry.get("Rights"))
+    artist = artist.strip() if artist else None
+    rights = rights.strip() if rights else None
+    if rights and artist:
+        return rights if artist.lower() in rights.lower() else f"{rights} · {artist}"
+    return rights or artist or None
+
+
+def _pano_view(entry: dict) -> tuple[float | None, float | None, float | None]:
+    """Map GPano initial-view tags to viewer-ready ``(yaw, pitch, hfov)`` (#309).
+
+    ``InitialViewHeadingDegrees`` is a compass heading; the viewer wants yaw
+    relative to the image center, whose compass heading is
+    ``PoseHeadingDegrees`` (assumed North when the stitcher wrote none).
+    Pitch is clamped to a physical range; a nonsensical FoV is dropped
+    rather than handed to the viewer.
+    """
+    yaw = None
+    heading = _maybe_float(entry.get("InitialViewHeadingDegrees"))
+    if heading is not None:
+        pose = _maybe_float(entry.get("PoseHeadingDegrees")) or 0.0
+        yaw = (heading - pose + 180.0) % 360.0 - 180.0
+    pitch = _maybe_float(entry.get("InitialViewPitchDegrees"))
+    if pitch is not None:
+        pitch = max(-90.0, min(90.0, pitch))
+    hfov = _maybe_float(entry.get("InitialHorizontalFOVDegrees"))
+    if hfov is not None and not (10.0 <= hfov <= 170.0):
+        hfov = None
+    return yaw, pitch, hfov
 
 
 def _clean_base64(raw: object) -> str | None:
@@ -203,6 +266,7 @@ def points_from_exiftool_json(
         thumb_b64 = _extract_thumbnail_b64(entry)
         proj = entry.get("ProjectionType")
         is_pano = isinstance(proj, str) and proj.strip().lower() == "equirectangular"
+        yaw, pitch, hfov = _pano_view(entry) if is_pano else (None, None, None)
         points.append(
             PhotoPoint(
                 lat=lat,
@@ -216,6 +280,10 @@ def points_from_exiftool_json(
                 fnum=_maybe_float(entry.get("FNumber")),
                 thumbnail_b64=thumb_b64,
                 is_pano=is_pano,
+                pano_yaw=yaw,
+                pano_pitch=pitch,
+                pano_hfov=hfov,
+                credit=_credit_line(entry),
             )
         )
     points.sort(key=lambda p: p.name)
@@ -331,13 +399,21 @@ def photos_to_geojson(
     GeoJSON writer never passes it — a shared map must not accumulate fragile
     file references by default. Panoramic photos always carry ``"pano": true``
     (issue #283: it is type metadata, used for marker styling even when the
-    360° viewer itself is link-gated).
+    360° viewer itself is link-gated); their initial view (``yaw``/``pitch``/
+    ``hfov``, #309) and the ``credit`` line (#310) ride along the same way —
+    photo metadata, not viewer plumbing.
     """
     features: list[dict] = []
     for p in points:
         props: dict = {"name": p.name}
         if p.is_pano:
             props["pano"] = True
+            if p.pano_yaw is not None:
+                props["yaw"] = round(p.pano_yaw, 2)
+            if p.pano_pitch is not None:
+                props["pitch"] = round(p.pano_pitch, 2)
+            if p.pano_hfov is not None:
+                props["hfov"] = round(p.pano_hfov, 2)
         if link_base is not None:
             props["link"] = _link_href(p.name, link_base)
         if p.timestamp:
@@ -350,6 +426,8 @@ def photos_to_geojson(
         camera = camera_summary(p)
         if camera:
             props["camera"] = camera
+        if p.credit:
+            props["credit"] = p.credit
         if include_thumbnails and p.thumbnail_b64:
             props["thumb"] = p.thumbnail_b64
         features.append(
@@ -401,6 +479,8 @@ def photos_to_kml(points: list[PhotoPoint], title: str) -> str:
         camera = camera_summary(p)
         if camera:
             desc.append(escape(camera))
+        if p.credit:
+            desc.append(escape(p.credit))
         # No EXIF altitude -> clamp to terrain (a 0 m absolute placemark buries
         # the pin below ground in Google Earth); the altitude value is ignored
         # in that mode, so emit a placeholder 0.

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -42,14 +42,16 @@ _PANNELLUM_JS_SRI = "sha256-oosvezOf0KYCxnad8dymrUOvc7yMalvmcglxUonBKpo="
 # GeoJSON properties they govern. Excluded fields are stripped from the
 # embedded data itself, not merely hidden by the popup JS — a shared map must
 # not leak in its source what it hides in its UI. thumb/link/pano always
-# survive: the thumbnail is the photo itself, the link powers the 360°
-# viewer, and pano is marker-type metadata.
-POPUP_FIELDS = ("name", "timestamp", "camera", "altitude")
+# survive (the thumbnail is the photo itself, the link powers the 360°
+# viewer, and pano is marker-type metadata), as do the pano initial-view
+# props (yaw/pitch/hfov, #309 — view configuration, not personal data).
+POPUP_FIELDS = ("name", "timestamp", "camera", "altitude", "credit")
 _FIELD_TO_PROP = {
     "name": "name",
     "timestamp": "timestamp",
     "camera": "camera",
     "altitude": "alt",
+    "credit": "credit",
 }
 
 
@@ -113,6 +115,7 @@ _TEMPLATE = """<!DOCTYPE html>
   html, body {{ height: 100%; margin: 0; }}
   #map {{ height: 100%; }}
   .photo-popup img {{ max-width: 260px; display: block; margin-bottom: 4px; }}
+  .photo-popup .photo-credit {{ opacity: .75; font-size: 90%; }}
   .photo-tooltip img {{ max-width: 160px; display: block; margin-bottom: 2px; }}
   /* Per-type markers (issue #283): blue dot = photo, orange dot = 360 pano.
      The same classes render the swatches in the layer-control legend, and
@@ -195,7 +198,8 @@ _PANO_JS = """
 let panoViewer = null;
 const panoOverlay = document.getElementById('pano-overlay');
 const panoContainer = document.getElementById('pano-viewer');
-function openPano(src) {
+function openPano(a) {
+  const src = a.getAttribute('href');
   if (panoViewer) { panoViewer.destroy(); panoViewer = null; }
   panoOverlay.style.display = 'block';
   if (location.protocol === 'file:') {
@@ -213,9 +217,14 @@ function openPano(src) {
   // Lazy: the original file is only fetched here, on first click. Pannellum
   // renders its own error text in the container if the load fails (missing
   // file, WebGL texture limit); the popup's plain link remains the fallback.
-  panoViewer = pannellum.viewer('pano-viewer', {
-    type: 'equirectangular', panorama: src, autoLoad: true
-  });
+  const cfg = { type: 'equirectangular', panorama: src, autoLoad: true };
+  // Initial view (#309) and credit (#310) arrive as data- attributes.
+  if (a.dataset.yaw !== undefined) cfg.yaw = Number(a.dataset.yaw);
+  if (a.dataset.pitch !== undefined) cfg.pitch = Number(a.dataset.pitch);
+  if (a.dataset.hfov !== undefined) cfg.hfov = Number(a.dataset.hfov);
+  // Pannellum renders the author byline with innerHTML — esc() is mandatory.
+  if (a.dataset.credit) cfg.author = esc(a.dataset.credit);
+  panoViewer = pannellum.viewer('pano-viewer', cfg);
 }
 function closePano() {
   panoOverlay.style.display = 'none';
@@ -225,7 +234,7 @@ document.getElementById('pano-close').addEventListener('click', closePano);
 document.addEventListener('keydown', e => { if (e.key === 'Escape') closePano(); });
 document.addEventListener('click', e => {
   const a = e.target.closest && e.target.closest('a.pano-open');
-  if (a) { e.preventDefault(); openPano(a.getAttribute('href')); }
+  if (a) { e.preventDefault(); openPano(a); }
 });
 """
 
@@ -302,8 +311,16 @@ function buildPopup(f) {
   let html = '<div class="photo-popup">';
   if (p.link && p.pano) {
     // GPano panorama: the thumbnail/name click opens the embedded 360 viewer
-    // (see _PANO_JS); a plain "open original" link is appended below.
-    html += `<a href="${esc(p.link)}" class="pano-open">${inner}</a>`;
+    // (see _PANO_JS); a plain "open original" link is appended below. The
+    // pano's initial view (#309) and credit (#310) ride along as data-
+    // attributes for openPano. yaw/pitch/hfov are numbers straight from the
+    // embedded JSON, never strings.
+    let attrs = '';
+    if (typeof p.yaw === 'number') attrs += ` data-yaw="${p.yaw}"`;
+    if (typeof p.pitch === 'number') attrs += ` data-pitch="${p.pitch}"`;
+    if (typeof p.hfov === 'number') attrs += ` data-hfov="${p.hfov}"`;
+    if (p.credit) attrs += ` data-credit="${esc(p.credit)}"`;
+    html += `<a href="${esc(p.link)}" class="pano-open"${attrs}>${inner}</a>`;
   } else if (p.link) {
     // Opt-in (--link-originals): thumbnail + filename open the original file.
     html += `<a href="${esc(p.link)}" target="_blank" rel="noopener">${inner}</a>`;
@@ -316,6 +333,7 @@ function buildPopup(f) {
     html += `<br><a href="${esc(p.link)}" target="_blank" rel="noopener">open original</a>`;
   }
   if (p.alt !== undefined) html += `<br>altitude: ${Number(p.alt).toFixed(0)} m`;
+  if (p.credit) html += `<br><span class="photo-credit">${esc(p.credit)}</span>`;
   html += '</div>';
   return html;
 }

--- a/tests/test_geo_photomap.py
+++ b/tests/test_geo_photomap.py
@@ -544,6 +544,156 @@ def test_geojson_pano_property_with_link_base_only_on_panos():
     assert "pano" not in by_name["flat.jpg"]
 
 
+# ---------------------------------------------------------------------------
+# Pano initial view (#309): GPano InitialView* tags are compass-frame; the
+# viewer wants yaw relative to the image center (whose heading is
+# PoseHeadingDegrees). Attribution (#310): Artist/Copyright become one line.
+
+
+def _pano_entry(**extra) -> dict:
+    e = {"SourceFile": "p.jpg", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+         "ProjectionType": "equirectangular"}
+    e.update(extra)
+    return e
+
+
+def test_scan_requests_view_and_authorship_tags(monkeypatch, tmp_path):
+    seen: dict = {}
+
+    def fake_run(args, **kwargs):
+        seen["args"] = args
+        return _Proc(stdout="[]")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    scan_photos(tmp_path)
+    for tag in (
+        "-XMP-GPano:PoseHeadingDegrees",
+        "-XMP-GPano:InitialViewHeadingDegrees",
+        "-XMP-GPano:InitialViewPitchDegrees",
+        "-XMP-GPano:InitialHorizontalFOVDegrees",
+        "-EXIF:Artist",
+        "-EXIF:Copyright",
+        "-XMP-dc:Creator",
+        "-XMP-dc:Rights",
+    ):
+        assert tag in seen["args"]
+
+
+def test_initial_view_heading_maps_to_yaw_relative_to_pose():
+    points, _ = points_from_exiftool_json(
+        [_pano_entry(InitialViewHeadingDegrees=200.0, PoseHeadingDegrees=180.0)]
+    )
+    assert points[0].pano_yaw == 20.0
+
+
+def test_initial_view_yaw_wraps_to_signed_half_turn():
+    # 350° vs pose 20° is 30° to the *left*, not 330° to the right.
+    points, _ = points_from_exiftool_json(
+        [_pano_entry(InitialViewHeadingDegrees=350.0, PoseHeadingDegrees=20.0)]
+    )
+    assert points[0].pano_yaw == -30.0
+
+
+def test_initial_view_without_pose_assumes_center_is_north():
+    points, _ = points_from_exiftool_json(
+        [_pano_entry(InitialViewHeadingDegrees=270.0)]
+    )
+    assert points[0].pano_yaw == -90.0
+
+
+def test_initial_view_pitch_clamped_and_fov_sanity_checked():
+    points, _ = points_from_exiftool_json([
+        _pano_entry(InitialViewPitchDegrees=120.0),
+        _pano_entry(SourceFile="q.jpg", InitialHorizontalFOVDegrees=500.0),
+        _pano_entry(SourceFile="r.jpg", InitialHorizontalFOVDegrees=90.0),
+    ])
+    by_name = {p.name: p for p in points}
+    assert by_name["p.jpg"].pano_pitch == 90.0
+    assert by_name["q.jpg"].pano_hfov is None  # nonsense value dropped
+    assert by_name["r.jpg"].pano_hfov == 90.0
+
+
+def test_view_tags_ignored_on_non_panos():
+    points, _ = points_from_exiftool_json(
+        [{"SourceFile": "a.jpg", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+          "InitialViewHeadingDegrees": 90.0}]
+    )
+    assert points[0].pano_yaw is None
+
+
+def test_pano_without_view_tags_has_no_view():
+    points, _ = points_from_exiftool_json([_pano_entry()])
+    p = points[0]
+    assert (p.pano_yaw, p.pano_pitch, p.pano_hfov) == (None, None, None)
+
+
+def _credit_of(**tags) -> str | None:
+    entry = {"SourceFile": "a.jpg", "GPSLatitude": 1.0, "GPSLongitude": 2.0}
+    entry.update(tags)
+    points, _ = points_from_exiftool_json([entry])
+    return points[0].credit
+
+
+def test_credit_copyright_containing_artist_is_not_repeated():
+    assert _credit_of(Artist="Jane Doe",
+                      Copyright="© 2026 Jane Doe") == "© 2026 Jane Doe"
+
+
+def test_credit_joins_distinct_copyright_and_artist():
+    assert _credit_of(Artist="Jane Doe",
+                      Copyright="All rights reserved") == \
+        "All rights reserved · Jane Doe"
+
+
+def test_credit_single_tags_pass_through():
+    assert _credit_of(Artist="Jane Doe") == "Jane Doe"
+    assert _credit_of(Copyright="© 2026") == "© 2026"
+    assert _credit_of() is None
+
+
+def test_credit_falls_back_to_xmp_dublin_core():
+    # ExifTool returns XMP-dc:Creator as a list.
+    assert _credit_of(Creator=["Jane", "Joe"], Rights="© 2026") == \
+        "© 2026 · Jane, Joe"
+
+
+def test_geojson_carries_view_and_credit_props():
+    pts = [
+        PhotoPoint(lat=1.0, lon=2.0, alt=None, name="pano.jpg", is_pano=True,
+                   pano_yaw=-30.0, pano_pitch=10.0, pano_hfov=90.0,
+                   credit="© 2026 Jane"),
+        PhotoPoint(lat=3.0, lon=4.0, alt=None, name="flat.jpg",
+                   credit="© 2026 Jane"),
+    ]
+    by_name = {
+        f["properties"]["name"]: f["properties"]
+        for f in photos_to_geojson(pts)["features"]
+    }
+    pano = by_name["pano.jpg"]
+    assert (pano["yaw"], pano["pitch"], pano["hfov"]) == (-30.0, 10.0, 90.0)
+    assert pano["credit"] == "© 2026 Jane"
+    flat = by_name["flat.jpg"]
+    assert flat["credit"] == "© 2026 Jane"
+    assert "yaw" not in flat and "pitch" not in flat and "hfov" not in flat
+
+
+def test_geojson_omits_view_props_when_unset():
+    props = photos_to_geojson([_PANO_POINT])["features"][0]["properties"]
+    assert props["pano"] is True
+    for key in ("yaw", "pitch", "hfov", "credit"):
+        assert key not in props
+
+
+def test_kml_description_includes_credit():
+    pts = [PhotoPoint(lat=1.0, lon=2.0, alt=None, name="a.jpg",
+                      credit="© 2026 <Jane>")]
+    kml = photos_to_kml(pts, title="t")
+    root = ET.fromstring(kml)  # escaped credit keeps the XML well-formed
+    desc = next(root.iter(f"{_KML_NS}Placemark")).find(f"{_KML_NS}description")
+    # Balloons render CDATA as HTML, so the angle brackets must arrive escaped.
+    assert "© 2026 &lt;Jane&gt;" in desc.text
+
+
 def test_redact_photo_points_fuzz_rounds_to_3_decimals():
     from dji_metadata_embedder.geo.photomap import redact_photo_points
 

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -313,6 +313,56 @@ def test_html_touch_devices_get_larger_pin_tap_target():
     assert ".pin-hit" in html  # centering CSS for the dot inside the hit box
 
 
+# Pano initial view (#309) and attribution (#310): the pano anchor carries
+# the viewer-ready values as data- attributes; openPano forwards them to
+# Pannellum. The credit line renders in popups and as the viewer byline.
+
+
+VIEW_POINTS = [
+    PhotoPoint(lat=60.1686, lon=24.9539, alt=None, name="pano.jpg",
+               is_pano=True, pano_yaw=-30.0, pano_pitch=10.0, pano_hfov=90.0,
+               credit="© 2026 Jane"),
+]
+
+
+def test_html_pano_anchor_carries_view_data_attributes():
+    html = photos_to_html(VIEW_POINTS, title="t", link_base="")
+    # Popup template writes the attributes only for numeric values...
+    for snippet in ('data-yaw="${p.yaw}"', 'data-pitch="${p.pitch}"',
+                    'data-hfov="${p.hfov}"', "typeof p.yaw === 'number'"):
+        assert snippet in html
+    # ...and openPano forwards them to the Pannellum config.
+    assert "cfg.yaw = Number(a.dataset.yaw)" in html
+    assert "cfg.pitch = Number(a.dataset.pitch)" in html
+    assert "cfg.hfov = Number(a.dataset.hfov)" in html
+    props = _embedded_geojson(html)["features"][0]["properties"]
+    assert (props["yaw"], props["pitch"], props["hfov"]) == (-30.0, 10.0, 90.0)
+
+
+def test_html_pano_viewer_byline_is_escaped():
+    html = photos_to_html(VIEW_POINTS, title="t", link_base="")
+    # Pannellum renders the author with innerHTML, so the value must pass
+    # through esc() on its way into the config.
+    assert "cfg.author = esc(a.dataset.credit)" in html
+
+
+def test_html_popup_shows_credit_line():
+    html = photos_to_html(VIEW_POINTS, title="t")
+    assert "photo-credit" in html          # popup line + its CSS
+    assert "if (p.credit)" in html         # presence-guarded like every field
+    props = _embedded_geojson(html)["features"][0]["properties"]
+    assert props["credit"] == "© 2026 Jane"
+
+
+def test_html_popup_fields_can_strip_credit():
+    html = photos_to_html(VIEW_POINTS, title="t",
+                          popup_fields=frozenset({"name"}))
+    props = _embedded_geojson(html)["features"][0]["properties"]
+    assert "credit" not in props
+    # View props are configuration, not personal data — never filtered.
+    assert props["yaw"] == -30.0
+
+
 # Popup content control (issue #296): --popup-fields decides what the HTML
 # discloses. Excluded fields are stripped from the embedded GeoJSON itself,
 # not merely hidden by the popup JS — a shared map must not leak in its
@@ -331,7 +381,7 @@ def test_parse_popup_fields_rejects_unknown_and_names_valid_ones():
         parse_popup_fields("shutter")
     msg = str(ei.value)
     assert "shutter" in msg
-    for valid in ("name", "timestamp", "camera", "altitude"):
+    for valid in ("name", "timestamp", "camera", "altitude", "credit"):
         assert valid in msg
     with pytest.raises(ValueError):
         parse_popup_fields("")


### PR DESCRIPTION
Implements #309 and #310 (community DM requests).

## Initial view (#309)
- Scan now reads `PoseHeadingDegrees` + the three `InitialView*` GPano tags.
- Per the Photo Sphere XMP spec, `InitialViewHeadingDegrees` is a **compass** heading — ingestion converts it to Pannellum yaw relative to the image center (`yaw = heading − pose`, normalized to ±180; pose assumed North when the stitcher wrote none). Verified against the spec; Pannellum 2.5.6 itself only parses Pose/cropped-area XMP, not InitialView, so this is done at build time.
- Pitch clamped to ±90; FoV outside 10–170° dropped rather than handed to the viewer.
- Values flow as GeoJSON props (`yaw`/`pitch`/`hfov`, panos only) → `data-` attributes on the pano anchor → Pannellum config.
- Users set the opening view per image with ExifTool (documented in geospatial.md) — no new CLI surface.

## Attribution (#310)
- `EXIF:Artist`/`EXIF:Copyright` (XMP `dc:Creator`/`dc:Rights` fallback; Creator lists joined) combine into one `credit` line; artist isn't repeated when the copyright text already names them.
- Shown in HTML popups (muted style), KML balloons, GeoJSON `credit` prop, and as the 360° viewer byline — escaped before entering the Pannellum config since Pannellum renders the author via `innerHTML`.
- `--popup-fields` gains `credit`, so a shared map can strip it like any other field; view props are configuration and never filtered.

Tests: 20 new (yaw math incl. wrap-around and missing pose, clamps, credit derivation matrix, GeoJSON/KML/HTML surfacing, popup-fields stripping, byline escaping). Full suite + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnWu4rkYn3gx1FefG1sLH5