### PR TITLE
docs: pre-v1.23.0 release pass

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -53,8 +53,13 @@ This workflow is **not** triggered by the release tag. It only runs via
 release has completed:
 
 ```bash
-gh workflow run release-winget.yml -f version=X.Y.Z
+gh workflow run release-winget.yml -f version=X.Y.Z                    # portable CLI
+gh workflow run release-winget.yml -f version=X.Y.Z -f package=desktop # desktop installer
 ```
+
+The `desktop` run submits the separate `CallMarcus.DJIMetadataEmbedder.Desktop`
+package (manifests in `winget/desktop/`). Only submit it for releases whose
+installer is code-signed (v1.23.0+) — see `winget/README.md`.
 
 When run it will:
 1. Verify version sync using `python tools/sync_version.py --check`
@@ -116,14 +121,19 @@ The `tools/sync_version.py` script keeps version numbers consistent across:
 
 ## Winget Integration
 
-The project maintains local winget manifests in the `/winget` directory:
+The project maintains local winget manifests in the `/winget` directory —
+two package sets (see `winget/README.md`):
 
-- **Package ID**: `CallMarcus.DJIMetadataEmbedder`
-- **Moniker**: `dji-embed`
-- **Submission**: Manual via `gh workflow run release-winget.yml -f version=X.Y.Z` (not auto-triggered by the release tag)
+- **Package IDs**: `CallMarcus.DJIMetadataEmbedder` (portable CLI, moniker
+  `dji-embed`) and `CallMarcus.DJIMetadataEmbedder.Desktop` (desktop
+  installer, `winget/desktop/`, v1.23.0+ signed releases only)
+- **Submission**: Manual via `gh workflow run release-winget.yml -f version=X.Y.Z`
+  (add `-f package=desktop` for the installer; not auto-triggered by the
+  release tag)
 - **Community review**: PRs created in microsoft/winget-pkgs
 
 Users can install via:
 ```powershell
-winget install CallMarcus.DJIMetadataEmbedder
+winget install CallMarcus.DJIMetadataEmbedder          # portable CLI
+winget install CallMarcus.DJIMetadataEmbedder.Desktop  # desktop app + tools
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ Use the guides in this site to embed GPS data in your footage, redact sensitive 
 
 - [Installation](installation.md)
 - [User Guide](user_guide.md)
+- [Maps & Panoramas](geospatial.md) — photo maps, flight maps, the 360° viewer
 - [Decision Table](decision-table.md)
 - [Recipes](recipes.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,9 @@ and run it. One installer carries everything:
 - pinned FFmpeg and ExifTool builds, so nothing else needs installing.
 
 No admin rights needed — it installs per-user. The uninstaller removes the
-PATH entries again.
+PATH entries again. From v1.23.0 the installer and every binary inside it
+are Authenticode code-signed, so Windows shows a verified publisher instead
+of an "unknown publisher" warning.
 
 ### Windows – bootstrap script
 
@@ -41,6 +43,16 @@ script above, which bundles everything. For MP4 timed-metadata support you can
 also let the tool install its own pinned ExifTool: `dji-embed doctor --install
 exiftool` (any OS, no admin rights).
 
+The full desktop-app installer is also on winget as a separate package
+(from v1.23.0, appearing shortly after each release once the winget
+moderators approve it):
+
+```powershell
+winget install CallMarcus.DJIMetadataEmbedder.Desktop
+```
+
+Install one or the other — both put `dji-embed` on PATH.
+
 ### Windows – manual path
 
 ```powershell
@@ -50,9 +62,15 @@ pip install dji-drone-metadata-embedder
 ### macOS
 
 ```bash
-brew install ffmpeg exiftool
-pip install dji-drone-metadata-embedder
+brew install ffmpeg exiftool pipx
+pipx install dji-drone-metadata-embedder
 ```
+
+Homebrew's Python is [externally managed](https://peps.python.org/pep-0668/),
+so a bare `pip install` is refused with an `externally-managed-environment`
+error — `pipx` installs the tool into its own isolated environment and puts
+`dji-embed` on your PATH (run `pipx ensurepath` once if the command isn't
+found in a new terminal).
 
 ### Linux
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -568,6 +568,35 @@ grep -E "(iso|shutter|fnum)" DJI_0001.SRT | head -3
 
 ---
 
+## 🗺️ Map & Panorama Issues
+
+### 360° Panoramas Open as Flat Images
+
+**Problem:** Clicking a panorama on a `photomap` map shows a stretched flat
+photo instead of the interactive 360° viewer
+
+**Cause:** The map was opened by double-clicking the HTML file. Browsers
+block the viewer's image access on `file://` pages, so it silently falls
+back to a plain image. The map needs to come from a local web server.
+
+**Solutions:**
+```bash
+# Build and serve in one step (opens your browser)
+dji-embed photomap /path/to/photos --link-originals --serve
+
+# Or serve an already-built map folder later
+dji-embed serve /path/to/photos
+```
+
+The server binds to a private local address on your machine only — nothing
+is uploaded. The desktop app's *Make a map* task does this automatically.
+
+Panoramas need their GPano metadata intact to be detected — see
+[Maps & Panoramas](geospatial.md) before resizing or re-exporting them, as
+most editors silently strip it.
+
+---
+
 ## 🐛 Advanced Troubleshooting
 
 ### Debug Mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Home: index.md
   - Installation: installation.md
   - User Guide: user_guide.md
+  - Maps & Panoramas: geospatial.md
   - Decision Table: decision-table.md
   - Recipes: recipes.md
   - Troubleshooting: troubleshooting.md


### PR DESCRIPTION
Documentation audit ahead of cutting v1.23.0 (the first signed release, first Desktop winget submission, and the release the GUI's new CLI discovery screen links to). Four gaps found and fixed:

1. **`docs/geospatial.md` was missing from the mkdocs nav and index** — the photomap/flightmap/360°-viewer guide (the features the whole announcement leads with) was unreachable on the published site unless you had a direct URL. Now "Maps & Panoramas" in the nav.
2. **`installation.md`**: notes the Authenticode-signed installer (v1.23.0+), adds the `CallMarcus.DJIMetadataEmbedder.Desktop` winget package (with the "appears after moderator approval" caveat and the install-one-or-the-other rule), and fixes the macOS instructions — the documented `pip install` is refused by Homebrew Python's PEP 668 externally-managed-environment guard, so it now uses pipx (matching what we've recommended in community answers).
3. **`RELEASE.md`**: the winget runbook now shows both dispatch commands, including `-f package=desktop`, and the signed-releases-only rule for the desktop package.
4. **`troubleshooting.md`**: new "Map & Panorama Issues" section covering the most common community question — panoramas opening as flat images when the HTML file is double-clicked (`file://`), pointing at `--serve` / `dji-embed serve` / the desktop app, plus the GPano-stripping warning.

`uv run mkdocs build` passes clean. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnWu4rkYn3gx1FefG1sLH5