### PR TITLE
feat(flightmap): flight playback animation in the HTML viewer (#267)

### DIFF
--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -21,7 +21,7 @@ from xml.sax.saxutils import escape
 from .. import utilities
 from ..utilities import load_samples, redact_coords
 from .geometry import haversine_m
-from .track import Track, TrackPoint, build_track_from_samples
+from .track import Track, TrackPoint, _cue_seconds, build_track_from_samples
 
 logger = logging.getLogger(__name__)
 
@@ -297,27 +297,53 @@ def _flight_properties(track: Track) -> dict:
     return props
 
 
+def _relative_times(points: list[TrackPoint]) -> list[float]:
+    """Per-point seconds since the flight start, for playback (#267).
+
+    UTC datetimes are the preferred clock; if any point lacks one, the whole
+    flight falls back to SRT cue times so a single flight never mixes two
+    time bases. Clamped non-decreasing so a corrupt cue cannot run the
+    animation backwards.
+    """
+    if all(p.utc is not None for p in points):
+        base = points[0].utc
+        assert base is not None
+        raw = [(p.utc - base).total_seconds() for p in points if p.utc is not None]
+    else:
+        base_cue = _cue_seconds(points[0].timestamp)
+        raw = [_cue_seconds(p.timestamp) - base_cue for p in points]
+    times: list[float] = []
+    for t in raw:
+        t = round(t, 1)
+        times.append(max(t, times[-1]) if times else t)
+    return times
+
+
 def flights_to_geojson(tracks: list[Track]) -> dict:
     """Return a GeoJSON ``FeatureCollection`` with one feature per flight.
 
     Each flight is a ``LineString`` carrying name/start/duration/altitude
-    summary properties; a single-fix clip degrades to a ``Point`` because
-    RFC 7946 §3.1.4 requires two or more positions in a LineString. Unlike
-    the single-track exporter no per-sample Point features are emitted — at
+    summary properties plus ``times_s`` — per-point seconds relative to the
+    flight start — which drives the HTML viewer's playback animation (#267).
+    A single-fix clip degrades to a ``Point`` (RFC 7946 §3.1.4 requires two
+    or more positions in a LineString) and carries no times. Unlike the
+    single-track exporter no per-sample Point features are emitted — at
     archive scale they would swamp the map and the file.
     """
     features: list[dict] = []
     for track in tracks:
         coords = [[p.lon, p.lat, p.alt] for p in track.points]
+        properties = _flight_properties(track)
         if len(coords) >= 2:
             geometry: dict = {"type": "LineString", "coordinates": coords}
+            properties["times_s"] = _relative_times(track.points)
         else:
             geometry = {"type": "Point", "coordinates": coords[0]}
         features.append(
             {
                 "type": "Feature",
                 "geometry": geometry,
-                "properties": _flight_properties(track),
+                "properties": properties,
             }
         )
     return {"type": "FeatureCollection", "features": features}

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -42,6 +42,14 @@ _TEMPLATE = """<!DOCTYPE html>
   html, body {{ height: 100%; margin: 0; }}
   #map {{ height: 100%; }}
   .flight-popup {{ font: 13px/1.5 sans-serif; }}
+  /* Playback control (issue #267) */
+  .playback {{ background: #fff; border-radius: 4px; padding: 6px 10px;
+              box-shadow: 0 1px 5px rgba(0,0,0,.4); display: flex;
+              gap: 8px; align-items: center; font: 13px/1 sans-serif; }}
+  .playback button {{ border: none; background: none; cursor: pointer;
+                     font-size: 15px; padding: 0; }}
+  .playback input[type=range] {{ width: 140px; }}
+  .playback span {{ font-variant-numeric: tabular-nums; }}
 </style>
 </head>
 <body>
@@ -99,6 +107,7 @@ function popupHtml(p) {
 
 const overlays = {};
 const allLatLngs = [];
+const runs = [];   // playback (#267): flights with usable per-point times
 (data.features || []).forEach((f, i) => {
   if (!f.geometry) return;
   const color = PALETTE[i % PALETTE.length];
@@ -109,6 +118,11 @@ const allLatLngs = [];
     latlngs = f.geometry.coordinates.map(c => [c[1], c[0]]);
     L.polyline(latlngs, { color, weight: 3 })
       .bindPopup(popupHtml(p)).addTo(group);
+    const times = p.times_s;
+    if (Array.isArray(times) && times.length === latlngs.length &&
+        times[times.length - 1] > 0) {
+      runs.push({ latlngs, times, color, group, cursor: 0, marker: null });
+    }
   } else {                                             // single-fix clip
     const c = f.geometry.coordinates;
     latlngs = [[c[1], c[0]]];
@@ -131,6 +145,89 @@ if (allLatLngs.length > 1) {
 }
 if (Object.keys(overlays).length > 1) {
   L.control.layers(null, overlays).addTo(map);
+}
+
+// Flight playback (issue #267): a hand-rolled requestAnimationFrame animator
+// — no plugin, no new pinned assets. Every flight replays on a shared
+// relative clock (each from its own takeoff), so a folder of flights can be
+// compared side by side. The control is inert until Play is pressed; the
+// default map costs nothing extra. Each flight's dot lives in that flight's
+// layer group, so the layer control hides it together with the track.
+const maxT = Math.max(0, ...runs.map(r => r.times[r.times.length - 1]));
+if (runs.length && maxT > 0) {
+  const ctl = L.control({ position: 'bottomleft' });
+  ctl.onAdd = () => {
+    const div = L.DomUtil.create('div', 'playback');
+    div.innerHTML =
+      '<button id="pb-play" type="button" title="Play flights">&#9654;</button>' +
+      '<button id="pb-speed" type="button" title="Playback speed">1&times;</button>' +
+      `<input id="pb-slider" type="range" min="0" max="${maxT}" step="0.1" value="0">` +
+      `<span id="pb-time">0:00 / ${fmtDuration(Math.round(maxT))}</span>`;
+    L.DomEvent.disableClickPropagation(div);
+    return div;
+  };
+  ctl.addTo(map);
+  const playBtn = document.getElementById('pb-play');
+  const speedBtn = document.getElementById('pb-speed');
+  const slider = document.getElementById('pb-slider');
+  const timeEl = document.getElementById('pb-time');
+  const SPEEDS = [1, 5, 20, 60];
+  const pb = { t: 0, playing: false, speed: 1, raf: null, last: 0 };
+
+  function positionAt(run, t) {
+    const times = run.times, lls = run.latlngs;
+    if (t <= times[0]) return lls[0];
+    if (t >= times[times.length - 1]) return lls[lls.length - 1];
+    let i = run.cursor;
+    if (times[i] > t) i = 0;                       // seeked backwards
+    while (times[i + 1] < t) i++;
+    run.cursor = i;
+    const t0 = times[i], t1 = times[i + 1];
+    const f = t1 > t0 ? (t - t0) / (t1 - t0) : 1;
+    const a = lls[i], b = lls[i + 1];
+    return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f];
+  }
+  function render() {
+    for (const run of runs) {
+      const pos = positionAt(run, pb.t);
+      if (!run.marker) {
+        run.marker = L.circleMarker(pos, { radius: 7, color: '#fff', weight: 2,
+          fillColor: run.color, fillOpacity: 1 }).addTo(run.group);
+      } else run.marker.setLatLng(pos);
+    }
+    slider.value = pb.t;
+    timeEl.textContent =
+      `${fmtDuration(Math.round(pb.t))} / ${fmtDuration(Math.round(maxT))}`;
+  }
+  function pause() {
+    pb.playing = false;
+    playBtn.innerHTML = '&#9654;';
+    if (pb.raf) cancelAnimationFrame(pb.raf);
+  }
+  function tick(now) {
+    if (!pb.playing) return;
+    pb.t = Math.min(maxT, pb.t + (now - pb.last) / 1000 * pb.speed);
+    pb.last = now;
+    render();
+    if (pb.t >= maxT) { pause(); return; }
+    pb.raf = requestAnimationFrame(tick);
+  }
+  function play() {
+    if (pb.t >= maxT) pb.t = 0;
+    pb.playing = true;
+    playBtn.innerHTML = '&#10074;&#10074;';
+    pb.last = performance.now();
+    pb.raf = requestAnimationFrame(tick);
+  }
+  playBtn.addEventListener('click', () => pb.playing ? pause() : play());
+  speedBtn.addEventListener('click', () => {
+    pb.speed = SPEEDS[(SPEEDS.indexOf(pb.speed) + 1) % SPEEDS.length];
+    speedBtn.innerHTML = `${pb.speed}&times;`;
+  });
+  slider.addEventListener('input', () => {
+    pb.t = Number(slider.value);
+    render();
+  });
 }
 """
 

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -100,6 +100,46 @@ def test_flights_to_geojson_one_feature_per_flight():
     assert "start" not in point["properties"]  # no UTC -> no start/duration
 
 
+def test_flights_to_geojson_embeds_relative_times_from_utc():
+    # Playback (#267): every LineString carries times_s — per-point seconds
+    # relative to the flight start — so viewers can animate the flight.
+    line, point = flights_to_geojson(_tracks())["features"]
+    assert line["properties"]["times_s"] == [0.0, 243.0]
+    assert "times_s" not in point["properties"]  # a Point cannot animate
+
+
+def test_times_fall_back_to_cue_seconds_without_utc():
+    track = Track(name="f", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=3.0, timestamp="00:00:01,000"),
+        TrackPoint(lat=1.001, lon=2.001, alt=4.0, timestamp="00:00:03,500"),
+    ])
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert props["times_s"] == [0.0, 2.5]
+
+
+def test_times_use_cues_when_any_utc_missing():
+    # Mixed UTC availability must not mix two time bases inside one flight.
+    track = Track(name="f", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=3.0, timestamp="00:00:00,000",
+                   utc=datetime(2026, 6, 15, 12, 0, 0)),
+        TrackPoint(lat=1.001, lon=2.001, alt=4.0, timestamp="00:00:02,000"),
+    ])
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert props["times_s"] == [0.0, 2.0]
+
+
+def test_times_clamped_monotonic():
+    # A cue that jumps backwards (corrupt SRT) must not run the animation
+    # backwards; the offending sample pins to the previous time.
+    track = Track(name="f", points=[
+        TrackPoint(lat=1.0, lon=2.0, alt=3.0, timestamp="00:00:05,000"),
+        TrackPoint(lat=1.001, lon=2.001, alt=4.0, timestamp="00:00:04,000"),
+        TrackPoint(lat=1.002, lon=2.002, alt=5.0, timestamp="00:00:06,000"),
+    ])
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert props["times_s"] == [0.0, 0.0, 1.0]
+
+
 def test_flights_to_kml_one_placemark_per_flight():
     kml = flights_to_kml(_tracks(), title="My flights")
     assert kml.count("<Placemark>") == 2

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -112,6 +112,25 @@ def test_html_draws_tracks_with_layer_control():
     assert "PALETTE" in html
 
 
+# Flight playback (#267): a hand-rolled requestAnimationFrame animator moves
+# a marker along each track, driven by the embedded per-point times.
+
+
+def test_html_embeds_playback_times():
+    data = _embedded_geojson(flights_to_html(TRACKS, title="t"))
+    assert data["features"][0]["properties"]["times_s"] == [0.0, 60.0]
+    assert data["features"][1]["properties"]["times_s"] == [0.0, 1.0]
+
+
+def test_html_has_playback_control_without_new_dependencies():
+    html = flights_to_html(TRACKS, title="t")
+    assert "requestAnimationFrame" in html
+    assert "playback" in html
+    # Hand-rolled animator, not a plugin: the SRI-pinned asset count is
+    # unchanged (leaflet css + js only).
+    assert html.count('integrity="sha256-') == 2
+
+
 def test_html_empty_tracks_still_valid_document():
     html = flights_to_html([], title="t")
     assert html.lstrip().startswith("<!DOCTYPE html>")


### PR DESCRIPTION
Implements #267 — animate a marker along each flight track, driven by the per-point timestamps.

## What

- **`flights_to_geojson`**: every LineString feature now carries `times_s`, per-point seconds relative to the flight start. UTC datetimes are the preferred clock; if any point lacks one the whole flight falls back to SRT cue times (never mixing bases inside a flight); values are clamped non-decreasing so a corrupt cue can't run the animation backwards. Single-fix `Point` clips carry no times. The `.geojson` export gains the same field.
- **HTML viewer**: a small playback control (bottom-left) with play/pause, speed cycling (1×/5×/20×/60×), a scrub slider, and elapsed/total time. One colored dot per flight interpolates along its track; all flights replay on a shared relative clock (each from its own takeoff) so a folder of flights can be compared side by side.

## Decisions the issue left open

- **Plugin vs hand-rolled**: hand-rolled `requestAnimationFrame` (~70 lines inline). LeafletPlayback was considered and skipped — no new pinned+SRI asset, no staleness risk, and the SRI-count test now locks that in.
- **Flag vs UI toggle**: UI toggle. The control is inert until Play is pressed, so the default map stays lightweight; the only data cost is the compact `times_s` array (~1 Hz after the #263 thinning).
- Dots are added to each flight's layer group, so the existing layer control hides a flight's playback dot together with its track.

## Testing

- 6 new tests (times derivation incl. UTC/cue fallback + monotonic clamping; embedded data; control presence + unchanged SRI count); full suite 649 passed, ruff + mypy clean.
- Generated app JS validated with `node --check`.
- E2E on real footage: a 356-point joined flight renders times 0–357.7 s and the control appears.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoV1YNLVJTeVixXdaiKYis