### PR TITLE
feat(gui): CLI discovery screen — a soft landing into the dji-embed command line

### DIFF
--- a/docs/superpowers/specs/2026-07-14-desktop-gui-design.md
+++ b/docs/superpowers/specs/2026-07-14-desktop-gui-design.md
@@ -53,6 +53,9 @@ with a trillion features in irrational navigation paths.
 3. **The escape hatch is a sentence, not a pane.** Power users are pointed at
    the CLI in a footer line ("Need more control? `dji-embed --help`"). "Can the
    GUI also do X?" is answered with documentation, not another checkbox.
+   *Amended 2026-07-17 (#293): the footer sentence became a link to a
+   read-only CLI discovery screen — curated examples, a shell-launch button,
+   the live `--help` output. Still no fourth task card, no settings.*
 
 ## Architecture
 

--- a/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
@@ -1,0 +1,83 @@
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class CliDiscoveryViewModelTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-clidisc-").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    [Fact]
+    public void Starter_commands_all_run_dji_embed()
+    {
+        var vm = new CliDiscoveryViewModel(null, () => { });
+        Assert.NotEmpty(vm.StarterCommands);
+        Assert.All(vm.StarterCommands, c =>
+        {
+            Assert.StartsWith("dji-embed", c.Command);
+            Assert.False(string.IsNullOrWhiteSpace(c.Description));
+        });
+    }
+
+    [Fact]
+    public async Task Load_help_captures_the_cli_help_output()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+            ["Usage: dji-embed [OPTIONS] COMMAND", "  photomap  Map photos"]);
+        var vm = new CliDiscoveryViewModel(cli, () => { });
+
+        await vm.LoadHelpCommand.ExecuteAsync(null);
+
+        Assert.Contains("Usage: dji-embed", vm.HelpText);
+        Assert.Contains("photomap", vm.HelpText);
+    }
+
+    [Fact]
+    public async Task Expanding_triggers_the_help_load()
+    {
+        var cli = FakeCli.WriteEventStream(_dir, ["Usage: dji-embed"]);
+        var vm = new CliDiscoveryViewModel(cli, () => { });
+
+        vm.HelpExpanded = true;
+
+        // The expander load is fire-and-forget; wait for it to land.
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (vm.HelpText is null && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
+        Assert.Contains("Usage: dji-embed", vm.HelpText);
+    }
+
+    [Fact]
+    public async Task Help_is_loaded_only_once()
+    {
+        var argsFile = Path.Combine(_dir, "args.txt");
+        var cli = FakeCli.WriteArgsRecorder(_dir, argsFile, ["Usage: x"]);
+        var vm = new CliDiscoveryViewModel(cli, () => { });
+
+        await vm.LoadHelpCommand.ExecuteAsync(null);
+        await vm.LoadHelpCommand.ExecuteAsync(null);
+
+        Assert.Single(File.ReadAllLines(argsFile));
+    }
+
+    [Fact]
+    public async Task Missing_cli_shows_the_reinstall_message()
+    {
+        var vm = new CliDiscoveryViewModel(null, () => { });
+        await vm.LoadHelpCommand.ExecuteAsync(null);
+        Assert.Contains("could not be found", vm.HelpText);
+    }
+
+    [Fact]
+    public async Task Broken_cli_shows_the_manual_fallback()
+    {
+        var cli = FakeCli.WriteEventStream(_dir, ["boom"], exitCode: 2);
+        var vm = new CliDiscoveryViewModel(cli, () => { });
+        await vm.LoadHelpCommand.ExecuteAsync(null);
+        Assert.Contains("dji-embed --help", vm.HelpText);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/HomeScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/HomeScreenTests.cs
@@ -8,8 +8,9 @@ using DjiEmbed.Gui.Views;
 namespace DjiEmbed.Gui.Tests;
 
 // The home screen is the anti-bloat contract made testable (design spec
-// 2026-07-14): exactly three task cards, one question, a CLI escape-hatch
-// footer — no menu bar, no tabs, no settings.
+// 2026-07-14, amended by #293): exactly three task cards, one question,
+// and a footer link to the CLI discovery screen — no menu bar, no tabs,
+// no settings, no fourth card.
 public class HomeScreenTests
 {
     private static MainWindow ShowMainWindow()
@@ -33,7 +34,9 @@ public class HomeScreenTests
     {
         var window = ShowMainWindow();
         var buttons = window.GetVisualDescendants().OfType<Button>().ToList();
-        Assert.Equal(3, buttons.Count);
+        // Three cards plus the footer link — nothing else is clickable.
+        Assert.Equal(3, buttons.Count(b => b.Classes.Contains("card")));
+        Assert.Equal(4, buttons.Count);
         var texts = window.GetVisualDescendants()
             .OfType<TextBlock>().Select(t => t.Text).ToList();
         Assert.Contains("Make a map", texts);
@@ -42,12 +45,14 @@ public class HomeScreenTests
     }
 
     [AvaloniaFact]
-    public void Home_screen_has_cli_escape_hatch_footer()
+    public void Home_screen_has_cli_escape_hatch_footer_link()
     {
         var window = ShowMainWindow();
-        var texts = window.GetVisualDescendants()
-            .OfType<TextBlock>().Select(t => t.Text ?? "").ToList();
-        Assert.Contains(texts, t => t.Contains("dji-embed"));
+        var link = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Classes.Contains("footerLink"));
+        var text = string.Join(" ", link.GetVisualDescendants()
+            .OfType<TextBlock>().Select(t => t.Text ?? ""));
+        Assert.Contains("dji-embed", text);
     }
 
     [AvaloniaFact]

--- a/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
@@ -61,6 +61,35 @@ public class NavigationTests
     }
 
     [AvaloniaFact]
+    public void Footer_link_navigates_to_the_cli_discovery_screen()
+    {
+        var window = new MainWindow { DataContext = new MainViewModel() };
+        window.Show();
+
+        var link = window.GetVisualDescendants().OfType<Button>()
+            .First(b => b.Classes.Contains("footerLink"));
+        link.Focus();
+        window.KeyPressQwerty(Avalonia.Input.PhysicalKey.Enter,
+            Avalonia.Input.RawInputModifiers.None);
+
+        Assert.NotNull(window.GetVisualDescendants()
+            .OfType<CliDiscoveryView>().FirstOrDefault());
+    }
+
+    [AvaloniaFact]
+    public void Cli_discovery_back_button_returns_home()
+    {
+        var main = new MainViewModel();
+        var window = new MainWindow { DataContext = main };
+        window.Show();
+        main.StartTask(TaskKind.CliDiscovery);
+
+        var vm = Assert.IsType<CliDiscoveryViewModel>(main.CurrentPage);
+        vm.GoHomeCommand.Execute(null);
+        Assert.IsType<HomeViewModel>(main.CurrentPage);
+    }
+
+    [AvaloniaFact]
     public void Map_flow_back_button_returns_home()
     {
         var main = new MainViewModel();

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -103,6 +103,10 @@ public class ScreenshotCaptureTests
         }
         Capture(failedWindow, Png("embed-failed-details"));
 
+        var discovery = new CliDiscoveryViewModel(null, NoOp());
+        CaptureView(new CliDiscoveryView { DataContext = discovery },
+            Png("cli-discovery"));
+
         var setup = new CheckSetupViewModel(null, new DjiEmbedRunner(), NoOp());
         setup.Step = FlowStep.Done;
         setup.AllGood = true;

--- a/gui/DjiEmbed.Gui.Tests/TerminalLauncherTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/TerminalLauncherTests.cs
@@ -1,0 +1,36 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class TerminalLauncherTests
+{
+    [Fact]
+    public void Prefers_windows_terminal_then_falls_back_to_powershell()
+    {
+        var candidates = TerminalLauncher.Candidates(@"C:\Users\demo");
+
+        Assert.Equal(2, candidates.Count);
+        Assert.Equal("wt.exe", candidates[0].FileName);
+        Assert.Equal("powershell.exe", candidates[1].FileName);
+    }
+
+    [Fact]
+    public void Every_candidate_stays_open_and_proves_the_cli_works()
+    {
+        foreach (var psi in TerminalLauncher.Candidates(@"C:\Users\demo"))
+        {
+            Assert.Contains("-NoExit", psi.ArgumentList);
+            Assert.Contains("dji-embed --help", psi.ArgumentList);
+            Assert.Equal(@"C:\Users\demo", psi.WorkingDirectory);
+        }
+    }
+
+    [Fact]
+    public void Windows_terminal_opens_in_the_requested_folder()
+    {
+        var wt = TerminalLauncher.Candidates(@"C:\Users\demo")[0];
+        var args = wt.ArgumentList.ToList();
+        var d = args.IndexOf("-d");
+        Assert.True(d >= 0 && args[d + 1] == @"C:\Users\demo");
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
+++ b/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// Launches an interactive shell that lands the user on proof the CLI
+/// works (#293): Windows Terminal when installed, classic PowerShell
+/// otherwise, pre-running "dji-embed --help" so the first thing they see
+/// is output, not a blank prompt.
+/// </summary>
+public static class TerminalLauncher
+{
+    private const string ProofCommand = "dji-embed --help";
+
+    /// <summary>
+    /// Candidate launches, best first. Pure so tests can assert the exact
+    /// invocations without spawning shells.
+    /// </summary>
+    public static IReadOnlyList<ProcessStartInfo> Candidates(
+        string workingDirectory)
+    {
+        // wt.exe resolves through the App Execution Alias when Windows
+        // Terminal is installed; a missing alias throws at Start and the
+        // loop falls through to powershell.exe.
+        var wt = new ProcessStartInfo("wt.exe")
+        {
+            UseShellExecute = true,
+            WorkingDirectory = workingDirectory,
+        };
+        wt.ArgumentList.Add("-d");
+        wt.ArgumentList.Add(workingDirectory);
+        wt.ArgumentList.Add("powershell");
+        wt.ArgumentList.Add("-NoExit");
+        wt.ArgumentList.Add("-Command");
+        wt.ArgumentList.Add(ProofCommand);
+
+        var ps = new ProcessStartInfo("powershell.exe")
+        {
+            UseShellExecute = true,
+            WorkingDirectory = workingDirectory,
+        };
+        ps.ArgumentList.Add("-NoExit");
+        ps.ArgumentList.Add("-Command");
+        ps.ArgumentList.Add(ProofCommand);
+
+        return [wt, ps];
+    }
+
+    /// <summary>Tries each candidate in order; false when none started.</summary>
+    public static bool Launch()
+    {
+        var home = Environment.GetFolderPath(
+            Environment.SpecialFolder.UserProfile);
+        foreach (var psi in Candidates(home))
+        {
+            try
+            {
+                Process.Start(psi);
+                return true;
+            }
+            catch (Exception e) when (e is Win32Exception
+                or InvalidOperationException or PlatformNotSupportedException)
+            {
+                // Not installed on this machine — try the next one.
+            }
+        }
+        return false;
+    }
+}

--- a/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>One curated example command on the discovery screen.</summary>
+public sealed record StarterCommand(string Command, string Description);
+
+/// <summary>
+/// The CLI discovery screen (#293): a read-only soft landing from the app
+/// into the dji-embed command line for users who have outgrown the three
+/// task cards. One shell-launch button, curated examples, the live --help
+/// output — no settings, no new task flows (anti-bloat rules).
+/// </summary>
+public partial class CliDiscoveryViewModel(string? cliPath, Action goHome)
+    : ViewModelBase
+{
+    public const string DocsUrl =
+        "https://callmarcus.github.io/dji-drone-metadata-embedder/";
+
+    /// <summary>
+    /// Curated to show what the GUI deliberately can't do. Static strings —
+    /// the live --help expander covers completeness.
+    /// </summary>
+    public IReadOnlyList<StarterCommand> StarterCommands { get; } =
+    [
+        new(@"dji-embed convert gpx flight.SRT",
+            "Turn one flight log into a GPX track any mapping tool can read"),
+        new(@"dji-embed embed D:\Footage --redact fuzz",
+            "Embed telemetry with the GPS positions fuzzed for privacy"),
+        new(@"dji-embed validate D:\Footage",
+            "Check every video/flight-log pair for telemetry drift"),
+        new("dji-embed doctor",
+            "Full system diagnostics, beyond the app's setup check"),
+    ];
+
+    [ObservableProperty]
+    public partial string? HelpText { get; set; }
+
+    [ObservableProperty]
+    public partial bool HelpExpanded { get; set; }
+
+    private bool _helpRequested;
+
+    // Expanding the "every command" section triggers the one-time load, so
+    // nothing is spawned for users who never open it.
+    partial void OnHelpExpandedChanged(bool value)
+    {
+        if (value)
+        {
+            _ = LoadHelpAsync();
+        }
+    }
+
+    /// <summary>
+    /// Fills the expander from the bundled CLI's own --help, so new
+    /// commands appear with zero screen maintenance. DjiEmbedRunner is not
+    /// used here: it appends --progress jsonl, and --help output is plain
+    /// text, not the event contract.
+    /// </summary>
+    [RelayCommand]
+    private async Task LoadHelpAsync()
+    {
+        if (_helpRequested)
+        {
+            return;
+        }
+        _helpRequested = true;
+        if (cliPath is null)
+        {
+            HelpText = "The dji-embed engine could not be found next to "
+                + "this app. Reinstalling the application should fix this.";
+            return;
+        }
+        try
+        {
+            HelpText = await RunHelpAsync(cliPath);
+        }
+        catch (Exception)
+        {
+            HelpText = "The command list could not be loaded. Open a "
+                + "terminal and run  dji-embed --help  to see it.";
+        }
+    }
+
+    private static async Task<string> RunHelpAsync(string cliPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = cliPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
+        psi.ArgumentList.Add("--help");
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("--help did not start");
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        var stdout = await stdoutTask;
+        _ = await stderrTask;
+        if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(stdout))
+        {
+            throw new InvalidOperationException(
+                $"--help exited {process.ExitCode}");
+        }
+        return stdout.Trim();
+    }
+
+    [RelayCommand]
+    private void OpenTerminal() => TerminalLauncher.Launch();
+
+    [RelayCommand]
+    private void OpenDocs() =>
+        Process.Start(new ProcessStartInfo(DocsUrl) { UseShellExecute = true });
+
+    [RelayCommand]
+    private void GoHome() => goHome();
+}

--- a/gui/DjiEmbed.Gui/ViewModels/HomeViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/HomeViewModel.cs
@@ -8,13 +8,16 @@ public enum TaskKind
     MakeMap,
     EmbedTelemetry,
     CheckSetup,
+    CliDiscovery,
 }
 
 /// <summary>
 /// The home screen: one question, exactly three task cards, a CLI escape
 /// hatch in the footer. The anti-bloat rules in the design spec
 /// (docs/superpowers/specs/2026-07-14-desktop-gui-design.md) are binding:
-/// no menu bar, no tabs, no settings dialog.
+/// no menu bar, no tabs, no settings dialog. The footer sentence is a
+/// link to the read-only CLI discovery screen (#293) — an amendment of
+/// the escape-hatch rule, not a fourth task card.
 /// </summary>
 public partial class HomeViewModel(Action<TaskKind> onChoose) : ViewModelBase
 {
@@ -28,4 +31,7 @@ public partial class HomeViewModel(Action<TaskKind> onChoose) : ViewModelBase
 
     [RelayCommand]
     private void CheckSetup() => onChoose(TaskKind.CheckSetup);
+
+    [RelayCommand]
+    private void CliDiscovery() => onChoose(TaskKind.CliDiscovery);
 }

--- a/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
@@ -32,6 +32,8 @@ public partial class MainViewModel : ViewModelBase
                 CliLocator.Find(), new DjiEmbedRunner(), GoHome),
             TaskKind.CheckSetup => new CheckSetupViewModel(
                 CliLocator.Find(), new DjiEmbedRunner(), GoHome),
+            TaskKind.CliDiscovery => new CliDiscoveryViewModel(
+                CliLocator.Find(), GoHome),
             _ => CurrentPage,
         };
     }

--- a/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml
+++ b/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml
@@ -1,0 +1,94 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DjiEmbed.Gui.ViewModels"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="520"
+             x:Class="DjiEmbed.Gui.Views.CliDiscoveryView"
+             x:DataType="vm:CliDiscoveryViewModel">
+
+    <UserControl.Styles>
+        <Style Selector="TextBlock.mono">
+            <Setter Property="FontFamily" Value="Consolas,Menlo,monospace" />
+            <Setter Property="FontSize" Value="13" />
+        </Style>
+    </UserControl.Styles>
+
+    <DockPanel Margin="32,28">
+        <TextBlock DockPanel.Dock="Top" Text="The command line"
+                   FontSize="24" FontWeight="SemiBold" Margin="0,0,0,16" />
+
+        <Button DockPanel.Dock="Bottom" HorizontalAlignment="Center"
+                Margin="0,14,0,0" Command="{Binding GoHomeCommand}">
+            <TextBlock Text="Back" />
+        </Button>
+
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Spacing="16" Margin="0,0,12,0">
+
+                <!-- The key revelation: the CLI is already installed. -->
+                <TextBlock TextWrapping="Wrap" FontSize="14">
+                    Everything this app does — and a lot more — runs on the
+                    dji-embed command line, and it is already installed:
+                    the app's installer put it on your PATH. Open any
+                    terminal, type dji-embed, and it just works.
+                </TextBlock>
+
+                <Button HorizontalAlignment="Left"
+                        Command="{Binding OpenTerminalCommand}">
+                    <TextBlock Text="Open PowerShell and try it" />
+                </Button>
+
+                <TextBlock Text="A few things only the command line can do:"
+                           FontWeight="SemiBold" Margin="0,4,0,0" />
+
+                <ItemsControl ItemsSource="{Binding StarterCommands}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:StarterCommand">
+                            <StackPanel Margin="0,0,0,12">
+                                <DockPanel>
+                                    <Button DockPanel.Dock="Right"
+                                            VerticalAlignment="Center"
+                                            Margin="8,0,0,0"
+                                            Click="OnCopyCommandClick">
+                                        <TextBlock Text="Copy" FontSize="12" />
+                                    </Button>
+                                    <Border Background="#20808080"
+                                            CornerRadius="4" Padding="10,6">
+                                        <TextBlock Classes="mono"
+                                                   Text="{Binding Command}"
+                                                   TextWrapping="Wrap" />
+                                    </Border>
+                                </DockPanel>
+                                <TextBlock Text="{Binding Description}"
+                                           Opacity="0.7" FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Margin="2,4,0,0" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <Expander Header="Every command (live from dji-embed --help)"
+                          IsExpanded="{Binding HelpExpanded, Mode=TwoWay}">
+                    <ScrollViewer MaxHeight="220"
+                                  VerticalScrollBarVisibility="Auto">
+                        <TextBlock Classes="mono"
+                                   Text="{Binding HelpText}"
+                                   TextWrapping="Wrap" Margin="0,6" />
+                    </ScrollViewer>
+                </Expander>
+
+                <Button HorizontalAlignment="Left" Padding="0"
+                        Background="Transparent" Cursor="Hand"
+                        Command="{Binding OpenDocsCommand}">
+                    <TextBlock Text="Read the full guide online →"
+                               FontSize="13"
+                               TextDecorations="Underline" />
+                </Button>
+
+            </StackPanel>
+        </ScrollViewer>
+    </DockPanel>
+
+</UserControl>

--- a/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml.cs
@@ -1,0 +1,21 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Views;
+
+public partial class CliDiscoveryView : UserControl
+{
+    public CliDiscoveryView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnCopyCommandClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button { DataContext: StarterCommand c } button)
+        {
+            _ = ClipboardCopy.CopyAsync(button, c.Command);
+        }
+    }
+}

--- a/gui/DjiEmbed.Gui/Views/HomeView.axaml
+++ b/gui/DjiEmbed.Gui/Views/HomeView.axaml
@@ -31,6 +31,18 @@
             <Setter Property="Margin" Value="0,4,0,0" />
             <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
+        <!-- The footer link reads as a sentence, not a fourth card. -->
+        <Style Selector="Button.footerLink">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+        </Style>
+        <Style Selector="Button.footerLink:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+        </Style>
+        <Style Selector="Button.footerLink:pointerover TextBlock">
+            <Setter Property="Opacity" Value="1" />
+        </Style>
     </UserControl.Styles>
 
     <Panel>
@@ -53,11 +65,15 @@
                    Foreground="White"
                    Margin="0,0,0,24" />
 
-        <!-- The escape hatch is a sentence, not a pane. -->
-        <TextBlock DockPanel.Dock="Bottom"
-                   Text="Need more control? The dji-embed command line has every option."
-                   Foreground="White" Opacity="0.75" FontSize="12"
-                   Margin="0,20,0,0" TextWrapping="Wrap" />
+        <!-- The escape hatch is a sentence, not a pane — since #293 the
+             sentence links to the read-only CLI discovery screen. -->
+        <Button DockPanel.Dock="Bottom" Classes="footerLink"
+                HorizontalAlignment="Left" Margin="0,20,0,0"
+                Command="{Binding CliDiscoveryCommand}">
+            <TextBlock Text="Want more? Everything here runs on the dji-embed command line →"
+                       Foreground="White" Opacity="0.75" FontSize="12"
+                       TextWrapping="Wrap" TextDecorations="Underline" />
+        </Button>
 
         <StackPanel Spacing="14" VerticalAlignment="Top">
             <Button Classes="card" Command="{Binding MakeMapCommand}">


### PR DESCRIPTION
Closes #293.

The home screen's footer sentence is promoted into a **link** (not a fourth task card) that opens a new read-only screen:

- **The key revelation** — `dji-embed` is already installed and on PATH; the installer did that.
- **Four curated starter commands** with Copy buttons, chosen to show what the GUI *can't* do (`convert gpx`, `embed --redact fuzz`, `validate`, `doctor`).
- **"Open PowerShell and try it"** — launches Windows Terminal when installed (`wt.exe` via its execution alias), classic `powershell.exe` otherwise, `-NoExit` and pre-running `dji-embed --help` so the user lands on proof-it-works. Candidates are built by a pure `TerminalLauncher.Candidates()` so tests assert the exact invocations without spawning shells.
- **Live full command list** — an expander that lazily runs the bundled CLI's own `--help` once (plain process, not `DjiEmbedRunner` — the runner force-appends `--progress jsonl`, which help output isn't). Zero screen maintenance as commands are added.
- **Docs link** to the GitHub Pages site.

Contract evolution, per the issue: the headless home test now locks **exactly 3 card buttons + 1 footer link** (still asserts total button count), and the design spec's escape-hatch rule carries a dated amendment note.

One deviation from the issue text: the shell opens in the user's home folder, not the "last-used folder" — the app deliberately persists nothing (anti-bloat: no settings), and threading session state across viewmodels for a working directory didn't seem worth it. Easy to add later if it grates.

93 tests pass locally (11 new: viewmodel load/once/fallback matrix, TerminalLauncher invocations, navigation both ways, amended home contract). Screenshot tooling now captures the new screen (`cli-discovery.png`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnWu4rkYn3gx1FefG1sLH5