### PR TITLE
GUI 2.0 M2: inline map preview in the workspace pane

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -35,7 +35,8 @@ Two ways to use it — same engine:
 
 1. **Windows app** ("DJI Metadata Embedder"): install, open, drop a folder,
    pick a mode (*Flight map*, *Photo map*, *Embed telemetry*, *Setup*), and
-   press the action button. No terminal.
+   press the action button; finished maps render right in the app's preview
+   pane, with an *Open in browser* pop-out. No terminal.
 2. **`dji-embed` command line**: every feature, all platforms. The Windows
    app's installer puts `dji-embed` on your PATH automatically.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -596,6 +596,15 @@ Panoramas need their GPano metadata intact to be detected — see
 [Maps & Panoramas](geospatial.md) before resizing or re-exporting them, as
 most editors silently strip it.
 
+### Maps open in the browser instead of inside the app
+
+The inline map preview uses **Microsoft Edge WebView2**, which ships
+preinstalled on Windows 11 and later. On machines without it (typically
+older Windows 10 installs), the app quietly falls back to opening maps in
+your default browser — every map feature works there too. To get the
+inline preview, install the
+[WebView2 runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
+
 ---
 
 ## 🐛 Advanced Troubleshooting

--- a/gui/DjiEmbed.Gui.Tests/DropZoneAffordanceTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/DropZoneAffordanceTests.cs
@@ -30,7 +30,8 @@ public class DropZoneAffordanceTests
     private static WorkspaceView PickView() => new()
     {
         DataContext = new WorkspaceViewModel(
-            null, new DjiEmbedRunner(), new MapServer(), () => { }),
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false),
     };
 
     [AvaloniaFact]

--- a/gui/DjiEmbed.Gui.Tests/FailureDetailsTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FailureDetailsTests.cs
@@ -18,7 +18,8 @@ public class FailureDetailsTests
     private static WorkspaceViewModel FailedVm(string details)
     {
         var vm = new WorkspaceViewModel(
-            null, new DjiEmbedRunner(), new MapServer(), () => { });
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
         vm.Step = FlowStep.Failed;
         vm.ErrorMessage = "Something went wrong.";
         vm.ErrorDetails = details;
@@ -66,7 +67,8 @@ public class FailureDetailsTests
     public void No_details_means_no_tail()
     {
         var vm = new WorkspaceViewModel(
-            null, new DjiEmbedRunner(), new MapServer(), () => { });
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
         Assert.Null(vm.ErrorDetailsTail);
     }
 

--- a/gui/DjiEmbed.Gui.Tests/FakeMapServer.cs
+++ b/gui/DjiEmbed.Gui.Tests/FakeMapServer.cs
@@ -11,7 +11,8 @@ internal sealed class FakeMapServer(string? url) : IMapServer
 {
     public List<string> Requests { get; } = [];
 
-    public Task<string?> GetUrlAsync(string cliPath, string htmlPath)
+    public Task<string?> GetUrlAsync(
+        string cliPath, string htmlPath, CancellationToken cancellationToken)
     {
         Requests.Add(htmlPath);
         return Task.FromResult(url);

--- a/gui/DjiEmbed.Gui.Tests/FakeMapServer.cs
+++ b/gui/DjiEmbed.Gui.Tests/FakeMapServer.cs
@@ -1,0 +1,19 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+/// <summary>
+/// Deterministic stand-in for the managed map server: records every HTML
+/// path it is asked about and answers with a fixed URL (null = "the server
+/// could not start"), so no test ever spawns a real `serve` child.
+/// </summary>
+internal sealed class FakeMapServer(string? url) : IMapServer
+{
+    public List<string> Requests { get; } = [];
+
+    public Task<string?> GetUrlAsync(string cliPath, string htmlPath)
+    {
+        Requests.Add(htmlPath);
+        return Task.FromResult(url);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/FlowLayoutTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlowLayoutTests.cs
@@ -33,7 +33,8 @@ public class FlowLayoutTests
     }
 
     private static WorkspaceViewModel WorkspaceVm()
-        => new(null, new DjiEmbedRunner(), new MapServer(), () => { });
+        => new(null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
 
     private static Button VisibleButton(Window window, string caption) =>
         window.GetVisualDescendants().OfType<Button>()

--- a/gui/DjiEmbed.Gui.Tests/FlowProgressAndWarningsTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlowProgressAndWarningsTests.cs
@@ -29,7 +29,8 @@ public class FlowProgressAndWarningsTests : IDisposable
     }
 
     private static WorkspaceViewModel Vm(string? cli) =>
-        new(cli, new DjiEmbedRunner(), new MapServer(), () => { });
+        new(cli, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
 
     [Fact]
     public void Progress_detail_names_the_file_and_the_count()

--- a/gui/DjiEmbed.Gui.Tests/MapServerTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/MapServerTests.cs
@@ -25,7 +25,7 @@ public class MapServerTests : IDisposable
         // The fake stays alive after printing, like a real serve child.
         var cli = FakeCli.WriteEventStream(_dir,
             ["http://127.0.0.1:54321/photomap.html"], sleepSeconds: 30);
-        var url = await server.GetUrlAsync(cli, MapFile());
+        var url = await server.GetUrlAsync(cli, MapFile(), CancellationToken.None);
         Assert.Equal("http://127.0.0.1:54321/photomap.html", url);
     }
 
@@ -35,10 +35,11 @@ public class MapServerTests : IDisposable
         using var server = new MapServer();
         var cli = FakeCli.WriteEventStream(_dir,
             ["http://127.0.0.1:54321/photomap.html"], sleepSeconds: 30);
-        await server.GetUrlAsync(cli, MapFile());
+        await server.GetUrlAsync(cli, MapFile(), CancellationToken.None);
         // Same folder, other map: no second child — the URL is composed
         // from the running server's base address.
-        var url = await server.GetUrlAsync(cli, MapFile("flightmap.html"));
+        var url = await server.GetUrlAsync(
+            cli, MapFile("flightmap.html"), CancellationToken.None);
         Assert.Equal("http://127.0.0.1:54321/flightmap.html", url);
     }
 
@@ -49,7 +50,8 @@ public class MapServerTests : IDisposable
         var cli = FakeCli.WriteEventStream(_dir,
             ["Serving map at http://127.0.0.1:54321/ - press Ctrl+C to stop"],
             sleepSeconds: 30);
-        Assert.Null(await server.GetUrlAsync(cli, MapFile()));
+        Assert.Null(await server.GetUrlAsync(
+            cli, MapFile(), CancellationToken.None));
     }
 
     [Fact]
@@ -59,10 +61,10 @@ public class MapServerTests : IDisposable
         // Exits right after printing — a crashed/killed server.
         var cli = FakeCli.WriteEventStream(_dir,
             ["http://127.0.0.1:54321/photomap.html"]);
-        var first = await server.GetUrlAsync(cli, MapFile());
+        var first = await server.GetUrlAsync(cli, MapFile(), CancellationToken.None);
         Assert.NotNull(first);
         await Task.Delay(500, TestContext.Current.CancellationToken);
-        var second = await server.GetUrlAsync(cli, MapFile());
+        var second = await server.GetUrlAsync(cli, MapFile(), CancellationToken.None);
         Assert.NotNull(second);
     }
 
@@ -71,6 +73,7 @@ public class MapServerTests : IDisposable
     {
         using var server = new MapServer();
         var cli = Path.Combine(_dir, "does-not-exist");
-        Assert.Null(await server.GetUrlAsync(cli, MapFile()));
+        Assert.Null(await server.GetUrlAsync(
+            cli, MapFile(), CancellationToken.None));
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/RevealTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/RevealTests.cs
@@ -1,0 +1,29 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+// Reveal.For is the pure seam behind "Show in folder" — like
+// TerminalLauncher.Candidates, tests assert the exact invocation
+// without spawning a file manager.
+public class RevealTests
+{
+    [Fact]
+    public void Windows_select_argument_quotes_the_full_path()
+    {
+        Assert.Equal("/select,\"C:\\a b\\map.html\"",
+            Reveal.SelectArgument("C:\\a b\\map.html"));
+    }
+
+    [Fact]
+    public void Non_windows_reveal_opens_the_containing_directory()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return; // the runtime branch under test is unreachable here
+        }
+        var psi = Reveal.For("/tmp/some dir/map.html");
+        Assert.NotNull(psi);
+        Assert.Equal("/tmp/some dir", psi.FileName);
+        Assert.True(psi.UseShellExecute);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/RevealTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/RevealTests.cs
@@ -15,12 +15,25 @@ public class RevealTests
     }
 
     [Fact]
+    public void Windows_reveal_asks_explorer_to_select_the_file()
+    {
+        Assert.SkipWhen(!OperatingSystem.IsWindows(),
+            "Reveal.For only takes the explorer.exe branch on Windows");
+
+        var full = Path.GetFullPath("C:\\a b\\map.html");
+        var psi = Reveal.For("C:\\a b\\map.html");
+        Assert.NotNull(psi);
+        Assert.Equal("explorer.exe", psi.FileName);
+        Assert.Equal(Reveal.SelectArgument(full), psi.Arguments);
+        Assert.False(psi.UseShellExecute);
+    }
+
+    [Fact]
     public void Non_windows_reveal_opens_the_containing_directory()
     {
-        if (OperatingSystem.IsWindows())
-        {
-            return; // the runtime branch under test is unreachable here
-        }
+        Assert.SkipWhen(OperatingSystem.IsWindows(),
+            "Reveal.For only takes the containing-directory branch off Windows");
+
         var psi = Reveal.For("/tmp/some dir/map.html");
         Assert.NotNull(psi);
         Assert.Equal("/tmp/some dir", psi.FileName);

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -46,7 +46,8 @@ public class ScreenshotCaptureTests
             Png("home"));
 
         var workspace = new WorkspaceViewModel(
-            null, new DjiEmbedRunner(), new MapServer(), NoOp());
+            null, new DjiEmbedRunner(), new FakeMapServer(null), NoOp(),
+            previewAvailable: static () => false);
         CaptureView(new WorkspaceView { DataContext = workspace },
             Png("workspace-pick"));
 
@@ -70,7 +71,8 @@ public class ScreenshotCaptureTests
             Png("workspace-done"));
 
         var setupDone = new WorkspaceViewModel(
-            null, new DjiEmbedRunner(), new MapServer(), NoOp());
+            null, new DjiEmbedRunner(), new FakeMapServer(null), NoOp(),
+            previewAvailable: static () => false);
         setupDone.Step = FlowStep.Done;
         setupDone.AllGood = true;
         setupDone.SetupItems.Add(new SetupItem(
@@ -81,7 +83,8 @@ public class ScreenshotCaptureTests
             Png("workspace-setup-done"));
 
         var failed = new WorkspaceViewModel(
-            null, new DjiEmbedRunner(), new MapServer(), NoOp());
+            null, new DjiEmbedRunner(), new FakeMapServer(null), NoOp(),
+            previewAvailable: static () => false);
         failed.Step = FlowStep.Failed;
         failed.ErrorMessage = "Something went wrong while embedding the "
             + "flight data. Your original videos were not changed.";

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -115,6 +115,59 @@ public class ScreenshotCaptureTests
             Png("cli-discovery"), width: 560, height: 520);
     }
 
+    /// <summary>
+    /// Done step with an inline map preview: toolbar plus the preview
+    /// inset. Headless has no web engine, so the pane itself renders
+    /// blank — the capture is for reviewing the surrounding layout.
+    /// Deliberately a separate method rather than part of
+    /// Captures_every_screen_to_dir_when_requested: this one constructs
+    /// a NativeWebView, and that is kept isolated from the main matrix
+    /// run — don't merge them.
+    /// </summary>
+    [AvaloniaFact]
+    public void Captures_preview_state_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture the preview state.");
+        Directory.CreateDirectory(dir!);
+
+        var vm = new WorkspaceViewModel(
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
+        // Forward slashes, unlike the other fake paths: the toolbar shows
+        // Path.GetFileName(PreviewPath), and on the Linux capture host
+        // that only splits on '/' — backslashes would render whole.
+        vm.PreviewPath = "C:/Users/demo/Videos/flight/flight_map.html";
+        vm.PreviewUrl = "http://127.0.0.1:1/flight_map.html";
+        vm.Step = FlowStep.Done;
+        CaptureView(new WorkspaceView { DataContext = vm },
+            Path.Combine(dir!, "workspace-preview.png"));
+    }
+
+    /// <summary>
+    /// Done step on a machine without a usable WebView2: the done card
+    /// with the WebView2-unavailable note visible instead of the inline
+    /// map, above the output row whose Open button the note points at.
+    /// </summary>
+    [AvaloniaFact]
+    public void Captures_degraded_done_state_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture the degraded state.");
+        Directory.CreateDirectory(dir!);
+
+        var vm = new WorkspaceViewModel(
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
+        vm.Outputs.Add(@"C:\Users\demo\Videos\flight\flight_map.html");
+        vm.PreviewUnavailable = true;
+        vm.Step = FlowStep.Done;
+        CaptureView(new WorkspaceView { DataContext = vm },
+            Path.Combine(dir!, "workspace-done-degraded.png"));
+    }
+
     private static void CaptureView(
         Control view, string outPath, double width = 1140, double height = 720) =>
         Capture(new Window { Width = width, Height = height, Content = view },

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -117,11 +117,14 @@ public class ScreenshotCaptureTests
 
     /// <summary>
     /// Done step with an inline map preview: toolbar plus the preview
-    /// inset. Headless has no web engine, so the pane itself renders
-    /// blank — the capture is for reviewing the surrounding layout.
-    /// Deliberately a separate method rather than part of
-    /// Captures_every_screen_to_dir_when_requested: this one constructs
-    /// a NativeWebView, and that is kept isolated from the main matrix
+    /// inset. The view's WebView gate is pinned false, so the pane shows
+    /// the calm fallback note instead of a NativeWebView — deterministic
+    /// on every host (constructing the control headlessly would fail
+    /// asynchronously on display-less CI), and better for layout review
+    /// than the blank pane it used to render. Deliberately a separate
+    /// method rather than part of
+    /// Captures_every_screen_to_dir_when_requested: this one exercises
+    /// the attach path, and that is kept isolated from the main matrix
     /// run — don't merge them.
     /// </summary>
     [AvaloniaFact]
@@ -141,8 +144,11 @@ public class ScreenshotCaptureTests
         vm.PreviewPath = "C:/Users/demo/Videos/flight/flight_map.html";
         vm.PreviewUrl = "http://127.0.0.1:1/flight_map.html";
         vm.Step = FlowStep.Done;
-        CaptureView(new WorkspaceView { DataContext = vm },
-            Path.Combine(dir!, "workspace-preview.png"));
+        // Gate before DataContext: assigning the DataContext fires
+        // SyncPreview immediately, which would otherwise probe for real.
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        view.DataContext = vm;
+        CaptureView(view, Path.Combine(dir!, "workspace-preview.png"));
     }
 
     /// <summary>
@@ -164,7 +170,11 @@ public class ScreenshotCaptureTests
         vm.Outputs.Add(@"C:\Users\demo\Videos\flight\flight_map.html");
         vm.PreviewUnavailable = true;
         vm.Step = FlowStep.Done;
-        CaptureView(new WorkspaceView { DataContext = vm },
+        // No PreviewUrl is set, so nothing attaches — but pin the gate
+        // anyway so this capture can never construct a WebView on any host.
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        view.DataContext = vm;
+        CaptureView(view,
             Path.Combine(dir!, "workspace-done-degraded.png"));
     }
 

--- a/gui/DjiEmbed.Gui.Tests/WebViewSupportTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WebViewSupportTests.cs
@@ -1,0 +1,19 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+// WebViewSupport is the real default probe behind the VM's
+// previewAvailable seam (every VM test pins its own fake) — off Windows
+// there is never a WebView2 runtime, so the probe must say no and send
+// the app down the done-card + note degradation path.
+public class WebViewSupportTests
+{
+    [Fact]
+    public void Off_windows_the_preview_is_never_likely_available()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(),
+            "On Windows the answer depends on the machine's WebView2 runtime");
+
+        Assert.False(WebViewSupport.IsLikelyAvailable);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -15,7 +15,14 @@ public class WorkspaceScreenTests
 {
     private static Window ShowWorkspace(WorkspaceViewModel? vm = null)
     {
-        var view = new WorkspaceView { DataContext = vm ?? NewWorkspaceViewModel() };
+        // Pin the WebView gate false BEFORE DataContext: assigning the
+        // DataContext fires SyncPreview immediately, and this suite must
+        // never construct a NativeWebView — its adapter failures surface
+        // asynchronously on the dispatcher (GTK on display-less CI), not
+        // in any catchable ctor. False makes every attach take the
+        // fallback-note path deterministically on every platform.
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        view.DataContext = vm ?? NewWorkspaceViewModel();
         var window = new Window { Content = view, Width = 1140, Height = 720 };
         window.Show();
         return window;
@@ -99,8 +106,10 @@ public class WorkspaceScreenTests
     [AvaloniaFact]
     public void Setting_a_preview_url_never_crashes_a_machine_without_webview()
     {
-        // This headless/Linux run has no web engine: attaching must degrade
-        // to the in-pane note (or a blank host) — never throw.
+        // The gate is pinned false (see ShowWorkspace): a machine without a
+        // usable web engine must degrade to the in-pane note — never throw,
+        // never even construct the control — and the note must actually be
+        // visible; that is the machine-without-webview UX promise.
         var window = ShowWorkspace();
         var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
         vm.PreviewPath = "flightmap.html";
@@ -110,8 +119,8 @@ public class WorkspaceScreenTests
         window.UpdateLayout();
         var host = window.GetVisualDescendants().OfType<Border>()
             .Single(b => b.Name == "PreviewHost");
-        Assert.NotNull(host.Child);            // attach path ran: webview OR fallback note
-        Assert.True(host.Child is NativeWebView or TextBlock);
+        var note = Assert.IsType<TextBlock>(host.Child);   // fallback note, not a WebView
+        Assert.True(note.IsEffectivelyVisible);
         vm.GoHomeCommand.Execute(null);
         Dispatcher.UIThread.RunJobs();
         Assert.Null(host.Child);               // leaving Done detaches whatever was there

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using DjiEmbed.Gui.Services;
 using DjiEmbed.Gui.ViewModels;
@@ -72,6 +73,9 @@ public class WorkspaceScreenTests
         Assert.Contains(images, i => i.Source is not null);
     }
 
+    // Hidden controls stay in the visual tree, so existence checks prove
+    // nothing about the IsVisible bindings — these two tests assert
+    // IsEffectivelyVisible in both directions instead.
     [AvaloniaFact]
     public void Preview_state_shows_toolbar_and_hides_the_done_card()
     {
@@ -80,13 +84,17 @@ public class WorkspaceScreenTests
         vm.PreviewPath = "flightmap.html";
         vm.PreviewUrl = "http://127.0.0.1:1/flightmap.html";
         vm.Step = FlowStep.Done;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
         var buttons = window.GetVisualDescendants().OfType<Button>().ToList();
-        Assert.Single(buttons, b => b.Name == "OpenInBrowserButton");
-        Assert.Single(buttons, b => b.Name == "ShowInFolderButton");
-        Assert.Single(window.GetVisualDescendants().OfType<Border>(),
-            b => b.Name == "PreviewHost");
-        Assert.True(vm.ShowPreview);
-        Assert.False(vm.ShowDoneCard);
+        Assert.True(buttons.Single(b => b.Name == "OpenInBrowserButton")
+            .IsEffectivelyVisible);
+        Assert.True(buttons.Single(b => b.Name == "ShowInFolderButton")
+            .IsEffectivelyVisible);
+        Assert.True(window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "PreviewHost").IsEffectivelyVisible);
+        Assert.False(window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Text == "✅ Done").IsEffectivelyVisible);
     }
 
     [AvaloniaFact]
@@ -96,8 +104,14 @@ public class WorkspaceScreenTests
         var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
         vm.PreviewUnavailable = true;
         vm.Step = FlowStep.Done;
-        var texts = window.GetVisualDescendants().OfType<TextBlock>()
-            .Select(t => t.Text ?? "").ToList();
-        Assert.Contains(texts, t => t.Contains("WebView2"));
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var tip = window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => (t.Text ?? "").Contains("WebView2"));
+        Assert.True(tip.IsEffectivelyVisible);
+
+        vm.PreviewUnavailable = false;   // a healthy Done never shows the tip
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(tip.IsEffectivelyVisible);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -71,4 +71,33 @@ public class WorkspaceScreenTests
         var images = window.GetVisualDescendants().OfType<Image>().ToList();
         Assert.Contains(images, i => i.Source is not null);
     }
+
+    [AvaloniaFact]
+    public void Preview_state_shows_toolbar_and_hides_the_done_card()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.PreviewPath = "flightmap.html";
+        vm.PreviewUrl = "http://127.0.0.1:1/flightmap.html";
+        vm.Step = FlowStep.Done;
+        var buttons = window.GetVisualDescendants().OfType<Button>().ToList();
+        Assert.Single(buttons, b => b.Name == "OpenInBrowserButton");
+        Assert.Single(buttons, b => b.Name == "ShowInFolderButton");
+        Assert.Single(window.GetVisualDescendants().OfType<Border>(),
+            b => b.Name == "PreviewHost");
+        Assert.True(vm.ShowPreview);
+        Assert.False(vm.ShowDoneCard);
+    }
+
+    [AvaloniaFact]
+    public void Degraded_done_card_carries_the_calm_webview_note()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.PreviewUnavailable = true;
+        vm.Step = FlowStep.Done;
+        var texts = window.GetVisualDescendants().OfType<TextBlock>()
+            .Select(t => t.Text ?? "").ToList();
+        Assert.Contains(texts, t => t.Contains("WebView2"));
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -98,6 +98,26 @@ public class WorkspaceScreenTests
     }
 
     [AvaloniaFact]
+    public void Setting_a_preview_url_never_crashes_a_machine_without_webview()
+    {
+        // This headless/Linux run has no web engine: attaching must degrade
+        // to the in-pane note (or a blank host) — never throw.
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.PreviewPath = "flightmap.html";
+        vm.PreviewUrl = "http://127.0.0.1:1/flightmap.html";
+        vm.Step = FlowStep.Done;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var host = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "PreviewHost");
+        Assert.NotNull(host.Child);            // attach path ran: webview OR fallback note
+        vm.GoHomeCommand.Execute(null);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Null(host.Child);               // leaving Done detaches whatever was there
+    }
+
+    [AvaloniaFact]
     public void Degraded_done_card_carries_the_calm_webview_note()
     {
         var window = ShowWorkspace();

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -13,18 +13,17 @@ namespace DjiEmbed.Gui.Tests;
 // a CLI footer link — no menu bar, no tabs, no settings.
 public class WorkspaceScreenTests
 {
-    private static Window ShowWorkspace()
+    private static Window ShowWorkspace(WorkspaceViewModel? vm = null)
     {
-        var view = new WorkspaceView
-        {
-            DataContext = new WorkspaceViewModel(
-                "unused", new DjiEmbedRunner(), new FakeMapServer(null), () => { },
-                previewAvailable: static () => false),
-        };
+        var view = new WorkspaceView { DataContext = vm ?? NewWorkspaceViewModel() };
         var window = new Window { Content = view, Width = 1140, Height = 720 };
         window.Show();
         return window;
     }
+
+    private static WorkspaceViewModel NewWorkspaceViewModel() =>
+        new("unused", new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
 
     [AvaloniaFact]
     public void Mode_strip_shows_exactly_the_four_m1_modes()
@@ -112,9 +111,31 @@ public class WorkspaceScreenTests
         var host = window.GetVisualDescendants().OfType<Border>()
             .Single(b => b.Name == "PreviewHost");
         Assert.NotNull(host.Child);            // attach path ran: webview OR fallback note
+        Assert.True(host.Child is NativeWebView or TextBlock);
         vm.GoHomeCommand.Execute(null);
         Dispatcher.UIThread.RunJobs();
         Assert.Null(host.Child);               // leaving Done detaches whatever was there
+        vm.PreviewUrl = "http://127.0.0.1:1/again.html";
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(host.Child);            // and a second run re-attaches
+    }
+
+    [AvaloniaFact]
+    public void Recreated_view_syncs_an_already_live_preview()
+    {
+        // The VM outlives the view: ViewLocator rebuilds the workspace view
+        // on every CurrentPage flip (footer link → CLI discovery → back), so
+        // a fresh view must adopt a preview that is already showing.
+        var vm = NewWorkspaceViewModel();
+        vm.PreviewPath = "flightmap.html";
+        vm.PreviewUrl = "http://127.0.0.1:1/flightmap.html";
+        vm.Step = FlowStep.Done;
+        var window = ShowWorkspace(vm);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var host = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "PreviewHost");
+        Assert.NotNull(host.Child);
     }
 
     [AvaloniaFact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -17,7 +17,8 @@ public class WorkspaceScreenTests
         var view = new WorkspaceView
         {
             DataContext = new WorkspaceViewModel(
-                "unused", new DjiEmbedRunner(), new MapServer(), () => { }),
+                "unused", new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+                previewAvailable: static () => false),
         };
         var window = new Window { Content = view, Width = 1140, Height = 720 };
         window.Show();

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -21,9 +21,16 @@ public class WorkspaceViewModelTests : IDisposable
         return folder;
     }
 
+    // The REAL default probe is true on Windows, so a map-run test built
+    // without an explicit probe would spawn `serve` children on a Windows
+    // dev machine — pin probe=false and a fake server so every test is
+    // deterministic on every OS.
     private static WorkspaceViewModel Vm(
-        string? cli, Func<string?>? cliResolver = null) =>
-        new(cli, new DjiEmbedRunner(), new MapServer(), () => { }, cliResolver);
+        string? cli, Func<string?>? cliResolver = null,
+        IMapServer? mapServer = null, Func<bool>? previewAvailable = null) =>
+        new(cli, new DjiEmbedRunner(), mapServer ?? new FakeMapServer(null),
+            () => { }, cliResolver,
+            previewAvailable ?? (static () => false));
 
     [Fact]
     public void Starts_idle_with_flight_map_selected_and_no_folder()
@@ -147,8 +154,7 @@ public class WorkspaceViewModelTests : IDisposable
         {
             ["doctor"] = (DoctorStream, 0),
         });
-        var vm = new WorkspaceViewModel(null, new DjiEmbedRunner(),
-            new MapServer(), () => { }, () => cli);
+        var vm = Vm(null, cliResolver: () => cli);
         vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Setup);
         await vm.RunCommand.ExecuteAsync(null);
         Assert.Equal(FlowStep.Done, vm.Step);
@@ -157,8 +163,7 @@ public class WorkspaceViewModelTests : IDisposable
     [Fact]
     public async Task Missing_cli_without_resolver_still_fails_cleanly()
     {
-        var vm = new WorkspaceViewModel(null, new DjiEmbedRunner(),
-            new MapServer(), () => { }, null);
+        var vm = Vm(null, cliResolver: null);
         await vm.SetFolderAsync(MakeFolder(srt: true));
         await vm.RunCommand.ExecuteAsync(null);
         Assert.Equal(FlowStep.Failed, vm.Step);
@@ -412,5 +417,16 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.True(sawRunning, "expected a progress item while running");
         Assert.Equal(1, vm.Current);
         Assert.Equal(1, vm.Total);
+    }
+
+    private sealed class FakeMapServer(string? url) : IMapServer
+    {
+        public List<string> Requests { get; } = [];
+
+        public Task<string?> GetUrlAsync(string cliPath, string htmlPath)
+        {
+            Requests.Add(htmlPath);
+            return Task.FromResult(url);
+        }
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -600,6 +600,25 @@ public class WorkspaceViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task Canceled_preview_priming_is_cancellation_not_degradation()
+    {
+        // PrimePreviewAsync must rethrow OperationCanceledException BEFORE
+        // its catch-all: cancel during server startup is the Cancel button,
+        // not a broken preview — no note, and back to the idle pane.
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var vm = Vm(cli, mapServer: new CanceledMapServer(),
+            previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Pick, vm.Step);
+        Assert.False(vm.PreviewUnavailable);
+        Assert.Null(vm.PreviewUrl);
+    }
+
+    [Fact]
     public void Show_in_folder_without_a_preview_is_a_safe_no_op()
     {
         var vm = Vm("unused");
@@ -612,5 +631,12 @@ public class WorkspaceViewModelTests : IDisposable
         public Task<string?> GetUrlAsync(
             string cliPath, string htmlPath, CancellationToken cancellationToken) =>
             throw new InvalidOperationException("server exploded");
+    }
+
+    private sealed class CanceledMapServer : IMapServer
+    {
+        public Task<string?> GetUrlAsync(
+            string cliPath, string htmlPath, CancellationToken cancellationToken) =>
+            throw new OperationCanceledException();
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -599,6 +599,14 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.True(vm.PreviewUnavailable);
     }
 
+    [Fact]
+    public void Show_in_folder_without_a_preview_is_a_safe_no_op()
+    {
+        var vm = Vm("unused");
+        vm.ShowInFolderCommand.Execute(null);   // must not throw or spawn
+        Assert.Null(vm.PreviewPath);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -418,15 +418,4 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Equal(1, vm.Current);
         Assert.Equal(1, vm.Total);
     }
-
-    private sealed class FakeMapServer(string? url) : IMapServer
-    {
-        public List<string> Requests { get; } = [];
-
-        public Task<string?> GetUrlAsync(string cliPath, string htmlPath)
-        {
-            Requests.Add(htmlPath);
-            return Task.FromResult(url);
-        }
-    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -546,4 +546,63 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Contains(nameof(WorkspaceViewModel.ShowPreview), notified);
         Assert.Contains(nameof(WorkspaceViewModel.ShowDoneCard), notified);
     }
+
+    [Fact]
+    public async Task Photomap_done_primes_the_preview_too()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["photomap"] = (PhotomapStream, 0),
+        });
+        var server = new FakeMapServer("http://127.0.0.1:8/photomap.html");
+        var vm = Vm(cli, mapServer: server, previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Equal("http://127.0.0.1:8/photomap.html", vm.PreviewUrl);
+        Assert.Equal(["photomap.html"], server.Requests);
+    }
+
+    [Fact]
+    public async Task Failed_map_run_never_asks_for_a_server()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (new[]
+            {
+                """{"v": 1, "event": "start", "command": "flightmap", "total": 1}""",
+                """{"v": 1, "event": "error", "message": "boom"}""",
+            }, 1),
+        });
+        var server = new FakeMapServer("http://127.0.0.1:8/f.html");
+        var vm = Vm(cli, mapServer: server, previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Empty(server.Requests);
+        Assert.False(vm.PreviewUnavailable);
+    }
+
+    [Fact]
+    public async Task Server_exception_degrades_without_failing_the_run()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var vm = Vm(cli, mapServer: new ThrowingMapServer(),
+            previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Null(vm.PreviewUrl);
+        Assert.True(vm.PreviewUnavailable);
+    }
+
+    private sealed class ThrowingMapServer : IMapServer
+    {
+        public Task<string?> GetUrlAsync(
+            string cliPath, string htmlPath, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("server exploded");
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -418,4 +418,132 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Equal(1, vm.Current);
         Assert.Equal(1, vm.Total);
     }
+
+    [Fact]
+    public async Task Map_done_primes_the_inline_preview()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var server = new FakeMapServer("http://127.0.0.1:8/flightmap.html");
+        var vm = Vm(cli, mapServer: server, previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Equal("http://127.0.0.1:8/flightmap.html", vm.PreviewUrl);
+        Assert.Equal("flightmap.html", vm.PreviewPath);
+        Assert.Equal(["flightmap.html"], server.Requests);
+        Assert.True(vm.ShowPreview);
+        Assert.False(vm.ShowDoneCard);
+        Assert.False(vm.PreviewUnavailable);
+    }
+
+    [Fact]
+    public async Task No_webview_engine_degrades_to_the_done_card_with_a_note()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var server = new FakeMapServer("http://127.0.0.1:8/flightmap.html");
+        var vm = Vm(cli, mapServer: server, previewAvailable: static () => false);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Null(vm.PreviewUrl);
+        Assert.True(vm.PreviewUnavailable);
+        Assert.True(vm.ShowDoneCard);
+        Assert.False(vm.ShowPreview);
+        Assert.Empty(server.Requests);   // never even asked for a server
+    }
+
+    [Fact]
+    public async Task Server_failure_degrades_the_same_calm_way()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var vm = Vm(cli, mapServer: new FakeMapServer(null),
+            previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);   // a dead preview never fails the run
+        Assert.Null(vm.PreviewUrl);
+        Assert.True(vm.PreviewUnavailable);
+    }
+
+    [Fact]
+    public async Task Non_map_done_shows_the_plain_card_without_any_note()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["doctor"] = (DoctorStream, 0),
+        });
+        var server = new FakeMapServer("http://127.0.0.1:8/x.html");
+        var vm = Vm(cli, mapServer: server, previewAvailable: static () => true);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Setup);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Null(vm.PreviewUrl);
+        Assert.False(vm.PreviewUnavailable);
+        Assert.True(vm.ShowDoneCard);
+        Assert.Empty(server.Requests);
+    }
+
+    [Fact]
+    public async Task Process_another_clears_the_preview()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var vm = Vm(cli, mapServer: new FakeMapServer("http://127.0.0.1:8/f.html"),
+            previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.NotNull(vm.PreviewUrl);
+        vm.GoHomeCommand.Execute(null);
+        Assert.Equal(FlowStep.Pick, vm.Step);
+        Assert.Null(vm.PreviewUrl);
+        Assert.Null(vm.PreviewPath);
+        Assert.False(vm.ShowPreview);
+    }
+
+    [Fact]
+    public async Task A_new_run_resets_stale_preview_state()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+            ["doctor"] = (DoctorStream, 0),
+        });
+        var vm = Vm(cli, mapServer: new FakeMapServer("http://127.0.0.1:8/f.html"),
+            previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.NotNull(vm.PreviewUrl);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Setup);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Null(vm.PreviewUrl);         // the doctor run wiped the old map
+        Assert.False(vm.PreviewUnavailable);
+    }
+
+    [Fact]
+    public async Task Preview_visibility_properties_notify_bindings()
+    {
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["flightmap"] = (FlightmapStream, 0),
+        });
+        var vm = Vm(cli, mapServer: new FakeMapServer("http://127.0.0.1:8/f.html"),
+            previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Contains(nameof(WorkspaceViewModel.ShowPreview), notified);
+        Assert.Contains(nameof(WorkspaceViewModel.ShowDoneCard), notified);
+    }
 }

--- a/gui/DjiEmbed.Gui/DjiEmbed.Gui.csproj
+++ b/gui/DjiEmbed.Gui/DjiEmbed.Gui.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageReference Include="Avalonia.Controls.WebView" Version="12.0.1" />
     <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>

--- a/gui/DjiEmbed.Gui/Services/IMapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/IMapServer.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// The map-serving seam: hands out a local-HTTP URL for a generated HTML
+/// map. Implemented by <see cref="MapServer"/>; faked in tests so no
+/// <c>dji-embed serve</c> child is ever spawned there.
+/// </summary>
+public interface IMapServer
+{
+    /// <summary>Null when no server could be started — callers fall back
+    /// to opening the file directly.</summary>
+    Task<string?> GetUrlAsync(string cliPath, string htmlPath);
+}

--- a/gui/DjiEmbed.Gui/Services/IMapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/IMapServer.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DjiEmbed.Gui.Services;
@@ -10,6 +11,8 @@ namespace DjiEmbed.Gui.Services;
 public interface IMapServer
 {
     /// <summary>Null when no server could be started — callers fall back
-    /// to opening the file directly.</summary>
-    Task<string?> GetUrlAsync(string cliPath, string htmlPath);
+    /// to opening the file directly. Cancellation surfaces as
+    /// OperationCanceledException, never as null.</summary>
+    Task<string?> GetUrlAsync(
+        string cliPath, string htmlPath, CancellationToken cancellationToken);
 }

--- a/gui/DjiEmbed.Gui/Services/MapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/MapServer.cs
@@ -16,7 +16,7 @@ namespace DjiEmbed.Gui.Services;
 /// the lifeline, so a server can never outlive this app even if no kill
 /// ever runs.
 /// </summary>
-public sealed class MapServer : IDisposable
+public sealed class MapServer : IMapServer, IDisposable
 {
     private static readonly TimeSpan StartTimeout = TimeSpan.FromSeconds(10);
 

--- a/gui/DjiEmbed.Gui/Services/MapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/MapServer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DjiEmbed.Gui.Services;
@@ -29,7 +30,8 @@ public sealed class MapServer : IMapServer, IDisposable
     /// falls back to opening the file directly (the map minus the pano
     /// viewer, never nothing).
     /// </summary>
-    public async Task<string?> GetUrlAsync(string cliPath, string htmlPath)
+    public async Task<string?> GetUrlAsync(
+        string cliPath, string htmlPath, CancellationToken cancellationToken)
     {
         var dir = Path.GetDirectoryName(Path.GetFullPath(htmlPath));
         if (dir is null)
@@ -69,7 +71,7 @@ public sealed class MapServer : IMapServer, IDisposable
         {
             return null;
         }
-        var url = await ReadUrlLineAsync(process);
+        var url = await ReadUrlLineAsync(process, cancellationToken);
         if (url is null)
         {
             TryKill(process);
@@ -80,11 +82,21 @@ public sealed class MapServer : IMapServer, IDisposable
         return url;
     }
 
-    private static async Task<string?> ReadUrlLineAsync(Process process)
+    private static async Task<string?> ReadUrlLineAsync(
+        Process process, CancellationToken cancellationToken)
     {
         var read = process.StandardOutput.ReadLineAsync();
-        if (await Task.WhenAny(read, Task.Delay(StartTimeout)) != read)
+        if (await Task.WhenAny(
+                read, Task.Delay(StartTimeout, cancellationToken)) != read)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                // Canceled must not look like "server failed to start":
+                // reap the just-started child, then let the flow unwind.
+                TryKill(process);
+                process.Dispose();
+                throw new OperationCanceledException(cancellationToken);
+            }
             return null;
         }
         var line = (await read)?.Trim();

--- a/gui/DjiEmbed.Gui/Services/MapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/MapServer.cs
@@ -39,11 +39,15 @@ public sealed class MapServer : IMapServer, IDisposable
             return null;
         }
         var page = Path.GetFileName(htmlPath);
-        if (_running.TryGetValue(dir, out var live) && !live.Process.HasExited)
+        if (_running.TryGetValue(dir, out var live))
         {
-            return live.BaseUrl + page;
+            if (!live.Process.HasExited)
+            {
+                return live.BaseUrl + page;
+            }
+            live.Process.Dispose();   // dead child: reap the handle too
+            _running.Remove(dir);
         }
-        _running.Remove(dir);
 
         var psi = new ProcessStartInfo
         {

--- a/gui/DjiEmbed.Gui/Services/Reveal.cs
+++ b/gui/DjiEmbed.Gui/Services/Reveal.cs
@@ -10,17 +10,32 @@ public static class Reveal
 {
     public static void InFolder(string path)
     {
+        if (For(path) is { } psi)
+        {
+            Process.Start(psi);
+        }
+    }
+
+    /// <summary>
+    /// The launch a reveal would make, or null when the path has no
+    /// containing directory. Pure so tests can assert the exact
+    /// invocation without spawning file managers.
+    /// </summary>
+    internal static ProcessStartInfo? For(string path)
+    {
         var full = Path.GetFullPath(path);
         if (OperatingSystem.IsWindows())
         {
-            Process.Start(new ProcessStartInfo("explorer.exe",
-                $"/select,\"{full}\"")
-            { UseShellExecute = false });
-            return;
+            return new ProcessStartInfo("explorer.exe", SelectArgument(full))
+            { UseShellExecute = false };
         }
-        if (Path.GetDirectoryName(full) is { } dir)
-        {
-            Process.Start(new ProcessStartInfo(dir) { UseShellExecute = true });
-        }
+        return Path.GetDirectoryName(full) is { } dir
+            ? new ProcessStartInfo(dir) { UseShellExecute = true }
+            : null;
     }
+
+    /// <summary>explorer.exe's highlight-this-file argument; the quotes
+    /// keep paths with spaces intact.</summary>
+    internal static string SelectArgument(string fullPath) =>
+        $"/select,\"{fullPath}\"";
 }

--- a/gui/DjiEmbed.Gui/Services/Reveal.cs
+++ b/gui/DjiEmbed.Gui/Services/Reveal.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>Opens the OS file manager with a file highlighted (Windows)
+/// or its folder shown (elsewhere).</summary>
+public static class Reveal
+{
+    public static void InFolder(string path)
+    {
+        var full = Path.GetFullPath(path);
+        if (OperatingSystem.IsWindows())
+        {
+            Process.Start(new ProcessStartInfo("explorer.exe",
+                $"/select,\"{full}\"")
+            { UseShellExecute = false });
+            return;
+        }
+        if (Path.GetDirectoryName(full) is { } dir)
+        {
+            Process.Start(new ProcessStartInfo(dir) { UseShellExecute = true });
+        }
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/WebViewSupport.cs
+++ b/gui/DjiEmbed.Gui/Services/WebViewSupport.cs
@@ -1,16 +1,51 @@
 using System;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
 
 namespace DjiEmbed.Gui.Services;
 
 /// <summary>
-/// Whether the inline map preview is worth attempting on this machine.
-/// The app ships for Windows, where WebView2 is preinstalled from
-/// Windows 11 on; elsewhere (dev boxes, CI) the preview degrades to the
-/// done-card and the browser, per the GUI 2.0 spec's degradation rule.
-/// A machine that passes this probe but still lacks a usable engine is
-/// caught by the try/catch around the control itself.
+/// Whether the inline map preview is worth attempting on this machine:
+/// Windows with the WebView2 runtime actually installed. The app ships
+/// for Windows, where WebView2 is preinstalled from Windows 11 on — but
+/// on a runtime-less Windows 10 the control attaches silently and stays
+/// blank, so the OS check alone isn't enough; probing the runtime's
+/// registry footprint sends those machines down the done-card + note
+/// path instead, per the GUI 2.0 spec's degradation rule. A machine that
+/// passes this probe but still lacks a usable engine is caught by the
+/// try/catch around the control itself.
 /// </summary>
 public static class WebViewSupport
 {
-    public static bool IsLikelyAvailable => OperatingSystem.IsWindows();
+    public static bool IsLikelyAvailable =>
+        OperatingSystem.IsWindows() && HasWebView2Runtime();
+
+    // Documented runtime detection: the EdgeUpdate client key for the WebView2 runtime
+    // ({F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}) with a plausible "pv" version value.
+    // https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#detect-if-a-suitable-webview2-runtime-is-already-installed
+    [SupportedOSPlatform("windows")]
+    private static bool HasWebView2Runtime()
+    {
+        const string wow64 = @"SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
+        const string plain = @"SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
+        try
+        {
+            return HasPlausiblePv(Registry.LocalMachine, wow64)
+                || HasPlausiblePv(Registry.LocalMachine, plain)
+                || HasPlausiblePv(Registry.CurrentUser, plain);
+        }
+        catch
+        {
+            // Unreadable registry: assume no runtime — the degraded path works everywhere,
+            // a silently blank preview pane does not.
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool HasPlausiblePv(RegistryKey hive, string path)
+    {
+        using var key = hive.OpenSubKey(path);
+        return key?.GetValue("pv") is string pv && pv.Length > 0 && pv != "0.0.0.0";
+    }
 }

--- a/gui/DjiEmbed.Gui/Services/WebViewSupport.cs
+++ b/gui/DjiEmbed.Gui/Services/WebViewSupport.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// Whether the inline map preview is worth attempting on this machine.
+/// The app ships for Windows, where WebView2 is preinstalled from
+/// Windows 11 on; elsewhere (dev boxes, CI) the preview degrades to the
+/// done-card and the browser, per the GUI 2.0 spec's degradation rule.
+/// A machine that passes this probe but still lacks a usable engine is
+/// caught by the try/catch around the control itself.
+/// </summary>
+public static class WebViewSupport
+{
+    public static bool IsLikelyAvailable => OperatingSystem.IsWindows();
+}

--- a/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
@@ -91,6 +91,14 @@ public abstract partial class FlowViewModel(
     partial void OnTotalChanged(int? value) =>
         OnPropertyChanged(nameof(ProgressDetail));
 
+    partial void OnStepChanged(FlowStep value) => OnStepChangedCore(value);
+
+    /// <summary>Hook for subclasses whose derived state depends on
+    /// <see cref="Step"/> — source-generated partials can only live here.</summary>
+    protected virtual void OnStepChangedCore(FlowStep value)
+    {
+    }
+
     private CancellationTokenSource? _cts;
 
     /// <summary>The bundled CLI path, for subclasses that spawn beyond

--- a/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
@@ -101,6 +101,10 @@ public abstract partial class FlowViewModel(
 
     private CancellationTokenSource? _cts;
 
+    /// <summary>The running flow's cancellation token, for subclass steps
+    /// that await outside <see cref="RunCliAsync"/> yet must stay cancelable.</summary>
+    protected CancellationToken FlowToken => _cts?.Token ?? CancellationToken.None;
+
     /// <summary>The bundled CLI path, for subclasses that spawn beyond
     /// <see cref="RunCliAsync"/> (null when the CLI is missing).
     /// Settable so a long-lived flow can re-probe a missing CLI.</summary>

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -134,6 +134,15 @@ public partial class WorkspaceViewModel : FlowViewModel
     [RelayCommand]
     private void OpenCliDiscovery() => _openCliDiscovery();
 
+    [RelayCommand]
+    private void ShowInFolder()
+    {
+        if (PreviewPath is not null)
+        {
+            Reveal.InFolder(PreviewPath);
+        }
+    }
+
     /// <summary>"Process another": back to idle, keep folder and mode.</summary>
     protected override void GoHomeCore()
     {

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -119,6 +120,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         {
             SelectedMode = SuggestedMode;
         }
+        ResetPreview();
         Step = FlowStep.Pick;
     }
 
@@ -174,7 +176,7 @@ public partial class WorkspaceViewModel : FlowViewModel
                 PreviewUnavailable = true;
                 return true;
             }
-            var url = await _mapServer.GetUrlAsync(CliPath, html);
+            var url = await _mapServer.GetUrlAsync(CliPath, html, FlowToken);
             if (url is null)
             {
                 PreviewUnavailable = true;
@@ -182,6 +184,10 @@ public partial class WorkspaceViewModel : FlowViewModel
             }
             PreviewPath = html;      // path first: the view reads it when the URL lands
             PreviewUrl = url;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;   // ExecuteFlowAsync maps this to Step = Pick.
         }
         catch (Exception)
         {
@@ -281,7 +287,9 @@ public partial class WorkspaceViewModel : FlowViewModel
         if (CliPath is not null
             && path.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
         {
-            var url = await _mapServer.GetUrlAsync(CliPath, path);
+            // Opening an output isn't part of a flow — nothing cancels it.
+            var url = await _mapServer.GetUrlAsync(
+                CliPath, path, CancellationToken.None);
             if (url is not null)
             {
                 Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -16,18 +16,22 @@ namespace DjiEmbed.Gui.ViewModels;
 /// </summary>
 public partial class WorkspaceViewModel : FlowViewModel
 {
-    private readonly MapServer _mapServer;
+    private readonly IMapServer _mapServer;
     private readonly Action _openCliDiscovery;
     private readonly Func<string?>? _cliResolver;
+    private readonly Func<bool> _previewAvailable;
 
     public WorkspaceViewModel(string? cli, DjiEmbedRunner runner,
-        MapServer mapServer, Action openCliDiscovery,
-        Func<string?>? cliResolver = null)
+        IMapServer mapServer, Action openCliDiscovery,
+        Func<string?>? cliResolver = null,
+        Func<bool>? previewAvailable = null)
         : base(cli, runner, static () => { })
     {
         _mapServer = mapServer;
         _openCliDiscovery = openCliDiscovery;
         _cliResolver = cliResolver;
+        _previewAvailable = previewAvailable
+            ?? (static () => WebViewSupport.IsLikelyAvailable);
     }
 
     public IReadOnlyList<WorkspaceMode> Modes => WorkspaceMode.All;

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -50,6 +50,35 @@ public partial class WorkspaceViewModel : FlowViewModel
 
     public ObservableCollection<SetupItem> SetupItems { get; } = [];
 
+    [ObservableProperty]
+    public partial string? PreviewUrl { get; set; }
+
+    [ObservableProperty]
+    public partial string? PreviewPath { get; set; }
+
+    /// <summary>A map was made but the inline preview can't render here —
+    /// the done-card explains once, calmly.</summary>
+    [ObservableProperty]
+    public partial bool PreviewUnavailable { get; set; }
+
+    /// <summary>Done pane, card flavour (setup, embed, degraded maps).</summary>
+    public bool ShowDoneCard => Step == FlowStep.Done && PreviewUrl is null;
+
+    /// <summary>Done pane, inline-map flavour.</summary>
+    public bool ShowPreview => Step == FlowStep.Done && PreviewUrl is not null;
+
+    protected override void OnStepChangedCore(FlowStep value)
+    {
+        OnPropertyChanged(nameof(ShowDoneCard));
+        OnPropertyChanged(nameof(ShowPreview));
+    }
+
+    partial void OnPreviewUrlChanged(string? value)
+    {
+        OnPropertyChanged(nameof(ShowDoneCard));
+        OnPropertyChanged(nameof(ShowPreview));
+    }
+
     /// <summary>The action button lights up as soon as a run could work.</summary>
     public bool CanRun => !SelectedMode.NeedsFolder || SelectedFolder is not null;
 
@@ -104,7 +133,62 @@ public partial class WorkspaceViewModel : FlowViewModel
     private void OpenCliDiscovery() => _openCliDiscovery();
 
     /// <summary>"Process another": back to idle, keep folder and mode.</summary>
-    protected override void GoHomeCore() => Step = FlowStep.Pick;
+    protected override void GoHomeCore()
+    {
+        ResetPreview();
+        Step = FlowStep.Pick;
+    }
+
+    private void ResetPreview()
+    {
+        PreviewUrl = null;
+        PreviewPath = null;
+        PreviewUnavailable = false;
+    }
+
+    /// <summary>
+    /// After a successful map run: point the pane's WebView at the first
+    /// HTML output over the local server (#305 — file:// blocks the pano
+    /// viewer). Runs inside the flow so Done appears with the URL already
+    /// in hand; a preview that can't happen never fails the run.
+    /// </summary>
+    private async Task<bool> PrimePreviewAsync()
+    {
+        string? html = null;
+        foreach (var output in Outputs)
+        {
+            if (output.EndsWith(".html", StringComparison.OrdinalIgnoreCase))
+            {
+                html = output;
+                break;
+            }
+        }
+        if (html is null)
+        {
+            return true;
+        }
+        try
+        {
+            if (!_previewAvailable() || CliPath is null)
+            {
+                PreviewUnavailable = true;
+                return true;
+            }
+            var url = await _mapServer.GetUrlAsync(CliPath, html);
+            if (url is null)
+            {
+                PreviewUnavailable = true;
+                return true;
+            }
+            PreviewPath = html;      // path first: the view reads it when the URL lands
+            PreviewUrl = url;
+        }
+        catch (Exception)
+        {
+            PreviewUnavailable = true;
+        }
+        return true;
+    }
 
     [RelayCommand(CanExecute = nameof(CanRun))]
     private async Task RunAsync()
@@ -116,6 +200,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         }
         SetupItems.Clear();
         AllGood = false;
+        ResetPreview();
         if (SelectedMode.Kind == WorkspaceModeKind.Setup)
         {
             await RunSetupAsync();
@@ -134,8 +219,10 @@ public partial class WorkspaceViewModel : FlowViewModel
                      + "subfolders are included automatically.");
                 return;
             case WorkspaceModeKind.FlightMap:
-                await ExecuteFlowAsync(() => RunStepAsync(
-                    "Mapping your flights…", ["flightmap", folder, "-r"]));
+                await ExecuteFlowAsync(async () =>
+                    await RunStepAsync(
+                        "Mapping your flights…", ["flightmap", folder, "-r"])
+                    && await PrimePreviewAsync());
                 return;
             case WorkspaceModeKind.PhotoMap when !contents.HasPhotos:
                 Fail("No photos were found in that folder. Pick the folder "
@@ -146,9 +233,11 @@ public partial class WorkspaceViewModel : FlowViewModel
                 // --link-originals: the map is written inside the mapped
                 // folder, so the relative links are stable there — and they
                 // power the embedded 360° panorama viewer (#305).
-                await ExecuteFlowAsync(() => RunStepAsync(
-                    "Mapping your photos…",
-                    ["photomap", folder, "-r", "--link-originals"]));
+                await ExecuteFlowAsync(async () =>
+                    await RunStepAsync(
+                        "Mapping your photos…",
+                        ["photomap", folder, "-r", "--link-originals"])
+                    && await PrimePreviewAsync());
                 return;
             case WorkspaceModeKind.Embed when !contents.HasVideos:
                 Fail("No videos (.MP4) were found in that folder. Pick the "

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -215,9 +215,9 @@ public partial class WorkspaceViewModel : FlowViewModel
         }
         SetupItems.Clear();
         AllGood = false;
-        ResetPreview();
         if (SelectedMode.Kind == WorkspaceModeKind.Setup)
         {
+            ResetPreview();
             await RunSetupAsync();
             return;
         }
@@ -226,6 +226,9 @@ public partial class WorkspaceViewModel : FlowViewModel
             return;
         }
         var contents = await Task.Run(() => FolderInspector.Inspect(folder));
+        // Reset only now, past the awaited scan: clearing the preview any
+        // earlier flashes the stale done card while a live map is still up.
+        ResetPreview();
         switch (SelectedMode.Kind)
         {
             case WorkspaceModeKind.FlightMap when !contents.HasFlightLogs:

--- a/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
@@ -22,7 +22,6 @@ public static class WorkspaceConverters
         new(present => present ? "✓" : "✗");
 
     /// <summary>Toolbar label: just the map's file name.</summary>
-    public static readonly IValueConverter FileNameOnly =
-        new FuncValueConverter<string?, string?>(static p =>
-            p is null ? null : Path.GetFileName(p));
+    public static readonly FuncValueConverter<string?, string?> FileNameOnly =
+        new(static p => p is null ? null : Path.GetFileName(p));
 }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Avalonia.Data.Converters;
 using DjiEmbed.Gui.ViewModels;
 
@@ -19,4 +20,9 @@ public static class WorkspaceConverters
     /// <summary>Renders a setup-row's presence as a checkmark or cross glyph.</summary>
     public static readonly FuncValueConverter<bool, string> PresentGlyph =
         new(present => present ? "✓" : "✗");
+
+    /// <summary>Toolbar label: just the map's file name.</summary>
+    public static readonly IValueConverter FileNameOnly =
+        new FuncValueConverter<string?, string?>(static p =>
+            p is null ? null : Path.GetFileName(p));
 }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -290,7 +290,13 @@
                             </ItemsControl>
                         </ScrollViewer>
                     </Expander>
-                    <Border Name="PreviewHost" />
+                    <!-- Inset so the native WebView HWND (which ignores
+                         Avalonia clipping) sits inside the card's rounded
+                         silhouette instead of overdrawing its corners. -->
+                    <Border Name="PreviewHost" Margin="14,0,14,14"
+                            CornerRadius="8" ClipToBounds="True"
+                            BorderThickness="0,1,0,0"
+                            BorderBrush="#309aa7c8" />
                 </DockPanel>
 
                 <!-- Failed -->

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -250,6 +250,7 @@
                                 <Button Name="OpenInBrowserButton"
                                         Command="{Binding OpenOutputCommand}"
                                         CommandParameter="{Binding PreviewPath}"
+                                        AutomationProperties.Name="Open in browser"
                                         ToolTip.Tip="Open this map in your web browser">
                                     <TextBlock Text="Open in browser ↗" FontSize="12" />
                                 </Button>
@@ -273,18 +274,21 @@
                               IsVisible="{Binding !!Warnings.Count}">
                         <Expander.Header>
                             <TextBlock Text="{Binding Warnings.Count,
-                                           StringFormat='⚠️ {0} warning(s)'}"
+                                           StringFormat='⚠️ {0} warnings'}"
                                        FontSize="12" />
                         </Expander.Header>
-                        <ItemsControl ItemsSource="{Binding Warnings}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate x:DataType="x:String">
-                                    <TextBlock Text="{Binding}" TextWrapping="Wrap"
-                                               Opacity="0.85" FontSize="12"
-                                               Margin="0,2" />
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                        <ScrollViewer MaxHeight="140"
+                                      VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding Warnings}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="x:String">
+                                        <TextBlock Text="{Binding}" TextWrapping="Wrap"
+                                                   Opacity="0.85" FontSize="12"
+                                                   Margin="0,2" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
                     </Expander>
                     <Border Name="PreviewHost" />
                 </DockPanel>

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -199,7 +199,7 @@
                     </ItemsControl>
                     <TextBlock IsVisible="{Binding PreviewUnavailable}"
                                Opacity="0.65" FontSize="12" TextWrapping="Wrap"
-                               Text="The inline map preview isn't available on this computer — it uses Microsoft Edge WebView2, which comes preinstalled from Windows 11 on. Open shows the map in your browser instead; everything on it works there." />
+                               Text="The map couldn't be previewed inside the app — Open shows it in your browser instead. Inline preview needs Microsoft Edge WebView2, which comes preinstalled from Windows 11 on." />
                     <StackPanel Spacing="10" IsVisible="{Binding !!SetupItems.Count}">
                         <TextBlock FontSize="16"
                                    IsVisible="{Binding AllGood}"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -174,10 +174,9 @@
                     </Button>
                 </StackPanel>
 
-                <!-- Done: outputs (map/embed) and/or the setup checklist -->
-                <StackPanel IsVisible="{Binding Step,
-                                Converter={x:Static ObjectConverters.Equal},
-                                ConverterParameter={x:Static vm:FlowStep.Done}}"
+                <!-- Done, card flavour: setup checklist, embed outputs,
+                     and maps when the inline preview can't render. -->
+                <StackPanel IsVisible="{Binding ShowDoneCard}"
                             Spacing="16" MaxWidth="480"
                             VerticalAlignment="Center" Margin="28,0">
                     <TextBlock Text="✅ Done" FontSize="20" FontWeight="SemiBold" />
@@ -198,6 +197,9 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+                    <TextBlock IsVisible="{Binding PreviewUnavailable}"
+                               Opacity="0.65" FontSize="12" TextWrapping="Wrap"
+                               Text="The inline map preview isn't available on this computer — it uses Microsoft Edge WebView2, which comes preinstalled from Windows 11 on. Open shows the map in your browser instead; everything on it works there." />
                     <StackPanel Spacing="10" IsVisible="{Binding !!SetupItems.Count}">
                         <TextBlock FontSize="16"
                                    IsVisible="{Binding AllGood}"
@@ -238,6 +240,54 @@
                         <TextBlock Text="Process another" />
                     </Button>
                 </StackPanel>
+
+                <!-- Done, map flavour: the map itself, over the local server. -->
+                <DockPanel IsVisible="{Binding ShowPreview}">
+                    <Border DockPanel.Dock="Top" Padding="14,10">
+                        <DockPanel>
+                            <StackPanel DockPanel.Dock="Right"
+                                        Orientation="Horizontal" Spacing="8">
+                                <Button Name="OpenInBrowserButton"
+                                        Command="{Binding OpenOutputCommand}"
+                                        CommandParameter="{Binding PreviewPath}"
+                                        ToolTip.Tip="Open this map in your web browser">
+                                    <TextBlock Text="Open in browser ↗" FontSize="12" />
+                                </Button>
+                                <Button Name="ShowInFolderButton"
+                                        Command="{Binding ShowInFolderCommand}"
+                                        ToolTip.Tip="Show the map file in its folder">
+                                    <TextBlock Text="Show in folder" FontSize="12" />
+                                </Button>
+                                <Button Command="{Binding GoHomeCommand}">
+                                    <TextBlock Text="Process another" FontSize="12" />
+                                </Button>
+                            </StackPanel>
+                            <TextBlock Text="{Binding PreviewPath,
+                                           Converter={x:Static views:WorkspaceConverters.FileNameOnly}}"
+                                       VerticalAlignment="Center" Opacity="0.7"
+                                       FontSize="12"
+                                       TextTrimming="CharacterEllipsis" />
+                        </DockPanel>
+                    </Border>
+                    <Expander DockPanel.Dock="Top" Margin="14,0,14,8"
+                              IsVisible="{Binding !!Warnings.Count}">
+                        <Expander.Header>
+                            <TextBlock Text="{Binding Warnings.Count,
+                                           StringFormat='⚠️ {0} warning(s)'}"
+                                       FontSize="12" />
+                        </Expander.Header>
+                        <ItemsControl ItemsSource="{Binding Warnings}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="x:String">
+                                    <TextBlock Text="{Binding}" TextWrapping="Wrap"
+                                               Opacity="0.85" FontSize="12"
+                                               Margin="0,2" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </Expander>
+                    <Border Name="PreviewHost" />
+                </DockPanel>
 
                 <!-- Failed -->
                 <StackPanel IsVisible="{Binding Step,

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -1,15 +1,82 @@
+using System;
+using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
 using DjiEmbed.Gui.ViewModels;
 
 namespace DjiEmbed.Gui.Views;
 
 public partial class WorkspaceView : UserControl
 {
+    private WorkspaceViewModel? _vm;
+    private NativeWebView? _webView;
+
     public WorkspaceView()
     {
         InitializeComponent();
         FolderPicking.EnableDrop(this, SetFolderAsync, DropZone);
+        DataContextChanged += (_, _) =>
+        {
+            if (_vm is not null)
+            {
+                _vm.PropertyChanged -= OnVmPropertyChanged;
+            }
+            _vm = DataContext as WorkspaceViewModel;
+            if (_vm is not null)
+            {
+                _vm.PropertyChanged += OnVmPropertyChanged;
+            }
+        };
+    }
+
+    private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(WorkspaceViewModel.PreviewUrl))
+        {
+            return;
+        }
+        if (_vm?.PreviewUrl is { } url)
+        {
+            AttachPreview(url);
+        }
+        else
+        {
+            PreviewHost.Child = null;
+        }
+    }
+
+    /// <summary>
+    /// One WebView for the window's lifetime, created on first use. A
+    /// machine that gets this far but still has no usable engine (the
+    /// spec's old-Windows-10 case) gets a calm note in the pane — the
+    /// map is always one "Open in browser" click away, never an error
+    /// dialog.
+    /// </summary>
+    private void AttachPreview(string url)
+    {
+        try
+        {
+            _webView ??= new NativeWebView();
+            PreviewHost.Child = _webView;
+            _webView.Source = new Uri(url);
+        }
+        catch (Exception)
+        {
+            _webView = null;
+            PreviewHost.Child = new TextBlock
+            {
+                Text = "The map is ready — use “Open in browser” above to "
+                       + "view it. (The inline preview isn't available on "
+                       + "this computer.)",
+                TextWrapping = TextWrapping.Wrap,
+                Opacity = 0.7,
+                MaxWidth = 420,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+        }
     }
 
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -28,15 +28,22 @@ public partial class WorkspaceView : UserControl
             {
                 _vm.PropertyChanged += OnVmPropertyChanged;
             }
+            // The VM outlives the view (ViewLocator rebuilds it on every
+            // page flip): adopt any preview that is already showing.
+            SyncPreview();
         };
     }
 
     private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName != nameof(WorkspaceViewModel.PreviewUrl))
+        if (e.PropertyName == nameof(WorkspaceViewModel.PreviewUrl))
         {
-            return;
+            SyncPreview();
         }
+    }
+
+    private void SyncPreview()
+    {
         if (_vm?.PreviewUrl is { } url)
         {
             AttachPreview(url);
@@ -48,11 +55,11 @@ public partial class WorkspaceView : UserControl
     }
 
     /// <summary>
-    /// One WebView for the window's lifetime, created on first use. A
-    /// machine that gets this far but still has no usable engine (the
-    /// spec's old-Windows-10 case) gets a calm note in the pane — the
-    /// map is always one "Open in browser" click away, never an error
-    /// dialog.
+    /// One WebView per view instance, created on first use — the view is
+    /// rebuilt each time navigation returns here. A machine that gets
+    /// this far but still has no usable engine (the spec's
+    /// old-Windows-10 case) gets a calm note in the pane — the map is
+    /// always one "Open in browser" click away, never an error dialog.
     /// </summary>
     private void AttachPreview(string url)
     {
@@ -72,6 +79,7 @@ public partial class WorkspaceView : UserControl
                        + "this computer.)",
                 TextWrapping = TextWrapping.Wrap,
                 Opacity = 0.7,
+                FontSize = 13,
                 MaxWidth = 420,
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
+using DjiEmbed.Gui.Services;
 using DjiEmbed.Gui.ViewModels;
 
 namespace DjiEmbed.Gui.Views;
@@ -12,6 +13,16 @@ public partial class WorkspaceView : UserControl
 {
     private WorkspaceViewModel? _vm;
     private NativeWebView? _webView;
+
+    /// <summary>
+    /// Whether this machine can host a NativeWebView at all — a test seam
+    /// defaulting to the real probe. Must be decided before DataContext is
+    /// assigned: setting it fires SyncPreview immediately, so tests set
+    /// this first. See <see cref="AttachPreview"/> for why the gate, not
+    /// the try/catch, is the real protection.
+    /// </summary>
+    internal Func<bool> WebViewGate { get; set; } =
+        static () => WebViewSupport.IsLikelyAvailable;
 
     public WorkspaceView()
     {
@@ -63,6 +74,17 @@ public partial class WorkspaceView : UserControl
     /// </summary>
     private void AttachPreview(string url)
     {
+        if (!WebViewGate())
+        {
+            // Never even construct the control here: adapter creation
+            // happens on attach and its failures surface asynchronously
+            // via the dispatcher (observed: the GTK adapter throwing on
+            // display-less CI), where no try/catch of ours can reach
+            // them. The gate is the real protection; the catch below
+            // only covers synchronous construction failures.
+            PreviewHost.Child = MakeFallbackNote();
+            return;
+        }
         try
         {
             _webView ??= new NativeWebView();
@@ -72,20 +94,22 @@ public partial class WorkspaceView : UserControl
         catch (Exception)
         {
             _webView = null;
-            PreviewHost.Child = new TextBlock
-            {
-                Text = "The map is ready — use “Open in browser” above to "
-                       + "view it. (The inline preview isn't available on "
-                       + "this computer.)",
-                TextWrapping = TextWrapping.Wrap,
-                Opacity = 0.7,
-                FontSize = 13,
-                MaxWidth = 420,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
+            PreviewHost.Child = MakeFallbackNote();
         }
     }
+
+    private static TextBlock MakeFallbackNote() => new()
+    {
+        Text = "The map is ready — use “Open in browser” above to "
+               + "view it. (The inline preview isn't available on "
+               + "this computer.)",
+        TextWrapping = TextWrapping.Wrap,
+        Opacity = 0.7,
+        FontSize = 13,
+        MaxWidth = 420,
+        HorizontalAlignment = HorizontalAlignment.Center,
+        VerticalAlignment = VerticalAlignment.Center,
+    };
 
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>
         await FolderPicking.ChooseAsync(this, SetFolderAsync);


### PR DESCRIPTION
## Summary

Milestone 2 of the [GUI 2.0 workspace plan](docs/superpowers/specs/2026-07-18-gui-full-workspace-design.md): finished flight-map and photo-map runs now render **inside the app's preview pane** instead of only popping a browser.

- **Inline WebView preview** — `Avalonia.Controls.WebView` (MIT, bundled free with Avalonia 12) attaches a `NativeWebView` over the existing `dji-embed serve` loopback (`MapServer`), so panoramas and map tiles work exactly as they do in the browser. One map per pane, no navigation chrome (anti-bloat rules hold).
- **Map toolbar** — filename, *Open in browser* pop-out (same served URL), *Show in folder*, *Process another*; warnings tucked into a capped expander.
- **Graceful degradation** — `WebViewSupport` probes Windows **and** the documented WebView2-runtime registry footprint; machines without the runtime (typically older Windows 10) get the classic done card with per-output Open buttons plus a calm note. A preview that can't happen never fails a run, and cancel kills the primed server cleanly (OCE, not degradation).
- **Lifecycle correctness** — the VM outlives the view (ViewLocator rebuilds per page flip); a recreated view re-adopts a live preview (`SyncPreview()` on DataContextChanged, regression-tested).
- **Docs + packaging** — HELP.md and troubleshooting.md cover the WebView2 fallback; verified the win-x64 self-contained publish ships `Avalonia.Controls.WebView.dll` (managed-only package, single DLL is everything), so the installer's `publish/*` wildcard carries it.

Embed and Setup flows are untouched by preview logic. No CLI/Python changes.

Suite: **124 passed / 0 failed / 7 skipped, 0 warnings** (new skips are the two capture tests, env-gated). Every task went through spec + quality review, plus a final whole-branch review (verdict: SHIP).

## Test Plan
- [x] Full headless suite green at tip (124/0/7, 0 warnings)
- [x] Screenshot matrix rendered (`workspace-preview.png`, `workspace-done-degraded.png`)
- [x] `dotnet publish -r win-x64 --self-contained` contains `Avalonia.Controls.WebView.dll`
- [ ] Manual on real Windows: run a flight map → map renders inline; *Open in browser* and *Show in folder* work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMQa5GB7G32S72nLy7gfRH