### PR TITLE
GUI 2.0 M3b: Flight map curated options + Advanced expander

### DIFF
--- a/docs/superpowers/specs/2026-07-20-gui-m3b-flightmap-options-design.md
+++ b/docs/superpowers/specs/2026-07-20-gui-m3b-flightmap-options-design.md
@@ -1,0 +1,158 @@
+# GUI 2.0 — M3b: Flight map curated options + Advanced expander
+
+**Parent spec:** `docs/superpowers/specs/2026-07-18-gui-full-workspace-design.md`
+(GUI 2.0 full-workspace design; this is the M3b milestone slice.)
+
+**Predecessor:** M3a shipped `CommandBuilder` (per-mode argv, one source of
+truth for run + strip) and the live CLI transparency strip. M3b is the first
+mode to grow curated options that feed that seam.
+
+## Goal
+
+Give the **Flight map** mode a curated options panel between the MODE strip and
+the ACTION button. Each control maps to an existing `flightmap` CLI flag; the
+typed option state flows through `CommandBuilder` into both the executed run and
+the live CLI strip. No new CLI features — M3b surfaces capability that already
+exists.
+
+## Context: the real `flightmap` flag surface
+
+`flightmap` (src/dji_metadata_embedder/cli.py) accepts: `directory` (the folder,
+from the Source picker), `-o/--output`, `-f/--format` (`html`/`kml`/`geojson`/
+`all`, default `html`), `-r/--recursive`, `--title`, `--redact` (`none`/`fuzz`,
+default `none`), `--join-gap SECONDS` (default `15.0`), `--tz-offset` (default
+`auto`), `--tile-style` (default `osm`), plus `--progress`/`-v`/`-q`.
+
+Tile-style keys (src/dji_metadata_embedder/geo/tiles.py): `osm` (default),
+`osm-hot`, `opentopomap`, `cyclosm`.
+
+**Footprints are NOT a flightmap capability.** `--footprint`/`--footprint-interval`
+live only on `convert` (per-clip, redact=none only, needs the FOV/model table).
+The parent spec's "footprints toggle" for Flight map was aspirational; per the
+2026-07-20 brainstorm it is **dropped from M3b** and belongs to Convert mode
+(M3c+). No CLI work is added here.
+
+## Curated controls (always visible when Flight map is selected)
+
+| Control | Shape | Default | argv effect |
+|---|---|---|---|
+| **Include subfolders** | `ToggleSwitch` | ON | `-r` when on; omit when off |
+| **Map style** | `ComboBox` (4) | Standard (`osm`) | `--tile-style osm-hot`/`opentopomap`/`cyclosm` when non-default; omit for Standard |
+| **Privacy** | 2-way (segmented / `ComboBox`) | Keep exact | `--redact fuzz` when Fuzz; omit when Keep |
+| **Join split recordings within** | `Slider` + value readout | 15 s | `--join-gap N` when N ≠ 15; `0` reads as "don't join" |
+
+Map-style labels → keys: Standard→`osm`, Humanitarian→`osm-hot`,
+Topographic→`opentopomap`, Cycling→`cyclosm`.
+
+Privacy labels → keys: "Keep exact locations"→`none`, "Fuzz to ~100 m"→`fuzz`.
+
+Join-gap slider range 0–60 s, integer step, default 15. `0` is labelled as
+disabling the join.
+
+## Advanced expander (collapsed by default)
+
+| Control | Shape | Default | argv effect |
+|---|---|---|---|
+| **Also export KML + GeoJSON** | `CheckBox` | off | `--format all` when on; omit (`html`) when off |
+| **Time zone of clips** | `TextBox` | `auto` | `--tz-offset X` when ≠ `auto` (and non-empty) |
+| **Map title** | `TextBox` | empty (→ folder name) | `--title X` when non-empty |
+| **Save map to** | file picker (`TextBox` + Browse) | empty (→ source folder) | `--output PATH` when set |
+
+**Extra-formats refinement (deviates from parent spec's "chips"):** `flightmap
+--format` is single-valued and the inline preview requires the HTML output. Two
+independent KML/GeoJSON chips cannot map onto a single-valued flag without both
+still emitting `all`. M3b therefore uses **one honest checkbox** — "Also export
+KML + GeoJSON" → `--format all` — instead of chips. Approved in the 2026-07-20
+brainstorm.
+
+## Defaults invariant
+
+With nothing touched, the Flight map argv is **`flightmap <folder> -r`** —
+byte-identical to what M3a's `CommandBuilder.Build(FlightMap, folder)` produces
+today. Options only *add* flags; omit-at-default keeps the strip clean and keeps
+M3a's golden tests valid.
+
+`CommandBuilder` still omits `--progress jsonl`; `DjiEmbedRunner` appends it
+unconditionally at execution (unchanged from M3a). The strip shows the human
+form with program name `dji-embed` and a `<folder>` placeholder before a folder
+is picked.
+
+## Styling constraint
+
+All controls are the **standard Avalonia / SukiUI themed controls**
+(`ToggleSwitch`, `ComboBox`, `Slider`, `CheckBox`, `TextBox`, `Expander`) and
+inherit the app theme's default appearance — including light/dark — with no
+bespoke restyling. Do not hand-paint control chrome; rely on the theme defaults
+so the panel is visually consistent with the rest of the workspace. (Layout
+spacing/labels are fine to set; the *controls themselves* stay themed defaults.)
+
+## Architecture
+
+Follows the parent spec's per-mode-builder direction ("each mode ViewModel owns
+typed option state and one builder producing the argv").
+
+- **`FlightMapOptions`** — an immutable record of typed option state
+  (`Recursive`, `TileStyle`, `Privacy`, `JoinGap`, `ExportAll`, `TzOffset`,
+  `Title`, `Output`) with a `Defaults` value. Pure input to the builder =
+  golden-testable.
+- **`FlightMapOptionsViewModel`** (`ObservableObject`, `[ObservableProperty]`
+  per control) — bound to the controls; exposes `ToOptions()` producing a
+  `FlightMapOptions` snapshot. Holds the display lists for the ComboBoxes.
+- **`CommandBuilder.FlightMap(string folder, FlightMapOptions opts)`** — new
+  pure overload returning the argv. The existing `Build(kind, folder)` routes
+  its FlightMap arm through `FlightMap(folder, FlightMapOptions.Defaults)`, so
+  M3a's default-behavior golden tests are unchanged.
+- **`WorkspaceViewModel`** — exposes the `FlightMapOptions` VM as a property;
+  its flightmap `RunAsync` branch builds argv via
+  `CommandBuilder.FlightMap(folder, FlightMapOptions.ToOptions())`; and
+  `CommandPreview` uses the same when Flight map is the selected mode.
+  `CommandPreview` recomputes whenever any option changes (subscribe to the
+  options VM's `PropertyChanged`).
+- **`WorkspaceView`** — a new OPTIONS zone (between MODE and ACTION) hosting a
+  Flight map options panel, visible only when `SelectedMode.Kind == FlightMap`
+  (other modes render nothing yet — M3c/M3d add their own). Advanced is a
+  collapsed `Expander`. The "Save map to" Browse button uses the existing
+  code-behind file-picker pattern (a Control anchor, like the folder picker).
+
+Runner, strict-success rule, cancellation, and the M2 preview all carry over
+unchanged. The done-map preview already points at the run result's reported
+output path, so a "Save map to" override previews correctly without special
+handling.
+
+## Behavior notes
+
+- **Persistence:** options are in-memory VM state only — no disk persistence
+  (respects the "no settings dialog; only MRU + window bounds" rule). They
+  persist while the app is open and while switching modes away/back; a fresh
+  launch starts at defaults.
+- **Mode switch:** switching away from Flight map hides the panel; switching
+  back shows it with its state intact. `CommandPreview` reflects the selected
+  mode's argv.
+
+## Testing
+
+- **Golden argv** (`CommandBuilderTests`): defaults (`flightmap <f> -r`);
+  recursive-off drops `-r`; each non-default tile style; `fuzz`; join-gap `0`
+  and `30`; export-all → `--format all`; tz-offset; title with spaces (quoting);
+  output override.
+- **Options VM** (`FlightMapOptionsViewModelTests`): default values;
+  `ToOptions()` mapping for each control.
+- **Live preview** (`WorkspaceViewModelTests`): `CommandPreview` updates when an
+  option changes; reflects Flight map argv when that mode is selected.
+- **Screen** (`AvaloniaFact`): Flight map renders the options panel with the
+  Advanced expander collapsed; a non-flightmap mode does not render the panel.
+
+## Out of scope (M3b)
+
+- Footprints on flightmap (no such CLI capability; belongs to Convert / M3c+).
+- Photo map, Embed, Convert, Verify options (M3c/M3d and beyond).
+- Any new CLI flag, or changes to the `--progress jsonl` contract.
+- Independent KML-only / GeoJSON-only export (CLI is single-valued).
+- Persisting options to disk.
+
+## Milestone placement
+
+M3b is one releasable milestone / one PR under the M3 arc (M3a done). Sibling
+slices still open: M3c/M3d (Photo map, Embed options) and issue #328 (existing-map
+detection). Release remains **held** per the small-userbase call — M3b rides the
+next version bump with the already-merged #327 fix and M3a.

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -44,4 +44,144 @@ public class CommandBuilderTests
             Assert.DoesNotContain("--progress", CommandBuilder.Build(kind, "/x"));
         }
     }
+
+    // M3b: FlightMap(folder, opts) is the option-aware argv builder. Defaults
+    // must equal M3a's hardcoded output; every option adds flags, omitting at
+    // default so the strip stays clean.
+    [Fact]
+    public void Flight_map_defaults_match_the_m3a_recursive_form()
+    {
+        string[] expected = ["flightmap", "/x", "-r"];
+        Assert.Equal(expected,
+            CommandBuilder.FlightMap("/x", FlightMapOptions.Defaults));
+    }
+
+    [Fact]
+    public void Flight_map_build_delegates_to_the_options_overload()
+    {
+        Assert.Equal(
+            CommandBuilder.FlightMap("/x", FlightMapOptions.Defaults),
+            CommandBuilder.Build(WorkspaceModeKind.FlightMap, "/x"));
+    }
+
+    [Fact]
+    public void Recursive_off_drops_the_r_flag()
+    {
+        var opts = FlightMapOptions.Defaults with { Recursive = false };
+        Assert.Equal(["flightmap", "/x"], CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Theory]
+    [InlineData("osm-hot")]
+    [InlineData("opentopomap")]
+    [InlineData("cyclosm")]
+    public void Non_default_tile_style_is_emitted(string key)
+    {
+        var opts = FlightMapOptions.Defaults with { TileStyle = key };
+        Assert.Equal(["flightmap", "/x", "-r", "--tile-style", key],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Default_tile_style_is_omitted()
+    {
+        var opts = FlightMapOptions.Defaults with { TileStyle = "osm" };
+        Assert.DoesNotContain("--tile-style", CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Fuzz_privacy_adds_redact_fuzz()
+    {
+        var opts = FlightMapOptions.Defaults with { Privacy = MapPrivacy.Fuzz };
+        Assert.Equal(["flightmap", "/x", "-r", "--redact", "fuzz"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Keep_privacy_omits_redact()
+    {
+        Assert.DoesNotContain("--redact",
+            CommandBuilder.FlightMap("/x", FlightMapOptions.Defaults));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(30)]
+    public void Non_default_join_gap_is_emitted(int seconds)
+    {
+        var opts = FlightMapOptions.Defaults with { JoinGap = seconds };
+        Assert.Equal(
+            ["flightmap", "/x", "-r", "--join-gap", seconds.ToString()],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Default_join_gap_of_15_is_omitted()
+    {
+        Assert.DoesNotContain("--join-gap",
+            CommandBuilder.FlightMap("/x", FlightMapOptions.Defaults));
+    }
+
+    [Fact]
+    public void Export_all_adds_format_all()
+    {
+        var opts = FlightMapOptions.Defaults with { ExportAll = true };
+        Assert.Equal(["flightmap", "/x", "-r", "--format", "all"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Theory]
+    [InlineData("auto")]
+    [InlineData("AUTO")]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Auto_or_blank_timezone_is_omitted(string tz)
+    {
+        var opts = FlightMapOptions.Defaults with { TzOffset = tz };
+        Assert.DoesNotContain("--tz-offset", CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Explicit_timezone_is_emitted_trimmed()
+    {
+        var opts = FlightMapOptions.Defaults with { TzOffset = " +05:30 " };
+        Assert.Equal(["flightmap", "/x", "-r", "--tz-offset", "+05:30"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Title_is_emitted_when_set_and_stays_one_argument()
+    {
+        var opts = FlightMapOptions.Defaults with { Title = "Summer trip" };
+        Assert.Equal(["flightmap", "/x", "-r", "--title", "Summer trip"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Blank_title_is_omitted()
+    {
+        var opts = FlightMapOptions.Defaults with { Title = "   " };
+        Assert.DoesNotContain("--title", CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Output_override_is_emitted()
+    {
+        var opts = FlightMapOptions.Defaults with { Output = "/out/map.html" };
+        Assert.Equal(["flightmap", "/x", "-r", "--output", "/out/map.html"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void All_options_compose_in_a_stable_order()
+    {
+        var opts = new FlightMapOptions(
+            Recursive: false, TileStyle: "cyclosm", Privacy: MapPrivacy.Fuzz,
+            JoinGap: 0, ExportAll: true, TzOffset: "-8", Title: "T", Output: "/o.html");
+        Assert.Equal(
+            ["flightmap", "/x", "--tile-style", "cyclosm", "--redact", "fuzz",
+             "--join-gap", "0", "--format", "all", "--tz-offset", "-8",
+             "--title", "T", "--output", "/o.html"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
@@ -55,4 +55,12 @@ public class FlightMapOptionsViewModelTests
                 "-8", "Trip", "/out/map.html"),
             vm.ToOptions());
     }
+
+    [Fact]
+    public void Clear_output_resets_to_the_default()
+    {
+        var vm = new FlightMapOptionsViewModel { Output = "/out/map.html" };
+        vm.ClearOutputCommand.Execute(null);
+        Assert.Equal("", vm.Output);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
@@ -1,0 +1,58 @@
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class FlightMapOptionsViewModelTests
+{
+    [Fact]
+    public void Defaults_match_the_flightmap_options_defaults()
+    {
+        var vm = new FlightMapOptionsViewModel();
+        Assert.Equal(FlightMapOptions.Defaults, vm.ToOptions());
+    }
+
+    [Fact]
+    public void Default_selections_are_standard_and_keep()
+    {
+        var vm = new FlightMapOptionsViewModel();
+        Assert.True(vm.Recursive);
+        Assert.Equal("osm", vm.SelectedTileStyle.Key);
+        Assert.Equal(MapPrivacy.Keep, vm.SelectedPrivacy.Value);
+        Assert.Equal(15, vm.JoinGap);
+        Assert.False(vm.ExportAll);
+        Assert.Equal("auto", vm.TzOffset);
+        Assert.Equal("", vm.Title);
+        Assert.Equal("", vm.Output);
+    }
+
+    [Fact]
+    public void Offers_the_four_tile_styles_and_two_privacy_choices()
+    {
+        var vm = new FlightMapOptionsViewModel();
+        Assert.Equal(["osm", "osm-hot", "opentopomap", "cyclosm"],
+            vm.TileStyles.Select(t => t.Key));
+        Assert.Equal([MapPrivacy.Keep, MapPrivacy.Fuzz],
+            vm.PrivacyOptions.Select(p => p.Value));
+    }
+
+    [Fact]
+    public void ToOptions_reflects_every_mutated_control()
+    {
+        var vm = new FlightMapOptionsViewModel
+        {
+            Recursive = false,
+            JoinGap = 0,
+            ExportAll = true,
+            TzOffset = "-8",
+            Title = "Trip",
+            Output = "/out/map.html",
+        };
+        vm.SelectedTileStyle = vm.TileStyles.Single(t => t.Key == "cyclosm");
+        vm.SelectedPrivacy = vm.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
+
+        Assert.Equal(
+            new FlightMapOptions(false, "cyclosm", MapPrivacy.Fuzz, 0, true,
+                "-8", "Trip", "/out/map.html"),
+            vm.ToOptions());
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -177,4 +177,31 @@ public class WorkspaceScreenTests
         Assert.Single(window.GetVisualDescendants().OfType<Button>(),
             b => b.Name == "CopyCommandButton");
     }
+
+    // M3b: the Flight map options panel renders only for Flight map, with the
+    // Advanced expander closed by default.
+    [AvaloniaFact]
+    public void Flight_map_mode_shows_the_options_panel_with_advanced_collapsed()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "FlightOptionsPanel");
+        Assert.True(panel.IsEffectivelyVisible);
+        var advanced = window.GetVisualDescendants().OfType<Expander>()
+            .Single(e => e.Name == "FlightAdvanced");
+        Assert.False(advanced.IsExpanded);
+    }
+
+    [AvaloniaFact]
+    public void Non_flight_map_mode_hides_the_options_panel()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Setup);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "FlightOptionsPanel");
+        Assert.False(panel.IsEffectivelyVisible);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -667,6 +667,56 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
     }
 
+    // M3b: Flight map options flow through the run and the live strip.
+    [Fact]
+    public async Task Flight_map_options_reach_the_flightmap_argv()
+    {
+        var argsFile = Path.Combine(_dir, "args-opt.txt");
+        var cli = FakeCli.WriteArgsRecorder(_dir, argsFile, FlightmapStream);
+        var vm = Vm(cli);
+        vm.FlightOptions.SelectedPrivacy =
+            vm.FlightOptions.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
+        vm.FlightOptions.ExportAll = true;
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        var argv = File.ReadAllText(argsFile);
+        Assert.Contains("--redact fuzz", argv);
+        Assert.Contains("--format all", argv);
+    }
+
+    [Fact]
+    public void Command_preview_reflects_flight_options()
+    {
+        var vm = Vm("unused");   // default mode Flight map, no folder
+        vm.FlightOptions.ExportAll = true;
+        Assert.Contains("--format all", vm.CommandPreview);
+        vm.FlightOptions.Recursive = false;
+        Assert.DoesNotContain(" -r", vm.CommandPreview);
+    }
+
+    [Fact]
+    public void Changing_a_flight_option_notifies_command_preview()
+    {
+        var vm = Vm("unused");
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.FlightOptions.JoinGap = 0;
+        Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
+    }
+
+    [Fact]
+    public void Only_flight_map_mode_reports_the_options_panel_visible()
+    {
+        var vm = Vm("unused");
+        Assert.True(vm.IsFlightMapMode);
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Assert.False(vm.IsFlightMapMode);
+        Assert.Contains(nameof(WorkspaceViewModel.IsFlightMapMode), notified);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using DjiEmbed.Gui.ViewModels;
 
 namespace DjiEmbed.Gui.Services;
@@ -19,10 +21,64 @@ public static class CommandBuilder
     /// placeholder token when previewing).</param>
     public static string[] Build(WorkspaceModeKind kind, string? folder) => kind switch
     {
-        WorkspaceModeKind.FlightMap => ["flightmap", folder!, "-r"],
+        WorkspaceModeKind.FlightMap => FlightMap(folder!, FlightMapOptions.Defaults),
         WorkspaceModeKind.PhotoMap => ["photomap", folder!, "-r", "--link-originals"],
         WorkspaceModeKind.Embed => ["embed", folder!],
         WorkspaceModeKind.Setup => ["doctor"],
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
     };
+
+    /// <summary>
+    /// The Flight map argv from typed <paramref name="opts"/> (GUI 2.0 spec,
+    /// M3b). Flags are omitted at their defaults so an untouched run reads
+    /// <c>flightmap &lt;folder&gt; -r</c>, exactly like M3a. Order is fixed for
+    /// golden tests. No <c>--progress</c>: the runner appends that.
+    /// </summary>
+    public static string[] FlightMap(string folder, FlightMapOptions opts)
+    {
+        var args = new List<string> { "flightmap", folder };
+        if (opts.Recursive)
+        {
+            args.Add("-r");
+        }
+        if (opts.TileStyle != FlightMapOptions.Defaults.TileStyle)
+        {
+            args.Add("--tile-style");
+            args.Add(opts.TileStyle);
+        }
+        if (opts.Privacy == MapPrivacy.Fuzz)
+        {
+            args.Add("--redact");
+            args.Add("fuzz");
+        }
+        if (opts.JoinGap != FlightMapOptions.Defaults.JoinGap)
+        {
+            args.Add("--join-gap");
+            args.Add(opts.JoinGap.ToString(CultureInfo.InvariantCulture));
+        }
+        if (opts.ExportAll)
+        {
+            args.Add("--format");
+            args.Add("all");
+        }
+        var tz = opts.TzOffset.Trim();
+        if (tz.Length > 0 && !tz.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            args.Add("--tz-offset");
+            args.Add(tz);
+        }
+        var title = opts.Title.Trim();
+        if (title.Length > 0)
+        {
+            args.Add("--title");
+            args.Add(title);
+        }
+        var output = opts.Output.Trim();
+        if (output.Length > 0)
+        {
+            args.Add("--output");
+            args.Add(output);
+        }
+        return args.ToArray();
+    }
 }

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
@@ -1,0 +1,43 @@
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>How the Flight map treats GPS coordinates. Mirrors the two
+/// values <c>flightmap --redact</c> accepts (there is no "drop" for maps).</summary>
+public enum MapPrivacy
+{
+    Keep,
+    Fuzz,
+}
+
+/// <summary>
+/// Immutable, typed state for a Flight map run (GUI 2.0 spec, M3b). It is the
+/// single input to <see cref="Services.CommandBuilder.FlightMap"/>, so the argv
+/// is a pure function of this record — golden-testable. Every field maps to an
+/// existing <c>flightmap</c> flag; defaults reproduce M3a's hardcoded argv.
+/// </summary>
+/// <param name="TileStyle">A <c>tiles.py</c> key: <c>osm</c> (default),
+/// <c>osm-hot</c>, <c>opentopomap</c>, or <c>cyclosm</c>.</param>
+/// <param name="JoinGap">Seconds to chain size-split recordings; 15 = the CLI
+/// default, 0 = don't join.</param>
+/// <param name="ExportAll">Also write KML + GeoJSON (<c>--format all</c>); the
+/// CLI format is single-valued, so this is one honest toggle, not per-format.</param>
+/// <param name="TzOffset"><c>auto</c> (default) or an explicit UTC offset.</param>
+public sealed record FlightMapOptions(
+    bool Recursive,
+    string TileStyle,
+    MapPrivacy Privacy,
+    int JoinGap,
+    bool ExportAll,
+    string TzOffset,
+    string Title,
+    string Output)
+{
+    public static readonly FlightMapOptions Defaults = new(
+        Recursive: true,
+        TileStyle: "osm",
+        Privacy: MapPrivacy.Keep,
+        JoinGap: 15,
+        ExportAll: false,
+        TzOffset: "auto",
+        Title: "",
+        Output: "");
+}

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>A selectable basemap: a friendly label over a <c>tiles.py</c> key.</summary>
+public sealed record TileChoice(string Label, string Key);
+
+/// <summary>A selectable privacy stance: a label over a <see cref="MapPrivacy"/>.</summary>
+public sealed record PrivacyChoice(string Label, MapPrivacy Value);
+
+/// <summary>
+/// Observable control state for the Flight map options panel (GUI 2.0 spec,
+/// M3b). Bound directly to the SukiUI-themed controls; <see cref="ToOptions"/>
+/// snapshots it into the immutable <see cref="FlightMapOptions"/> the builder
+/// consumes. Lives on <see cref="WorkspaceViewModel"/>; in-memory only.
+/// </summary>
+public partial class FlightMapOptionsViewModel : ViewModelBase
+{
+    public IReadOnlyList<TileChoice> TileStyles { get; } =
+    [
+        new("Standard", "osm"),
+        new("Humanitarian", "osm-hot"),
+        new("Topographic", "opentopomap"),
+        new("Cycling", "cyclosm"),
+    ];
+
+    public IReadOnlyList<PrivacyChoice> PrivacyOptions { get; } =
+    [
+        new("Keep exact locations", MapPrivacy.Keep),
+        new("Fuzz to ~100 m", MapPrivacy.Fuzz),
+    ];
+
+    [ObservableProperty]
+    public partial bool Recursive { get; set; } = true;
+
+    [ObservableProperty]
+    public partial TileChoice SelectedTileStyle { get; set; }
+
+    [ObservableProperty]
+    public partial PrivacyChoice SelectedPrivacy { get; set; }
+
+    [ObservableProperty]
+    public partial int JoinGap { get; set; } = 15;
+
+    [ObservableProperty]
+    public partial bool ExportAll { get; set; }
+
+    [ObservableProperty]
+    public partial string TzOffset { get; set; } = "auto";
+
+    [ObservableProperty]
+    public partial string Title { get; set; } = "";
+
+    [ObservableProperty]
+    public partial string Output { get; set; } = "";
+
+    public FlightMapOptionsViewModel()
+    {
+        SelectedTileStyle = TileStyles[0];
+        SelectedPrivacy = PrivacyOptions[0];
+    }
+
+    public FlightMapOptions ToOptions() => new(
+        Recursive: Recursive,
+        TileStyle: SelectedTileStyle.Key,
+        Privacy: SelectedPrivacy.Value,
+        JoinGap: JoinGap,
+        ExportAll: ExportAll,
+        TzOffset: TzOffset,
+        Title: Title,
+        Output: Output);
+}

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace DjiEmbed.Gui.ViewModels;
 
@@ -70,4 +71,9 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
         TzOffset: TzOffset,
         Title: Title,
         Output: Output);
+
+    /// <summary>Reset the output override back to the default (write the map
+    /// into the source folder).</summary>
+    [RelayCommand]
+    private void ClearOutput() => Output = "";
 }

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -33,7 +33,13 @@ public partial class WorkspaceViewModel : FlowViewModel
         _cliResolver = cliResolver;
         _previewAvailable = previewAvailable
             ?? (static () => WebViewSupport.IsLikelyAvailable);
+        FlightOptions.PropertyChanged += (_, _) =>
+            OnPropertyChanged(nameof(CommandPreview));
     }
+
+    /// <summary>Curated option state for the Flight map mode (M3b). Feeds both
+    /// the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
+    public FlightMapOptionsViewModel FlightOptions { get; } = new();
 
     public IReadOnlyList<WorkspaceMode> Modes => WorkspaceMode.All;
 
@@ -83,6 +89,9 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>The action button lights up as soon as a run could work.</summary>
     public bool CanRun => !SelectedMode.NeedsFolder || SelectedFolder is not null;
 
+    /// <summary>Whether the Flight map options panel applies to the current mode.</summary>
+    public bool IsFlightMapMode => SelectedMode.Kind == WorkspaceModeKind.FlightMap;
+
     /// <summary>
     /// The exact human-facing <c>dji-embed</c> command the current mode +
     /// folder would run — the CLI transparency strip (GUI 2.0 spec, M3a).
@@ -96,8 +105,13 @@ public partial class WorkspaceViewModel : FlowViewModel
         {
             var folder = SelectedFolder
                 ?? (SelectedMode.NeedsFolder ? "<folder>" : null);
-            return CommandLine.Format(
-                "dji-embed", CommandBuilder.Build(SelectedMode.Kind, folder));
+            // folder! is safe for Flight map: its NeedsFolder is true, so the
+            // line above yields the "<folder>" placeholder (never null) when
+            // no folder is picked.
+            var argv = SelectedMode.Kind == WorkspaceModeKind.FlightMap
+                ? CommandBuilder.FlightMap(folder!, FlightOptions.ToOptions())
+                : CommandBuilder.Build(SelectedMode.Kind, folder);
+            return CommandLine.Format("dji-embed", argv);
         }
     }
 
@@ -112,6 +126,7 @@ public partial class WorkspaceViewModel : FlowViewModel
     {
         OnPropertyChanged(nameof(CanRun));
         OnPropertyChanged(nameof(CommandPreview));
+        OnPropertyChanged(nameof(IsFlightMapMode));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -260,7 +275,7 @@ public partial class WorkspaceViewModel : FlowViewModel
                 await ExecuteFlowAsync(async () =>
                     await RunStepAsync(
                         "Mapping your flights…",
-                        CommandBuilder.Build(SelectedMode.Kind, folder))
+                        CommandBuilder.FlightMap(folder, FlightOptions.ToOptions()))
                     && await PrimePreviewAsync());
                 return;
             case WorkspaceModeKind.PhotoMap when !contents.HasPhotos:

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -68,4 +68,28 @@ internal static class FolderPicking
     /// <summary>Toggles the "dragover" style class on the drop zone.</summary>
     internal static void SetDragOver(Control zone, bool active) =>
         zone.Classes.Set("dragover", active);
+
+    internal static async Task SaveMapAsync(Control anchor, Action<string> onPath)
+    {
+        if (TopLevel.GetTopLevel(anchor) is not { } top)
+        {
+            return;
+        }
+        var file = await top.StorageProvider.SaveFilePickerAsync(
+            new FilePickerSaveOptions
+            {
+                Title = "Save the flight map as",
+                SuggestedFileName = "flightmap.html",
+                DefaultExtension = "html",
+                FileTypeChoices =
+                [
+                    new FilePickerFileType("Web map") { Patterns = ["*.html"] },
+                ],
+            });
+        var path = file?.TryGetLocalPath();
+        if (path is not null)
+        {
+            onPath(path);
+        }
+    }
 }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -198,6 +198,15 @@
                                                             Click="OnChooseOutputClick">
                                                         <TextBlock Text="Choose…" FontSize="12" />
                                                     </Button>
+                                                    <Button DockPanel.Dock="Right"
+                                                            Margin="8,0,0,0"
+                                                            Name="ClearOutputButton"
+                                                            Command="{Binding FlightOptions.ClearOutputCommand}"
+                                                            IsVisible="{Binding FlightOptions.Output,
+                                                                Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                            ToolTip.Tip="Reset to the source folder">
+                                                        <TextBlock Text="Use default" FontSize="12" />
+                                                    </Button>
                                                     <Panel VerticalAlignment="Center">
                                                         <TextBlock Text="(inside the source folder)"
                                                                    IsVisible="{Binding FlightOptions.Output,

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -112,6 +112,112 @@
                         </StackPanel>
                     </suki:GlassCard>
 
+                    <Border Name="FlightOptionsPanel"
+                            IsVisible="{Binding IsFlightMapMode}">
+                        <StackPanel>
+                            <TextBlock Classes="zone" Text="OPTIONS" />
+                            <suki:GlassCard Padding="14">
+                                <StackPanel Spacing="12">
+                                    <DockPanel>
+                                        <ToggleSwitch DockPanel.Dock="Right"
+                                                      IsChecked="{Binding FlightOptions.Recursive}" />
+                                        <TextBlock Text="Include subfolders"
+                                                   VerticalAlignment="Center" />
+                                    </DockPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Map style" Opacity="0.7"
+                                                   FontSize="12" />
+                                        <ComboBox HorizontalAlignment="Stretch"
+                                                  ItemsSource="{Binding FlightOptions.TileStyles}"
+                                                  SelectedItem="{Binding FlightOptions.SelectedTileStyle}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:TileChoice">
+                                                    <TextBlock Text="{Binding Label}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Privacy" Opacity="0.7"
+                                                   FontSize="12" />
+                                        <ComboBox HorizontalAlignment="Stretch"
+                                                  ItemsSource="{Binding FlightOptions.PrivacyOptions}"
+                                                  SelectedItem="{Binding FlightOptions.SelectedPrivacy}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:PrivacyChoice">
+                                                    <TextBlock Text="{Binding Label}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <DockPanel>
+                                            <TextBlock DockPanel.Dock="Right"
+                                                       Text="{Binding FlightOptions.JoinGap, StringFormat='{}{0} s'}"
+                                                       Opacity="0.7" FontSize="12" />
+                                            <TextBlock Text="Join split recordings within"
+                                                       Opacity="0.7" FontSize="12" />
+                                        </DockPanel>
+                                        <Slider Minimum="0" Maximum="60"
+                                                TickFrequency="1" IsSnapToTickEnabled="True"
+                                                Value="{Binding FlightOptions.JoinGap}" />
+                                        <TextBlock Text="0 = keep split clips as separate flights"
+                                                   Opacity="0.5" FontSize="11" />
+                                    </StackPanel>
+
+                                    <Expander Name="FlightAdvanced" Header="Advanced"
+                                              IsExpanded="False">
+                                        <StackPanel Spacing="12" Margin="0,8,0,0">
+                                            <CheckBox IsChecked="{Binding FlightOptions.ExportAll}"
+                                                      Content="Also export KML + GeoJSON" />
+
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="Time zone of the clips"
+                                                           Opacity="0.7" FontSize="12" />
+                                                <TextBox Text="{Binding FlightOptions.TzOffset}"
+                                                         PlaceholderText="auto" />
+                                            </StackPanel>
+
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="Map title" Opacity="0.7"
+                                                           FontSize="12" />
+                                                <TextBox Text="{Binding FlightOptions.Title}"
+                                                         PlaceholderText="(folder name)" />
+                                            </StackPanel>
+
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="Save map to" Opacity="0.7"
+                                                           FontSize="12" />
+                                                <DockPanel>
+                                                    <Button DockPanel.Dock="Right"
+                                                            Margin="8,0,0,0"
+                                                            Name="ChooseOutputButton"
+                                                            Click="OnChooseOutputClick">
+                                                        <TextBlock Text="Choose…" FontSize="12" />
+                                                    </Button>
+                                                    <Panel VerticalAlignment="Center">
+                                                        <TextBlock Text="(inside the source folder)"
+                                                                   IsVisible="{Binding FlightOptions.Output,
+                                                                       Converter={x:Static StringConverters.IsNullOrEmpty}}"
+                                                                   Opacity="0.5" FontSize="12" />
+                                                        <TextBlock Text="{Binding FlightOptions.Output}"
+                                                                   IsVisible="{Binding FlightOptions.Output,
+                                                                       Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                                   TextTrimming="CharacterEllipsis"
+                                                                   Opacity="0.8" FontSize="12" />
+                                                    </Panel>
+                                                </DockPanel>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Expander>
+                                </StackPanel>
+                            </suki:GlassCard>
+                        </StackPanel>
+                    </Border>
+
                     <TextBlock Classes="zone" Text="ACTION" />
                     <Button Name="RunButton" Classes="Flat"
                             HorizontalAlignment="Stretch"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -114,6 +114,14 @@ public partial class WorkspaceView : UserControl
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>
         await FolderPicking.ChooseAsync(this, SetFolderAsync);
 
+    private async void OnChooseOutputClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is WorkspaceViewModel vm)
+        {
+            await FolderPicking.SaveMapAsync(this, p => vm.FlightOptions.Output = p);
+        }
+    }
+
     private async void OnCopyDetailsClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is FlowViewModel vm)


### PR DESCRIPTION
## Summary

M3b gives the desktop app's **Flight map** mode a curated options panel (between the mode strip and the action button), plus an Advanced expander. Every control maps to an existing `flightmap` CLI flag through the M3a `CommandBuilder` seam, so the live **CLI transparency strip** updates as you twiddle options, and what the strip shows is exactly what runs. No new CLI features; no `--progress` in the builder; option state is in-memory only.

Spec: `docs/superpowers/specs/2026-07-20-gui-m3b-flightmap-options-design.md`

**Curated controls** (always visible for Flight map):
- **Include subfolders** — `-r` (default on)
- **Map style** — `--tile-style` (Standard `osm` omitted; Humanitarian / Topographic / Cycling)
- **Privacy** — Keep / Fuzz → `--redact fuzz`
- **Join split recordings within** — slider → `--join-gap N` (default 15 omitted; 0 = don't join)

**Advanced expander** (collapsed by default):
- **Also export KML + GeoJSON** → `--format all` (the CLI format is single-valued, so this is one honest toggle, not per-format chips)
- **Time zone of the clips** → `--tz-offset` (default `auto`)
- **Map title** → `--title`
- **Save map to** → `--output` (save-file picker + a "Use default" reset)

**Defaults invariant:** untouched, the argv is `flightmap <folder> -r` — byte-identical to M3a, so its golden tests stay green.

Footprints were dropped from M3b (they're a `convert`-only capability, not a `flightmap` flag). Controls are standard SukiUI-themed Avalonia controls with no bespoke restyling.

## Implementation

Built TDD, subagent-driven, with two-stage review (spec then code-quality) per task and a final whole-branch review:
- `FlightMapOptions` record + `CommandBuilder.FlightMap(folder, opts)` (pure, golden-tested argv)
- `FlightMapOptionsViewModel` (typed control state → `ToOptions()`)
- Wired into `WorkspaceViewModel` (`FlightOptions`, `IsFlightMapMode`, run + strip routing)
- The options panel in `WorkspaceView.axaml` + save-file picker

## Test plan

- [x] Full GUI suite green: **173 passed / 0 failed / 7 skipped** (the 7 are env-gated E2E/screenshot/Windows-reveal)
- [x] Release build: **0 warnings**
- [x] Golden argv tests for every option (on/off of each omit-at-default, stable ordering, quoting)
- [x] `CommandPreview` updates live on any option change; run uses the same builder call
- [x] Screen tests: panel renders for Flight map with Advanced collapsed; hidden for other modes
- [ ] Maintainer manual E2E on real Windows (twiddle options, confirm the strip + generated map)

**Release is held** (small userbase, maintainer's call) — this rides the next version bump alongside #327 and M3a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2hviX55tFh846EugJLR8m