### PR TITLE
feat(geo): oblique view-frustum camera footprints from gimbal attitude (#265)

### DIFF
--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -89,13 +89,14 @@ from pre-existing environmental gaps.
   v1.9.0). Every renderer consumes the same GeoJSON. Remaining follow-ups are
   now tracked as issues:
   [#265](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/265)
-  oblique-trapezoid / view-frustum footprints — unblocked, since gimbal
-  attitude is already parsed from SRT (`gb_yaw`/`gb_pitch`) and the djmd MP4
-  track (DAT logs are *not* required, contrary to earlier assumptions);
+  oblique-trapezoid / view-frustum footprints — **shipped**: frames with
+  gimbal pitch project as ground trapezoids (clamped near the horizon),
+  nadir rectangles remain the attitude-less fallback;
   [#266](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/266)
   terrain/DEM support via an optional `[terrain]` extra;
   [#267](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/267)
-  flight playback animation in the flightmap viewer; and
+  flight playback animation in the flightmap viewer — **shipped** (play/
+  pause, speed, scrubbing; per-point `times_s` in the flight GeoJSON); and
   [#268](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/268)
   a 3D terrain view (MapLibre `--3d` template, deliberately parked).
 - **Richer web UI.** Incremental improvements to the Flask UI

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -27,8 +27,9 @@ flight path in Google Earth.
 ## Camera footprints
 
 Add `--footprint` to a `geojson` or `kml` conversion to include camera
-ground-footprint polygons in the output — one rectangle per sampled frame
-showing the area imaged by the lens at that moment.
+ground-footprint polygons in the output — one polygon per sampled frame
+showing the area imaged by the lens at that moment (a rectangle under a
+straight-down camera, a trapezoid when the gimbal is tilted — see below).
 
 ```bash
 dji-embed convert geojson DJI_0001.SRT --footprint --model air3
@@ -66,17 +67,28 @@ default. On the **Avata 360** format, which carries `gb_yaw` in the SRT, the
 real gimbal yaw is used instead, so the footprint follows where the lens
 actually points.
 
-### Oblique frames are skipped
+### Oblique frames become trapezoids
 
-If the SRT carries gimbal pitch (`gb_pitch`) and the camera is more than ~30°
-off nadir, no footprint is drawn for that frame. Full oblique projection is
-deferred future work. When gimbal pitch is absent (most formats), nadir is
-assumed for every frame.
+If the SRT carries gimbal pitch (`gb_pitch`), each footprint is a true
+view-frustum projection: the four camera-corner rays are intersected with the
+ground plane, so a tilted camera yields a ground **trapezoid** instead of a
+rectangle (wider at the far edge, exactly as the lens sees it). In GeoJSON
+these polygons carry `"oblique": true` and a `"pitch"` property so they can
+be styled apart from nadir rectangles.
+
+Two guard rails keep near-horizon frames sane: frames with the camera at or
+above the horizon (pitch ≥ 0°) are skipped outright, and corner rays that
+miss the ground — or would land implausibly far away — are clamped to 8× the
+height above ground, so a slightly-tilted frame degrades to a capped
+trapezoid instead of stretching to the horizon.
+
+When gimbal pitch is absent (most formats), nadir is assumed for every frame
+and the original rectangle model applies; `-v` logs a note that footprints
+assume a straight-down camera.
 
 The bundled `samples/Avata360/clip.SRT` is a horizon-pointing (gimbal pitch ≈ 0°)
-360 capture — the nadir model intentionally skips every frame and produces no
-footprints. Gimbal yaw is used for footprint rotation only when the camera is
-near-nadir (pitch below the ~30° threshold).
+360 capture — every frame sits at the horizon gate and produces no
+footprints.
 
 ### Privacy — footprints suppressed under `--redact`
 

--- a/src/dji_metadata_embedder/geo/footprint.py
+++ b/src/dji_metadata_embedder/geo/footprint.py
@@ -1,10 +1,13 @@
 """Camera ground-footprint polygons projected from a :class:`Track`.
 
-Model (spec 2026-06-20): assume a nadir (straight-down) camera and size the
-footprint from height-above-ground and a 35mm-equivalent field of view, rotated
-to flight heading or to real gimbal yaw when the format carries it. Strongly
-oblique gimbal frames are skipped, not drawn. Flat-earth equirectangular
-projection (accurate at footprint scale).
+Model (spec 2026-06-20, oblique extension #265): when the telemetry carries
+gimbal pitch, the four camera-frustum corner rays are projected onto the
+ground plane — an oblique frame yields a trapezoid, clamped near the horizon
+so it cannot stretch to infinity, and frames at/above the horizon are
+skipped. Without attitude the original model applies: assume a nadir
+(straight-down) camera and size a rectangle from height-above-ground and a
+35mm-equivalent field of view, rotated to flight heading or to real gimbal
+yaw. Flat-earth equirectangular projection (accurate at footprint scale).
 """
 
 from __future__ import annotations
@@ -13,15 +16,18 @@ import logging
 import math
 from dataclasses import dataclass
 
-from .geometry import downsample_by_time, initial_bearing_deg
+from .geometry import downsample_by_time, frustum_ground_ring, initial_bearing_deg
 from .track import Track, TrackPoint
 
 logger = logging.getLogger(__name__)
 
 # DJI gimbal pitch: 0 deg = forward/horizon, -90 deg = straight down (nadir).
 NADIR_PITCH_DEG = -90.0
-# Skip footprints whose gimbal pitch is more than this far off nadir.
-OBLIQUE_GATE_DEG = 30.0
+# A frame within this many degrees of nadir is not flagged oblique.
+NADIR_EPS_DEG = 1.0
+# Frustum corners with no ground hit (or hits beyond this many times the
+# AGL) clamp to that ground distance, so near-horizon trapezoids stay finite.
+MAX_RANGE_AGL_FACTOR = 8.0
 # Metres per degree of latitude (WGS84 mean).
 _M_PER_DEG_LAT = 111320.0
 
@@ -116,7 +122,9 @@ def ground_footprint(
 @dataclass(frozen=True)
 class Footprint:
     """A camera ground footprint: a closed ``[(lon, lat), ...]`` ring plus the
-    properties that describe how it was projected."""
+    properties that describe how it was projected. ``pitch`` is the gimbal
+    pitch that drove a frustum projection (``None`` = nadir assumption) and
+    ``oblique`` flags rings that are trapezoids rather than nadir rectangles."""
 
     ring: list[tuple[float, float]]
     index: int
@@ -124,6 +132,8 @@ class Footprint:
     agl: float
     hfov: float
     vfov: float
+    pitch: float | None = None
+    oblique: bool = False
 
 
 def _agl(point: TrackPoint, ground_ref: float) -> float | None:
@@ -151,28 +161,54 @@ def _bearing(points: list[TrackPoint], i: int) -> float:
 
 
 def build_footprints(
-    track: Track, *, lens: LensSpec = DEFAULT_LENS, interval: float = 2.0
+    track: Track,
+    *,
+    lens: LensSpec = DEFAULT_LENS,
+    interval: float = 2.0,
+    max_range_m: float | None = None,
 ) -> list[Footprint]:
     """Project per-interval ground footprints for *track*.
 
-    Points are downsampled to roughly one per ``interval`` seconds. A point is
-    skipped when its AGL is non-positive/unknown, or when gimbal pitch shows the
-    camera is strongly oblique. Heading comes from course over ground, or gimbal
-    yaw when present. Redaction is the caller's responsibility (footprints should
-    only be built for ``redact == "none"``).
+    Points are downsampled to roughly one per ``interval`` seconds. When a
+    point carries gimbal pitch the footprint is a view-frustum ground
+    trapezoid (#265), clamped at ``max_range_m`` ground distance (default
+    ``MAX_RANGE_AGL_FACTOR`` × AGL) so near-horizon frames stay finite;
+    frames at/above the horizon are skipped. Without pitch the nadir
+    rectangle applies. A point is also skipped when its AGL is
+    non-positive/unknown. Heading comes from course over ground, or gimbal
+    yaw when present. Redaction is the caller's responsibility (footprints
+    should only be built for ``redact == "none"``).
     """
     sampled = downsample_by_time(track.points, interval)
     if not sampled:
         return []
+    if all(p.gimbal_pitch is None for p in sampled):
+        logger.info(
+            "%s: no gimbal attitude in telemetry; footprints assume a "
+            "straight-down (nadir) camera",
+            track.name,
+        )
     ground_ref = track.points[0].alt
     out: list[Footprint] = []
     for i, p in enumerate(sampled):
-        if p.gimbal_pitch is not None and abs(p.gimbal_pitch - NADIR_PITCH_DEG) > OBLIQUE_GATE_DEG:
-            continue
         agl = _agl(p, ground_ref)
         if agl is None or agl <= 0:
             continue
         hfov, vfov = fov_degrees(lens, p.focal_len)
-        ring = ground_footprint(p.lat, p.lon, agl, hfov, vfov, _bearing(sampled, i))
-        out.append(Footprint(ring, i, p.timestamp, agl, hfov, vfov))
+        bearing = _bearing(sampled, i)
+        if p.gimbal_pitch is not None:
+            if p.gimbal_pitch >= 0:
+                continue  # camera at/above the horizon: no ground footprint
+            ring = frustum_ground_ring(
+                p.lat, p.lon, agl, bearing, p.gimbal_pitch, hfov, vfov,
+                max_range_m if max_range_m is not None
+                else MAX_RANGE_AGL_FACTOR * agl,
+            )
+            out.append(Footprint(
+                ring, i, p.timestamp, agl, hfov, vfov, pitch=p.gimbal_pitch,
+                oblique=abs(p.gimbal_pitch - NADIR_PITCH_DEG) > NADIR_EPS_DEG,
+            ))
+        else:
+            ring = ground_footprint(p.lat, p.lon, agl, hfov, vfov, bearing)
+            out.append(Footprint(ring, i, p.timestamp, agl, hfov, vfov))
     return out

--- a/src/dji_metadata_embedder/geo/geojson.py
+++ b/src/dji_metadata_embedder/geo/geojson.py
@@ -20,20 +20,26 @@ logger = logging.getLogger(__name__)
 
 
 def _footprint_feature(fp: Footprint) -> dict:
+    properties = {
+        "kind": "footprint",
+        "index": fp.index,
+        "timestamp": fp.timestamp,
+        "agl": round(fp.agl, 3),
+        "hfov": round(fp.hfov, 1),
+        "vfov": round(fp.vfov, 1),
+        # Oblique frustum trapezoids (#265) can be styled apart from nadir
+        # rectangles; pitch rides along when a frustum projection was used.
+        "oblique": fp.oblique,
+    }
+    if fp.pitch is not None:
+        properties["pitch"] = fp.pitch
     return {
         "type": "Feature",
         "geometry": {
             "type": "Polygon",
             "coordinates": [[[lon, lat] for lon, lat in fp.ring]],
         },
-        "properties": {
-            "kind": "footprint",
-            "index": fp.index,
-            "timestamp": fp.timestamp,
-            "agl": round(fp.agl, 3),
-            "hfov": round(fp.hfov, 1),
-            "vfov": round(fp.vfov, 1),
-        },
+        "properties": properties,
     }
 
 

--- a/src/dji_metadata_embedder/geo/geometry.py
+++ b/src/dji_metadata_embedder/geo/geometry.py
@@ -13,6 +13,60 @@ from .track import TrackPoint
 
 # Mean Earth radius (m, IUGG) for the haversine helpers.
 EARTH_R = 6371008.8
+# Metres per degree of latitude (WGS84 mean), shared by the flat-earth
+# footprint projections.
+M_PER_DEG_LAT = 111320.0
+
+
+def frustum_ground_ring(
+    lat: float,
+    lon: float,
+    agl: float,
+    heading_deg: float,
+    pitch_deg: float,
+    hfov_deg: float,
+    vfov_deg: float,
+    max_range_m: float,
+) -> list[tuple[float, float]]:
+    """Project the four camera-frustum corner rays onto flat ground (#265).
+
+    The camera sits ``agl`` metres above the ground plane, yawed to
+    ``heading_deg`` (clockwise from north) and pitched ``pitch_deg`` (DJI
+    convention: 0 = horizon, -90 = nadir). Corner rays that meet the ground
+    are projected exactly; rays at or above the horizon — and ground hits
+    beyond ``max_range_m`` — clamp to ``max_range_m`` along their azimuth, so
+    a near-horizon frame degrades to a capped trapezoid instead of an
+    unbounded one. Returns a closed ``[(lon, lat), ...]`` ring
+    (far-left, far-right, near-right, near-left in image terms).
+    """
+    th = math.radians(pitch_deg)
+    tan_h = math.tan(math.radians(hfov_deg) / 2)
+    tan_v = math.tan(math.radians(vfov_deg) / 2)
+    fwd_n, fwd_z = math.cos(th), math.sin(th)  # optical axis, pre-yaw
+    up_n, up_z = -math.sin(th), math.cos(th)   # camera-up, pre-yaw
+    psi = math.radians(heading_deg)
+    cos_p, sin_p = math.cos(psi), math.sin(psi)
+    m_per_deg_lon = M_PER_DEG_LAT * max(math.cos(math.radians(lat)), 1e-6)
+
+    ring: list[tuple[float, float]] = []
+    for sh, sv in ((-1, 1), (1, 1), (1, -1), (-1, -1)):
+        de = sh * tan_h                        # east component, pre-yaw
+        dn = fwd_n + sv * tan_v * up_n
+        dz = fwd_z + sv * tan_v * up_z
+        horiz = math.hypot(de, dn)
+        if dz < 0:
+            dist = min(agl / -dz * horiz, max_range_m)
+        else:
+            dist = max_range_m                 # ray at/above the horizon
+        if horiz > 1e-12:
+            east0, north0 = de / horiz * dist, dn / horiz * dist
+        else:
+            east0, north0 = 0.0, 0.0           # ray straight down
+        east = east0 * cos_p + north0 * sin_p
+        north = -east0 * sin_p + north0 * cos_p
+        ring.append((lon + east / m_per_deg_lon, lat + north / M_PER_DEG_LAT))
+    ring.append(ring[0])
+    return ring
 
 
 def point_utc(p: TrackPoint) -> datetime:

--- a/tests/test_geo_footprint.py
+++ b/tests/test_geo_footprint.py
@@ -90,3 +90,46 @@ def test_build_footprints_uses_gimbal_yaw_when_present():
     lat_extent_90 = max(lat for _, lat in fp90.ring) - min(lat for _, lat in fp90.ring)
     # Default lens HFOV != VFOV, so a 90 deg yaw changes the N-S extent.
     assert abs(lat_extent_0 - lat_extent_90) > 1e-7
+
+
+# Oblique view-frustum footprints (#265): frames with real gimbal pitch keep
+# a footprint (a ground trapezoid) instead of being skipped; only frames at
+# or above the horizon are dropped. Without attitude the nadir rectangle
+# remains, flagged non-oblique.
+
+
+def test_build_footprints_oblique_pitch_now_projected():
+    pts = [_pt(0.0, 0.0, 0, rel_alt=100.0, gimbal_pitch=-45.0, gimbal_yaw=0.0)]
+    fps = build_footprints(Track("t", pts), interval=0.0)
+    assert len(fps) == 1
+    fp = fps[0]
+    assert fp.oblique is True
+    assert fp.pitch == -45.0
+    # Far edge (north, heading 0) reaches beyond the nadir half-height.
+    assert max(lat for _, lat in fp.ring) > 56.25 / M_PER_DEG
+
+
+def test_build_footprints_still_skips_horizon_pitch():
+    pts = [_pt(0.0, 0.0, 0, rel_alt=50.0, gimbal_pitch=0.0),
+           _pt(0.0001, 0.0, 1, rel_alt=50.0, gimbal_pitch=5.0)]
+    assert build_footprints(Track("t", pts), interval=0.0) == []
+
+
+def test_build_footprints_nadir_fallback_is_not_oblique():
+    pts = [_pt(0.0, 0.0, 0, rel_alt=50.0), _pt(0.0001, 0.0, 1, rel_alt=50.0)]
+    fps = build_footprints(Track("t", pts), interval=0.0)
+    assert fps and all(fp.oblique is False for fp in fps)
+    assert all(fp.pitch is None for fp in fps)
+
+
+def test_build_footprints_near_nadir_pitch_matches_rectangle():
+    # A -90 deg gimbal frame goes through the frustum path but must land on
+    # the same rectangle the nadir model draws.
+    from dji_metadata_embedder.geo.footprint import fov_degrees as _fov
+    pts = [_pt(0.0, 0.0, 0, rel_alt=100.0, gimbal_pitch=-90.0, gimbal_yaw=0.0)]
+    fp = build_footprints(Track("t", pts), interval=0.0)[0]
+    hfov, vfov = _fov(DEFAULT_LENS, None)
+    expected = ground_footprint(0.0, 0.0, 100.0, hfov, vfov, 0.0)
+    got = {(round(lon, 9), round(lat, 9)) for lon, lat in fp.ring}
+    want = {(round(lon, 9), round(lat, 9)) for lon, lat in expected}
+    assert got == want

--- a/tests/test_geo_geojson.py
+++ b/tests/test_geo_geojson.py
@@ -74,3 +74,22 @@ def test_geojson_without_footprints_unchanged():
     gj = track_to_geojson(track)
     assert not [f for f in gj["features"]
                 if f["geometry"] and f["geometry"]["type"] == "Polygon"]
+
+
+def test_geojson_footprint_carries_oblique_flag():
+    # Oblique frustum footprints (#265): consumers can style trapezoids
+    # differently, so the feature says how it was projected.
+    from dji_metadata_embedder.geo.footprint import build_footprints
+    from dji_metadata_embedder.geo.geojson import track_to_geojson
+    from dji_metadata_embedder.geo.track import Track, TrackPoint
+    from datetime import datetime
+
+    pts = [TrackPoint(lat=0.0, lon=0.0, alt=100.0, timestamp="0",
+                      utc=datetime(2026, 1, 1), rel_alt=100.0,
+                      gimbal_pitch=-45.0, gimbal_yaw=0.0)]
+    fps = build_footprints(Track("t", pts), interval=0.0)
+    gj = track_to_geojson(Track("t", pts), footprints=fps)
+    poly = [f for f in gj["features"]
+            if f["geometry"] and f["geometry"]["type"] == "Polygon"][0]
+    assert poly["properties"]["oblique"] is True
+    assert poly["properties"]["pitch"] == -45.0

--- a/tests/test_geo_geometry.py
+++ b/tests/test_geo_geometry.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime, timedelta
 
 from dji_metadata_embedder.geo.geometry import (
@@ -28,3 +29,72 @@ def test_downsample_keeps_first_and_last():
     kept = downsample_by_time(pts, 2.0)
     # First, one >=2s later, and the final point.
     assert [round((point_utc(p) - point_utc(pts[0])).total_seconds()) for p in kept] == [0, 2, 4]
+
+
+# Oblique view-frustum ground projection (#265). The 45-degree-pitch cases
+# have exact closed forms with the 24mm/4:3 lens (tan(HFOV/2) = 0.75,
+# tan(VFOV/2) = 0.5625): the cosines cancel, so the far edge sits at
+# 100 * (1 + 0.5625) / (1 - 0.5625) = 357.142857... m and the near edge at
+# 100 * (1 - 0.5625) / (1 + 0.5625) = 28.0 m for a 100 m AGL camera.
+
+M_PER_DEG = 111320.0
+HFOV = math.degrees(2 * math.atan(0.75))
+VFOV = math.degrees(2 * math.atan(0.5625))
+
+
+def _ring_en(ring):
+    """Ring [(lon, lat), ...] -> open list of (east_m, north_m) offsets."""
+    return [(lon * M_PER_DEG, lat * M_PER_DEG) for lon, lat in ring[:-1]]
+
+
+def test_frustum_nadir_matches_rectangle():
+    from dji_metadata_embedder.geo.geometry import frustum_ground_ring
+    ring = frustum_ground_ring(0.0, 0.0, 100.0, 0.0, -90.0, HFOV, VFOV, 10000.0)
+    assert len(ring) == 5 and ring[0] == ring[-1]
+    en = _ring_en(ring)
+    assert max(abs(abs(e) - 75.0) for e, _ in en) < 1e-6
+    assert max(abs(abs(n) - 56.25) for _, n in en) < 1e-6
+
+
+def test_frustum_oblique_45_exact_trapezoid():
+    from dji_metadata_embedder.geo.geometry import frustum_ground_ring
+    ring = frustum_ground_ring(0.0, 0.0, 100.0, 0.0, -45.0, HFOV, VFOV, 10000.0)
+    en = _ring_en(ring)
+    norths = sorted(n for _, n in en)
+    # Near corners at 28.0 m, far corners at 2500/7 = 357.142857 m north.
+    assert abs(norths[0] - 28.0) < 1e-6 and abs(norths[1] - 28.0) < 1e-6
+    assert abs(norths[2] - 2500.0 / 7.0) < 1e-6
+    assert abs(norths[3] - 2500.0 / 7.0) < 1e-6
+    # The far edge is wider across-track than the near edge (a trapezoid).
+    far_w = max(abs(e) for e, n in en if n > 100)
+    near_w = max(abs(e) for e, n in en if n < 100)
+    assert far_w > near_w > 0
+
+
+def test_frustum_clamps_rays_at_or_above_horizon():
+    from dji_metadata_embedder.geo.geometry import frustum_ground_ring
+    # Pitch -20 deg puts the top frustum corners ~9.4 deg ABOVE the horizon:
+    # they never meet the ground, so they clamp to max_range along their
+    # azimuth instead of shooting to infinity.
+    ring = frustum_ground_ring(0.0, 0.0, 100.0, 0.0, -20.0, HFOV, VFOV, 500.0)
+    dists = [math.hypot(e, n) for e, n in _ring_en(ring)]
+    assert max(dists) < 500.0 + 1e-6
+    assert sum(1 for d in dists if abs(d - 500.0) < 1e-6) == 2  # both far corners
+
+
+def test_frustum_caps_finite_but_distant_corners():
+    from dji_metadata_embedder.geo.geometry import frustum_ground_ring
+    # At -45 deg everything hits the ground, but a 200 m cap still binds the
+    # 357 m far corners.
+    ring = frustum_ground_ring(0.0, 0.0, 100.0, 0.0, -45.0, HFOV, VFOV, 200.0)
+    dists = [math.hypot(e, n) for e, n in _ring_en(ring)]
+    assert max(dists) < 200.0 + 1e-6
+
+
+def test_frustum_rotates_with_heading():
+    from dji_metadata_embedder.geo.geometry import frustum_ground_ring
+    north = frustum_ground_ring(0.0, 0.0, 100.0, 0.0, -45.0, HFOV, VFOV, 1000.0)
+    east = frustum_ground_ring(0.0, 0.0, 100.0, 90.0, -45.0, HFOV, VFOV, 1000.0)
+    # Heading east moves the far edge from +north onto +east.
+    assert abs(max(n for _, n in _ring_en(north)) -
+               max(e for e, _ in _ring_en(east))) < 1e-6


### PR DESCRIPTION
Implements #265 — the roadmap's oblique-trapezoid footprints, unblocked since gimbal attitude already flows from SRT (`gb_yaw`/`gb_pitch`) and the djmd MP4 extractor.

## What

- **`geo/geometry.py`**: new `frustum_ground_ring()` — projects the four camera-frustum corner rays onto the flat ground plane from AGL, heading, gimbal pitch, and H/V FOV. In-house math (~40 lines), zero new dependencies, per the issue's explicit no-`cameratransform` constraint.
- **`build_footprints`**: pitch present → frustum trapezoid (replacing the old skip-if->30°-off-nadir gate); pitch ≥ 0° (at/above horizon) → frame skipped; no attitude → the existing nadir rectangle, plus a verbose note that a straight-down camera is assumed.
- **Horizon clamping**: corner rays that miss the ground, or hit beyond a max ground range (default 8× AGL, `max_range_m` overridable), clamp to that range along their azimuth — near-horizon frames degrade to capped trapezoids instead of stretching to infinity.
- **GeoJSON**: footprint features gain `oblique` (bool) and `pitch`; KML renders the new rings unchanged.
- **Docs**: `geospatial.md` footprint section rewritten; roadmap updated (#265 and #267 marked shipped).

## Correctness anchors

- At −90° pitch the frustum path reproduces the nadir rectangle exactly (test-locked, so the two models can't drift apart).
- The −45° case has an exact closed form with the 24 mm/4:3 lens (tan HFOV/2 = 0.75, tan VFOV/2 = 0.5625): far edge at 2500/7 m, near edge at 28.0 m for 100 m AGL — asserted to 1e-6. This replaces the suggested `cameratransform` dev-oracle; the hand-derived values serve the same role without the dependency.

## Testing

- 10 new tests (5 math incl. horizon clamp + range cap + heading rotation; 4 builder-level; 1 GeoJSON schema); full suite 659 passed, ruff + mypy clean.
- E2E: real no-attitude footage → 47 nadir rectangles + the verbose fallback note; the horizon-pointing Avata360 sample → 0 polygons (gate); a −45°-pitch variant → trapezoids whose far/near edge ratio (2.88) matches the closed-form prediction for its 28 mm lens (2.86).

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoV1YNLVJTeVixXdaiKYis