### PR TITLE
M3a: CommandBuilder + CLI transparency strip (GUI 2.0)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -1,0 +1,47 @@
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+// M3a: one source of truth for each mode's argv (no --progress; the runner
+// appends that). These goldens pin today's behaviour so later option slices
+// can only extend it deliberately.
+public class CommandBuilderTests
+{
+    [Fact]
+    public void Flight_map_builds_recursive_flightmap()
+    {
+        string[] expected = ["flightmap", "/x", "-r"];
+        Assert.Equal(expected, CommandBuilder.Build(WorkspaceModeKind.FlightMap, "/x"));
+    }
+
+    [Fact]
+    public void Photo_map_links_originals_for_the_pano_viewer()
+    {
+        string[] expected = ["photomap", "/x", "-r", "--link-originals"];
+        Assert.Equal(expected, CommandBuilder.Build(WorkspaceModeKind.PhotoMap, "/x"));
+    }
+
+    [Fact]
+    public void Embed_is_bare()
+    {
+        string[] expected = ["embed", "/x"];
+        Assert.Equal(expected, CommandBuilder.Build(WorkspaceModeKind.Embed, "/x"));
+    }
+
+    [Fact]
+    public void Setup_is_doctor_and_ignores_the_folder()
+    {
+        string[] expected = ["doctor"];
+        Assert.Equal(expected, CommandBuilder.Build(WorkspaceModeKind.Setup, null));
+    }
+
+    [Fact]
+    public void No_mode_ever_includes_the_progress_flag()
+    {
+        foreach (var kind in Enum.GetValues<WorkspaceModeKind>())
+        {
+            Assert.DoesNotContain("--progress", CommandBuilder.Build(kind, "/x"));
+        }
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/CommandLineTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandLineTests.cs
@@ -30,4 +30,20 @@ public class CommandLineTests
     {
         Assert.Equal("dji-embed", CommandLine.Format("dji-embed", []));
     }
+
+    [Fact]
+    public void Quotes_an_arg_containing_a_tab_whitespace_is_not_just_spaces()
+    {
+        Assert.Equal("dji-embed x \"a\tb\"",
+            CommandLine.Format("dji-embed", ["x", "a\tb"]));
+    }
+
+    [Fact]
+    public void Passes_an_embedded_double_quote_through_verbatim_display_only_not_shell_safe()
+    {
+        // No whitespace ⇒ unquoted; the embedded quote is left as-is. This
+        // documents that Format is display quoting, not shell escaping.
+        Assert.Equal("dji-embed check a\"b",
+            CommandLine.Format("dji-embed", ["check", "a\"b"]));
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/CommandLineTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandLineTests.cs
@@ -1,0 +1,33 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class CommandLineTests
+{
+    [Fact]
+    public void Prefixes_the_program_and_leaves_simple_args_bare()
+    {
+        Assert.Equal("dji-embed flightmap /footage -r",
+            CommandLine.Format("dji-embed", ["flightmap", "/footage", "-r"]));
+    }
+
+    [Fact]
+    public void Quotes_args_that_contain_spaces()
+    {
+        Assert.Equal("dji-embed flightmap \"/my footage/june\" -r",
+            CommandLine.Format("dji-embed", ["flightmap", "/my footage/june", "-r"]));
+    }
+
+    [Fact]
+    public void Quotes_an_empty_arg_so_it_is_not_swallowed()
+    {
+        Assert.Equal("dji-embed check \"\"",
+            CommandLine.Format("dji-embed", ["check", ""]));
+    }
+
+    [Fact]
+    public void No_args_is_just_the_program()
+    {
+        Assert.Equal("dji-embed", CommandLine.Format("dji-embed", []));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
@@ -43,7 +43,7 @@ public class NavigationTests
         window.Show();
 
         var link = window.GetVisualDescendants().OfType<Button>()
-            .First(b => b.Classes.Contains("footerLink"));
+            .Single(b => b.Classes.Contains("footerLink"));
         link.Focus();
         window.KeyPressQwerty(Avalonia.Input.PhysicalKey.Enter,
             Avalonia.Input.RawInputModifiers.None);

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -64,12 +64,8 @@ public class WorkspaceScreenTests
     public void Cli_escape_hatch_footer_link_survives()
     {
         var window = ShowWorkspace();
-        // The M3a transparency strip's Copy button reuses the footerLink
-        // style too, so identify the escape hatch by its "dji-embed" text.
         var link = window.GetVisualDescendants().OfType<Button>()
-            .Single(b => b.Classes.Contains("footerLink")
-                && b.GetVisualDescendants().OfType<TextBlock>()
-                    .Any(t => (t.Text ?? "").Contains("dji-embed")));
+            .Single(b => b.Classes.Contains("footerLink"));
         var text = string.Join(" ", link.GetVisualDescendants()
             .OfType<TextBlock>().Select(t => t.Text ?? ""));
         Assert.Contains("dji-embed", text);

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -64,8 +64,12 @@ public class WorkspaceScreenTests
     public void Cli_escape_hatch_footer_link_survives()
     {
         var window = ShowWorkspace();
+        // The M3a transparency strip's Copy button reuses the footerLink
+        // style too, so identify the escape hatch by its "dji-embed" text.
         var link = window.GetVisualDescendants().OfType<Button>()
-            .Single(b => b.Classes.Contains("footerLink"));
+            .Single(b => b.Classes.Contains("footerLink")
+                && b.GetVisualDescendants().OfType<TextBlock>()
+                    .Any(t => (t.Text ?? "").Contains("dji-embed")));
         var text = string.Join(" ", link.GetVisualDescendants()
             .OfType<TextBlock>().Select(t => t.Text ?? ""));
         Assert.Contains("dji-embed", text);
@@ -163,5 +167,18 @@ public class WorkspaceScreenTests
         vm.PreviewUnavailable = false;   // a healthy Done never shows the tip
         Dispatcher.UIThread.RunJobs();
         Assert.False(tip.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Cli_transparency_strip_shows_the_live_command()
+    {
+        var window = ShowWorkspace();   // default mode Flight map, no folder
+        var strip = window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "CommandPreviewText");
+        Assert.Contains("dji-embed flightmap", strip.Text);
+        Assert.Contains("<folder>", strip.Text);          // no folder picked yet
+        Assert.DoesNotContain("--progress", strip.Text);  // teaching form, not the machine flag
+        Assert.Single(window.GetVisualDescendants().OfType<Button>(),
+            b => b.Name == "CopyCommandButton");
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -626,6 +626,47 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Null(vm.PreviewPath);
     }
 
+    // M3a: the CLI transparency strip reads CommandPreview — the exact
+    // human-facing dji-embed command the current mode + folder would run.
+    [Fact]
+    public void Command_preview_shows_the_teaching_form_before_a_folder_is_picked()
+    {
+        var vm = Vm("unused");   // starts on Flight map, no folder
+        Assert.Equal("dji-embed flightmap <folder> -r", vm.CommandPreview);
+        Assert.DoesNotContain("--progress", vm.CommandPreview);
+    }
+
+    [Fact]
+    public async Task Command_preview_uses_the_real_folder_once_picked()
+    {
+        var vm = Vm("unused");
+        var folder = MakeFolder(srt: true);
+        await vm.SetFolderAsync(folder);
+        Assert.Contains(folder, vm.CommandPreview);
+        Assert.DoesNotContain("<folder>", vm.CommandPreview);
+    }
+
+    [Fact]
+    public void Command_preview_tracks_the_selected_mode()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Setup);
+        Assert.Equal("dji-embed doctor", vm.CommandPreview);
+    }
+
+    [Fact]
+    public async Task Command_preview_notifies_on_mode_and_folder_change()
+    {
+        var vm = Vm("unused");
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
+        notified.Clear();
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -1,0 +1,28 @@
+using System;
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// The single source of truth for the <c>dji-embed</c> argv a workspace mode
+/// runs (GUI 2.0 spec, M3a). Both the runner and the CLI transparency strip
+/// consume this, so what the user sees is exactly what executes. It omits
+/// <c>--progress jsonl</c> on purpose: <see cref="DjiEmbedRunner"/> appends
+/// that machine-only flag at execution, and the strip teaches the human form.
+/// Later slices (M3b+) grow this with typed option state.
+/// </summary>
+public static class CommandBuilder
+{
+    /// <param name="folder">The source folder for modes that need one; ignored
+    /// for <see cref="WorkspaceModeKind.Setup"/>. Callers guarantee it is
+    /// non-null for folder-needing modes (a real path when running, or a
+    /// placeholder token when previewing).</param>
+    public static string[] Build(WorkspaceModeKind kind, string? folder) => kind switch
+    {
+        WorkspaceModeKind.FlightMap => ["flightmap", folder!, "-r"],
+        WorkspaceModeKind.PhotoMap => ["photomap", folder!, "-r", "--link-originals"],
+        WorkspaceModeKind.Embed => ["embed", folder!],
+        WorkspaceModeKind.Setup => ["doctor"],
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+    };
+}

--- a/gui/DjiEmbed.Gui/Services/CommandLine.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandLine.cs
@@ -4,11 +4,14 @@ using System.Linq;
 namespace DjiEmbed.Gui.Services;
 
 /// <summary>
-/// Renders an argv as a single copy-pasteable command line for the CLI
-/// transparency strip (GUI 2.0 spec, M3a). Minimal quoting: an argument is
-/// double-quoted only when empty or containing whitespace. Paths cannot
-/// contain a literal double-quote on Windows or POSIX, so no escaping of
-/// embedded quotes is needed.
+/// Renders an argv as a single command line for the CLI transparency strip
+/// (GUI 2.0 spec, M3a). This is <b>best-effort display quoting</b> — for
+/// readability and copy convenience only — and is <b>not shell-safe</b>: an
+/// argument is double-quoted only when empty or containing whitespace, and
+/// nothing else is escaped. It does not neutralise shell metacharacters, so
+/// it must never be used to build a command that is actually executed. Real
+/// execution goes through <see cref="System.Diagnostics.ProcessStartInfo"/>'s
+/// <c>ArgumentList</c>, which escapes each argument independently.
 /// </summary>
 public static class CommandLine
 {

--- a/gui/DjiEmbed.Gui/Services/CommandLine.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandLine.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// Renders an argv as a single copy-pasteable command line for the CLI
+/// transparency strip (GUI 2.0 spec, M3a). Minimal quoting: an argument is
+/// double-quoted only when empty or containing whitespace. Paths cannot
+/// contain a literal double-quote on Windows or POSIX, so no escaping of
+/// embedded quotes is needed.
+/// </summary>
+public static class CommandLine
+{
+    public static string Format(string program, IReadOnlyList<string> args)
+    {
+        var parts = new List<string>(args.Count + 1) { program };
+        parts.AddRange(args.Select(Quote));
+        return string.Join(' ', parts);
+    }
+
+    private static string Quote(string arg) =>
+        arg.Length == 0 || arg.Any(char.IsWhiteSpace) ? $"\"{arg}\"" : arg;
+}

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -239,7 +239,8 @@ public partial class WorkspaceViewModel : FlowViewModel
             case WorkspaceModeKind.FlightMap:
                 await ExecuteFlowAsync(async () =>
                     await RunStepAsync(
-                        "Mapping your flights…", ["flightmap", folder, "-r"])
+                        "Mapping your flights…",
+                        CommandBuilder.Build(SelectedMode.Kind, folder))
                     && await PrimePreviewAsync());
                 return;
             case WorkspaceModeKind.PhotoMap when !contents.HasPhotos:
@@ -254,7 +255,7 @@ public partial class WorkspaceViewModel : FlowViewModel
                 await ExecuteFlowAsync(async () =>
                     await RunStepAsync(
                         "Mapping your photos…",
-                        ["photomap", folder, "-r", "--link-originals"])
+                        CommandBuilder.Build(SelectedMode.Kind, folder))
                     && await PrimePreviewAsync());
                 return;
             case WorkspaceModeKind.Embed when !contents.HasVideos:
@@ -265,14 +266,15 @@ public partial class WorkspaceViewModel : FlowViewModel
             case WorkspaceModeKind.Embed:
                 await ExecuteFlowAsync(() => RunStepAsync(
                     "Embedding flight data into new copies…",
-                    ["embed", folder]));
+                    CommandBuilder.Build(SelectedMode.Kind, folder)));
                 return;
         }
     }
 
     private Task RunSetupAsync() => ExecuteFlowAsync(async () =>
     {
-        var result = await RunCliAsync("Checking…", ["doctor"]);
+        var result = await RunCliAsync(
+            "Checking…", CommandBuilder.Build(WorkspaceModeKind.Setup, null));
         if (result.ExitCode != 0
             || result.Terminal is not { Kind: ProgressEventKind.Result } t)
         {

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -83,15 +83,35 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>The action button lights up as soon as a run could work.</summary>
     public bool CanRun => !SelectedMode.NeedsFolder || SelectedFolder is not null;
 
+    /// <summary>
+    /// The exact human-facing <c>dji-embed</c> command the current mode +
+    /// folder would run — the CLI transparency strip (GUI 2.0 spec, M3a).
+    /// Uses a <c>&lt;folder&gt;</c> placeholder before a folder is picked so
+    /// the strip teaches the command shape from the idle state. Never shows
+    /// <c>--progress jsonl</c> (an execution detail added by the runner).
+    /// </summary>
+    public string CommandPreview
+    {
+        get
+        {
+            var folder = SelectedFolder
+                ?? (SelectedMode.NeedsFolder ? "<folder>" : null);
+            return CommandLine.Format(
+                "dji-embed", CommandBuilder.Build(SelectedMode.Kind, folder));
+        }
+    }
+
     partial void OnSelectedFolderChanged(string? value)
     {
         OnPropertyChanged(nameof(CanRun));
+        OnPropertyChanged(nameof(CommandPreview));
         RunCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnSelectedModeChanged(WorkspaceMode value)
     {
         OnPropertyChanged(nameof(CanRun));
+        OnPropertyChanged(nameof(CommandPreview));
         RunCommand.NotifyCanExecuteChanged();
     }
 

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -121,6 +121,28 @@
                         <TextBlock Text="{Binding SelectedMode.Verb}"
                                    FontSize="15" FontWeight="SemiBold" />
                     </Button>
+                    <!-- CLI transparency strip (GUI 2.0 spec, M3a): the exact
+                         dji-embed command this run executes, live + copyable. -->
+                    <Border Name="CommandStrip" Margin="0,10,0,0"
+                            Padding="10,8" CornerRadius="6"
+                            Background="#11808080">
+                        <DockPanel>
+                            <Button DockPanel.Dock="Right" Name="CopyCommandButton"
+                                    Classes="footerLink" VerticalAlignment="Top"
+                                    Margin="8,0,0,0"
+                                    Click="OnCopyCommandClick"
+                                    AutomationProperties.Name="Copy command"
+                                    ToolTip.Tip="Copy command">
+                                <TextBlock Text="Copy" FontSize="11" Opacity="0.8" />
+                            </Button>
+                            <TextBlock Name="CommandPreviewText"
+                                       Text="{Binding CommandPreview}"
+                                       FontFamily="Cascadia Mono,Consolas,Menlo,monospace"
+                                       FontSize="11" Opacity="0.75"
+                                       TextWrapping="Wrap"
+                                       VerticalAlignment="Center" />
+                        </DockPanel>
+                    </Border>
                 </StackPanel>
             </DockPanel>
         </ScrollViewer>

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -23,12 +23,12 @@
         <Style Selector="Border#DropZone.dragover Rectangle.dropOutline">
             <Setter Property="Stroke" Value="#6366f1" />
         </Style>
-        <Style Selector="Button.footerLink">
+        <Style Selector="Button.footerLink, Button.copyLink">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="Padding" Value="0" />
             <Setter Property="Cursor" Value="Hand" />
         </Style>
-        <Style Selector="Button.footerLink:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Style Selector="Button.footerLink:pointerover /template/ ContentPresenter#PART_ContentPresenter, Button.copyLink:pointerover /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="Transparent" />
         </Style>
     </UserControl.Styles>
@@ -128,7 +128,7 @@
                             Background="#11808080">
                         <DockPanel>
                             <Button DockPanel.Dock="Right" Name="CopyCommandButton"
-                                    Classes="footerLink" VerticalAlignment="Top"
+                                    Classes="copyLink" VerticalAlignment="Top"
                                     Margin="8,0,0,0"
                                     Click="OnCopyCommandClick"
                                     AutomationProperties.Name="Copy command"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -122,6 +122,14 @@ public partial class WorkspaceView : UserControl
         }
     }
 
+    private async void OnCopyCommandClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is WorkspaceViewModel vm)
+        {
+            await ClipboardCopy.CopyAsync(this, vm.CommandPreview);
+        }
+    }
+
     private System.Threading.Tasks.Task SetFolderAsync(string folder) =>
         DataContext is WorkspaceViewModel vm
             ? vm.SetFolderAsync(folder)


### PR DESCRIPTION
First slice of milestone **M3** (per the 2026-07-18 GUI 2.0 spec), sliced **infra-first**: introduce the single-source-of-truth argv seam and the live CLI transparency strip, with **no new user options yet**. Later slices (M3b/c/d) add curated option controls per mode on top of this foundation.

## What's in this slice

- **`CommandBuilder`** (`Services/CommandBuilder.cs`) — one pure function mapping each workspace mode to its `dji-embed` argv (exactly today's hardcoded args, minus `--progress jsonl`, which `DjiEmbedRunner` still appends at execution). Both the runner path and the strip consume it, so what the user sees can't drift from what runs.
- **`CommandLine.Format`** (`Services/CommandLine.cs`) — renders that argv as a copy-pasteable command with minimal, best-effort **display** quoting (explicitly documented as not shell-safe; real execution goes through `ProcessStartInfo.ArgumentList`).
- **`RunAsync`/`RunSetupAsync`** now build argv via `CommandBuilder` at all four call sites (behaviour-preserving; the existing arg-recorder tests are the safety net).
- **`CommandPreview`** on `WorkspaceViewModel` + a mono **CLI transparency strip** with a Copy button under the action button. Shows `dji-embed <mode> …` (program name, not the bundled EXE), a `<folder>` placeholder before a folder is picked, and never the internal `--progress` flag.

## Testing

- New: golden argv tests, formatter/quoting tests (incl. tab-whitespace + embedded-quote display cases), `CommandPreview` behaviour + notification tests, and a headless test that the strip renders.
- Full GUI suite: **140 passed / 7 skipped / 0 failed** (skips are the env-gated screenshot captures). Release build: **0 warnings**.
- Built TDD, subagent-driven, with independent spec-compliance + code-quality review; review nits fixed in the final commit (distinct `copyLink` class so `footerLink` stays a unique test identity; corrected `CommandLine` docstring).

## Scope / not in this PR

No option controls, no Advanced expanders, no Convert/Verify, and not #328 — those are later M3 slices. The strip renders today's fixed args by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)