### PR TITLE
feat(winget): manifest set + workflow support for the desktop installer package

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -13,6 +13,14 @@ on:
         description: 'Version to submit to winget (e.g., 1.2.0)'
         required: true
         type: string
+      package:
+        description: 'Which package to submit (#307): the portable CLI or the desktop installer'
+        required: true
+        type: choice
+        options:
+          - cli
+          - desktop
+        default: cli
 
 permissions:
   contents: read
@@ -59,42 +67,54 @@ jobs:
             $version = (uv run python -c "import sys; sys.path.insert(0, 'src'); from dji_metadata_embedder import __version__; print(__version__)")
             $tag = "v$version"
           }
+          # Two package sets share this workflow (#307): the portable CLI EXE
+          # and the desktop Inno installer. Same flow, different manifest
+          # directory and release asset.
+          if ('${{ inputs.package }}' -eq 'desktop') {
+            $packageId = 'CallMarcus.DJIMetadataEmbedder.Desktop'
+            $manifestSrc = 'winget/desktop'
+            $asset = "dji-metadata-embedder-setup-$version.exe"
+          } else {
+            $packageId = 'CallMarcus.DJIMetadataEmbedder'
+            $manifestSrc = 'winget'
+            $asset = 'dji-embed.exe'
+          }
           $url = "https://github.com/${{ github.repository }}/releases/download/$tag/"
           Write-Host "Submitting to winget with version: $version"
           Write-Host "URL: $url"
-          Write-Host "Package ID: CallMarcus.DJIMetadataEmbedder"
-          
+          Write-Host "Package ID: $packageId"
+
           # First verify the release exists and get the actual hash
-          $exeUrl = "${url}dji-embed.exe"
-          Write-Host "Checking EXE URL: $exeUrl"
-          
+          $exeUrl = "${url}${asset}"
+          Write-Host "Checking asset URL: $exeUrl"
+
           try {
             $response = Invoke-WebRequest -Uri $exeUrl -Method Head
-            Write-Host "EXE exists: HTTP $($response.StatusCode)"
+            Write-Host "Asset exists: HTTP $($response.StatusCode)"
           } catch {
-            Write-Host "ERROR: EXE not found at $exeUrl"
-            throw "Release assets not found. Make sure the GitHub release exists with dji-embed.exe"
+            Write-Host "ERROR: asset not found at $exeUrl"
+            throw "Release assets not found. Make sure the GitHub release exists with $asset"
           }
-          
+
           # Download and calculate actual hash
-          Invoke-WebRequest -Uri $exeUrl -OutFile "temp-dji-embed.exe"
-          $actualHash = Get-FileHash "temp-dji-embed.exe" -Algorithm SHA256
-          Write-Host "Actual EXE hash: $($actualHash.Hash)"
-          
+          Invoke-WebRequest -Uri $exeUrl -OutFile "temp-asset.bin"
+          $actualHash = Get-FileHash "temp-asset.bin" -Algorithm SHA256
+          Write-Host "Actual asset hash: $($actualHash.Hash)"
+
           # Inject the real installer hash. The InstallerUrl version is already
           # kept current by tools/sync_version.py at release-prep time.
-          $installerManifest = Get-Content "winget/CallMarcus.DJIMetadataEmbedder.installer.yaml" -Raw
+          $installerManifest = Get-Content "$manifestSrc/$packageId.installer.yaml" -Raw
           $installerManifest = $installerManifest -replace "PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE", $actualHash.Hash
-          Set-Content "winget/CallMarcus.DJIMetadataEmbedder.installer.yaml" $installerManifest
+          Set-Content "$manifestSrc/$packageId.installer.yaml" $installerManifest
 
           # wingetcreate submit takes a SINGLE directory containing exactly the
           # manifest set. winget/ also holds README.md, so stage the three
           # manifests in a clean directory and submit that.
           $manifestDir = Join-Path $env:RUNNER_TEMP "winget-manifests"
           New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
-          Copy-Item "winget/CallMarcus.DJIMetadataEmbedder.yaml" $manifestDir
-          Copy-Item "winget/CallMarcus.DJIMetadataEmbedder.installer.yaml" $manifestDir
-          Copy-Item "winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml" $manifestDir
+          Copy-Item "$manifestSrc/$packageId.yaml" $manifestDir
+          Copy-Item "$manifestSrc/$packageId.installer.yaml" $manifestDir
+          Copy-Item "$manifestSrc/$packageId.locale.en-US.yaml" $manifestDir
 
           # Submit the prepared manifest directory
           try {

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -137,14 +137,22 @@ def _update_targets(version: str, root: Path) -> None:
             # current version so the manifest never ships stale release notes.
             _replace_in_file(manifest, r"(releases/tag/v)(?P<ver>\d+\.\d+\.\d+)", rf"\g<1>{version}")
 
-        # Update installer URL version references in installer manifest
-        installer_files = list(winget_dir.glob("*.installer.yaml")) + list(winget_dir.glob("*.installer.yml"))
+        # Update installer URL version references in installer manifests
+        # (rglob: the desktop package set lives in winget/desktop/)
+        installer_files = list(winget_dir.rglob("*.installer.yaml")) + list(winget_dir.rglob("*.installer.yml"))
         for installer_file in installer_files:
             # Update download URLs that contain version numbers
             _replace_in_file(
-                installer_file, 
-                r"(https://github\.com/[^/]+/[^/]+/releases/download/v)(?P<ver>\d+\.\d+\.\d+)/", 
+                installer_file,
+                r"(https://github\.com/[^/]+/[^/]+/releases/download/v)(?P<ver>\d+\.\d+\.\d+)/",
                 rf"\g<1>{version}/"
+            )
+            # The desktop installer asset carries the version in its
+            # filename too (dji-metadata-embedder-setup-X.Y.Z.exe)
+            _replace_in_file(
+                installer_file,
+                r"(dji-metadata-embedder-setup-)(?P<ver>\d+\.\d+\.\d+)(\.exe)",
+                rf"\g<1>{version}\g<3>",
             )
 
 
@@ -190,6 +198,9 @@ def _check_targets(version: str, root: Path) -> bool:
             if ".installer." in manifest.name:
                 url_match = re.search(r"https://github\.com/[^/]+/[^/]+/releases/download/v(?P<ver>\d+\.\d+\.\d+)/", text)
                 if url_match and url_match.group("ver") != version:
+                    mismatches.append(manifest)
+                setup_match = re.search(r"dji-metadata-embedder-setup-(?P<ver>\d+\.\d+\.\d+)\.exe", text)
+                if setup_match and setup_match.group("ver") != version:
                     mismatches.append(manifest)
 
     if mismatches:

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -41,6 +41,9 @@ ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/relea
 PurchaseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder
 InstallationNotes: |
   After installation, run 'dji-embed doctor' to verify dependencies are installed.
+
+  Note: the desktop app package (CallMarcus.DJIMetadataEmbedder.Desktop)
+  also installs the dji-embed command - install one or the other, not both.
   
   The tool requires FFmpeg to be available in your PATH. Use the bootstrap installer for automatic setup:
   iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedder/master/tools/bootstrap.ps1 | iex

--- a/winget/README.md
+++ b/winget/README.md
@@ -4,9 +4,18 @@ This directory contains Windows Package Manager (winget) manifest files for the 
 
 ## 📦 Manifest Files
 
-- **`CallMarcus.DJIMetadataEmbedder.yaml`** - Version manifest (main entry point)
-- **`CallMarcus.DJIMetadataEmbedder.installer.yaml`** - Installer configuration
-- **`CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml`** - Localized package information
+Two package sets live here (#307):
+
+- **`CallMarcus.DJIMetadataEmbedder`** (this directory) — the ~13 MB portable
+  CLI EXE. `.yaml` version manifest, `.installer.yaml` configuration,
+  `.locale.en-US.yaml` package information.
+- **`CallMarcus.DJIMetadataEmbedder.Desktop`** (`desktop/`) — the full desktop
+  app installer (GUI + bundled FFmpeg/ExifTool, Inno Setup, per-user). Same
+  three-file structure. Kept as a **separate ID** so portable-CLI users are
+  never force-upgraded onto a ~127 MB installer.
+
+Both put `dji-embed` on PATH — the descriptions tell users to install one or
+the other.
 
 ## 🔄 Version Synchronization
 
@@ -58,8 +67,13 @@ Winget submission is **manual**. The `release-winget.yml` workflow is
 with `dji-embed.exe` exists, trigger it by hand:
 
 ```bash
-gh workflow run release-winget.yml -f version=1.11.0
+gh workflow run release-winget.yml -f version=1.11.0                    # portable CLI
+gh workflow run release-winget.yml -f version=1.11.0 -f package=desktop # desktop installer
 ```
+
+The desktop package should only be submitted for releases whose installer is
+code-signed (v1.23.0+): an unsigned 127 MB installer is maximum surface for
+the Defender false-positive class that stalled winget-pkgs#402067.
 
 When run, the workflow:
 

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
+PackageVersion: 1.22.0
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallerType: inno
+Scope: user
+UpgradeBehavior: install
+AppsAndFeaturesEntries:
+# Inno ARP key = AppId + "_is1"; the AppId is pinned never-change in
+# installer/DjiMetadataEmbedder.iss, so upgrades always find the install.
+- ProductCode: '{A0F2FECD-3BEB-4832-9BC6-4A57B20ED947}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v1.22.0/dji-metadata-embedder-setup-1.22.0.exe
+  InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
+PackageVersion: 1.22.0
+PackageLocale: en-US
+Publisher: CallMarcus
+PublisherUrl: https://github.com/CallMarcus
+PublisherSupportUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/issues
+Author: CallMarcus
+PackageName: DJI Metadata Embedder Desktop
+PackageUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder
+License: MIT
+LicenseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/LICENSE
+Copyright: Copyright (c) 2024 CallMarcus
+CopyrightUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/LICENSE
+ShortDescription: Desktop app to map DJI drone footage and embed flight telemetry into videos
+Description: |
+  Desktop application for DJI drone footage: drag a folder in and get
+  interactive maps of your flights and photos (including a 360-degree
+  panorama viewer), or embed the flight telemetry from DJI .SRT logs into
+  the video files so photo apps can sort and place them.
+
+  This installer bundles everything the app needs (FFmpeg, ExifTool, the
+  dji-embed command-line engine) and installs per-user with no admin
+  rights required.
+
+  Note: this package also puts the dji-embed command on PATH. Install
+  either this desktop package or the portable CLI package
+  (CallMarcus.DJIMetadataEmbedder) - not both.
+Tags:
+- dji
+- drone
+- metadata
+- telemetry
+- gps
+- video
+- map
+- panorama
+- gui
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v1.22.0
+InstallationNotes: |
+  Start the app from the Start menu ("DJI Metadata Embedder"). The
+  dji-embed command is also available in new terminals.
+Documentations:
+- DocumentLabel: Help
+  DocumentUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/HELP.md
+- DocumentLabel: Troubleshooting
+  DocumentUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/docs/troubleshooting.md
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
+PackageVersion: 1.22.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Prep for #307 — everything needed so that right after the first signed release (v1.23.0), the desktop installer can be submitted with one dispatch:

```
gh workflow run release-winget.yml -f version=1.23.0 -f package=desktop
```

- **`winget/desktop/`**: `CallMarcus.DJIMetadataEmbedder.Desktop` manifest set (version/installer/locale). `InstallerType: inno`, `Scope: user`, `AppsAndFeaturesEntries.ProductCode` pinned to the never-change Inno AppId + `_is1` so upgrade detection matches ARP. Separate package ID per the issue: portable-CLI users are never force-upgraded onto the ~127 MB installer.
- **`release-winget.yml`**: new `package` dispatch input (choice `cli`/`desktop`, default `cli`) selects manifest directory + release asset; hash injection and staging logic now parameterized, CLI path behavior unchanged.
- **`sync_version.py`**: installer-URL updates now use `rglob` (they missed `winget/desktop/`), and the desktop asset's *filename* version (`dji-metadata-embedder-setup-X.Y.Z.exe`) is bumped and `--check`ed too — verified with a full 9.9.9 round-trip dry run.
- Cross-notes in both locale manifests ("install one or the other — both put dji-embed on PATH") and a winget/README.md section including the signed-releases-only rule for the desktop package.

Not in this PR: the actual first submission (needs the v1.23.0 signed installer asset to exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnWu4rkYn3gx1FefG1sLH5