### PR TITLE
feat(gui): 360° panoramas open in the real viewer from Make a map

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -78,8 +78,10 @@ Every command accepts `--help` for its options.
   folder; open it in a browser. Videos' flights: `dji-embed flightmap D:\Footage`.
 - **"My 360° panoramas won't open / black viewer":** browsers block the 360°
   viewer on maps opened straight from disk (`file://`). Rebuild with
-  `dji-embed photomap <folder> --serve` — it serves the map at a private
-  local address (`127.0.0.1`, your computer only) and opens the browser.
+  `dji-embed photomap <folder> --serve`, or serve an existing map with
+  `dji-embed serve <folder>` — both serve at a private local address
+  (`127.0.0.1`, your computer only) and open the browser. The desktop app
+  does this automatically when you open a map from its Done screen.
 - **"Get GPS into my videos so photo apps sort them":**
   `dji-embed embed D:\Footage` — needs the `.SRT` flight logs next to the
   MP4s with matching names (enable video captions/subtitles in the DJI app

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -324,6 +324,20 @@ This writes the map, serves its folder at a private local address
 (`http://127.0.0.1:<port>` — reachable only from your own computer), and
 opens it in your browser. Press Ctrl+C in the terminal to stop.
 
+To serve a map that already exists without rebuilding it, use the
+standalone `serve` command:
+
+```bash
+dji-embed serve /path/to/panoramas                       # opens photomap.html
+dji-embed serve ./footage --page flightmap.html
+```
+
+(The desktop app uses this under the hood: maps opened from its Done
+screen are served automatically, so the 360° viewer just works there.)
+Wrapper flags for that kind of integration: `--no-browser`, `--url-only`
+(print the bare URL as the first line), and `--exit-with-stdin` (stop when
+stdin closes, tying the server to the app that started it).
+
 Notes:
 
 - Opened straight from disk (double-clicking `photomap.html`), the 360°

--- a/gui/DjiEmbed.Gui.Tests/DropZoneAffordanceTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/DropZoneAffordanceTests.cs
@@ -30,7 +30,7 @@ public class DropZoneAffordanceTests
         "makemap" => new MakeMapView
         {
             DataContext = new MakeMapViewModel(
-                null, new DjiEmbedRunner(), () => { }),
+                null, new DjiEmbedRunner(), new MapServer(), () => { }),
         },
         _ => new EmbedTelemetryView
         {

--- a/gui/DjiEmbed.Gui.Tests/FakeCli.cs
+++ b/gui/DjiEmbed.Gui.Tests/FakeCli.cs
@@ -55,6 +55,24 @@ internal static class FakeCli
         return WriteScript(dir, sh);
     }
 
+    /// <summary>
+    /// A fake CLI that appends its argv to <paramref name="argsFile"/>, then
+    /// plays back <paramref name="stdoutLines"/> and exits 0.
+    /// </summary>
+    internal static string WriteArgsRecorder(string dir, string argsFile,
+        IEnumerable<string> stdoutLines)
+    {
+        if (IsWindows)
+        {
+            return WriteScript(dir, "@echo off\r\n"
+                + $"echo %* >> \"{argsFile}\"\r\n"
+                + EchoLinesCmd(stdoutLines) + "exit /b 0\r\n");
+        }
+        return WriteScript(dir, "#!/bin/sh\n"
+            + $"echo \"$@\" >> '{argsFile}'\n"
+            + EchoLinesSh(stdoutLines) + "exit 0\n");
+    }
+
     private static string EchoLinesCmd(IEnumerable<string> lines) =>
         string.Concat(lines.Select(l =>
             "echo " + l.Replace("\"", "\"\"") + "\r\n"));

--- a/gui/DjiEmbed.Gui.Tests/FlowProgressAndWarningsTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlowProgressAndWarningsTests.cs
@@ -119,7 +119,7 @@ public class FlowProgressAndWarningsTests : IDisposable
     [AvaloniaFact]
     public void Makemap_done_screen_shows_warnings()
     {
-        var vm = new MakeMapViewModel(null, new DjiEmbedRunner(), () => { });
+        var vm = new MakeMapViewModel(null, new DjiEmbedRunner(), new MapServer(), () => { });
         vm.Step = FlowStep.Done;
         vm.Warnings.Add("IMG_0001.JPG: no GPS position");
         var window = ShowView(new MakeMapView { DataContext = vm });

--- a/gui/DjiEmbed.Gui.Tests/MakeMapViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/MakeMapViewModelTests.cs
@@ -33,7 +33,7 @@ public class MakeMapViewModelTests : IDisposable
     ];
 
     private static MakeMapViewModel Vm(string? cli, bool wentHome = false) =>
-        new(cli, new DjiEmbedRunner(), () => { });
+        new(cli, new DjiEmbedRunner(), new MapServer(), () => { });
 
     [Fact]
     public void Starts_on_the_pick_step()
@@ -85,6 +85,18 @@ public class MakeMapViewModelTests : IDisposable
         await vm.StartCommand.ExecuteAsync(MakeFolder(srt: true, photos: true));
         Assert.Equal(FlowStep.Done, vm.Step);
         Assert.Equal(["flightmap.html", "photomap.html"], vm.Outputs);
+    }
+
+    [Fact]
+    public async Task Photomap_step_links_originals_for_the_pano_viewer()
+    {
+        // #305: without --link-originals the map has no pano viewer at all.
+        var argsFile = Path.Combine(_dir, "args.txt");
+        var cli = FakeCli.WriteArgsRecorder(_dir, argsFile, PhotomapStream);
+        var vm = Vm(cli);
+        await vm.StartCommand.ExecuteAsync(MakeFolder(photos: true));
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Contains("--link-originals", File.ReadAllText(argsFile));
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/MapServerTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/MapServerTests.cs
@@ -1,0 +1,76 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class MapServerTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-mapserver-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string MapFile(string name = "photomap.html")
+    {
+        var folder = Path.Combine(_dir, "maps");
+        Directory.CreateDirectory(folder);
+        var path = Path.Combine(folder, name);
+        File.WriteAllText(path, "<p>map</p>");
+        return path;
+    }
+
+    [Fact]
+    public async Task Returns_the_first_stdout_line_as_the_url()
+    {
+        using var server = new MapServer();
+        // The fake stays alive after printing, like a real serve child.
+        var cli = FakeCli.WriteEventStream(_dir,
+            ["http://127.0.0.1:54321/photomap.html"], sleepSeconds: 30);
+        var url = await server.GetUrlAsync(cli, MapFile());
+        Assert.Equal("http://127.0.0.1:54321/photomap.html", url);
+    }
+
+    [Fact]
+    public async Task Reuses_the_folder_server_for_a_second_page()
+    {
+        using var server = new MapServer();
+        var cli = FakeCli.WriteEventStream(_dir,
+            ["http://127.0.0.1:54321/photomap.html"], sleepSeconds: 30);
+        await server.GetUrlAsync(cli, MapFile());
+        // Same folder, other map: no second child — the URL is composed
+        // from the running server's base address.
+        var url = await server.GetUrlAsync(cli, MapFile("flightmap.html"));
+        Assert.Equal("http://127.0.0.1:54321/flightmap.html", url);
+    }
+
+    [Fact]
+    public async Task Non_url_output_yields_null_for_the_file_fallback()
+    {
+        using var server = new MapServer();
+        var cli = FakeCli.WriteEventStream(_dir,
+            ["Serving map at http://127.0.0.1:54321/ - press Ctrl+C to stop"],
+            sleepSeconds: 30);
+        Assert.Null(await server.GetUrlAsync(cli, MapFile()));
+    }
+
+    [Fact]
+    public async Task Dead_server_is_replaced_on_the_next_open()
+    {
+        using var server = new MapServer();
+        // Exits right after printing — a crashed/killed server.
+        var cli = FakeCli.WriteEventStream(_dir,
+            ["http://127.0.0.1:54321/photomap.html"]);
+        var first = await server.GetUrlAsync(cli, MapFile());
+        Assert.NotNull(first);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+        var second = await server.GetUrlAsync(cli, MapFile());
+        Assert.NotNull(second);
+    }
+
+    [Fact]
+    public async Task Unstartable_cli_yields_null()
+    {
+        using var server = new MapServer();
+        var cli = Path.Combine(_dir, "does-not-exist");
+        Assert.Null(await server.GetUrlAsync(cli, MapFile()));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -45,7 +45,7 @@ public class ScreenshotCaptureTests
         Capture(new MainWindow { DataContext = new MainViewModel() },
             Png("home"));
 
-        var makeMap = new MakeMapViewModel(null, new DjiEmbedRunner(), NoOp());
+        var makeMap = new MakeMapViewModel(null, new DjiEmbedRunner(), new MapServer(), NoOp());
         CaptureView(new MakeMapView { DataContext = makeMap },
             Png("makemap-pick"));
 

--- a/gui/DjiEmbed.Gui/Services/MapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/MapServer.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// Manages one <c>dji-embed serve</c> child per served folder so GUI-made
+/// maps open over local HTTP instead of file:// — browsers block the 360°
+/// panorama viewer's WebGL image access on file:// pages (#305). The child
+/// prints its URL as the first stdout line (<c>--url-only</c>) and stops
+/// when its stdin closes (<c>--exit-with-stdin</c>): the held-open pipe is
+/// the lifeline, so a server can never outlive this app even if no kill
+/// ever runs.
+/// </summary>
+public sealed class MapServer : IDisposable
+{
+    private static readonly TimeSpan StartTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly Dictionary<string, (Process Process, string BaseUrl)> _running =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// URL serving <paramref name="htmlPath"/>, starting (or reusing) its
+    /// folder's server. Null when no server could be started — the caller
+    /// falls back to opening the file directly (the map minus the pano
+    /// viewer, never nothing).
+    /// </summary>
+    public async Task<string?> GetUrlAsync(string cliPath, string htmlPath)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(htmlPath));
+        if (dir is null)
+        {
+            return null;
+        }
+        var page = Path.GetFileName(htmlPath);
+        if (_running.TryGetValue(dir, out var live) && !live.Process.HasExited)
+        {
+            return live.BaseUrl + page;
+        }
+        _running.Remove(dir);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = cliPath,
+            RedirectStandardInput = true,   // held open: the child's lifeline
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+        };
+        string[] args =
+            ["serve", dir, "--page", page, "--no-browser", "--url-only",
+             "--exit-with-stdin"];
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+        var process = new Process { StartInfo = psi };
+        try
+        {
+            process.Start();
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+        var url = await ReadUrlLineAsync(process);
+        if (url is null)
+        {
+            TryKill(process);
+            process.Dispose();
+            return null;
+        }
+        _running[dir] = (process, url[..(url.LastIndexOf('/') + 1)]);
+        return url;
+    }
+
+    private static async Task<string?> ReadUrlLineAsync(Process process)
+    {
+        var read = process.StandardOutput.ReadLineAsync();
+        if (await Task.WhenAny(read, Task.Delay(StartTimeout)) != read)
+        {
+            return null;
+        }
+        var line = (await read)?.Trim();
+        return line is not null
+            && line.StartsWith("http://127.0.0.1:", StringComparison.Ordinal)
+            ? line
+            : null;
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (Exception)
+        {
+            // Already gone.
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var (process, _) in _running.Values)
+        {
+            TryKill(process);
+            process.Dispose();
+        }
+        _running.Clear();
+    }
+}

--- a/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
@@ -93,6 +93,10 @@ public abstract partial class FlowViewModel(
 
     private CancellationTokenSource? _cts;
 
+    /// <summary>The bundled CLI path, for subclasses that spawn beyond
+    /// <see cref="RunCliAsync"/> (null when the CLI is missing).</summary>
+    protected string? CliPath => cliPath;
+
     /// <summary>Fails fast when the bundled CLI is missing.</summary>
     protected bool EnsureCli()
     {
@@ -200,8 +204,14 @@ public abstract partial class FlowViewModel(
     private void Cancel() => _cts?.Cancel();
 
     [RelayCommand]
-    private void OpenOutput(string path) =>
+    private Task OpenOutput(string path) => OpenOutputCoreAsync(path);
+
+    /// <summary>Opens one Done-screen output; subclasses may redirect.</summary>
+    protected virtual Task OpenOutputCoreAsync(string path)
+    {
         Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+        return Task.CompletedTask;
+    }
 
     [RelayCommand]
     private void GoHome() => goHome();

--- a/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
@@ -12,6 +12,11 @@ public partial class MainViewModel : ViewModelBase
     [ObservableProperty]
     public partial ViewModelBase CurrentPage { get; set; }
 
+    // App-lifetime map server pool: revisiting "Make a map" reuses running
+    // servers. No dispose hook needed — each server child exits when its
+    // stdin pipe closes, i.e. when this process ends (MapServer docs).
+    private readonly MapServer _mapServer = new();
+
     public MainViewModel()
     {
         CurrentPage = new HomeViewModel(StartTask);
@@ -22,7 +27,7 @@ public partial class MainViewModel : ViewModelBase
         CurrentPage = kind switch
         {
             TaskKind.MakeMap => new MakeMapViewModel(
-                CliLocator.Find(), new DjiEmbedRunner(), GoHome),
+                CliLocator.Find(), new DjiEmbedRunner(), _mapServer, GoHome),
             TaskKind.EmbedTelemetry => new EmbedTelemetryViewModel(
                 CliLocator.Find(), new DjiEmbedRunner(), GoHome),
             TaskKind.CheckSetup => new CheckSetupViewModel(

--- a/gui/DjiEmbed.Gui/ViewModels/MakeMapViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MakeMapViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using DjiEmbed.Gui.Services;
@@ -11,8 +12,8 @@ namespace DjiEmbed.Gui.ViewModels;
 /// through the bundled CLI and collects the map files it names.
 /// </summary>
 public partial class MakeMapViewModel(
-    string? cliPath, DjiEmbedRunner runner, Action goHome)
-    : FlowViewModel(cliPath, runner, goHome)
+    string? cli, DjiEmbedRunner runner, MapServer mapServer, Action goHome)
+    : FlowViewModel(cli, runner, goHome)
 {
     protected override string GenericFailureMessage =>
         "Something went wrong while making the map.";
@@ -39,12 +40,37 @@ public partial class MakeMapViewModel(
             {
                 return false;
             }
+            // --link-originals: the map is written inside the mapped folder,
+            // so the relative links are stable there — and they are what
+            // powers the embedded 360° panorama viewer (#305).
             if (contents.HasPhotos && !await RunStepAsync(
-                    "Mapping your photos…", ["photomap", folder, "-r"]))
+                    "Mapping your photos…",
+                    ["photomap", folder, "-r", "--link-originals"]))
             {
                 return false;
             }
             return true;
         });
+    }
+
+    /// <summary>
+    /// HTML maps open through a managed local server instead of file://,
+    /// which blocks the 360° panorama viewer (#305). A server that fails
+    /// to start falls back to the plain file open — the map minus the
+    /// pano viewer, never nothing.
+    /// </summary>
+    protected override async Task OpenOutputCoreAsync(string path)
+    {
+        if (CliPath is not null
+            && path.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
+        {
+            var url = await mapServer.GetUrlAsync(CliPath, path);
+            if (url is not null)
+            {
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+                return;
+            }
+        }
+        await base.OpenOutputCoreAsync(path);
     }
 }

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -882,6 +882,63 @@ def flightmap(
         )
 
 
+@main.command()
+@click.argument("directory", type=click.Path(exists=True, file_okay=False))
+@click.option(
+    "--page", default="photomap.html", show_default=True, metavar="FILE",
+    help="Map file to open, relative to DIRECTORY.",
+)
+@click.option(
+    "--no-browser", is_flag=True,
+    help="Do not open the browser; just print the URL and serve.",
+)
+@click.option(
+    "--url-only", is_flag=True,
+    help="Print the bare URL as the first output line — a stable contract "
+         "for wrapper apps that parse it.",
+)
+@click.option(
+    "--exit-with-stdin", is_flag=True,
+    help="Stop serving when stdin closes, tying the server's lifetime to "
+         "the app that started it.",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Log each HTTP request")
+@click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
+def serve(
+    directory: str,
+    page: str,
+    no_browser: bool,
+    url_only: bool,
+    exit_with_stdin: bool,
+    verbose: bool,
+    quiet: bool,
+) -> None:
+    """Serve a generated map folder at a private local address (this computer only).
+
+    Maps open fine straight from disk except the 360° panorama viewer,
+    which browsers block on file:// pages; serving over local HTTP
+    (http://127.0.0.1, loopback only) unblocks it. Serves DIRECTORY until
+    Ctrl+C. Equivalent to the server behind 'photomap --serve', without
+    rebuilding the map first.
+    """
+    setup_logging(verbose, quiet)
+    src = Path(directory)
+    if not (src / page).is_file():
+        raise click.ClickException(
+            f"{page} not found in {src} — run 'dji-embed photomap' or "
+            "'dji-embed flightmap' first, or point --page at the map file"
+        )
+    serve_directory(
+        src,
+        page,
+        quiet=quiet,
+        log_requests=verbose,
+        open_browser=not no_browser,
+        bare_url=url_only,
+        stop_on_stdin_eof=exit_with_stdin,
+    )
+
+
 @main.command(hidden=True)
 @click.argument(
     "paths",

--- a/src/dji_metadata_embedder/geo/serve.py
+++ b/src/dji_metadata_embedder/geo/serve.py
@@ -7,6 +7,8 @@ This module is the loopback-only server behind ``dji-embed photomap --serve``.
 
 from __future__ import annotations
 
+import sys
+import threading
 import webbrowser
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -35,6 +37,21 @@ def _make_server(directory: Path, *, log_requests: bool = False) -> ThreadingHTT
     return server
 
 
+def _shutdown_on_stdin_eof(httpd: ThreadingHTTPServer) -> None:
+    """Block until stdin reaches EOF, then stop the server.
+
+    A wrapper app (the desktop GUI) holds the child's stdin pipe open for
+    the child's lifetime; when the wrapper exits — cleanly or not — the pipe
+    closes and the server goes down with it, so no orphaned server can
+    outlive the app that started it.
+    """
+    try:
+        sys.stdin.buffer.read()
+    except (OSError, ValueError):
+        pass
+    httpd.shutdown()
+
+
 def serve_directory(
     directory: Path,
     filename: str,
@@ -42,15 +59,33 @@ def serve_directory(
     quiet: bool = False,
     log_requests: bool = False,
     open_browser: bool = True,
+    bare_url: bool = False,
+    stop_on_stdin_eof: bool = False,
 ) -> None:
-    """Serve *directory* until Ctrl+C, opening *filename* in the browser."""
+    """Serve *directory* until Ctrl+C, opening *filename* in the browser.
+
+    ``bare_url`` prints the URL alone as the first stdout line — the stable
+    contract wrapper apps parse (dji-embed serve --url-only). Flushed
+    explicitly: under a pipe, stdout is block-buffered and the wrapper
+    needs the line before the server settles in to run forever.
+    ``stop_on_stdin_eof`` additionally stops serving when stdin closes
+    (see :func:`_shutdown_on_stdin_eof`).
+    """
     with _make_server(directory, log_requests=log_requests) as httpd:
         port = httpd.server_address[1]
         url = f"http://127.0.0.1:{port}/{filename}"
         # The URL is the product of the command: printed even under --quiet.
-        click.echo(f"Serving map at {url} — press Ctrl+C to stop")
+        if bare_url:
+            click.echo(url)
+            sys.stdout.flush()
+        else:
+            click.echo(f"Serving map at {url} — press Ctrl+C to stop")
         if open_browser:
             webbrowser.open(url)
+        if stop_on_stdin_eof:
+            threading.Thread(
+                target=_shutdown_on_stdin_eof, args=(httpd,), daemon=True
+            ).start()
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -1,0 +1,48 @@
+from click.testing import CliRunner
+
+from dji_metadata_embedder import cli as cli_mod
+from dji_metadata_embedder.cli import main
+
+
+def test_serve_missing_page_is_clean_error(tmp_path):
+    res = CliRunner().invoke(main, ["serve", str(tmp_path)])
+    assert res.exit_code != 0
+    assert "photomap.html not found" in res.output
+    assert "--page" in res.output
+
+
+def test_serve_defaults(tmp_path, monkeypatch):
+    (tmp_path / "photomap.html").write_text("<p>map</p>", encoding="utf-8")
+    seen: dict = {}
+
+    def fake_serve(directory, page, **kwargs):
+        seen["page"] = page
+        seen.update(kwargs)
+
+    monkeypatch.setattr(cli_mod, "serve_directory", fake_serve)
+    res = CliRunner().invoke(main, ["serve", str(tmp_path)])
+    assert res.exit_code == 0, res.output
+    assert seen["page"] == "photomap.html"
+    assert seen["open_browser"] is True
+    assert seen["bare_url"] is False
+    assert seen["stop_on_stdin_eof"] is False
+
+
+def test_serve_wrapper_flags_pass_through(tmp_path, monkeypatch):
+    (tmp_path / "flightmap.html").write_text("<p>map</p>", encoding="utf-8")
+    seen: dict = {}
+
+    def fake_serve(directory, page, **kwargs):
+        seen["page"] = page
+        seen.update(kwargs)
+
+    monkeypatch.setattr(cli_mod, "serve_directory", fake_serve)
+    res = CliRunner().invoke(main, [
+        "serve", str(tmp_path), "--page", "flightmap.html",
+        "--no-browser", "--url-only", "--exit-with-stdin",
+    ])
+    assert res.exit_code == 0, res.output
+    assert seen["page"] == "flightmap.html"
+    assert seen["open_browser"] is False
+    assert seen["bare_url"] is True
+    assert seen["stop_on_stdin_eof"] is True

--- a/tests/test_geo_serve.py
+++ b/tests/test_geo_serve.py
@@ -107,3 +107,50 @@ def test_serve_directory_open_browser_false_and_quiet(tmp_path, monkeypatch, cap
     assert "http://127.0.0.1:" in out
     assert "Stopped." not in out
     assert opened == []
+
+
+# Wrapper contract (#305): --url-only / --exit-with-stdin let the desktop
+# GUI manage a server child whose lifetime is tied to the app.
+
+
+def test_serve_directory_bare_url_prints_only_the_url_first(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(webbrowser, "open", lambda url: True)
+
+    def fake_serve_forever(self, poll_interval=0.5):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(ThreadingHTTPServer, "serve_forever", fake_serve_forever)
+    serve_directory(
+        _fixture_dir(tmp_path), "photomap.html",
+        quiet=True, open_browser=False, bare_url=True,
+    )
+    first = capsys.readouterr().out.splitlines()[0]
+    assert first.startswith("http://127.0.0.1:")
+    assert first.endswith("/photomap.html")
+
+
+def test_serve_directory_stops_when_stdin_closes(tmp_path, monkeypatch):
+    import io
+    import sys
+
+    # Simulated wrapper exit: stdin already at EOF must take the server down
+    # without any signal or kill.
+    class _ClosedStdin:
+        buffer = io.BytesIO(b"")
+
+    monkeypatch.setattr(sys, "stdin", _ClosedStdin())
+    monkeypatch.setattr(webbrowser, "open", lambda url: True)
+    done = threading.Event()
+
+    def run():
+        serve_directory(
+            _fixture_dir(tmp_path), "photomap.html",
+            quiet=True, open_browser=False, stop_on_stdin_eof=True,
+        )
+        done.set()
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    assert done.wait(timeout=10), "server did not stop on stdin EOF"


### PR DESCRIPTION
Fixes #305 — GUI-made photomaps showed photospheres as flat stills because (1) the GUI never passed `--link-originals` (the 360° viewer is link-gated) and (2) it opened maps from `file://`, where browsers block Pannellum's WebGL image access.

**Design decision** (issue listed three directions; flagging for veto): kept the GUI a thin frontend by giving the CLI a managed serve contract instead of embedding a server in the app.

## CLI
- New `dji-embed serve DIRECTORY [--page FILE]` — serves an existing map folder at `127.0.0.1:<random port>` without rebuilding (same server as `photomap --serve`). Friendly error when the page is missing.
- Wrapper flags: `--no-browser`, `--url-only` (bare URL as the first stdout line, explicitly flushed for pipes), `--exit-with-stdin` (a daemon thread reads stdin to EOF, then shuts the server down).

## GUI
- `MakeMapViewModel` passes `--link-originals` (the map lives inside the mapped folder, so relative links are stable there).
- New `MapServer` service: one `serve` child per folder, reused across opens; parses the URL line with a 10 s timeout; falls back to the plain file open if anything fails. Opening an HTML output now launches the browser at the served URL.
- Lifetime safety needs no disposal plumbing: the GUI holds each child's stdin pipe open, so when the app exits — cleanly or crashed — the pipe closes and the server exits itself (verified E2E: `serve --exit-with-stdin < /dev/null` prints the URL and exits 0).

## Tests
- Python: serve-command defaults/pass-through/missing-page, bare-URL output, stdin-EOF shutdown (real server in a thread). 643 passed; ruff + mypy green.
- .NET: MapServer URL parse/reuse/dead-server-replacement/non-URL fallback/unstartable CLI; `--link-originals` asserted via a new argv-recording FakeCli. 82 passed.

Docs: geospatial.md (`serve` section) + HELP.md (360° troubleshooting now mentions the app does this automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnWu4rkYn3gx1FefG1sLH5