### PR TITLE
feat(gui): surface maps that already exist in the chosen folder (#328)

### DIFF
--- a/docs/superpowers/specs/2026-07-20-gui-existing-maps-design.md
+++ b/docs/superpowers/specs/2026-07-20-gui-existing-maps-design.md
@@ -1,0 +1,244 @@
+# GUI — Surface maps that already exist in the chosen folder (#328)
+
+**Issue:** #328 — found during a manual UI test of v1.26.0 on Windows 11.
+**Parent spec:** `docs/superpowers/specs/2026-07-18-gui-full-workspace-design.md`
+(GUI 2.0 full-workspace design.) This is a standalone fix under that design,
+not an M3 milestone slice.
+
+## Goal
+
+Pick a folder that already contains `flightmap.html` or `photomap.html` and the
+app currently pretends they don't exist — the only route back to a map you
+already made is to make it again. This change probes for those maps on folder
+pick, lists them in the left column, and lets you open one in the app's own
+preview pane.
+
+No CLI work. No persistence.
+
+## What exists today
+
+- `FolderInspector.Inspect` classifies by extension only (`.srt` / photos /
+  videos) and stops early once all three are found. `.html` matches nothing.
+- `WorkspaceViewModel.PreviewUrl` is written only by `PrimePreviewAsync`, which
+  reads `Outputs` — populated exclusively from a run's terminal JSONL event.
+- Both preview panes are gated on `Step == FlowStep.Done`, so nothing can render
+  while `Step == Pick`.
+- The idle pane is a static hero: background image plus two fixed lines.
+
+The GUI never passes `-o` by default, so the CLI's defaults apply and the paths
+are deterministic: `<folder>/flightmap.html` (`cli.py:854`) and
+`<folder>/photomap.html` (`cli.py:699`). 360° panoramas are not separate files —
+the Pannellum viewer is embedded inside `photomap.html`.
+
+## Decisions (2026-07-20 brainstorm)
+
+| Question | Decision |
+|---|---|
+| Where do existing maps surface? | A row in the **left column**, between MODE and OPTIONS. The preview pane's idle hero is untouched. |
+| What does **Open** do? | Renders the map **inline** in the app's preview pane — the same WebView a finished run uses. |
+| Staleness | **Yes** — a quiet line when the map predates the newest media of its own kind. |
+| Does the action button relabel to "Regenerate"? | **No.** The row already says a map exists, and M3b's "Save map to" override would make "Regenerate" a lie. |
+
+## Detection
+
+### `FolderContents` gains per-kind timestamps
+
+```csharp
+public sealed record FolderContents(
+    bool HasFlightLogs, bool HasPhotos, bool HasVideos,
+    DateTime? NewestFlightLogUtc, DateTime? NewestPhotoUtc);
+```
+
+Per-kind, not one global "newest media": new photos must not mark the flight map
+stale, and vice versa. Videos get no timestamp — they produce no map.
+
+`Inspect` loses its `break`-when-all-three-found shortcut, because the newest
+write time is only known after the full walk. The scan already runs on a
+background thread (`Task.Run` in `SetFolderAsync` and `RunAsync`), and it is
+already recursive, so this costs a full enumeration on folders that would
+previously have exited early.
+
+### `ExistingMapFinder`
+
+```csharp
+public sealed record ExistingMap(
+    string Path, string Title, DateTime WrittenUtc, bool Stale);
+
+public static class ExistingMapFinder
+{
+    public static IReadOnlyList<ExistingMap> Find(
+        string directory, FolderContents contents);
+}
+```
+
+Probes exactly two paths — `flightmap.html`, `photomap.html` — directly in the
+chosen directory (not recursive; the CLI writes them at the top level).
+Titles are `"Flight map"` and `"Photo map"` — the same strings as
+`WorkspaceMode.Title` for those kinds, so the row and the mode strip agree.
+Order is flight map first, then photo map. A folder with neither yields an empty
+list.
+
+`WrittenUtc` is `File.GetLastWriteTimeUtc`. Staleness pairs each map with its own
+source kind:
+
+- `flightmap.html` → `Stale` when `contents.NewestFlightLogUtc > WrittenUtc`
+- `photomap.html` → `Stale` when `contents.NewestPhotoUtc > WrittenUtc`
+
+A null timestamp (no media of that kind) is never stale.
+
+A file that vanishes or throws between `Exists` and the timestamp read is
+skipped, not surfaced — the scan must never fail a folder pick.
+
+### `RelativeTime`
+
+```csharp
+public static class RelativeTime
+{
+    public static string Describe(DateTime whenUtc, DateTime nowUtc);
+}
+```
+
+`nowUtc` is a parameter so tests need no clock seam.
+
+| Age | Output |
+|---|---|
+| negative (clock skew) or < 1 minute | `just now` |
+| < 1 hour | `1 minute ago` / `N minutes ago` |
+| < 1 day | `1 hour ago` / `N hours ago` |
+| otherwise | `1 day ago` / `N days ago` |
+
+No week/month/year tiers and no absolute-date fallback: `"412 days ago"` is
+unambiguous, and tiers are more code and more test surface than the readability
+buys. Values truncate (2 h 55 m reads `2 hours ago`).
+
+## Browsing an existing map
+
+### ViewModel
+
+`WorkspaceViewModel` gains:
+
+```csharp
+public ObservableCollection<ExistingMap> ExistingMaps { get; } = [];
+```
+
+- Populated at the end of `SetFolderAsync`, from the same `FolderContents` the
+  mode suggestion already uses — one scan, not two. `Find` runs inside that same
+  background `Task.Run`, so its `File.Exists` probes stay off the UI thread; the
+  collection is then filled on the awaited continuation.
+- Cleared and repopulated on every folder pick; cleared by `ClearFolder`.
+- Mode-agnostic: the row reflects what is on disk regardless of the selected
+  mode, because it answers "what's already here", not "what would this run do".
+
+Row buttons bind to commands taking the item as a parameter — no per-row
+ViewModel:
+
+- `OpenExistingMapCommand(ExistingMap)` — serve and preview (below).
+  `CanExecute` is `Step != FlowStep.Running`; `OnStepChangedCore` calls
+  `NotifyCanExecuteChanged` so the buttons grey out for the duration of a run.
+- `ShowExistingMapInFolderCommand(ExistingMap)` — `Reveal.InFolder(map.Path)`.
+
+`OpenExistingMap` mirrors `PrimePreviewAsync`: get a URL from `IMapServer`, set
+`PreviewPath` first, then `PreviewUrl` (the view reads the path when the URL
+lands). Where it differs: when the WebView is unavailable or the server returns
+no URL, it **falls back to opening the map in the system browser** rather than
+setting `PreviewUnavailable`. A done-card explaining why the preview can't
+render belongs to a run that just finished; here the user asked for one specific
+map, and the browser satisfies that ask. Reuses `OpenOutputCoreAsync`.
+
+### Pane gates
+
+| Property | Before | After |
+|---|---|---|
+| `ShowPreview` | `Step == Done && PreviewUrl is not null` | `PreviewUrl is not null && (Step == Done \|\| Step == Pick)` |
+| `ShowDoneCard` | `Step == Done && PreviewUrl is null` | unchanged |
+| idle hero | bound to `Step == Pick` in XAML | new `ShowIdle => Step == FlowStep.Pick && PreviewUrl is null` |
+
+`ShowIdle` is a real ViewModel property rather than a XAML multi-binding, so the
+idle/preview split is testable without a visual tree.
+
+### Collision safety
+
+A browsed preview can never survive into a run, because all three existing exits
+already call `ResetPreview()`:
+
+- `SetFolderAsync` — a new folder clears the previous folder's map.
+- `RunAsync` — resets past the awaited scan (deliberately, so a live map isn't
+  flashed away early).
+- `GoHomeCore` ("Process another"/"Close map") — back to the hero.
+
+Plus `OpenExistingMapCommand` is disabled while `Step == Running`.
+
+### Fixing a latent leak this exposes
+
+`Outputs` and `Warnings` are cleared only at run start
+(`FlowViewModel.cs:131-132`). Today that is invisible. Once a preview can render
+during `Step == Pick`, a run in folder A would show its warnings over folder B's
+browsed map. `SetFolderAsync` will clear both — which its own doc comment ("a
+new folder is a fresh start") already claims.
+
+## View
+
+A new `ExistingMapsPanel` between the MODE `GlassCard` and `FlightOptionsPanel`,
+visible on `ExistingMaps.Count`:
+
+```
+ALREADY IN THIS FOLDER
+┌──────────────────────────────┐
+│ 🗺  Flight map                │
+│    2 days ago                │
+│    ⚠ New footage since this  │
+│      map was made            │
+│    [Open]  [Show in folder]  │
+└──────────────────────────────┘
+```
+
+- Zone label `ALREADY IN THIS FOLDER` using the existing `zone` class.
+- One `GlassCard` per map inside an `ItemsControl` bound to `ExistingMaps`.
+- The stale line is visible on `Stale`; the relative time comes from a converter
+  over `WrittenUtc` (`WorkspaceConverters`, alongside `FileNameOnly`) that calls
+  `RelativeTime.Describe(value, DateTime.UtcNow)` at bind time. Reading the clock
+  in the view keeps `RelativeTime` itself clock-free and testable.
+- Standard Avalonia / SukiUI themed controls throughout, inheriting the app
+  theme in both light and dark — the M3b styling constraint carries over.
+
+The preview header (`WorkspaceView.axaml:382-409`) is reused as-is. Its third
+button's **text** switches on step — `Done` → "Process another", `Pick` →
+"Close map" — because nothing has been processed when you are browsing a map
+that was already there. The command (`GoHomeCommand`) is unchanged.
+
+## Testing
+
+- **`ExistingMapFinderTests`** (temp directories): empty folder → no maps; flight
+  map only; photo map only; both → flight first; stale when the matching media is
+  newer; not stale when the map is newer; not stale when no media of that kind
+  exists; photos newer than the flight map do not stale it.
+- **`RelativeTimeTests`**: each tier boundary plus singular/plural and a
+  future timestamp.
+- **`FolderInspectorTests`**: per-kind newest timestamps populated; null when
+  that kind is absent; existing classification tests still pass.
+- **`WorkspaceViewModelTests`**: pick populates `ExistingMaps`; a folder with no
+  maps leaves it empty; a second pick replaces the contents; `ClearFolder`
+  empties it; `OpenExistingMap` sets `PreviewUrl` while `Step == Pick` and flips
+  `ShowPreview` true / `ShowIdle` false; starting a run resets the preview; the
+  open command is disabled while `Step == Running`; a folder pick clears
+  `Outputs` and `Warnings`.
+- **`WorkspaceScreenTests`** (`AvaloniaFact`): the panel renders when maps exist
+  and is hidden when the list is empty.
+
+## Out of scope
+
+- Finding maps saved outside the folder via M3b's "Save map to" override. The
+  two default paths are the honest 95% case; an index or persisted record of
+  past outputs is a different feature.
+- Surfacing `flightmap.kml` / `flightmap.geojson` (from `--format all`). They are
+  exports, not something the app can open.
+- Recursive search for maps in subfolders.
+- Any persistence: no MRU, no on-disk state (that is #319).
+- The M5 recents/task-cards idle pane. If M5 lands later, these cards are a
+  natural fit for the same pane — this change does not block or presume it.
+- Deleting or renaming an existing map from the row.
+
+## Release
+
+Rides the next version bump alongside the already-merged #327 fix, M3a and M3b.
+Release remains held per the small-userbase call.

--- a/gui/DjiEmbed.Gui.Tests/ExistingMapFinderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ExistingMapFinderTests.cs
@@ -1,0 +1,136 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class ExistingMapFinderTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-existing-maps-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private static readonly DateTime Old =
+        new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static readonly DateTime Recent =
+        new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private string Map(string fileName, DateTime writtenUtc)
+    {
+        var path = Path.Combine(_dir, fileName);
+        File.WriteAllText(path, "<html></html>");
+        File.SetLastWriteTimeUtc(path, writtenUtc);
+        return path;
+    }
+
+    private static FolderContents Contents(
+        DateTime? newestFlightLog = null, DateTime? newestPhoto = null) =>
+        new(newestFlightLog is not null, newestPhoto is not null, false,
+            newestFlightLog, newestPhoto);
+
+    [Fact]
+    public void A_folder_with_no_maps_yields_nothing()
+    {
+        Assert.Empty(ExistingMapFinder.Find(_dir, Contents()));
+    }
+
+    [Fact]
+    public void Finds_the_flight_map_with_its_title_and_path()
+    {
+        var path = Map("flightmap.html", Recent);
+
+        var map = Assert.Single(ExistingMapFinder.Find(_dir, Contents()));
+
+        Assert.Equal(path, map.Path);
+        Assert.Equal("Flight map", map.Title);
+        Assert.Equal(Recent, map.WrittenUtc);
+        Assert.False(map.Stale);
+    }
+
+    [Fact]
+    public void Finds_the_photo_map()
+    {
+        Map("photomap.html", Recent);
+
+        var map = Assert.Single(ExistingMapFinder.Find(_dir, Contents()));
+
+        Assert.Equal("Photo map", map.Title);
+    }
+
+    [Fact]
+    public void Lists_the_flight_map_before_the_photo_map()
+    {
+        Map("photomap.html", Recent);
+        Map("flightmap.html", Recent);
+
+        var maps = ExistingMapFinder.Find(_dir, Contents());
+
+        Assert.Equal(["Flight map", "Photo map"],
+            maps.Select(m => m.Title).ToArray());
+    }
+
+    [Fact]
+    public void A_map_older_than_its_own_footage_is_stale()
+    {
+        Map("flightmap.html", Old);
+
+        var map = Assert.Single(
+            ExistingMapFinder.Find(_dir, Contents(newestFlightLog: Recent)));
+
+        Assert.True(map.Stale);
+    }
+
+    [Fact]
+    public void A_map_newer_than_its_footage_is_not_stale()
+    {
+        Map("flightmap.html", Recent);
+
+        var map = Assert.Single(
+            ExistingMapFinder.Find(_dir, Contents(newestFlightLog: Old)));
+
+        Assert.False(map.Stale);
+    }
+
+    [Fact]
+    public void New_photos_do_not_make_the_flight_map_stale()
+    {
+        Map("flightmap.html", Old);
+
+        var map = Assert.Single(
+            ExistingMapFinder.Find(_dir, Contents(newestPhoto: Recent)));
+
+        Assert.False(map.Stale);
+    }
+
+    [Fact]
+    public void A_map_with_no_footage_of_its_kind_is_not_stale()
+    {
+        Map("photomap.html", Old);
+
+        var map = Assert.Single(ExistingMapFinder.Find(_dir, Contents()));
+
+        Assert.False(map.Stale);
+    }
+
+    [Fact]
+    public void A_photo_map_older_than_its_photos_is_stale()
+    {
+        Map("photomap.html", Old);
+
+        var map = Assert.Single(
+            ExistingMapFinder.Find(_dir, Contents(newestPhoto: Recent)));
+
+        Assert.True(map.Stale);
+    }
+
+    [Fact]
+    public void Footage_stamped_at_the_maps_own_time_is_not_stale()
+    {
+        Map("flightmap.html", Recent);
+
+        var map = Assert.Single(
+            ExistingMapFinder.Find(_dir, Contents(newestFlightLog: Recent)));
+
+        Assert.False(map.Stale);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
@@ -16,6 +16,9 @@ public class FolderInspectorTests : IDisposable
         File.WriteAllText(path, "");
     }
 
+    private void Stamp(DateTime utc, params string[] parts) =>
+        File.SetLastWriteTimeUtc(Path.Combine([_dir, .. parts]), utc);
+
     [Fact]
     public void Detects_flight_logs_only()
     {
@@ -63,5 +66,47 @@ public class FolderInspectorTests : IDisposable
         var c = FolderInspector.Inspect(_dir);
         Assert.True(c.HasVideos);
         Assert.False(c.HasPhotos);
+    }
+
+    [Fact]
+    public void Records_the_newest_flight_log_time_across_subfolders()
+    {
+        var older = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var newer = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        Touch("DJI_0001.SRT");
+        Touch("sub", "DJI_0002.SRT");
+        Stamp(older, "DJI_0001.SRT");
+        Stamp(newer, "sub", "DJI_0002.SRT");
+
+        var c = FolderInspector.Inspect(_dir);
+
+        Assert.Equal(newer, c.NewestFlightLogUtc);
+    }
+
+    [Fact]
+    public void Flight_log_and_photo_times_are_tracked_separately()
+    {
+        var srtTime = new DateTime(2026, 2, 2, 0, 0, 0, DateTimeKind.Utc);
+        var photoTime = new DateTime(2026, 5, 5, 0, 0, 0, DateTimeKind.Utc);
+        Touch("DJI_0001.SRT");
+        Touch("IMG_1.JPG");
+        Stamp(srtTime, "DJI_0001.SRT");
+        Stamp(photoTime, "IMG_1.JPG");
+
+        var c = FolderInspector.Inspect(_dir);
+
+        Assert.Equal(srtTime, c.NewestFlightLogUtc);
+        Assert.Equal(photoTime, c.NewestPhotoUtc);
+    }
+
+    [Fact]
+    public void A_kind_that_is_absent_has_no_timestamp()
+    {
+        Touch("IMG_1.JPG");
+
+        var c = FolderInspector.Inspect(_dir);
+
+        Assert.Null(c.NewestFlightLogUtc);
+        Assert.NotNull(c.NewestPhotoUtc);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
@@ -100,6 +100,77 @@ public class FolderInspectorTests : IDisposable
     }
 
     [Fact]
+    public void A_hidden_file_is_still_classified()
+    {
+        // The walk asks EnumerationOptions to skip nothing by attribute:
+        // its default (Hidden | System) would quietly lose media the
+        // SearchOption overload used to find.
+        // A leading dot is what hidden means on Unix; on Windows it is the
+        // attribute bit, which only sticks there.
+        Touch(".IMG_1.JPG");
+        var path = Path.Combine(_dir, ".IMG_1.JPG");
+        if (OperatingSystem.IsWindows())
+        {
+            File.SetAttributes(path, FileAttributes.Hidden);
+        }
+        Assert.SkipUnless(File.GetAttributes(path).HasFlag(FileAttributes.Hidden),
+            "This filesystem does not carry the Hidden attribute.");
+
+        var c = FolderInspector.Inspect(_dir);
+
+        Assert.True(c.HasPhotos);
+    }
+
+    [Fact]
+    public void An_unreadable_subfolder_is_skipped_not_thrown()
+    {
+        // The folder pick runs from an async void handler, so anything the
+        // walk throws reaches the dispatcher unobserved.
+        Assert.SkipWhen(OperatingSystem.IsWindows(),
+            "Permissions are modelled with ACLs on Windows, not file modes.");
+        // The Skip above has already ended the test on Windows; the platform
+        // analyzer only reads the explicit guard.
+        if (!OperatingSystem.IsWindows())
+        {
+            Touch("IMG_1.JPG");
+            Touch("locked", "DJI_0001.SRT");
+            var locked = Path.Combine(_dir, "locked");
+            File.SetUnixFileMode(locked, UnixFileMode.None);
+            try
+            {
+                Assert.SkipWhen(CanRead(locked),
+                    "This user can read the directory anyway (root?).");
+
+                var c = FolderInspector.Inspect(_dir);
+
+                Assert.True(c.HasPhotos);
+            }
+            finally
+            {
+                // Dispose deletes the tree recursively; let it back in.
+                File.SetUnixFileMode(locked,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite
+                    | UnixFileMode.UserExecute);
+            }
+        }
+    }
+
+    private static bool CanRead(string directory)
+    {
+        try
+        {
+            foreach (var _ in Directory.EnumerateFiles(directory))
+            {
+            }
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    [Fact]
     public void A_kind_that_is_absent_has_no_timestamp()
     {
         Touch("IMG_1.JPG");

--- a/gui/DjiEmbed.Gui.Tests/RelativeTimeTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/RelativeTimeTests.cs
@@ -1,0 +1,28 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class RelativeTimeTests
+{
+    private static readonly DateTime Now =
+        new(2026, 7, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    [Theory]
+    [InlineData(-5, "just now")]        // clock skew: stamped in the future
+    [InlineData(0, "just now")]
+    [InlineData(0.9, "just now")]
+    [InlineData(1, "1 minute ago")]
+    [InlineData(59, "59 minutes ago")]
+    [InlineData(60, "1 hour ago")]
+    [InlineData(175, "2 hours ago")]    // 2 h 55 m truncates down
+    [InlineData(1439, "23 hours ago")]
+    [InlineData(1440, "1 day ago")]
+    [InlineData(2880, "2 days ago")]
+    [InlineData(412 * 24 * 60, "412 days ago")]
+    public void Describes_the_age_in_the_largest_whole_unit(
+        double minutesAgo, string expected)
+    {
+        Assert.Equal(expected,
+            RelativeTime.Describe(Now.AddMinutes(-minutesAgo), Now));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -178,6 +178,35 @@ public class ScreenshotCaptureTests
             Path.Combine(dir!, "workspace-done-degraded.png"));
     }
 
+    /// <summary>
+    /// Pick step on a folder an earlier run already mapped: the
+    /// "Already in this folder" zone at its tallest — both map kinds, one
+    /// of them stale — so the left column's fold can be reviewed in the
+    /// exact case that inserts it above OPTIONS.
+    /// </summary>
+    [AvaloniaFact]
+    public void Captures_existing_maps_panel_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture the existing-maps panel.");
+        Directory.CreateDirectory(dir!);
+
+        var vm = new WorkspaceViewModel(
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
+        vm.SelectedFolder = @"C:\Users\demo\Videos\flight";
+        vm.ExistingMaps.Add(new ExistingMap(
+            @"C:\Users\demo\Videos\flight\flightmap.html", "Flight map",
+            DateTime.UtcNow.AddDays(-2), Stale: true));
+        vm.ExistingMaps.Add(new ExistingMap(
+            @"C:\Users\demo\Videos\flight\photomap.html", "Photo map",
+            DateTime.UtcNow.AddHours(-3), Stale: false));
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        view.DataContext = vm;
+        CaptureView(view, Path.Combine(dir!, "workspace-existing-maps.png"));
+    }
+
     private static void CaptureView(
         Control view, string outPath, double width = 1140, double height = 720) =>
         Capture(new Window { Width = width, Height = height, Content = view },

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -204,4 +204,138 @@ public class WorkspaceScreenTests
             .Single(b => b.Name == "FlightOptionsPanel");
         Assert.False(panel.IsEffectivelyVisible);
     }
+
+    [AvaloniaFact]
+    public async Task A_folder_with_an_existing_map_shows_the_already_here_panel()
+    {
+        var dir = Directory.CreateTempSubdirectory("djiembed-screen-maps").FullName;
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "DJI_0001.SRT"), "");
+            File.WriteAllText(Path.Combine(dir, "flightmap.html"), "");
+            var window = ShowWorkspace();
+            var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+
+            await vm.SetFolderAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var panel = window.GetVisualDescendants().OfType<Border>()
+                .Single(b => b.Name == "ExistingMapsPanel");
+            Assert.True(panel.IsEffectivelyVisible);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // A state transition, not a fresh window: asserting "hidden" on a
+    // workspace that never had maps would pass against a hard-coded False
+    // or a misspelled binding path. Picking a second folder also proves
+    // ExistingMaps.Clear() propagates through the !!Count binding.
+    [AvaloniaFact]
+    public async Task A_picked_folder_with_no_existing_maps_hides_the_panel()
+    {
+        var withMap = Directory.CreateTempSubdirectory("djiembed-screen-with").FullName;
+        var without = Directory.CreateTempSubdirectory("djiembed-screen-without").FullName;
+        try
+        {
+            File.WriteAllText(Path.Combine(withMap, "DJI_0001.SRT"), "");
+            File.WriteAllText(Path.Combine(withMap, "flightmap.html"), "");
+            File.WriteAllText(Path.Combine(without, "DJI_0001.SRT"), "");
+            var window = ShowWorkspace();
+            var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+            var panel = window.GetVisualDescendants().OfType<Border>()
+                .Single(b => b.Name == "ExistingMapsPanel");
+
+            await vm.SetFolderAsync(withMap);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Assert.True(panel.IsEffectivelyVisible);
+
+            await vm.SetFolderAsync(without);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Assert.False(panel.IsEffectivelyVisible);
+        }
+        finally
+        {
+            Directory.Delete(withMap, recursive: true);
+            Directory.Delete(without, recursive: true);
+        }
+    }
+
+    // The item template is most of this panel, and the outer Border's
+    // visibility says nothing about it. ExistingMaps is a public collection,
+    // so the rows can be driven straight from the VM — no temp dirs needed.
+    [AvaloniaFact]
+    public void An_existing_map_row_shows_its_title_age_and_live_commands()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.ExistingMaps.Add(new ExistingMap(@"C:\d\flightmap.html", "Flight map",
+            DateTime.UtcNow.AddDays(-2), Stale: true));
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var texts = window.GetVisualDescendants().OfType<TextBlock>()
+            .Select(t => t.Text ?? "").ToList();
+        Assert.Contains("Flight map", texts);
+        Assert.Contains("2 days ago", texts);
+        Assert.True(window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "StaleNote").IsEffectivelyVisible);
+        // Identity, not enabledness, is what proves the
+        // $parent[ItemsControl].((vm:WorkspaceViewModel)DataContext) path
+        // resolved: an Avalonia Button with a null Command still renders
+        // enabled (verified by deleting the binding — every enabled-based
+        // assertion still passed), so only the instance is load-bearing.
+        var open = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "OpenExistingMapButton");
+        Assert.Same(vm.OpenExistingMapCommand, open.Command);
+        Assert.Same(vm.ExistingMaps[0], open.CommandParameter);
+        Assert.True(open.IsEffectivelyEnabled);   // and CanExecute lets it click
+        var reveal = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ShowExistingMapButton");
+        Assert.Same(vm.ShowExistingMapInFolderCommand, reveal.Command);
+        Assert.Same(vm.ExistingMaps[0], reveal.CommandParameter);
+    }
+
+    [AvaloniaFact]
+    public void A_fresh_existing_map_hides_the_stale_note()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.ExistingMaps.Add(new ExistingMap(@"C:\d\photomap.html", "Photo map",
+            DateTime.UtcNow.AddHours(-3), Stale: false));
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        Assert.False(window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "StaleNote").IsEffectivelyVisible);
+    }
+
+    // The preview header's GoHome button says "Process another" only when a
+    // run actually produced the map — browsing one the folder already had
+    // processed nothing.
+    [AvaloniaFact]
+    public void Preview_header_labels_the_go_home_button_for_the_step()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.PreviewPath = "flightmap.html";
+        vm.PreviewUrl = "http://127.0.0.1:1/flightmap.html";
+        vm.Step = FlowStep.Pick;              // an existing map, browsed
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var button = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ClosePreviewButton");
+        var label = button.GetVisualDescendants().OfType<TextBlock>().Single();
+        Assert.Equal("Close map", label.Text);
+
+        vm.Step = FlowStep.Done;              // a map this run just made
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.Equal("Process another", label.Text);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -780,6 +780,38 @@ public class WorkspaceViewModelTests : IDisposable
     }
 
     [Fact]
+    public void Process_another_drops_the_previous_runs_outputs_and_warnings()
+    {
+        // GoHome is the other door into Step == Pick, where a browsed map can
+        // now render: the last run's warnings must not frame it.
+        var vm = Vm("unused");
+        vm.Outputs.Add("C:\\out\\flightmap.html");
+        vm.Warnings.Add("something from the run just finished");
+        vm.Step = FlowStep.Done;
+
+        vm.GoHomeCommand.Execute(null);
+
+        Assert.Empty(vm.Outputs);
+        Assert.Empty(vm.Warnings);
+        Assert.True(vm.ShowIdle);
+    }
+
+    [Fact]
+    public async Task Clearing_the_folder_drops_a_browsed_preview()
+    {
+        var vm = PreviewingVm();
+        await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
+        await vm.OpenExistingMapCommand.ExecuteAsync(vm.ExistingMaps[0]);
+        Assert.True(vm.ShowPreview);
+
+        vm.ClearFolderCommand.Execute(null);
+
+        Assert.Null(vm.PreviewUrl);
+        Assert.False(vm.ShowPreview);
+        Assert.True(vm.ShowIdle);
+    }
+
+    [Fact]
     public async Task Opening_an_existing_map_previews_it_on_the_pick_step()
     {
         var vm = PreviewingVm();

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -11,13 +11,16 @@ public class WorkspaceViewModelTests : IDisposable
     public void Dispose() => Directory.Delete(_dir, recursive: true);
 
     private string MakeFolder(
-        bool srt = false, bool photos = false, bool videos = false)
+        bool srt = false, bool photos = false, bool videos = false,
+        bool flightMap = false, bool photoMap = false)
     {
         var folder = Path.Combine(_dir, "footage-" + Guid.NewGuid().ToString("N")[..6]);
         Directory.CreateDirectory(folder);
         if (srt) File.WriteAllText(Path.Combine(folder, "DJI_0001.SRT"), "");
         if (photos) File.WriteAllText(Path.Combine(folder, "IMG_1.JPG"), "");
         if (videos) File.WriteAllText(Path.Combine(folder, "DJI_0001.MP4"), "");
+        if (flightMap) File.WriteAllText(Path.Combine(folder, "flightmap.html"), "");
+        if (photoMap) File.WriteAllText(Path.Combine(folder, "photomap.html"), "");
         return folder;
     }
 
@@ -715,6 +718,145 @@ public class WorkspaceViewModelTests : IDisposable
         vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
         Assert.False(vm.IsFlightMapMode);
         Assert.Contains(nameof(WorkspaceViewModel.IsFlightMapMode), notified);
+    }
+
+    private const string FakeUrl = "http://127.0.0.1:65535/flightmap.html";
+
+    private static WorkspaceViewModel PreviewingVm() =>
+        Vm("cli", mapServer: new FakeMapServer(FakeUrl),
+            previewAvailable: static () => true);
+
+    [Fact]
+    public async Task Picking_a_folder_lists_the_maps_it_already_has()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(
+            MakeFolder(srt: true, flightMap: true, photoMap: true));
+
+        Assert.Equal(["Flight map", "Photo map"],
+            vm.ExistingMaps.Select(m => m.Title).ToArray());
+    }
+
+    [Fact]
+    public async Task A_folder_without_maps_lists_none()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+
+        Assert.Empty(vm.ExistingMaps);
+    }
+
+    [Fact]
+    public async Task A_second_pick_replaces_the_list()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+
+        Assert.Empty(vm.ExistingMaps);
+    }
+
+    [Fact]
+    public async Task Clearing_the_folder_clears_the_list()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
+        vm.ClearFolderCommand.Execute(null);
+
+        Assert.Empty(vm.ExistingMaps);
+    }
+
+    [Fact]
+    public async Task A_folder_pick_drops_the_previous_runs_outputs_and_warnings()
+    {
+        var vm = Vm("unused");
+        vm.Outputs.Add("C:\\old\\flightmap.html");
+        vm.Warnings.Add("something from the last folder");
+
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+
+        Assert.Empty(vm.Outputs);
+        Assert.Empty(vm.Warnings);
+    }
+
+    [Fact]
+    public async Task Opening_an_existing_map_previews_it_on_the_pick_step()
+    {
+        var vm = PreviewingVm();
+        await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
+        var map = Assert.Single(vm.ExistingMaps);
+
+        await vm.OpenExistingMapCommand.ExecuteAsync(map);
+
+        Assert.Equal(FlowStep.Pick, vm.Step);
+        Assert.Equal(FakeUrl, vm.PreviewUrl);
+        Assert.Equal(map.Path, vm.PreviewPath);
+        Assert.True(vm.ShowPreview);
+        Assert.False(vm.ShowIdle);
+        Assert.False(vm.ShowDoneCard);
+    }
+
+    [Fact]
+    public async Task Picking_another_folder_drops_a_browsed_preview()
+    {
+        var vm = PreviewingVm();
+        await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
+        await vm.OpenExistingMapCommand.ExecuteAsync(vm.ExistingMaps[0]);
+
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+
+        Assert.Null(vm.PreviewUrl);
+        Assert.False(vm.ShowPreview);
+        Assert.True(vm.ShowIdle);
+    }
+
+    [Fact]
+    public async Task A_run_takes_the_pane_back_from_a_browsed_map()
+    {
+        // The run's own output must replace what the user was browsing.
+        // FlightmapStream reports the bare name "flightmap.html", which the
+        // browsed absolute path can never be mistaken for.
+        var argsFile = Path.Combine(_dir, "args-browsed.txt");
+        var cli = FakeCli.WriteArgsRecorder(_dir, argsFile, FlightmapStream);
+        var vm = Vm(cli, mapServer: new FakeMapServer(FakeUrl),
+            previewAvailable: static () => true);
+        await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
+        await vm.OpenExistingMapCommand.ExecuteAsync(vm.ExistingMaps[0]);
+        Assert.True(vm.ShowPreview);
+        Assert.True(Path.IsPathRooted(vm.PreviewPath));
+
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Equal("flightmap.html", vm.PreviewPath);
+    }
+
+    [Fact]
+    public async Task The_open_command_is_disabled_while_a_run_is_in_flight()
+    {
+        var vm = PreviewingVm();
+        await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
+        var map = vm.ExistingMaps[0];
+        Assert.True(vm.OpenExistingMapCommand.CanExecute(map));
+        // CanExecute is evaluated live, so the assertion below passes with or
+        // without the notification — but a real button only re-reads it when
+        // told to, so assert the telling too.
+        var notified = false;
+        vm.OpenExistingMapCommand.CanExecuteChanged += (_, _) => notified = true;
+
+        vm.Step = FlowStep.Running;
+
+        Assert.False(vm.OpenExistingMapCommand.CanExecute(map));
+        Assert.True(notified);
+    }
+
+    [Fact]
+    public void The_idle_hero_shows_when_nothing_is_previewed()
+    {
+        var vm = Vm("unused");
+
+        Assert.True(vm.ShowIdle);
+        Assert.False(vm.ShowPreview);
     }
 
     private sealed class ThrowingMapServer : IMapServer

--- a/gui/DjiEmbed.Gui/Services/ExistingMapFinder.cs
+++ b/gui/DjiEmbed.Gui/Services/ExistingMapFinder.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>A map an earlier run already left in the chosen folder.</summary>
+public sealed record ExistingMap(
+    string Path, string Title, DateTime WrittenUtc, bool Stale);
+
+/// <summary>
+/// Finds maps a previous run left in the chosen folder. The GUI never passes
+/// <c>-o</c> by default, so the CLI's defaults apply and the two paths are
+/// deterministic: <c>flightmap.html</c> and <c>photomap.html</c>, written
+/// directly in the mapped folder. A map redirected elsewhere by the Flight
+/// map "Save map to" override is deliberately out of scope (#328 spec) —
+/// finding those would need a persisted record of past outputs.
+/// </summary>
+public static class ExistingMapFinder
+{
+    public static IReadOnlyList<ExistingMap> Find(
+        string directory, FolderContents contents)
+    {
+        var found = new List<ExistingMap>();
+        if (Probe(directory, "flightmap.html", "Flight map",
+                contents.NewestFlightLogUtc) is { } flight)
+        {
+            found.Add(flight);
+        }
+        if (Probe(directory, "photomap.html", "Photo map",
+                contents.NewestPhotoUtc) is { } photo)
+        {
+            found.Add(photo);
+        }
+        return found;
+    }
+
+    private static ExistingMap? Probe(string directory, string fileName,
+        string title, DateTime? newestSourceUtc)
+    {
+        // One metadata snapshot: FileInfo.Exists caches the stat that
+        // LastWriteTimeUtc then reads, so a file deleted mid-scan can't
+        // surface as a phantom row stamped 1601.
+        var file = new FileInfo(Path.Combine(directory, fileName));
+        if (!file.Exists)
+        {
+            return null;
+        }
+        // A null source time (no footage of this kind) lifts to false: a map
+        // nothing could have outrun is not stale.
+        var written = file.LastWriteTimeUtc;
+        return new ExistingMap(file.FullName, title, written,
+            newestSourceUtc > written);
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/FolderInspector.cs
+++ b/gui/DjiEmbed.Gui/Services/FolderInspector.cs
@@ -4,44 +4,51 @@ using System.IO;
 namespace DjiEmbed.Gui.Services;
 
 public sealed record FolderContents(
-    bool HasFlightLogs, bool HasPhotos, bool HasVideos);
+    bool HasFlightLogs, bool HasPhotos, bool HasVideos,
+    DateTime? NewestFlightLogUtc, DateTime? NewestPhotoUtc);
 
 /// <summary>
 /// Decides which commands apply to a dropped folder. Extension-only and
 /// recursive, mirroring the CLI dragdrop semantics: the CLI itself is the
 /// authority on whether files actually contain telemetry/GPS.
+/// Also records the newest write time per media kind, which is what tells
+/// an existing map it has been outrun by new footage (#328). Videos get no
+/// timestamp because they produce no map.
 /// </summary>
 public static class FolderInspector
 {
     public static FolderContents Inspect(string directory)
     {
-        var hasFlightLogs = false;
-        var hasPhotos = false;
         var hasVideos = false;
+        DateTime? newestFlightLog = null;
+        DateTime? newestPhoto = null;
+        // No early exit: the newest write time is only known once every
+        // file has been seen.
         foreach (var file in Directory.EnumerateFiles(
                      directory, "*", SearchOption.AllDirectories))
         {
             var ext = Path.GetExtension(file);
             if (ext.Equals(".srt", StringComparison.OrdinalIgnoreCase))
             {
-                hasFlightLogs = true;
+                newestFlightLog = Newer(newestFlightLog, File.GetLastWriteTimeUtc(file));
             }
             else if (ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
                      || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
                      || ext.Equals(".dng", StringComparison.OrdinalIgnoreCase))
             {
-                hasPhotos = true;
+                newestPhoto = Newer(newestPhoto, File.GetLastWriteTimeUtc(file));
             }
             else if (ext.Equals(".mp4", StringComparison.OrdinalIgnoreCase)
                      || ext.Equals(".mov", StringComparison.OrdinalIgnoreCase))
             {
                 hasVideos = true;
             }
-            if (hasFlightLogs && hasPhotos && hasVideos)
-            {
-                break;
-            }
         }
-        return new FolderContents(hasFlightLogs, hasPhotos, hasVideos);
+        return new FolderContents(
+            newestFlightLog is not null, newestPhoto is not null, hasVideos,
+            newestFlightLog, newestPhoto);
     }
+
+    private static DateTime Newer(DateTime? running, DateTime candidate) =>
+        running is { } previous && previous >= candidate ? previous : candidate;
 }

--- a/gui/DjiEmbed.Gui/Services/FolderInspector.cs
+++ b/gui/DjiEmbed.Gui/Services/FolderInspector.cs
@@ -23,9 +23,18 @@ public static class FolderInspector
         DateTime? newestFlightLog = null;
         DateTime? newestPhoto = null;
         // No early exit: the newest write time is only known once every
-        // file has been seen.
-        foreach (var file in Directory.EnumerateFiles(
-                     directory, "*", SearchOption.AllDirectories))
+        // file has been seen. IgnoreInaccessible keeps an unreadable
+        // subfolder from throwing out of the (async void) folder pick.
+        foreach (var file in Directory.EnumerateFiles(directory, "*",
+                     new EnumerationOptions
+                     {
+                         RecurseSubdirectories = true,
+                         IgnoreInaccessible = true,
+                         // The SearchOption overload this replaces skipped
+                         // nothing by attribute; EnumerationOptions would
+                         // default to skipping Hidden and System files.
+                         AttributesToSkip = FileAttributes.None,
+                     }))
         {
             var ext = Path.GetExtension(file);
             if (ext.Equals(".srt", StringComparison.OrdinalIgnoreCase))

--- a/gui/DjiEmbed.Gui/Services/RelativeTime.cs
+++ b/gui/DjiEmbed.Gui/Services/RelativeTime.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// Ages in words for on-screen timestamps ("2 days ago"). Takes "now" as a
+/// parameter rather than reading the clock, so it stays pure and testable;
+/// the view's converter supplies <c>DateTime.UtcNow</c> at bind time.
+/// </summary>
+public static class RelativeTime
+{
+    public static string Describe(DateTime whenUtc, DateTime nowUtc)
+    {
+        var age = nowUtc - whenUtc;
+        if (age < TimeSpan.FromMinutes(1))
+        {
+            return "just now";
+        }
+        if (age < TimeSpan.FromHours(1))
+        {
+            return Ago((int)age.TotalMinutes, "minute");
+        }
+        if (age < TimeSpan.FromDays(1))
+        {
+            return Ago((int)age.TotalHours, "hour");
+        }
+        return Ago((int)age.TotalDays, "day");
+    }
+
+    private static string Ago(int count, string unit) =>
+        count == 1 ? $"1 {unit} ago" : $"{count} {unit}s ago";
+}

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -57,6 +57,10 @@ public partial class WorkspaceViewModel : FlowViewModel
 
     public ObservableCollection<SetupItem> SetupItems { get; } = [];
 
+    /// <summary>Maps this folder already had when it was picked (#328) —
+    /// what is on disk, independent of the selected mode.</summary>
+    public ObservableCollection<ExistingMap> ExistingMaps { get; } = [];
+
     [ObservableProperty]
     public partial string? PreviewUrl { get; set; }
 
@@ -71,20 +75,31 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Done pane, card flavour (setup, embed, degraded maps).</summary>
     public bool ShowDoneCard => Step == FlowStep.Done && PreviewUrl is null;
 
-    /// <summary>Done pane, inline-map flavour.</summary>
-    public bool ShowPreview => Step == FlowStep.Done && PreviewUrl is not null;
+    /// <summary>Inline-map pane: a finished run's map, or one the folder
+    /// already had and the user asked to see (#328).</summary>
+    public bool ShowPreview =>
+        PreviewUrl is not null
+        && (Step == FlowStep.Done || Step == FlowStep.Pick);
+
+    /// <summary>The hero empty state: idle with nothing to show.</summary>
+    public bool ShowIdle => Step == FlowStep.Pick && PreviewUrl is null;
+
+    /// <summary>The three pane gates all derive from Step + PreviewUrl, so
+    /// every writer of either has to re-raise all three.</summary>
+    private void RaiseGateChanged()
+    {
+        OnPropertyChanged(nameof(ShowDoneCard));
+        OnPropertyChanged(nameof(ShowPreview));
+        OnPropertyChanged(nameof(ShowIdle));
+    }
 
     protected override void OnStepChangedCore(FlowStep value)
     {
-        OnPropertyChanged(nameof(ShowDoneCard));
-        OnPropertyChanged(nameof(ShowPreview));
+        RaiseGateChanged();
+        OpenExistingMapCommand.NotifyCanExecuteChanged();
     }
 
-    partial void OnPreviewUrlChanged(string? value)
-    {
-        OnPropertyChanged(nameof(ShowDoneCard));
-        OnPropertyChanged(nameof(ShowPreview));
-    }
+    partial void OnPreviewUrlChanged(string? value) => RaiseGateChanged();
 
     /// <summary>The action button lights up as soon as a run could work.</summary>
     public bool CanRun => !SelectedMode.NeedsFolder || SelectedFolder is not null;
@@ -145,16 +160,37 @@ public partial class WorkspaceViewModel : FlowViewModel
             return;
         }
         SelectedFolder = folder;
-        var contents = await Task.Run(() => FolderInspector.Inspect(folder));
+        // One background pass: the classification the mode suggestion needs
+        // and the map probe that depends on its timestamps.
+        var scan = await Task.Run(() =>
+        {
+            var contents = FolderInspector.Inspect(folder);
+            return (contents, maps: ExistingMapFinder.Find(folder, contents));
+        });
+        // A second pick can land while this scan is in flight; the newest
+        // pick owns the state, so a scan that has been overtaken just stops.
+        if (SelectedFolder != folder)
+        {
+            return;
+        }
         SuggestedMode =
-            contents.HasFlightLogs ? WorkspaceMode.Of(WorkspaceModeKind.FlightMap)
-            : contents.HasPhotos ? WorkspaceMode.Of(WorkspaceModeKind.PhotoMap)
-            : contents.HasVideos ? WorkspaceMode.Of(WorkspaceModeKind.Embed)
+            scan.contents.HasFlightLogs ? WorkspaceMode.Of(WorkspaceModeKind.FlightMap)
+            : scan.contents.HasPhotos ? WorkspaceMode.Of(WorkspaceModeKind.PhotoMap)
+            : scan.contents.HasVideos ? WorkspaceMode.Of(WorkspaceModeKind.Embed)
             : null;
         if (SuggestedMode is not null)
         {
             SelectedMode = SuggestedMode;
         }
+        ExistingMaps.Clear();
+        foreach (var map in scan.maps)
+        {
+            ExistingMaps.Add(map);
+        }
+        // A new folder is a fresh start: the previous run's outputs and
+        // warnings must not frame a map that was already sitting here.
+        Outputs.Clear();
+        Warnings.Clear();
         ResetPreview();
         Step = FlowStep.Pick;
     }
@@ -164,6 +200,7 @@ public partial class WorkspaceViewModel : FlowViewModel
     {
         SelectedFolder = null;
         SuggestedMode = null;
+        ExistingMaps.Clear();
     }
 
     [RelayCommand]
@@ -177,6 +214,57 @@ public partial class WorkspaceViewModel : FlowViewModel
             Reveal.InFolder(PreviewPath);
         }
     }
+
+    /// <summary>A run owns the preview pane while it is in flight. Private:
+    /// it raises no PropertyChanged, so nothing may bind it — a button gets
+    /// this gate from the command's own CanExecute.</summary>
+    private bool CanOpenExistingMap => Step != FlowStep.Running;
+
+    /// <summary>
+    /// Show a map the folder already had, in the pane a finished run would
+    /// use. Mirrors <see cref="PrimePreviewAsync"/>, except that a preview
+    /// which can't render falls back to the browser rather than an
+    /// explanatory card: the user asked for this one map, and the browser
+    /// answers that ask.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanOpenExistingMap))]
+    private async Task OpenExistingMapAsync(ExistingMap map)
+    {
+        if (!_previewAvailable() || CliPath is null)
+        {
+            // OpenOutputCoreAsync still routes through the map server, so the
+            // browser gets an http:// URL and the 360° viewer keeps working.
+            await OpenOutputCoreAsync(map.Path);
+            return;
+        }
+        string? url;
+        try
+        {
+            // Browsing isn't part of a flow — nothing cancels it.
+            url = await _mapServer.GetUrlAsync(
+                CliPath, map.Path, CancellationToken.None);
+        }
+        // Nothing to cancel back to — any failure, cancellation included,
+        // just means "browser instead". (PrimePreviewAsync rethrows
+        // OperationCanceledException because it runs inside a flow.)
+        catch (Exception)
+        {
+            url = null;
+        }
+        if (url is null)
+        {
+            // base., not the override: the override's first move is another
+            // GetUrlAsync, and this one just failed.
+            await base.OpenOutputCoreAsync(map.Path);
+            return;
+        }
+        PreviewPath = map.Path;   // path first: the view reads it when the URL lands
+        PreviewUrl = url;
+    }
+
+    [RelayCommand]
+    private void ShowExistingMapInFolder(ExistingMap map) =>
+        Reveal.InFolder(map.Path);
 
     /// <summary>"Process another": back to idle, keep folder and mode.</summary>
     protected override void GoHomeCore()

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -201,6 +201,9 @@ public partial class WorkspaceViewModel : FlowViewModel
         SelectedFolder = null;
         SuggestedMode = null;
         ExistingMaps.Clear();
+        // A map browsed out of that folder can't outlive it: without this the
+        // pane keeps rendering it with no folder and no drop hero behind it.
+        ResetPreview();
     }
 
     [RelayCommand]
@@ -270,6 +273,10 @@ public partial class WorkspaceViewModel : FlowViewModel
     protected override void GoHomeCore()
     {
         ResetPreview();
+        // The other door into Pick, where a map the folder already had can
+        // render: the finished run's outputs and warnings must not follow it.
+        Outputs.Clear();
+        Warnings.Clear();
         Step = FlowStep.Pick;
     }
 

--- a/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using Avalonia.Data.Converters;
+using DjiEmbed.Gui.Services;
 using DjiEmbed.Gui.ViewModels;
 
 namespace DjiEmbed.Gui.Views;
@@ -24,4 +26,20 @@ public static class WorkspaceConverters
     /// <summary>Toolbar label: just the map's file name.</summary>
     public static readonly FuncValueConverter<string?, string?> FileNameOnly =
         new(static p => p is null ? null : Path.GetFileName(p));
+
+    /// <summary>
+    /// An existing map's age in words ("2 days ago"). The clock is read here
+    /// so <see cref="RelativeTime"/> itself stays pure. It is read once per
+    /// bind and never ticks afterwards — deliberately: the list is rebuilt
+    /// from disk on every folder pick, and the buckets are coarse enough
+    /// (minutes, hours, days) that a stale string is only ever wrong for a
+    /// window nobody stares at the panel through.
+    /// </summary>
+    public static readonly FuncValueConverter<DateTime, string> AgeInWords =
+        new(static utc => RelativeTime.Describe(utc, DateTime.UtcNow));
+
+    /// <summary>Label for the preview header's GoHome button: nothing has
+    /// been processed when the map on screen was already in the folder.</summary>
+    public static readonly FuncValueConverter<FlowStep, string> PreviewGoHomeLabel =
+        new(static step => step == FlowStep.Done ? "Process another" : "Close map");
 }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -424,7 +424,7 @@
                     </Button>
                 </StackPanel>
 
-                <!-- Done, map flavour: the map itself, over the local server. -->
+                <!-- Map pane: a finished run's map, or one the folder already had. -->
                 <DockPanel IsVisible="{Binding ShowPreview}">
                     <Border DockPanel.Dock="Top" Padding="14,10">
                         <DockPanel>

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -112,6 +112,54 @@
                         </StackPanel>
                     </suki:GlassCard>
 
+                    <Border Name="ExistingMapsPanel"
+                            IsVisible="{Binding !!ExistingMaps.Count}">
+                        <StackPanel>
+                            <TextBlock Classes="zone" Text="ALREADY IN THIS FOLDER" />
+                            <ItemsControl ItemsSource="{Binding ExistingMaps}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Spacing="6" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="svc:ExistingMap">
+                                        <suki:GlassCard Padding="14">
+                                            <StackPanel Spacing="6">
+                                                <TextBlock Text="{Binding Title}"
+                                                           FontWeight="SemiBold" />
+                                                <TextBlock FontSize="12" Opacity="0.7"
+                                                           Text="{Binding WrittenUtc,
+                                                               Converter={x:Static views:WorkspaceConverters.AgeInWords}}" />
+                                                <TextBlock Name="StaleNote"
+                                                           FontSize="12" Opacity="0.7"
+                                                           TextWrapping="Wrap"
+                                                           IsVisible="{Binding Stale}"
+                                                           Text="⚠️ New footage since this map was made" />
+                                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                                    <Button Name="OpenExistingMapButton"
+                                                            Command="{Binding $parent[ItemsControl].((vm:WorkspaceViewModel)DataContext).OpenExistingMapCommand}"
+                                                            CommandParameter="{Binding}"
+                                                            AutomationProperties.Name="{Binding Title, StringFormat='Open {0}'}"
+                                                            ToolTip.Tip="Open this map — in the preview pane, or your browser if preview isn't available here">
+                                                        <TextBlock Text="Open" FontSize="12" />
+                                                    </Button>
+                                                    <Button Name="ShowExistingMapButton"
+                                                            Command="{Binding $parent[ItemsControl].((vm:WorkspaceViewModel)DataContext).ShowExistingMapInFolderCommand}"
+                                                            CommandParameter="{Binding}"
+                                                            AutomationProperties.Name="{Binding Title, StringFormat='Show {0} in folder'}"
+                                                            ToolTip.Tip="Show the map file in its folder">
+                                                        <TextBlock Text="Show in folder" FontSize="12" />
+                                                    </Button>
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </suki:GlassCard>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
                     <Border Name="FlightOptionsPanel"
                             IsVisible="{Binding IsFlightMapMode}">
                         <StackPanel>
@@ -267,9 +315,7 @@
             <Panel>
 
                 <!-- Idle: the home screen reborn as the empty state. -->
-                <Panel IsVisible="{Binding Step,
-                          Converter={x:Static ObjectConverters.Equal},
-                          ConverterParameter={x:Static vm:FlowStep.Pick}}">
+                <Panel IsVisible="{Binding ShowIdle}">
                     <Image Source="avares://DjiEmbed.Gui/Assets/home-background.png"
                            Stretch="UniformToFill" />
                     <Border>
@@ -396,8 +442,12 @@
                                         ToolTip.Tip="Show the map file in its folder">
                                     <TextBlock Text="Show in folder" FontSize="12" />
                                 </Button>
-                                <Button Command="{Binding GoHomeCommand}">
-                                    <TextBlock Text="Process another" FontSize="12" />
+                                <Button Name="ClosePreviewButton"
+                                        Command="{Binding GoHomeCommand}"
+                                        ToolTip.Tip="Close this map and go back to the start">
+                                    <TextBlock FontSize="12"
+                                               Text="{Binding Step,
+                                                   Converter={x:Static views:WorkspaceConverters.PreviewGoHomeLabel}}" />
                                 </Button>
                             </StackPanel>
                             <TextBlock Text="{Binding PreviewPath,


### PR DESCRIPTION
## Summary

Picking a folder that already contains `flightmap.html` or `photomap.html` used to show nothing — the only route back to a map you'd already made was to make it again (#328, found during manual testing of v1.26.0 on Windows 11).

Those maps now appear in an **ALREADY IN THIS FOLDER** zone in the left column, between MODE and OPTIONS, with their age in words, a quiet staleness note when newer footage of that map's own kind exists, and **Open** / **Show in folder** buttons. Open renders the map inline in the same WebView pane a finished run uses, falling back to the system browser where inline preview isn't available.

Design spec: `docs/superpowers/specs/2026-07-20-gui-existing-maps-design.md`.

- `FolderInspector` gains per-kind newest-write timestamps (`NewestFlightLogUtc` / `NewestPhotoUtc`) — per-kind so new photos don't mark the flight map stale, and vice versa. Videos get none; they produce no map. This costs the early-exit shortcut, since the newest write time is only known after the full walk.
- `ExistingMapFinder` probes exactly the two default CLI output paths in the chosen directory. Not recursive, no "Save map to" override discovery, no KML/GeoJSON siblings — all deliberately out of scope.
- `RelativeTime.Describe(whenUtc, nowUtc)` takes "now" as a parameter, so it stays clock-free and testable; the view's converter supplies `DateTime.UtcNow` at bind time.
- The preview pane's gate widens from `Step == Done` to `Done || Pick`, and a new `ShowIdle` VM property makes the idle/preview split testable without a visual tree. `SetFolderAsync`, `GoHomeCore` and `ClearFolder` now reset the pane state so a past run's warnings can't frame a map it never produced.
- The preview header's third button reads "Close map" at `Pick` and "Process another" at `Done` — nothing has been processed when you're browsing a map that was already there. Same `GoHomeCommand`.

No CLI work. No persistence.

The last commit closes three gaps a whole-branch review caught that the per-commit reviews structurally couldn't: "Process another" and the folder ✕ both left a previous run's state on screen once a browsed map could render at `Step == Pick`, and dropping `FolderInspector`'s early exit made an unreadable subfolder reachable as an unhandled dispatcher exception (now `IgnoreInaccessible`, with `AttributesToSkip = FileAttributes.None` so hidden media is still found).

### Known follow-ups (not in this PR)

- `SyncPreview` in `WorkspaceView.axaml.cs` has a currently-unreachable divergence between the WebView's attach trigger (`PreviewUrl`) and the pane's visibility (`ShowPreview`); hardening it is deferred.
- `ExistingMaps` is a snapshot taken at folder pick and isn't re-probed after a run, so a map regenerated in place keeps its old age until the folder is re-picked.
- The browser-fallback branch of `OpenExistingMapAsync` has no test — both paths end in `Process.Start`, which needs a seam to test without launching a real browser on CI.

## Test plan

- `~/.dotnet/dotnet build gui/DjiEmbed.Gui.sln -c Release` — clean, **0 warnings**.
- `~/.dotnet/dotnet test gui/DjiEmbed.Gui.sln` — **216 passed / 0 failed / 8 skipped**.
- New coverage:
  - `ExistingMapFinderTests` (temp dirs): empty folder; flight only; photo only; both, flight first; stale when the matching media is newer; not stale when the map is newer, when no media of that kind exists, or when timestamps are equal; new photos don't stale the flight map.
  - `RelativeTimeTests`: every tier boundary, singular/plural, and a future-stamped file (clock skew → "just now").
  - `FolderInspectorTests`: newest time across subfolders; kinds tracked separately; absent kind has no timestamp; a hidden file is still classified; an unreadable subfolder is skipped rather than thrown.
  - `WorkspaceViewModelTests`: pick populates the list; no maps → empty; a second pick replaces it; `ClearFolder` empties it and drops a browsed preview; Open previews at `Step == Pick` and flips `ShowPreview`/`ShowIdle`; picking another folder drops a browsed preview; a run takes the pane back; the command is disabled (and re-raises `CanExecuteChanged`) while running; a folder pick and "Process another" both clear `Outputs`/`Warnings`.
  - `WorkspaceScreenTests` (`AvaloniaFact`): panel shows with maps and hides on a second pick without them; a row renders title, age, stale note, and both commands bound to the right VM instance and item; the stale note hides when fresh; the header button relabels across `Pick`/`Done`.
- Every test pins the WebView gate and the preview probe false, so none constructs a `NativeWebView`, opens a browser, or touches the network. The screenshot capture for this panel is skipped unless `DJIEMBED_CAPTURE_DIR` is set.

### Manual (Windows)

1. Point the app at a folder holding an old `flightmap.html` + `photomap.html` — both rows appear with plausible ages.
2. Touch a `.SRT` in that folder, re-pick — the flight map row gains the stale note and the photo map row does not.
3. **Open** on each — renders inline; **Show in folder** selects the file.
4. Start a run — both Open buttons grey out for the duration.
5. Pick a different folder while a map is previewed — the hero comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2hviX55tFh846EugJLR8m
