### PR TITLE
feat(maps): --tile-style option for photomap and flightmap basemaps

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -218,6 +218,22 @@ Details worth knowing:
   the same time, a split flight interleaved with the other drone's files
   is not joined. Rare in practice — open an issue if it bites you.
 
+### Basemap styles (`--tile-style`)
+
+Both `flightmap` and `photomap` can swap the HTML map's basemap between
+keyless OpenStreetMap renders:
+
+```bash
+dji-embed flightmap ./footage --tile-style opentopomap
+dji-embed photomap ./photos --tile-style osm-hot
+```
+
+`osm` (default), `osm-hot` (Humanitarian style, high contrast),
+`opentopomap` (topographic with contour lines — nice for mountain flights),
+and `cyclosm` (cycling-oriented, detailed paths). Each style carries its
+provider's attribution automatically. KML and GeoJSON outputs have no
+basemap and are unchanged.
+
 ## Photo map (`photomap`)
 
 ```bash

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -22,6 +22,8 @@ from .telemetry_converter import (
     summarize_sun,
 )
 from .geo import (
+    DEFAULT_TILE_STYLE,
+    TILE_STYLES,
     convert_to_geojson,
     convert_to_kml,
     convert_to_html,
@@ -233,6 +235,17 @@ _progress_option = click.option(
     help="Emit machine-readable progress events on stdout, one JSON object "
     "per line (see docs/PROGRESS_JSONL.md). Suppresses human output on "
     "stdout; warnings and logs still go to stderr.",
+)
+
+# Shared by photomap and flightmap (#311). Keyless OpenStreetMap-data styles
+# only; the choice affects the HTML basemap, other formats carry no basemap.
+_tile_style_option = click.option(
+    "--tile-style",
+    type=click.Choice(list(TILE_STYLES), case_sensitive=False),
+    default=DEFAULT_TILE_STYLE,
+    show_default=True,
+    help="Basemap style for the HTML map: standard OSM, Humanitarian "
+    "(osm-hot), topographic (opentopomap), or cycling (cyclosm).",
 )
 
 
@@ -567,6 +580,7 @@ def convert(
          "browsers block when the map is opened straight from disk. "
          "With -v, each HTTP request is logged.",
 )
+@_tile_style_option
 @_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
@@ -581,6 +595,7 @@ def photomap(
     popup_fields: str | None,
     redact: str,
     serve_map: bool,
+    tile_style: str,
     progress_mode: str | None,
     verbose: bool,
     quiet: bool,
@@ -696,6 +711,7 @@ def photomap(
                         points, out, map_title,
                         link_base=html_link_base,
                         popup_fields=popup_field_set,
+                        tile_style=tile_style.lower(),
                     )
                 elif f == "kml":
                     write_photos_kml(points, out, map_title)
@@ -757,6 +773,7 @@ def photomap(
     "detects it from each file's mtime; pass it explicitly when the files "
     "were copied through zip/cloud transfers that rewrote the mtimes.",
 )
+@_tile_style_option
 @_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
@@ -769,6 +786,7 @@ def flightmap(
     redact: str,
     join_gap: float,
     tz_offset: str,
+    tile_style: str,
     progress_mode: str | None,
     verbose: bool,
     quiet: bool,
@@ -844,7 +862,9 @@ def flightmap(
         for f, out in targets:
             try:
                 if f == "html":
-                    write_flights_html(tracks, out, map_title)
+                    write_flights_html(
+                        tracks, out, map_title, tile_style=tile_style.lower()
+                    )
                 elif f == "kml":
                     write_flights_kml(tracks, out, map_title)
                 else:

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -26,6 +26,7 @@ from .photomap import (
 )
 from .photomap_html import parse_popup_fields, photos_to_html, write_photos_html
 from .serve import serve_directory
+from .tiles import DEFAULT_TILE_STYLE, TILE_STYLES, TileStyle
 from .solar import sun_position
 from .track import Track, TrackPoint, build_track
 
@@ -58,6 +59,9 @@ __all__ = [
     "parse_popup_fields",
     "photos_to_html",
     "write_photos_html",
+    "DEFAULT_TILE_STYLE",
+    "TILE_STYLES",
+    "TileStyle",
     "scan_flights",
     "flights_to_geojson",
     "write_flights_geojson",

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -16,6 +16,7 @@ from html import escape
 from pathlib import Path
 
 from .flightmap import flights_to_geojson
+from .tiles import DEFAULT_TILE_STYLE, tile_layer_js
 from .track import Track
 
 logger = logging.getLogger(__name__)
@@ -60,10 +61,7 @@ _TEMPLATE = """<!DOCTYPE html>
 _APP_JS = """
 const data = JSON.parse(document.getElementById('flight-data').textContent);
 const map = L.map('map');
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  maxZoom: 19,
-  attribution: '&copy; OpenStreetMap contributors'
-}).addTo(map);
+__TILE_LAYER__
 
 const esc = s => String(s).replace(/[&<>"']/g,
   ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
@@ -137,8 +135,14 @@ if (Object.keys(overlays).length > 1) {
 """
 
 
-def flights_to_html(tracks: list[Track], title: str) -> str:
-    """Return a complete self-contained HTML flight map."""
+def flights_to_html(
+    tracks: list[Track], title: str, *, tile_style: str = DEFAULT_TILE_STYLE
+) -> str:
+    """Return a complete self-contained HTML flight map.
+
+    ``tile_style`` (issue #311): a :data:`~.tiles.TILE_STYLES` key selecting
+    the basemap drawn under the tracks.
+    """
     geojson = flights_to_geojson(tracks)
     # Escape "<" to "\\u003c" (a JSON Unicode escape) so JSON.parse round-trips
     # it while no literal "</script>" can break out of the data block.
@@ -149,12 +153,20 @@ def flights_to_html(tracks: list[Track], title: str) -> str:
         css_sri=_LEAFLET_CSS_SRI,
         js_sri=_LEAFLET_JS_SRI,
         data=data,
-        app_js=_APP_JS,
+        app_js=_APP_JS.replace("__TILE_LAYER__", tile_layer_js(tile_style)),
     )
 
 
-def write_flights_html(tracks: list[Track], output_path: Path, title: str) -> Path:
+def write_flights_html(
+    tracks: list[Track],
+    output_path: Path,
+    title: str,
+    *,
+    tile_style: str = DEFAULT_TILE_STYLE,
+) -> Path:
     """Write *tracks* as an HTML map to *output_path* and return it."""
-    output_path.write_text(flights_to_html(tracks, title), encoding="utf-8")
+    output_path.write_text(
+        flights_to_html(tracks, title, tile_style=tile_style), encoding="utf-8"
+    )
     logger.info("HTML flight map created: %s", output_path)
     return output_path

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -18,6 +18,7 @@ from html import escape
 from pathlib import Path
 
 from .photomap import PhotoPoint, photos_to_geojson
+from .tiles import DEFAULT_TILE_STYLE, tile_layer_js
 
 logger = logging.getLogger(__name__)
 
@@ -242,10 +243,7 @@ document.addEventListener('click', e => {
 _APP_JS = """
 const data = JSON.parse(document.getElementById('photo-data').textContent);
 const map = L.map('map');
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-  maxZoom: 19,
-  attribution: '&copy; OpenStreetMap contributors'
-}).addTo(map);
+__TILE_LAYER__
 
 const esc = s => String(s).replace(/[&<>"']/g,
   ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
@@ -392,6 +390,7 @@ def photos_to_html(
     *,
     link_base: str | None = None,
     popup_fields: frozenset[str] | None = None,
+    tile_style: str = DEFAULT_TILE_STYLE,
 ) -> str:
     """Return a complete self-contained HTML photo map.
 
@@ -406,6 +405,9 @@ def photos_to_html(
     ``popup_fields`` (issue #296): a set from :func:`parse_popup_fields`
     limiting which EXIF-derived details the map carries; ``None`` (default)
     keeps everything. Excluded fields never reach the HTML file.
+
+    ``tile_style`` (issue #311): a :data:`~.tiles.TILE_STYLES` key selecting
+    the basemap drawn under the markers.
     """
     geojson = photos_to_geojson(
         points, include_thumbnails=True, link_base=link_base
@@ -429,7 +431,9 @@ def photos_to_html(
         pano_head=_PANO_HEAD if pano_enabled else "",
         pano_overlay=_PANO_OVERLAY if pano_enabled else "",
         pano_scripts=_PANO_SCRIPT if pano_enabled else "",
-        app_js=_APP_JS + (_PANO_JS if pano_enabled else ""),
+        app_js=(_APP_JS + (_PANO_JS if pano_enabled else "")).replace(
+            "__TILE_LAYER__", tile_layer_js(tile_style)
+        ),
     )
 
 
@@ -440,11 +444,13 @@ def write_photos_html(
     *,
     link_base: str | None = None,
     popup_fields: frozenset[str] | None = None,
+    tile_style: str = DEFAULT_TILE_STYLE,
 ) -> Path:
     """Write *points* as an HTML map to *output_path* and return it."""
     output_path.write_text(
         photos_to_html(
-            points, title, link_base=link_base, popup_fields=popup_fields
+            points, title, link_base=link_base, popup_fields=popup_fields,
+            tile_style=tile_style,
         ),
         encoding="utf-8",
     )

--- a/src/dji_metadata_embedder/geo/tiles.py
+++ b/src/dji_metadata_embedder/geo/tiles.py
@@ -1,0 +1,73 @@
+"""Keyless basemap styles shared by the HTML map writers (#311).
+
+Each style pins a Leaflet tile URL template, the provider's required
+attribution, and its maximum zoom. Keyless community providers only — no
+API-key plumbing. All are OpenStreetMap-data styles, so the map reads the
+same, just drawn differently.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TileStyle:
+    """One basemap: Leaflet URL template + provider attribution + max zoom."""
+
+    url: str
+    max_zoom: int
+    attribution: str
+
+
+TILE_STYLES: dict[str, TileStyle] = {
+    "osm": TileStyle(
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        max_zoom=19,
+        attribution="&copy; OpenStreetMap contributors",
+    ),
+    "osm-hot": TileStyle(
+        url="https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+        max_zoom=19,
+        attribution=(
+            "&copy; OpenStreetMap contributors, style &copy; Humanitarian "
+            "OpenStreetMap Team, hosted by OpenStreetMap France"
+        ),
+    ),
+    "opentopomap": TileStyle(
+        url="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
+        max_zoom=17,
+        attribution=(
+            "map data &copy; OpenStreetMap contributors, SRTM | style "
+            "&copy; OpenTopoMap (CC-BY-SA)"
+        ),
+    ),
+    "cyclosm": TileStyle(
+        url="https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png",
+        max_zoom=20,
+        attribution=(
+            "&copy; OpenStreetMap contributors, style CyclOSM, hosted by "
+            "OpenStreetMap France"
+        ),
+    ),
+}
+
+DEFAULT_TILE_STYLE = "osm"
+
+
+def tile_layer_js(style: str) -> str:
+    """Return the Leaflet ``L.tileLayer(...).addTo(map)`` call for *style*.
+
+    The values are trusted module constants (URL template and attribution
+    HTML), embedded verbatim into the page's app script; ``json.dumps``
+    provides the JS string quoting. Unknown *style* raises ``KeyError`` —
+    the CLI restricts choices to :data:`TILE_STYLES` before this runs.
+    """
+    ts = TILE_STYLES[style]
+    return (
+        f"L.tileLayer({json.dumps(ts.url)}, {{\n"
+        f"  maxZoom: {ts.max_zoom},\n"
+        f"  attribution: {json.dumps(ts.attribution)}\n"
+        "}).addTo(map);"
+    )

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -189,3 +189,23 @@ def test_flightmap_join_gap_zero_disables(tmp_path):
     assert res.exit_code == 0, res.output
     assert "Mapped 2 flights" in res.output
     assert "Joined" not in res.output
+
+
+def test_flightmap_tile_style_selects_basemap(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "--tile-style", "opentopomap"]
+    )
+    assert res.exit_code == 0, res.output
+    text = (tmp_path / "flightmap.html").read_text(encoding="utf-8")
+    assert "tile.opentopomap.org" in text
+    assert "tile.openstreetmap.org" not in text
+
+
+def test_flightmap_tile_style_rejects_unknown(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "--tile-style", "watercolor"]
+    )
+    assert res.exit_code != 0
+    assert "watercolor" in res.output

--- a/tests/test_cli_photomap.py
+++ b/tests/test_cli_photomap.py
@@ -409,3 +409,14 @@ def test_photomap_popup_fields_without_html_output_warns(monkeypatch, tmp_path):
         ["photomap", str(tmp_path), "-f", "geojson", "--popup-fields", "none"])
     assert res.exit_code == 0, res.output
     assert "only affects HTML" in res.output
+
+
+def test_photomap_tile_style_selects_basemap(monkeypatch, tmp_path):
+    _mock_scan(monkeypatch)
+    res = CliRunner().invoke(
+        main, ["photomap", str(tmp_path), "--tile-style", "osm-hot"]
+    )
+    assert res.exit_code == 0, res.output
+    text = (tmp_path / "photomap.html").read_text(encoding="utf-8")
+    assert "tile.openstreetmap.fr/hot" in text
+    assert "Humanitarian" in text

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -128,3 +128,22 @@ def test_write_flights_html(tmp_path):
     result = write_flights_html(TRACKS, out, title="t")
     assert result == out
     assert "<!DOCTYPE html>" in out.read_text(encoding="utf-8")
+
+
+# Basemap styles (#311): the tile layer is generated from geo.tiles; the
+# default stays the standard OSM render.
+
+
+def test_html_default_tile_style_is_osm():
+    html = flights_to_html(TRACKS, title="t")
+    assert "tile.openstreetmap.org" in html
+    assert "__TILE_LAYER__" not in html
+
+
+def test_html_alternate_tile_style_swaps_provider():
+    html = flights_to_html(TRACKS, title="t", tile_style="opentopomap")
+    assert "tile.opentopomap.org" in html
+    assert "OpenTopoMap" in html
+    assert "maxZoom: 17" in html
+    assert "tile.openstreetmap.org" not in html
+    assert "__TILE_LAYER__" not in html

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -431,3 +431,21 @@ def test_html_popup_js_guards_every_optional_field():
     html = photos_to_html(POINTS, title="t")
     assert "if (p.name)" in html
     assert re.search(r"if \([^)]*p\.alt", html)
+
+
+# Basemap styles (#311): the tile layer is generated from geo.tiles; the
+# default stays the standard OSM render.
+
+
+def test_html_default_tile_style_is_osm():
+    html = photos_to_html(POINTS, title="t")
+    assert "tile.openstreetmap.org" in html
+    assert "__TILE_LAYER__" not in html
+
+
+def test_html_alternate_tile_style_swaps_provider():
+    html = photos_to_html(POINTS, title="t", tile_style="cyclosm")
+    assert "tile-cyclosm.openstreetmap.fr" in html
+    assert "CyclOSM" in html
+    assert "tile.openstreetmap.org" not in html
+    assert "__TILE_LAYER__" not in html

--- a/tests/test_geo_tiles.py
+++ b/tests/test_geo_tiles.py
@@ -1,0 +1,39 @@
+import pytest
+
+from dji_metadata_embedder.geo.tiles import (
+    DEFAULT_TILE_STYLE,
+    TILE_STYLES,
+    tile_layer_js,
+)
+
+
+def test_default_style_is_a_known_style():
+    assert DEFAULT_TILE_STYLE in TILE_STYLES
+
+
+def test_every_style_is_a_complete_leaflet_layer():
+    for name, ts in TILE_STYLES.items():
+        assert ts.url.startswith("https://"), name
+        # Leaflet template placeholders must survive into the page verbatim.
+        for placeholder in ("{z}", "{x}", "{y}"):
+            assert placeholder in ts.url, name
+        # All styles are OSM-data renders; the ODbL credit is mandatory.
+        assert "OpenStreetMap" in ts.attribution, name
+        assert 16 <= ts.max_zoom <= 21, name
+
+
+def test_tile_layer_js_emits_the_style_verbatim():
+    js = tile_layer_js("opentopomap")
+    ts = TILE_STYLES["opentopomap"]
+    assert js.startswith('L.tileLayer("https://')
+    assert ts.url in js
+    assert f"maxZoom: {ts.max_zoom}" in js
+    assert "OpenTopoMap" in js
+    assert js.endswith(".addTo(map);")
+
+
+def test_tile_layer_js_unknown_style_raises():
+    # The CLI's click.Choice guards this; a KeyError here means a programming
+    # error, not bad user input.
+    with pytest.raises(KeyError):
+        tile_layer_js("watercolor")


### PR DESCRIPTION
Implements #311 (community DM request — "a different style of OSM").

- New `geo/tiles.py`: four keyless OSM-data styles (`osm` default, `osm-hot`, `opentopomap`, `cyclosm`), each pinning URL template, provider attribution, and max zoom. No API-key plumbing.
- `photos_to_html`/`flights_to_html` gain `tile_style=`; the previously duplicated hardcoded `L.tileLayer` block in both writers is now generated from the shared table.
- Shared `--tile-style` click option on `photomap` and `flightmap` (click.Choice, case-insensitive). KML/GeoJSON unchanged — no basemap there.
- The per-video `convert html` track page keeps the default basemap (out of the issue's scope; trivial follow-up if requested).

Tests: tiles table invariants (placeholders, ODbL credit, zoom range), JS generation, default-vs-alternate style in both HTML writers, CLI pass-through + unknown-style rejection. Full suite + ruff + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnWu4rkYn3gx1FefG1sLH5