### PR TITLE
GUI 2.0 M3c: Photo map curated options + Advanced expander

### DIFF
--- a/docs/superpowers/specs/2026-07-20-gui-m3c-photomap-options-design.md
+++ b/docs/superpowers/specs/2026-07-20-gui-m3c-photomap-options-design.md
@@ -1,0 +1,225 @@
+# GUI 2.0 — M3c: Photo map curated options + Advanced expander
+
+**Parent spec:** `docs/superpowers/specs/2026-07-18-gui-full-workspace-design.md`
+(GUI 2.0 full-workspace design; this is the M3c milestone slice.)
+
+**Predecessors:** M3a shipped `CommandBuilder` (per-mode argv, one source of
+truth for run + strip) and the live CLI transparency strip. M3b gave **Flight
+map** its curated options panel and set the pattern this slice follows.
+
+## Goal
+
+Give the **Photo map** mode a curated options panel between the MODE strip and
+the ACTION button, plus an Advanced expander. Every control maps to an existing
+`photomap` CLI flag; the typed option state flows through `CommandBuilder` into
+both the executed run and the live CLI strip. No new CLI features — M3c surfaces
+capability that already exists.
+
+## Context: the real `photomap` flag surface
+
+`photomap` (`src/dji_metadata_embedder/cli.py:535-586`) accepts: `directory`
+(from the Source picker), `-o/--output`, `-f/--format`
+(`html`/`kml`/`geojson`/`all`, default `html`), `-r/--recursive`, `--title`,
+`--link-originals`, `--link-base PREFIX`, `--popup-fields LIST`, `--redact`
+(`none`/`fuzz`, default `none`), `--serve`, `--tile-style`, plus
+`--progress`/`-v`/`-q`.
+
+Differences from `flightmap` that shape this slice:
+
+- **No `--tz-offset`, no `--join-gap`** — both are SRT-telemetry concerns.
+- **`--serve` is impossible in the GUI.** `cli.py:616-620` raises a
+  `UsageError` when `--serve` is combined with `--progress jsonl`, and
+  `DjiEmbedRunner` appends that flag unconditionally at execution. The need it
+  serves (360° panoramas over HTTP) is already met by the M2 `MapServer`
+  loopback behind the inline preview, so nothing is lost.
+- **`--link-originals` is already hardcoded on** in the M3a argv
+  (`CommandBuilder.cs:33`). M3c turns it into a default-ON control, not a new
+  opt-in.
+
+Tile-style keys (`src/dji_metadata_embedder/geo/tiles.py`): `osm` (default),
+`osm-hot`, `opentopomap`, `cyclosm` — the same set Flight map offers.
+
+Popup fields (`src/dji_metadata_embedder/geo/photomap_html.py:49`):
+`POPUP_FIELDS = ("name", "timestamp", "camera", "altitude", "credit")`.
+
+## Curated controls (always visible when Photo map is selected)
+
+| Control | Shape | Default | argv effect |
+|---|---|---|---|
+| **Include subfolders** | `ToggleSwitch` | ON | `-r` when on; omit when off |
+| **Map style** | `ComboBox` (4) | Standard (`osm`) | `--tile-style osm-hot`/`opentopomap`/`cyclosm` when non-default; omit for Standard |
+| **Privacy** | `ComboBox` (2) | Keep exact | `--redact fuzz` when Fuzz; omit when Keep |
+| **Link pins to the original photos** | `CheckBox` | ON | `--link-originals` when on; omit when off |
+| **Popup details** | 5 `CheckBox`es | all ticked | see encoding below |
+
+Map-style and Privacy reuse M3b's label→key mappings verbatim (Standard→`osm`,
+Humanitarian→`osm-hot`, Topographic→`opentopomap`, Cycling→`cyclosm`; "Keep
+exact locations"→omit, "Fuzz to ~100 m"→`--redact fuzz`).
+
+**Link-to-originals** carries a hint that the 360° panorama viewer needs it.
+Turning it off produces a self-contained map whose popups do not reference local
+file paths — the shareable-single-file case.
+
+**Popup details** are labelled Name / Time / Camera / Altitude / Credit, with a
+one-line explanation that unticked details are left out of the HTML file
+entirely (the original photos are never modified).
+
+### `--popup-fields` encoding
+
+`CommandBuilder` owns this mapping; the options record stays dumb data.
+
+| State | argv |
+|---|---|
+| All five ticked | flag omitted (CLI default = show everything) |
+| None ticked | `--popup-fields none` |
+| Any subset | `--popup-fields a,b,c` in the canonical `POPUP_FIELDS` order: `name,timestamp,camera,altitude,credit` |
+
+The none-ticked case is **not cosmetic**: `parse_popup_fields`
+(`photomap_html.py:71`) raises `ValueError` on an empty comma list
+(`if unknown or not fields`), so emitting `--popup-fields ""` would fail the
+run. `none` is the only valid encoding of "no popup fields".
+
+### Fuzz caveat note
+
+When Privacy is **Fuzz** *and* Link-to-originals is **on**, a quiet one-line
+note appears under the privacy row:
+
+> Linked originals still carry exact GPS in their EXIF.
+
+This mirrors the note the CLI prints on stderr (`cli.py:665-671`), which the GUI
+would otherwise bury in the warnings area. It is driven by a real bool property
+on the options VM (not a XAML multi-binding) so it is assertable headless —
+following the `ShowIdle` precedent from issue #328.
+
+## Advanced expander (collapsed by default)
+
+| Control | Shape | Default | argv effect |
+|---|---|---|---|
+| **Also export KML + GeoJSON** | `CheckBox` | off | `--format all` when on; omit (`html`) when off |
+| **Map title** | `TextBox` | empty (→ folder name) | `--title X` when non-empty |
+| **Save map to** | file picker (`TextBox` + Browse + "Use default") | empty (→ source folder) | `--output PATH` when set |
+
+Same three controls, same save-picker and clear-output affordance as M3b — the
+`FolderPicking` / `ClearOutputCommand` pattern is reused, not reinvented.
+
+The single "Also export KML + GeoJSON" checkbox (rather than per-format chips)
+follows M3b's reasoning unchanged: `--format` is single-valued and the inline
+preview requires HTML output.
+
+## Defaults invariant
+
+With nothing touched, the Photo map argv is
+**`photomap <folder> -r --link-originals`** — byte-identical to what M3a's
+`CommandBuilder.Build(PhotoMap, folder)` produces today. Options only *add*
+flags; omit-at-default keeps the strip clean and keeps M3a's golden tests valid.
+
+`CommandBuilder` still omits `--progress jsonl`; `DjiEmbedRunner` appends it at
+execution. The strip shows the human form with program name `dji-embed` and a
+`<folder>` placeholder before a folder is picked.
+
+## Styling constraint
+
+All controls are the **standard Avalonia / SukiUI themed controls**
+(`ToggleSwitch`, `ComboBox`, `CheckBox`, `TextBox`, `Expander`) inheriting the
+app theme's default appearance in light and dark, with no bespoke restyling.
+Layout spacing and labels are ours; control chrome stays themed default.
+
+Known build gotcha carried from M3b: `TextBox.Watermark` is `[Obsolete]`
+(AVLN5001) in this Avalonia — use `PlaceholderText`.
+
+## Architecture
+
+Mirrors M3b's seam layout.
+
+- **`ViewModels/PhotoMapOptions.cs`** — an immutable record of typed option
+  state (`Recursive`, `TileStyle`, `Privacy`, `LinkOriginals`, `PopupFields`,
+  `ExportAll`, `Title`, `Output`) with a `Defaults` value. Reuses M3b's
+  `MapPrivacy` enum, whose `Keep`/`Fuzz` values are exactly `photomap --redact`'s
+  `none`/`fuzz`. `PopupFields` is a nested immutable record of five bools with an
+  `All` value; it holds no formatting logic.
+- **`ViewModels/PhotoMapOptionsViewModel.cs`** — `[ObservableProperty]` per
+  control, bound to the panel; `ToOptions()` snapshots it into
+  `PhotoMapOptions`. Exposes the fuzz-caveat bool and the `ClearOutputCommand`.
+- **`Services/CommandBuilder.cs`** — new pure overload
+  `PhotoMap(string folder, PhotoMapOptions opts)`. The existing
+  `Build(kind, folder)` routes its PhotoMap arm through
+  `PhotoMap(folder, PhotoMapOptions.Defaults)`, so M3a's default-behavior golden
+  tests are unchanged.
+- **`ViewModels/WorkspaceViewModel.cs`** — a `PhotoOptions` property; a new
+  `IsPhotoMapMode` computed property notified alongside `IsFlightMapMode`
+  (`WorkspaceViewModel.cs:144`); the PhotoMap `RunAsync` branch and
+  `CommandPreview` both build argv via
+  `CommandBuilder.PhotoMap(folder, PhotoOptions.ToOptions())`; the strip
+  recomputes on the options VM's `PropertyChanged` (same subscription pattern as
+  `FlightOptions`).
+- **`Views/WorkspaceView.axaml`** — a `PhotoOptionsPanel` border in the existing
+  OPTIONS zone, `IsVisible="{Binding IsPhotoMapMode}"`, with its own collapsed
+  Advanced `Expander`.
+
+### Shared tile-style list (targeted cleanup)
+
+The four `TileChoice` values currently live inside `FlightMapOptionsViewModel`.
+Both map modes consume the identical `--tile-style` key set, so the `TileChoice`
+record and the list move to a new `ViewModels/TileChoice.cs` exposing a static
+`TileChoice.All`, which both options VMs read. This is a move, not a rewrite:
+`FlightMapOptionsViewModel` keeps its `TileStyles` property, now returning the
+shared list, so M3b's tests and XAML bindings are untouched.
+
+The `MapPrivacy` enum stays where M3b put it (`ViewModels/FlightMapOptions.cs`)
+and is referenced by name from `PhotoMapOptions` — same namespace, no move, no
+churn in M3b's files beyond the tile-list extraction.
+
+Runner, strict-success rule, cancellation, and the M2/#328 preview all carry over
+unchanged. The done-map preview points at the run result's reported output path,
+so a "Save map to" override previews correctly with no special handling.
+
+## Behavior notes
+
+- **Persistence:** in-memory VM state only — no disk persistence (respects the
+  "no settings dialog; only MRU + window bounds" rule). Options survive mode
+  switches while the app is open; a fresh launch starts at defaults.
+- **Mode switch:** switching away from Photo map hides the panel; switching back
+  shows it with state intact. Only one options panel is visible at a time.
+- **Photo map with no photos:** the existing `PhotoMap when !contents.HasPhotos`
+  guard (`WorkspaceViewModel.cs:376`) is unchanged; options do not affect it.
+
+## Testing
+
+TDD throughout; red before green.
+
+- **Golden argv** (`CommandBuilderTests`): defaults
+  (`photomap <f> -r --link-originals`); recursive-off drops `-r`;
+  link-originals-off drops the flag; each non-default tile style; `fuzz`;
+  popup-fields all-ticked omits the flag; none-ticked → `--popup-fields none`;
+  a subset emits canonical order regardless of tick order; export-all →
+  `--format all`; title with spaces; output override.
+- **Options VM** (`PhotoMapOptionsViewModelTests`): default values;
+  `ToOptions()` mapping per control; the fuzz-caveat bool is true only when
+  Fuzz **and** LinkOriginals are both set; `ClearOutputCommand` resets Output.
+- **Live preview** (`WorkspaceViewModelTests`): `CommandPreview` updates when a
+  photo option changes; reflects Photo map argv when that mode is selected;
+  `IsPhotoMapMode` flips and notifies on mode change.
+- **Screen** (`AvaloniaFact`): Photo map renders the options panel with Advanced
+  collapsed; Flight map does not render the photo panel (and vice versa).
+  Per the #328 gotcha, any button assertion checks
+  `Assert.Same(vm.SomeCommand, button.Command)` — a `Button` with a **null**
+  `Command` still reports `IsEffectivelyEnabled == true`, so asserting
+  enabled-ness proves nothing about a binding.
+
+## Out of scope (M3c)
+
+- `--link-base` (publish-elsewhere prefix; its "requires `--link-originals`"
+  coupling is a GUI failure mode, and it is an exotic flag per the parent spec).
+- `--serve` (structurally incompatible with `--progress jsonl`; the inline
+  preview already covers it).
+- Embed options (M3d), Convert/Verify options and footprints (M4).
+- Any new CLI flag, or changes to the `--progress jsonl` contract.
+- Independent KML-only / GeoJSON-only export (CLI is single-valued).
+- Persisting options to disk.
+
+## Milestone placement
+
+M3c is one releasable milestone / one PR under the M3 arc (M3a, M3b and issue
+#328 done). Remaining sibling slice: M3d (Embed options). Release remains
+**held** per the small-userbase call — M3c rides the next version bump with the
+already-merged #327 fix, M3a, M3b and #328.

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -311,4 +311,20 @@ public class CommandBuilderTests
             PhotoMapOptions.Defaults with { Title = "   ", Output = "  " });
         Assert.Equal(["photomap", "/x", "-r", "--link-originals"], argv);
     }
+
+    [Fact]
+    public void Photo_map_all_options_compose_in_a_stable_order()
+    {
+        var opts = new PhotoMapOptions(
+            Recursive: true, TileStyle: "cyclosm", Privacy: MapPrivacy.Fuzz,
+            LinkOriginals: true,
+            Popup: new PopupFields(Name: true, Timestamp: false, Camera: true,
+                                    Altitude: false, Credit: true),
+            ExportAll: true, Title: "T", Output: "/o.html");
+        Assert.Equal(
+            ["photomap", "/x", "-r", "--tile-style", "cyclosm", "--redact", "fuzz",
+             "--link-originals", "--popup-fields", "name,camera,credit",
+             "--format", "all", "--title", "T", "--output", "/o.html"],
+            CommandBuilder.PhotoMap("/x", opts));
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -184,4 +184,131 @@ public class CommandBuilderTests
              "--title", "T", "--output", "/o.html"],
             CommandBuilder.FlightMap("/x", opts));
     }
+
+    // M3c: PhotoMap(folder, opts) is the option-aware argv builder. Defaults
+    // must equal M3a's hardcoded output; every option adds flags, omitting at
+    // default so the strip stays clean.
+    [Fact]
+    public void Photo_map_defaults_match_the_m3a_linked_form()
+    {
+        string[] expected = ["photomap", "/x", "-r", "--link-originals"];
+        Assert.Equal(expected,
+            CommandBuilder.PhotoMap("/x", PhotoMapOptions.Defaults));
+    }
+
+    [Fact]
+    public void Photo_map_build_delegates_to_the_options_overload()
+    {
+        Assert.Equal(
+            CommandBuilder.PhotoMap("/x", PhotoMapOptions.Defaults),
+            CommandBuilder.Build(WorkspaceModeKind.PhotoMap, "/x"));
+    }
+
+    [Fact]
+    public void Photo_map_without_recursive_drops_the_flag()
+    {
+        var argv = CommandBuilder.PhotoMap("/x",
+            PhotoMapOptions.Defaults with { Recursive = false });
+        Assert.Equal(["photomap", "/x", "--link-originals"], argv);
+    }
+
+    [Fact]
+    public void Photo_map_without_link_originals_drops_the_flag()
+    {
+        var argv = CommandBuilder.PhotoMap("/x",
+            PhotoMapOptions.Defaults with { LinkOriginals = false });
+        Assert.Equal(["photomap", "/x", "-r"], argv);
+    }
+
+    [Theory]
+    [InlineData("osm-hot")]
+    [InlineData("opentopomap")]
+    [InlineData("cyclosm")]
+    public void Photo_map_passes_a_non_default_tile_style(string key)
+    {
+        var argv = CommandBuilder.PhotoMap("/x",
+            PhotoMapOptions.Defaults with { TileStyle = key });
+        Assert.Equal(["photomap", "/x", "-r", "--tile-style", key,
+                      "--link-originals"], argv);
+    }
+
+    [Fact]
+    public void Photo_map_omits_the_default_tile_style()
+    {
+        Assert.DoesNotContain("--tile-style",
+            CommandBuilder.PhotoMap("/x", PhotoMapOptions.Defaults));
+    }
+
+    [Fact]
+    public void Photo_map_fuzz_redacts()
+    {
+        var argv = CommandBuilder.PhotoMap("/x",
+            PhotoMapOptions.Defaults with { Privacy = MapPrivacy.Fuzz });
+        Assert.Equal(["photomap", "/x", "-r", "--redact", "fuzz",
+                      "--link-originals"], argv);
+    }
+
+    [Fact]
+    public void Photo_map_omits_popup_fields_when_every_detail_is_shown()
+    {
+        Assert.DoesNotContain("--popup-fields",
+            CommandBuilder.PhotoMap("/x", PhotoMapOptions.Defaults));
+    }
+
+    [Fact]
+    public void Photo_map_encodes_no_popup_details_as_none()
+    {
+        // parse_popup_fields (photomap_html.py) REJECTS an empty comma list;
+        // "none" is the only valid encoding of "show nothing".
+        var argv = CommandBuilder.PhotoMap("/x",
+            PhotoMapOptions.Defaults with { Popup = PopupFields.None });
+        Assert.Equal(["photomap", "/x", "-r", "--link-originals",
+                      "--popup-fields", "none"], argv);
+    }
+
+    [Fact]
+    public void Photo_map_lists_a_popup_subset_in_the_cli_field_order()
+    {
+        // Ticked out of order; the flag must still read name,camera,credit —
+        // the POPUP_FIELDS order the CLI documents.
+        var argv = CommandBuilder.PhotoMap("/x", PhotoMapOptions.Defaults with
+        {
+            Popup = new PopupFields(Name: true, Timestamp: false, Camera: true,
+                                    Altitude: false, Credit: true),
+        });
+        Assert.Equal(["photomap", "/x", "-r", "--link-originals",
+                      "--popup-fields", "name,camera,credit"], argv);
+    }
+
+    [Fact]
+    public void Photo_map_export_all_writes_every_format()
+    {
+        var argv = CommandBuilder.PhotoMap("/x",
+            PhotoMapOptions.Defaults with { ExportAll = true });
+        Assert.Equal(["photomap", "/x", "-r", "--link-originals",
+                      "--format", "all"], argv);
+    }
+
+    [Fact]
+    public void Photo_map_passes_a_title_and_output()
+    {
+        var argv = CommandBuilder.PhotoMap("/x", PhotoMapOptions.Defaults with
+        {
+            Title = "  Sunday flight  ",
+            Output = " /out/map.html ",
+        });
+        // Trimmed, not quoted: quoting belongs to CommandLine.Format (the
+        // strip); argv elements reach the process verbatim.
+        Assert.Equal(["photomap", "/x", "-r", "--link-originals",
+                      "--title", "Sunday flight",
+                      "--output", "/out/map.html"], argv);
+    }
+
+    [Fact]
+    public void Photo_map_ignores_blank_title_and_output()
+    {
+        var argv = CommandBuilder.PhotoMap("/x",
+            PhotoMapOptions.Defaults with { Title = "   ", Output = "  " });
+        Assert.Equal(["photomap", "/x", "-r", "--link-originals"], argv);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/PhotoMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/PhotoMapOptionsViewModelTests.cs
@@ -1,0 +1,113 @@
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class PhotoMapOptionsViewModelTests
+{
+    [Fact]
+    public void Defaults_match_the_photomap_options_defaults()
+    {
+        var vm = new PhotoMapOptionsViewModel();
+        Assert.Equal(PhotoMapOptions.Defaults, vm.ToOptions());
+    }
+
+    [Fact]
+    public void Default_selections_are_standard_keep_and_linked()
+    {
+        var vm = new PhotoMapOptionsViewModel();
+        Assert.True(vm.Recursive);
+        Assert.Equal("osm", vm.SelectedTileStyle.Key);
+        Assert.Equal(MapPrivacy.Keep, vm.SelectedPrivacy.Value);
+        Assert.True(vm.LinkOriginals);
+        Assert.False(vm.ExportAll);
+        Assert.Equal("", vm.Title);
+        Assert.Equal("", vm.Output);
+    }
+
+    [Fact]
+    public void Every_popup_detail_starts_ticked()
+    {
+        var vm = new PhotoMapOptionsViewModel();
+        Assert.True(vm.ShowName);
+        Assert.True(vm.ShowTimestamp);
+        Assert.True(vm.ShowCamera);
+        Assert.True(vm.ShowAltitude);
+        Assert.True(vm.ShowCredit);
+        Assert.Equal(PopupFields.All, vm.ToOptions().Popup);
+    }
+
+    [Fact]
+    public void Shares_the_tile_list_with_the_flight_map_panel()
+    {
+        Assert.Same(TileChoice.All, new PhotoMapOptionsViewModel().TileStyles);
+    }
+
+    [Fact]
+    public void ToOptions_reflects_every_mutated_control()
+    {
+        var vm = new PhotoMapOptionsViewModel
+        {
+            Recursive = false,
+            LinkOriginals = false,
+            ShowCamera = false,
+            ShowAltitude = false,
+            ExportAll = true,
+            Title = "Sunday flight",
+            Output = "/out/map.html",
+        };
+        vm.SelectedTileStyle = vm.TileStyles.Single(t => t.Key == "opentopomap");
+        vm.SelectedPrivacy =
+            vm.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
+
+        var opts = vm.ToOptions();
+        Assert.Equal(new PhotoMapOptions(
+            Recursive: false,
+            TileStyle: "opentopomap",
+            Privacy: MapPrivacy.Fuzz,
+            LinkOriginals: false,
+            Popup: new PopupFields(Name: true, Timestamp: true, Camera: false,
+                                   Altitude: false, Credit: true),
+            ExportAll: true,
+            Title: "Sunday flight",
+            Output: "/out/map.html"), opts);
+    }
+
+    // The CLI prints this caveat on stderr, where the GUI would bury it in the
+    // warnings area — so the panel says it at the moment of the choice.
+    [Fact]
+    public void Fuzz_caveat_shows_only_when_fuzzing_and_linking()
+    {
+        var vm = new PhotoMapOptionsViewModel();
+        Assert.False(vm.ShowsFuzzCaveat);      // Keep + linked
+
+        vm.SelectedPrivacy =
+            vm.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
+        Assert.True(vm.ShowsFuzzCaveat);       // Fuzz + linked
+
+        vm.LinkOriginals = false;
+        Assert.False(vm.ShowsFuzzCaveat);      // Fuzz, nothing linked
+    }
+
+    [Fact]
+    public void Fuzz_caveat_notifies_on_both_of_its_inputs()
+    {
+        var vm = new PhotoMapOptionsViewModel();
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+
+        vm.SelectedPrivacy =
+            vm.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
+        vm.LinkOriginals = false;
+
+        Assert.Equal(2, notified.Count(
+            n => n == nameof(PhotoMapOptionsViewModel.ShowsFuzzCaveat)));
+    }
+
+    [Fact]
+    public void Clear_output_resets_to_the_source_folder()
+    {
+        var vm = new PhotoMapOptionsViewModel { Output = "/out/map.html" };
+        vm.ClearOutputCommand.Execute(null);
+        Assert.Equal("", vm.Output);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/PhotoMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/PhotoMapOptionsViewModelTests.cs
@@ -72,8 +72,9 @@ public class PhotoMapOptionsViewModelTests
             Output: "/out/map.html"), opts);
     }
 
-    // The CLI prints this caveat on stderr, where the GUI would bury it in the
-    // warnings area — so the panel says it at the moment of the choice.
+    // The CLI prints this caveat on stderr via click.echo(err=True), which a
+    // successful run's jsonl-only warnings area never sees — so the panel
+    // says it at the moment of the choice, the user's only chance to see it.
     [Fact]
     public void Fuzz_caveat_shows_only_when_fuzzing_and_linking()
     {

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -207,6 +207,55 @@ public class ScreenshotCaptureTests
         CaptureView(view, Path.Combine(dir!, "workspace-existing-maps.png"));
     }
 
+    /// <summary>
+    /// The Photo map curated options (M3c): once at its defaults with
+    /// Advanced closed — the state a novice actually meets — and once with
+    /// Advanced open, Fuzz chosen and popup details unticked, which is the
+    /// only state that renders the fuzz caveat and the "Use default" reset.
+    /// </summary>
+    [AvaloniaFact]
+    public void Captures_photo_map_options_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture the Photo map options.");
+        Directory.CreateDirectory(dir!);
+
+        var vm = new WorkspaceViewModel(
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
+        vm.SelectedFolder = @"C:\Users\demo\Pictures\flight";
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        view.DataContext = vm;
+        // Taller than the app's 720: the point of this capture is to review
+        // the whole panel at once, which the real window scrolls to reach.
+        CaptureView(view, Path.Combine(dir!, "workspace-photo-options.png"),
+            height: 1100);
+
+        vm.PhotoOptions.SelectedPrivacy = vm.PhotoOptions.PrivacyOptions
+            .Single(p => p.Value == MapPrivacy.Fuzz);
+        vm.PhotoOptions.ShowCamera = false;
+        vm.PhotoOptions.ShowAltitude = false;
+        vm.PhotoOptions.Output = @"C:\Users\demo\Desktop\holiday-map.html";
+        var opened = new WorkspaceView { WebViewGate = static () => false };
+        opened.DataContext = vm;
+        var window = new Window { Width = 1140, Height = 1400, Content = opened };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        opened.FindControl<Expander>("PhotoAdvanced")!.IsExpanded = true;
+        // The expander reveals its content with an animation; without
+        // advancing the headless render clock the capture catches it
+        // half-open and the Advanced rows are clipped away.
+        for (var i = 0; i < 80; i++)
+        {
+            AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+        Capture(window, Path.Combine(dir!, "workspace-photo-options-advanced.png"));
+    }
+
     private static void CaptureView(
         Control view, string outPath, double width = 1140, double height = 720) =>
         Capture(new Window { Width = width, Height = height, Content = view },

--- a/gui/DjiEmbed.Gui.Tests/TileChoiceTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/TileChoiceTests.cs
@@ -1,0 +1,31 @@
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+// M3c: both map modes offer the same --tile-style keys, so the list lives in
+// one place. Order is pinned because it is the ComboBox order (index 0 = the
+// CLI default, which every options VM selects at construction).
+public class TileChoiceTests
+{
+    [Fact]
+    public void All_lists_the_four_shared_basemaps_in_order()
+    {
+        Assert.Equal(["osm", "osm-hot", "opentopomap", "cyclosm"],
+            TileChoice.All.Select(t => t.Key));
+    }
+
+    [Fact]
+    public void All_labels_are_human_facing()
+    {
+        Assert.Equal(["Standard", "Humanitarian", "Topographic", "Cycling"],
+            TileChoice.All.Select(t => t.Label));
+    }
+
+    [Fact]
+    public void Flight_map_options_read_the_shared_list()
+    {
+        // Assert.Same, not Assert.Equal: a copy-pasted second list would pass
+        // an equality check and silently drift from this one later.
+        Assert.Same(TileChoice.All, new FlightMapOptionsViewModel().TileStyles);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -404,4 +404,49 @@ public class WorkspaceScreenTests
         // true, so identity is the only assertion that proves the binding.
         Assert.Same(vm.PhotoOptions.ClearOutputCommand, clear.Command);
     }
+
+    // The one privacy-relevant message in the panel: a fuzzed map still
+    // leaks exact GPS through linked originals. Proves the IsVisible
+    // binding path itself, not just the ViewModel property it reads.
+    [AvaloniaFact]
+    public void Fuzz_caveat_note_tracks_privacy_and_link_originals()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var note = window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "FuzzCaveatNote");
+        Assert.False(note.IsEffectivelyVisible);   // defaults: Keep + linked
+
+        vm.PhotoOptions.SelectedPrivacy = vm.PhotoOptions.PrivacyOptions[1];   // Fuzz
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(note.IsEffectivelyVisible);
+
+        vm.PhotoOptions.LinkOriginals = false;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.False(note.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Photo_map_link_originals_checkbox_binds_to_the_options_view_model()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var link = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "LinkOriginalsCheck");
+        Assert.True(link.IsChecked);
+        link.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.PhotoOptions.LinkOriginals);
+        Assert.DoesNotContain("--link-originals", vm.CommandPreview);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -405,6 +405,39 @@ public class WorkspaceScreenTests
         Assert.Same(vm.PhotoOptions.ClearOutputCommand, clear.Command);
     }
 
+    // Branch review: photomap links pins to the originals with an href
+    // RELATIVE to the HTML file, so redirecting "Save map to" outside the
+    // source folder silently breaks every "open the original" link.
+    [AvaloniaFact]
+    public async Task Link_reach_note_appears_only_when_the_output_would_leave_the_source_folder()
+    {
+        var dir = Directory.CreateTempSubdirectory("djiembed-screen-linkreach").FullName;
+        var elsewhere = Directory.CreateTempSubdirectory("djiembed-screen-linkreach-out").FullName;
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "IMG_1.JPG"), "");
+            var window = ShowWorkspace();
+            var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+            await vm.SetFolderAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var note = window.GetVisualDescendants().OfType<TextBlock>()
+                .Single(t => t.Name == "LinkReachNote");
+            Assert.False(note.IsEffectivelyVisible);
+
+            vm.PhotoOptions.Output = Path.Combine(elsewhere, "photomap.html");
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Assert.True(note.IsEffectivelyVisible);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+            Directory.Delete(elsewhere, recursive: true);
+        }
+    }
+
     // The one privacy-relevant message in the panel: a fuzzed map still
     // leaks exact GPS through linked originals. Proves the IsVisible
     // binding path itself, not just the ViewModel property it reads.

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -338,4 +338,70 @@ public class WorkspaceScreenTests
         window.UpdateLayout();
         Assert.Equal("Process another", label.Text);
     }
+
+    // M3c: the Photo map options panel renders only for Photo map, with the
+    // Advanced expander closed by default.
+    [AvaloniaFact]
+    public void Photo_map_mode_shows_its_options_panel_with_advanced_collapsed()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "PhotoOptionsPanel");
+        Assert.True(panel.IsEffectivelyVisible);
+        var advanced = window.GetVisualDescendants().OfType<Expander>()
+            .Single(e => e.Name == "PhotoAdvanced");
+        Assert.False(advanced.IsExpanded);
+        // The two map panels are mutually exclusive.
+        Assert.False(window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "FlightOptionsPanel").IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Flight_map_mode_hides_the_photo_options_panel()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "PhotoOptionsPanel");
+        Assert.False(panel.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Photo_map_popup_checkboxes_bind_to_the_options_view_model()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var camera = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "PopupCameraCheck");
+        Assert.True(camera.IsChecked);
+        camera.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.PhotoOptions.ShowCamera);
+        Assert.Contains("--popup-fields", vm.CommandPreview);
+    }
+
+    [AvaloniaFact]
+    public void Photo_map_clear_output_button_is_bound_to_its_command()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        vm.PhotoOptions.Output = "/out/map.html";
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var clear = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ClearPhotoOutputButton");
+        // A Button with a NULL Command still reports IsEffectivelyEnabled ==
+        // true, so identity is the only assertion that proves the binding.
+        Assert.Same(vm.PhotoOptions.ClearOutputCommand, clear.Command);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -1028,6 +1028,35 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.False(vm.PhotoLinksCannotReachOriginals);
     }
 
+    // Branch review finding (present since M3b, doubled by M3c): an absolute
+    // "Save map to" override belongs to the folder it was chosen for — carry
+    // it to a new folder and that folder's map silently overwrites the old
+    // one, or lands nowhere the new folder shows. Every OTHER option is
+    // deliberately app-session state (the GUI 2.0 spec: "options survive
+    // while the app is open") — this test guards both halves so neither
+    // regresses into the other.
+    [Fact]
+    public async Task A_new_folder_clears_the_save_map_override_but_keeps_other_options()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        vm.FlightOptions.Output = Path.Combine(_dir, "flightmap.html");
+        vm.FlightOptions.SelectedPrivacy =
+            vm.FlightOptions.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
+        vm.PhotoOptions.Output = Path.Combine(_dir, "photomap.html");
+        vm.PhotoOptions.SelectedTileStyle =
+            vm.PhotoOptions.TileStyles.Single(t => t.Key == "opentopomap");
+        vm.PhotoOptions.ShowCamera = false;
+
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+
+        Assert.Equal("", vm.FlightOptions.Output);
+        Assert.Equal("", vm.PhotoOptions.Output);
+        Assert.Equal(MapPrivacy.Fuzz, vm.FlightOptions.SelectedPrivacy.Value);
+        Assert.Equal("opentopomap", vm.PhotoOptions.SelectedTileStyle.Key);
+        Assert.False(vm.PhotoOptions.ShowCamera);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -891,6 +891,62 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.False(vm.ShowPreview);
     }
 
+    // M3c: Photo map options flow through the run and the live strip.
+    [Fact]
+    public async Task Photo_map_options_reach_the_photomap_argv()
+    {
+        var argsFile = Path.Combine(_dir, "args-photo-opt.txt");
+        var cli = FakeCli.WriteArgsRecorder(_dir, argsFile, PhotomapStream);
+        var vm = Vm(cli);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        vm.PhotoOptions.SelectedPrivacy =
+            vm.PhotoOptions.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
+        vm.PhotoOptions.ShowCamera = false;
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        var argv = File.ReadAllText(argsFile);
+        Assert.Contains("--redact fuzz", argv);
+        Assert.Contains("--popup-fields name,timestamp,altitude,credit", argv);
+        Assert.Contains("--link-originals", argv);
+    }
+
+    [Fact]
+    public void Command_preview_reflects_photo_options()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Assert.Contains("photomap", vm.CommandPreview);
+        vm.PhotoOptions.ExportAll = true;
+        Assert.Contains("--format all", vm.CommandPreview);
+        vm.PhotoOptions.LinkOriginals = false;
+        Assert.DoesNotContain("--link-originals", vm.CommandPreview);
+    }
+
+    [Fact]
+    public void Changing_a_photo_option_notifies_command_preview()
+    {
+        var vm = Vm("unused");
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.PhotoOptions.ShowCredit = false;
+        Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
+    }
+
+    [Fact]
+    public void Only_photo_map_mode_reports_the_photo_options_panel_visible()
+    {
+        var vm = Vm("unused");   // default mode Flight map
+        Assert.False(vm.IsPhotoMapMode);
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Assert.True(vm.IsPhotoMapMode);
+        Assert.False(vm.IsFlightMapMode);
+        Assert.Contains(nameof(WorkspaceViewModel.IsPhotoMapMode), notified);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -947,6 +947,87 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Contains(nameof(WorkspaceViewModel.IsPhotoMapMode), notified);
     }
 
+    // Branch review finding: photomap writes each pin's href RELATIVE to the
+    // HTML file, so a "Save map to" redirected outside the source folder
+    // silently breaks every "open the original" link — and with it the 360°
+    // panorama viewer. PhotoLinksCannotReachOriginals is the truth behind the
+    // panel's warning note.
+    [Fact]
+    public async Task Link_reach_note_is_false_at_defaults()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        Assert.False(vm.PhotoLinksCannotReachOriginals);
+    }
+
+    [Fact]
+    public async Task Link_reach_note_is_false_when_output_sits_in_the_source_folder()
+    {
+        var vm = Vm("unused");
+        var folder = MakeFolder(photos: true);
+        await vm.SetFolderAsync(folder);
+        vm.PhotoOptions.Output = Path.Combine(folder, "photomap.html");
+        Assert.False(vm.PhotoLinksCannotReachOriginals);
+    }
+
+    [Fact]
+    public async Task Link_reach_note_is_true_when_output_sits_outside_the_source_folder()
+    {
+        var vm = Vm("unused");
+        var folder = MakeFolder(photos: true);
+        await vm.SetFolderAsync(folder);
+        vm.PhotoOptions.Output = Path.Combine(_dir, "photomap.html");
+        Assert.True(vm.PhotoLinksCannotReachOriginals);
+    }
+
+    [Fact]
+    public async Task Link_reach_note_is_false_when_link_originals_is_off()
+    {
+        var vm = Vm("unused");
+        var folder = MakeFolder(photos: true);
+        await vm.SetFolderAsync(folder);
+        vm.PhotoOptions.Output = Path.Combine(_dir, "photomap.html");
+        vm.PhotoOptions.LinkOriginals = false;
+        Assert.False(vm.PhotoLinksCannotReachOriginals);
+    }
+
+    // D:\Trip and D:\Trip\ must read as the same folder — SelectedFolder is
+    // whatever the drop/pick handed us, untrimmed.
+    [Fact]
+    public async Task Link_reach_note_treats_a_trailing_separator_as_the_same_folder()
+    {
+        var vm = Vm("unused");
+        var folder = MakeFolder(photos: true);
+        await vm.SetFolderAsync(folder + Path.DirectorySeparatorChar);
+        vm.PhotoOptions.Output = Path.Combine(folder, "photomap.html");
+        Assert.False(vm.PhotoLinksCannotReachOriginals);
+    }
+
+    [Fact]
+    public async Task Link_reach_note_notifies_on_output_and_folder_changes()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+
+        vm.PhotoOptions.Output = Path.Combine(_dir, "photomap.html");
+        Assert.Contains(nameof(WorkspaceViewModel.PhotoLinksCannotReachOriginals), notified);
+
+        notified.Clear();
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        Assert.Contains(nameof(WorkspaceViewModel.PhotoLinksCannotReachOriginals), notified);
+    }
+
+    [Fact]
+    public async Task Link_reach_note_is_false_for_a_garbage_output_path()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        vm.PhotoOptions.Output = " bad";
+        Assert.False(vm.PhotoLinksCannotReachOriginals);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -22,7 +22,7 @@ public static class CommandBuilder
     public static string[] Build(WorkspaceModeKind kind, string? folder) => kind switch
     {
         WorkspaceModeKind.FlightMap => FlightMap(folder!, FlightMapOptions.Defaults),
-        WorkspaceModeKind.PhotoMap => ["photomap", folder!, "-r", "--link-originals"],
+        WorkspaceModeKind.PhotoMap => PhotoMap(folder!, PhotoMapOptions.Defaults),
         WorkspaceModeKind.Embed => ["embed", folder!],
         WorkspaceModeKind.Setup => ["doctor"],
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
@@ -80,5 +80,95 @@ public static class CommandBuilder
             args.Add(output);
         }
         return args.ToArray();
+    }
+
+    /// <summary>
+    /// The Photo map argv from typed <paramref name="opts"/> (GUI 2.0 spec,
+    /// M3c). Flags are omitted at their defaults so an untouched run reads
+    /// <c>photomap &lt;folder&gt; -r --link-originals</c>, exactly like M3a.
+    /// Order is fixed for golden tests. No <c>--progress</c>: the runner
+    /// appends that. No <c>--serve</c>: the CLI rejects it alongside
+    /// <c>--progress jsonl</c>, and the inline preview covers that need.
+    /// </summary>
+    public static string[] PhotoMap(string folder, PhotoMapOptions opts)
+    {
+        var args = new List<string> { "photomap", folder };
+        if (opts.Recursive)
+        {
+            args.Add("-r");
+        }
+        if (opts.TileStyle != PhotoMapOptions.Defaults.TileStyle)
+        {
+            args.Add("--tile-style");
+            args.Add(opts.TileStyle);
+        }
+        if (opts.Privacy == MapPrivacy.Fuzz)
+        {
+            args.Add("--redact");
+            args.Add("fuzz");
+        }
+        if (opts.LinkOriginals)
+        {
+            args.Add("--link-originals");
+        }
+        if (PopupFieldsValue(opts.Popup) is { } popup)
+        {
+            args.Add("--popup-fields");
+            args.Add(popup);
+        }
+        if (opts.ExportAll)
+        {
+            args.Add("--format");
+            args.Add("all");
+        }
+        var title = opts.Title.Trim();
+        if (title.Length > 0)
+        {
+            args.Add("--title");
+            args.Add(title);
+        }
+        var output = opts.Output.Trim();
+        if (output.Length > 0)
+        {
+            args.Add("--output");
+            args.Add(output);
+        }
+        return args.ToArray();
+    }
+
+    /// <summary>
+    /// The <c>--popup-fields</c> value, or <c>null</c> to omit the flag.
+    /// Names follow the CLI's own <c>POPUP_FIELDS</c> order. "Nothing ticked"
+    /// MUST encode as <c>none</c>: <c>parse_popup_fields</c> raises on an
+    /// empty comma list, so an empty string would fail the run.
+    /// </summary>
+    private static string? PopupFieldsValue(PopupFields fields)
+    {
+        if (fields == PopupFields.All)
+        {
+            return null;
+        }
+        var names = new List<string>(5);
+        if (fields.Name)
+        {
+            names.Add("name");
+        }
+        if (fields.Timestamp)
+        {
+            names.Add("timestamp");
+        }
+        if (fields.Camera)
+        {
+            names.Add("camera");
+        }
+        if (fields.Altitude)
+        {
+            names.Add("altitude");
+        }
+        if (fields.Credit)
+        {
+            names.Add("credit");
+        }
+        return names.Count == 0 ? "none" : string.Join(",", names);
     }
 }

--- a/gui/DjiEmbed.Gui/Services/ExistingMapFinder.cs
+++ b/gui/DjiEmbed.Gui/Services/ExistingMapFinder.cs
@@ -12,8 +12,8 @@ public sealed record ExistingMap(
 /// Finds maps a previous run left in the chosen folder. The GUI never passes
 /// <c>-o</c> by default, so the CLI's defaults apply and the two paths are
 /// deterministic: <c>flightmap.html</c> and <c>photomap.html</c>, written
-/// directly in the mapped folder. A map redirected elsewhere by the Flight
-/// map "Save map to" override is deliberately out of scope (#328 spec) —
+/// directly in the mapped folder. A map redirected elsewhere by either map
+/// mode's "Save map to" override is deliberately out of scope (#328 spec) —
 /// finding those would need a persisted record of past outputs.
 /// </summary>
 public static class ExistingMapFinder

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
@@ -4,9 +4,6 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace DjiEmbed.Gui.ViewModels;
 
-/// <summary>A selectable basemap: a friendly label over a <c>tiles.py</c> key.</summary>
-public sealed record TileChoice(string Label, string Key);
-
 /// <summary>A selectable privacy stance: a label over a <see cref="MapPrivacy"/>.</summary>
 public sealed record PrivacyChoice(string Label, MapPrivacy Value);
 
@@ -18,13 +15,7 @@ public sealed record PrivacyChoice(string Label, MapPrivacy Value);
 /// </summary>
 public partial class FlightMapOptionsViewModel : ViewModelBase
 {
-    public IReadOnlyList<TileChoice> TileStyles { get; } =
-    [
-        new("Standard", "osm"),
-        new("Humanitarian", "osm-hot"),
-        new("Topographic", "opentopomap"),
-        new("Cycling", "cyclosm"),
-    ];
+    public IReadOnlyList<TileChoice> TileStyles { get; } = TileChoice.All;
 
     public IReadOnlyList<PrivacyChoice> PrivacyOptions { get; } =
     [

--- a/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptions.cs
@@ -28,6 +28,8 @@ public sealed record PopupFields(
 /// Reuses <see cref="MapPrivacy"/>, whose two values are exactly the
 /// <c>none</c>/<c>fuzz</c> that <c>photomap --redact</c> accepts.
 /// </summary>
+/// <param name="TileStyle">A <c>tiles.py</c> key: <c>osm</c> (default),
+/// <c>osm-hot</c>, <c>opentopomap</c>, or <c>cyclosm</c>.</param>
 /// <param name="LinkOriginals">Popups link the thumbnail to the photo file.
 /// On by default: it is what powers the embedded 360° panorama viewer (#305).
 /// Off produces a self-contained map with no local paths in it.</param>

--- a/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptions.cs
@@ -1,0 +1,55 @@
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>
+/// Which details the HTML popups may show. Mirrors <c>POPUP_FIELDS</c> in
+/// <c>geo/photomap_html.py</c>; an unticked field is left out of the map file
+/// entirely (the photos themselves are never modified).
+/// </summary>
+public sealed record PopupFields(
+    bool Name,
+    bool Timestamp,
+    bool Camera,
+    bool Altitude,
+    bool Credit)
+{
+    /// <summary>Every detail — the CLI default, encoded by omitting the flag.</summary>
+    public static readonly PopupFields All = new(true, true, true, true, true);
+
+    /// <summary>No details — encoded as <c>--popup-fields none</c>.</summary>
+    public static readonly PopupFields None =
+        new(false, false, false, false, false);
+}
+
+/// <summary>
+/// Immutable, typed state for a Photo map run (GUI 2.0 spec, M3c). It is the
+/// single input to <see cref="Services.CommandBuilder.PhotoMap"/>, so the argv
+/// is a pure function of this record — golden-testable. Every field maps to an
+/// existing <c>photomap</c> flag; defaults reproduce M3a's hardcoded argv.
+/// Reuses <see cref="MapPrivacy"/>, whose two values are exactly the
+/// <c>none</c>/<c>fuzz</c> that <c>photomap --redact</c> accepts.
+/// </summary>
+/// <param name="LinkOriginals">Popups link the thumbnail to the photo file.
+/// On by default: it is what powers the embedded 360° panorama viewer (#305).
+/// Off produces a self-contained map with no local paths in it.</param>
+/// <param name="ExportAll">Also write KML + GeoJSON (<c>--format all</c>); the
+/// CLI format is single-valued, so this is one honest toggle, not per-format.</param>
+public sealed record PhotoMapOptions(
+    bool Recursive,
+    string TileStyle,
+    MapPrivacy Privacy,
+    bool LinkOriginals,
+    PopupFields Popup,
+    bool ExportAll,
+    string Title,
+    string Output)
+{
+    public static readonly PhotoMapOptions Defaults = new(
+        Recursive: true,
+        TileStyle: "osm",
+        Privacy: MapPrivacy.Keep,
+        LinkOriginals: true,
+        Popup: PopupFields.All,
+        ExportAll: false,
+        Title: "",
+        Output: "");
+}

--- a/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptionsViewModel.cs
@@ -64,9 +64,12 @@ public partial class PhotoMapOptionsViewModel : ViewModelBase
 
     /// <summary>
     /// True when the map coordinates are fuzzed but the popups still link the
-    /// originals — whose EXIF keeps the exact GPS. Mirrors the note the CLI
-    /// prints on stderr, which the GUI folds into the warnings area. A real
-    /// property (not a XAML multi-binding) so it is assertable headless.
+    /// originals — whose EXIF keeps the exact GPS. Mirrors a note the CLI
+    /// prints via <c>click.echo(err=True)</c>, but the GUI's warnings area
+    /// only collects jsonl <c>warning</c> events — on a successful run that
+    /// stderr line is discarded entirely, so this panel note is the user's
+    /// only chance to see it. A real property (not a XAML multi-binding) so
+    /// it is assertable headless.
     /// </summary>
     public bool ShowsFuzzCaveat =>
         SelectedPrivacy.Value == MapPrivacy.Fuzz && LinkOriginals;

--- a/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptionsViewModel.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>
+/// Observable control state for the Photo map options panel (GUI 2.0 spec,
+/// M3c). Bound directly to the SukiUI-themed controls; <see cref="ToOptions"/>
+/// snapshots it into the immutable <see cref="PhotoMapOptions"/> the builder
+/// consumes. Lives on <see cref="WorkspaceViewModel"/>; in-memory only.
+/// </summary>
+public partial class PhotoMapOptionsViewModel : ViewModelBase
+{
+    public IReadOnlyList<TileChoice> TileStyles { get; } = TileChoice.All;
+
+    public IReadOnlyList<PrivacyChoice> PrivacyOptions { get; } =
+    [
+        new("Keep exact locations", MapPrivacy.Keep),
+        new("Fuzz to ~100 m", MapPrivacy.Fuzz),
+    ];
+
+    [ObservableProperty]
+    public partial bool Recursive { get; set; } = true;
+
+    [ObservableProperty]
+    public partial TileChoice SelectedTileStyle { get; set; }
+
+    [ObservableProperty]
+    public partial PrivacyChoice SelectedPrivacy { get; set; }
+
+    [ObservableProperty]
+    public partial bool LinkOriginals { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool ShowName { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool ShowTimestamp { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool ShowCamera { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool ShowAltitude { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool ShowCredit { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool ExportAll { get; set; }
+
+    [ObservableProperty]
+    public partial string Title { get; set; } = "";
+
+    [ObservableProperty]
+    public partial string Output { get; set; } = "";
+
+    public PhotoMapOptionsViewModel()
+    {
+        SelectedTileStyle = TileStyles[0];
+        SelectedPrivacy = PrivacyOptions[0];
+    }
+
+    /// <summary>
+    /// True when the map coordinates are fuzzed but the popups still link the
+    /// originals — whose EXIF keeps the exact GPS. Mirrors the note the CLI
+    /// prints on stderr, which the GUI folds into the warnings area. A real
+    /// property (not a XAML multi-binding) so it is assertable headless.
+    /// </summary>
+    public bool ShowsFuzzCaveat =>
+        SelectedPrivacy.Value == MapPrivacy.Fuzz && LinkOriginals;
+
+    partial void OnSelectedPrivacyChanged(PrivacyChoice value) =>
+        OnPropertyChanged(nameof(ShowsFuzzCaveat));
+
+    partial void OnLinkOriginalsChanged(bool value) =>
+        OnPropertyChanged(nameof(ShowsFuzzCaveat));
+
+    public PhotoMapOptions ToOptions() => new(
+        Recursive: Recursive,
+        TileStyle: SelectedTileStyle.Key,
+        Privacy: SelectedPrivacy.Value,
+        LinkOriginals: LinkOriginals,
+        Popup: new PopupFields(
+            Name: ShowName,
+            Timestamp: ShowTimestamp,
+            Camera: ShowCamera,
+            Altitude: ShowAltitude,
+            Credit: ShowCredit),
+        ExportAll: ExportAll,
+        Title: Title,
+        Output: Output);
+
+    /// <summary>Reset the output override back to the default (write the map
+    /// into the source folder).</summary>
+    [RelayCommand]
+    private void ClearOutput() => Output = "";
+}

--- a/gui/DjiEmbed.Gui/ViewModels/TileChoice.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/TileChoice.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>A selectable basemap: a friendly label over a <c>tiles.py</c> key.</summary>
+public sealed record TileChoice(string Label, string Key)
+{
+    /// <summary>
+    /// The basemaps every map mode offers (GUI 2.0 spec, M3c). Flight map and
+    /// Photo map take the identical <c>--tile-style</c> keys, so they share one
+    /// list rather than two that can drift. Index 0 is the CLI default
+    /// (<c>osm</c>), which the options ViewModels select at construction.
+    /// </summary>
+    public static IReadOnlyList<TileChoice> All { get; } =
+    [
+        new("Standard", "osm"),
+        new("Humanitarian", "osm-hot"),
+        new("Topographic", "opentopomap"),
+        new("Cycling", "cyclosm"),
+    ];
+}

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -255,6 +255,13 @@ public partial class WorkspaceViewModel : FlowViewModel
         // warnings must not frame a map that was already sitting here.
         Outputs.Clear();
         Warnings.Clear();
+        // An absolute "Save map to" override belongs to the folder it was
+        // chosen for — carried to a new folder it either overwrites that
+        // folder's map or writes nowhere the new folder shows. Every other
+        // option (tile style, privacy, popup fields, ...) is deliberately
+        // app-session state that survives a folder change (GUI 2.0 spec).
+        FlightOptions.Output = "";
+        PhotoOptions.Output = "";
         ResetPreview();
         Step = FlowStep.Pick;
     }
@@ -443,9 +450,11 @@ public partial class WorkspaceViewModel : FlowViewModel
                      + "included automatically.");
                 return;
             case WorkspaceModeKind.PhotoMap:
-                // --link-originals: the map is written inside the mapped
-                // folder, so the relative links are stable there — and they
-                // power the embedded 360° panorama viewer (#305).
+                // --link-originals defaults on: it's what powers the embedded
+                // 360° panorama viewer (#305). Its relative hrefs only
+                // resolve while the map stays in the photo folder — both are
+                // now user choices, and PhotoLinksCannotReachOriginals is
+                // what warns before a redirected "Save map to" breaks them.
                 await ExecuteFlowAsync(async () =>
                     await RunStepAsync(
                         "Mapping your photos…",

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -36,7 +37,10 @@ public partial class WorkspaceViewModel : FlowViewModel
         FlightOptions.PropertyChanged += (_, _) =>
             OnPropertyChanged(nameof(CommandPreview));
         PhotoOptions.PropertyChanged += (_, _) =>
+        {
             OnPropertyChanged(nameof(CommandPreview));
+            OnPropertyChanged(nameof(PhotoLinksCannotReachOriginals));
+        };
     }
 
     /// <summary>Curated option state for the Flight map mode (M3b). Feeds both
@@ -117,6 +121,50 @@ public partial class WorkspaceViewModel : FlowViewModel
     public bool IsPhotoMapMode => SelectedMode.Kind == WorkspaceModeKind.PhotoMap;
 
     /// <summary>
+    /// True when a Photo map's "Save map to" override would leave the pins
+    /// unable to find the original photos. <c>photomap --link-originals</c>
+    /// writes each pin's href RELATIVE to the HTML file (the CLI's
+    /// <c>--link-base</c> is never passed here, so it defaults to the mapped
+    /// folder — see <c>geo/photomap.py</c>'s <c>_link_href</c>), and those
+    /// hrefs are what power the embedded 360° panorama viewer (#305). Redirect
+    /// the output elsewhere and every "open the original" link 404s, silently.
+    /// The fix is not a curated <c>--link-base</c> control — that flag stays
+    /// CLI-only by design — it's warning the user before they run. Any
+    /// exception from the path APIs (an unparseable path mid-typing) yields
+    /// false: a note computation must never throw into a binding.
+    /// </summary>
+    public bool PhotoLinksCannotReachOriginals
+    {
+        get
+        {
+            if (!PhotoOptions.LinkOriginals
+                || string.IsNullOrWhiteSpace(PhotoOptions.Output)
+                || SelectedFolder is null)
+            {
+                return false;
+            }
+            try
+            {
+                var outputDir = Path.GetDirectoryName(PhotoOptions.Output);
+                if (string.IsNullOrEmpty(outputDir))
+                {
+                    return false;
+                }
+                var fullOutputDir =
+                    Path.TrimEndingDirectorySeparator(Path.GetFullPath(outputDir));
+                var fullSourceDir =
+                    Path.TrimEndingDirectorySeparator(Path.GetFullPath(SelectedFolder));
+                return !string.Equals(fullOutputDir, fullSourceDir,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
     /// The exact human-facing <c>dji-embed</c> command the current mode +
     /// folder would run — the CLI transparency strip (GUI 2.0 spec, M3a).
     /// Uses a <c>&lt;folder&gt;</c> placeholder before a folder is picked so
@@ -148,6 +196,7 @@ public partial class WorkspaceViewModel : FlowViewModel
     {
         OnPropertyChanged(nameof(CanRun));
         OnPropertyChanged(nameof(CommandPreview));
+        OnPropertyChanged(nameof(PhotoLinksCannotReachOriginals));
         RunCommand.NotifyCanExecuteChanged();
     }
 

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -35,11 +35,17 @@ public partial class WorkspaceViewModel : FlowViewModel
             ?? (static () => WebViewSupport.IsLikelyAvailable);
         FlightOptions.PropertyChanged += (_, _) =>
             OnPropertyChanged(nameof(CommandPreview));
+        PhotoOptions.PropertyChanged += (_, _) =>
+            OnPropertyChanged(nameof(CommandPreview));
     }
 
     /// <summary>Curated option state for the Flight map mode (M3b). Feeds both
     /// the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
     public FlightMapOptionsViewModel FlightOptions { get; } = new();
+
+    /// <summary>Curated option state for the Photo map mode (M3c). Feeds both
+    /// the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
+    public PhotoMapOptionsViewModel PhotoOptions { get; } = new();
 
     public IReadOnlyList<WorkspaceMode> Modes => WorkspaceMode.All;
 
@@ -107,6 +113,9 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Whether the Flight map options panel applies to the current mode.</summary>
     public bool IsFlightMapMode => SelectedMode.Kind == WorkspaceModeKind.FlightMap;
 
+    /// <summary>Whether the Photo map options panel applies to the current mode.</summary>
+    public bool IsPhotoMapMode => SelectedMode.Kind == WorkspaceModeKind.PhotoMap;
+
     /// <summary>
     /// The exact human-facing <c>dji-embed</c> command the current mode +
     /// folder would run — the CLI transparency strip (GUI 2.0 spec, M3a).
@@ -120,12 +129,17 @@ public partial class WorkspaceViewModel : FlowViewModel
         {
             var folder = SelectedFolder
                 ?? (SelectedMode.NeedsFolder ? "<folder>" : null);
-            // folder! is safe for Flight map: its NeedsFolder is true, so the
-            // line above yields the "<folder>" placeholder (never null) when
-            // no folder is picked.
-            var argv = SelectedMode.Kind == WorkspaceModeKind.FlightMap
-                ? CommandBuilder.FlightMap(folder!, FlightOptions.ToOptions())
-                : CommandBuilder.Build(SelectedMode.Kind, folder);
+            // folder! is safe for the map modes: their NeedsFolder is true, so
+            // the line above yields the "<folder>" placeholder (never null)
+            // when no folder is picked.
+            var argv = SelectedMode.Kind switch
+            {
+                WorkspaceModeKind.FlightMap =>
+                    CommandBuilder.FlightMap(folder!, FlightOptions.ToOptions()),
+                WorkspaceModeKind.PhotoMap =>
+                    CommandBuilder.PhotoMap(folder!, PhotoOptions.ToOptions()),
+                _ => CommandBuilder.Build(SelectedMode.Kind, folder),
+            };
             return CommandLine.Format("dji-embed", argv);
         }
     }
@@ -142,6 +156,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(CanRun));
         OnPropertyChanged(nameof(CommandPreview));
         OnPropertyChanged(nameof(IsFlightMapMode));
+        OnPropertyChanged(nameof(IsPhotoMapMode));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -385,7 +400,7 @@ public partial class WorkspaceViewModel : FlowViewModel
                 await ExecuteFlowAsync(async () =>
                     await RunStepAsync(
                         "Mapping your photos…",
-                        CommandBuilder.Build(SelectedMode.Kind, folder))
+                        CommandBuilder.PhotoMap(folder, PhotoOptions.ToOptions()))
                     && await PrimePreviewAsync());
                 return;
             case WorkspaceModeKind.Embed when !contents.HasVideos:

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -69,7 +69,8 @@ internal static class FolderPicking
     internal static void SetDragOver(Control zone, bool active) =>
         zone.Classes.Set("dragover", active);
 
-    internal static async Task SaveMapAsync(Control anchor, Action<string> onPath)
+    internal static async Task SaveMapAsync(
+        Control anchor, Action<string> onPath, string title, string suggestedName)
     {
         if (TopLevel.GetTopLevel(anchor) is not { } top)
         {
@@ -78,8 +79,8 @@ internal static class FolderPicking
         var file = await top.StorageProvider.SaveFilePickerAsync(
             new FilePickerSaveOptions
             {
-                Title = "Save the flight map as",
-                SuggestedFileName = "flightmap.html",
+                Title = title,
+                SuggestedFileName = suggestedName,
                 DefaultExtension = "html",
                 FileTypeChoices =
                 [

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -395,6 +395,11 @@
                                                                    Opacity="0.8" FontSize="12" />
                                                     </Panel>
                                                 </DockPanel>
+                                                <TextBlock Name="LinkReachNote"
+                                                           Text="Pins can only open the original photos when the map is saved in the photo folder."
+                                                           IsVisible="{Binding PhotoLinksCannotReachOriginals}"
+                                                           TextWrapping="Wrap"
+                                                           Opacity="0.5" FontSize="11" />
                                             </StackPanel>
                                         </StackPanel>
                                     </Expander>

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -275,6 +275,134 @@
                         </StackPanel>
                     </Border>
 
+                    <Border Name="PhotoOptionsPanel"
+                            IsVisible="{Binding IsPhotoMapMode}">
+                        <StackPanel>
+                            <TextBlock Classes="zone" Text="OPTIONS" />
+                            <suki:GlassCard Padding="14">
+                                <StackPanel Spacing="12">
+                                    <DockPanel>
+                                        <ToggleSwitch DockPanel.Dock="Right"
+                                                      IsChecked="{Binding PhotoOptions.Recursive}" />
+                                        <TextBlock Text="Include subfolders"
+                                                   VerticalAlignment="Center" />
+                                    </DockPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Map style" Opacity="0.7"
+                                                   FontSize="12" />
+                                        <ComboBox HorizontalAlignment="Stretch"
+                                                  ItemsSource="{Binding PhotoOptions.TileStyles}"
+                                                  SelectedItem="{Binding PhotoOptions.SelectedTileStyle}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:TileChoice">
+                                                    <TextBlock Text="{Binding Label}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Privacy" Opacity="0.7"
+                                                   FontSize="12" />
+                                        <ComboBox HorizontalAlignment="Stretch"
+                                                  ItemsSource="{Binding PhotoOptions.PrivacyOptions}"
+                                                  SelectedItem="{Binding PhotoOptions.SelectedPrivacy}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:PrivacyChoice">
+                                                    <TextBlock Text="{Binding Label}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                        <TextBlock Name="FuzzCaveatNote"
+                                                   Text="Linked originals still carry exact GPS in their EXIF."
+                                                   IsVisible="{Binding PhotoOptions.ShowsFuzzCaveat}"
+                                                   TextWrapping="Wrap"
+                                                   Opacity="0.5" FontSize="11" />
+                                    </StackPanel>
+
+                                    <CheckBox Name="LinkOriginalsCheck"
+                                              IsChecked="{Binding PhotoOptions.LinkOriginals}"
+                                              Content="Link pins to the original photos"
+                                              ToolTip.Tip="Needed for the 360° panorama viewer. Off writes a map that stands alone." />
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Popup details" Opacity="0.7"
+                                                   FontSize="12" />
+                                        <WrapPanel>
+                                            <CheckBox Name="PopupNameCheck" Margin="0,0,14,0"
+                                                      Content="Name"
+                                                      IsChecked="{Binding PhotoOptions.ShowName}" />
+                                            <CheckBox Name="PopupTimeCheck" Margin="0,0,14,0"
+                                                      Content="Time"
+                                                      IsChecked="{Binding PhotoOptions.ShowTimestamp}" />
+                                            <CheckBox Name="PopupCameraCheck" Margin="0,0,14,0"
+                                                      Content="Camera"
+                                                      IsChecked="{Binding PhotoOptions.ShowCamera}" />
+                                            <CheckBox Name="PopupAltitudeCheck" Margin="0,0,14,0"
+                                                      Content="Altitude"
+                                                      IsChecked="{Binding PhotoOptions.ShowAltitude}" />
+                                            <CheckBox Name="PopupCreditCheck"
+                                                      Content="Credit"
+                                                      IsChecked="{Binding PhotoOptions.ShowCredit}" />
+                                        </WrapPanel>
+                                        <TextBlock Text="Unticked details are left out of the map file entirely. Your photos are never changed."
+                                                   TextWrapping="Wrap"
+                                                   Opacity="0.5" FontSize="11" />
+                                    </StackPanel>
+
+                                    <Expander Name="PhotoAdvanced" Header="Advanced"
+                                              IsExpanded="False">
+                                        <StackPanel Spacing="12" Margin="0,8,0,0">
+                                            <CheckBox IsChecked="{Binding PhotoOptions.ExportAll}"
+                                                      Content="Also export KML + GeoJSON" />
+
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="Map title" Opacity="0.7"
+                                                           FontSize="12" />
+                                                <TextBox Text="{Binding PhotoOptions.Title}"
+                                                         PlaceholderText="(folder name)" />
+                                            </StackPanel>
+
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="Save map to" Opacity="0.7"
+                                                           FontSize="12" />
+                                                <DockPanel>
+                                                    <Button DockPanel.Dock="Right"
+                                                            Margin="8,0,0,0"
+                                                            Name="ChoosePhotoOutputButton"
+                                                            Click="OnChoosePhotoOutputClick">
+                                                        <TextBlock Text="Choose…" FontSize="12" />
+                                                    </Button>
+                                                    <Button DockPanel.Dock="Right"
+                                                            Margin="8,0,0,0"
+                                                            Name="ClearPhotoOutputButton"
+                                                            Command="{Binding PhotoOptions.ClearOutputCommand}"
+                                                            IsVisible="{Binding PhotoOptions.Output,
+                                                                Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                            ToolTip.Tip="Reset to the source folder">
+                                                        <TextBlock Text="Use default" FontSize="12" />
+                                                    </Button>
+                                                    <Panel VerticalAlignment="Center">
+                                                        <TextBlock Text="(inside the source folder)"
+                                                                   IsVisible="{Binding PhotoOptions.Output,
+                                                                       Converter={x:Static StringConverters.IsNullOrEmpty}}"
+                                                                   Opacity="0.5" FontSize="12" />
+                                                        <TextBlock Text="{Binding PhotoOptions.Output}"
+                                                                   IsVisible="{Binding PhotoOptions.Output,
+                                                                       Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                                   TextTrimming="CharacterEllipsis"
+                                                                   Opacity="0.8" FontSize="12" />
+                                                    </Panel>
+                                                </DockPanel>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Expander>
+                                </StackPanel>
+                            </suki:GlassCard>
+                        </StackPanel>
+                    </Border>
+
                     <TextBlock Classes="zone" Text="ACTION" />
                     <Button Name="RunButton" Classes="Flat"
                             HorizontalAlignment="Stretch"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -118,7 +118,19 @@ public partial class WorkspaceView : UserControl
     {
         if (DataContext is WorkspaceViewModel vm)
         {
-            await FolderPicking.SaveMapAsync(this, p => vm.FlightOptions.Output = p);
+            await FolderPicking.SaveMapAsync(
+                this, p => vm.FlightOptions.Output = p,
+                "Save the flight map as", "flightmap.html");
+        }
+    }
+
+    private async void OnChoosePhotoOutputClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is WorkspaceViewModel vm)
+        {
+            await FolderPicking.SaveMapAsync(
+                this, p => vm.PhotoOptions.Output = p,
+                "Save the photo map as", "photomap.html");
         }
     }
 


### PR DESCRIPTION
Milestone M3c of the GUI 2.0 arc: the desktop app's **Photo map** mode gains a curated options panel plus an Advanced expander, mirroring what M3b did for Flight map. No new CLI features — this surfaces capability `photomap` already has.

Spec: `docs/superpowers/specs/2026-07-20-gui-m3c-photomap-options-design.md`

## Summary

**Curated panel** (visible only in Photo map mode): Include subfolders (`-r`), Map style (`--tile-style`), Privacy Keep/Fuzz (`--redact fuzz`), Link pins to the original photos (`--link-originals`), and five Popup detail checkboxes (`--popup-fields`).

**Advanced expander** (collapsed): Also export KML + GeoJSON (`--format all`), Map title (`--title`), Save map to (`--output`, with a save picker and a "Use default" reset).

Typed state flows `PhotoMapOptionsViewModel` → `PhotoMapOptions` record → `CommandBuilder.PhotoMap` → **both** the executed run and the live CLI transparency strip, so the strip cannot drift from what runs.

**Defaults invariant:** untouched, Photo map still runs `photomap <folder> -r --link-originals` — byte-identical to M3a. Options only add flags.

## Notable details

- **`--popup-fields` encoding is load-bearing.** All five ticked → flag omitted; none ticked → the literal `none`; a subset → comma list in the CLI's own `POPUP_FIELDS` order. An empty comma list is rejected by `parse_popup_fields`, so "untick everything" must not emit an empty value.
- **Two privacy notes the user would otherwise never see.** The fuzz caveat ("linked originals still carry exact GPS in their EXIF") is emitted by the CLI on stderr, which a *successful* run discards entirely — the panel note is the only place it surfaces.
- **Redirected maps are warned about.** `--link-originals` writes hrefs relative to the HTML file, so saving the map outside the photo folder silently breaks every "open the original" link and the 360° panorama viewer. The panel now says so before the run rather than adding a `--link-base` control (that flag stays CLI-only by design).
- **A "Save map to" override no longer follows the user to the next folder**, where it would have overwritten the previous folder's map. Fixed for both map modes — M3b's copy is unreleased, so it never shipped broken.
- Both map modes now share one tile-style list (`TileChoice.All`) instead of two that could drift.
- Deliberately out of scope: `--link-base`, and `--serve` (structurally incompatible with `--progress jsonl`; the inline preview covers that need).

## Test plan

- [x] GUI suite: **262 passed / 9 skipped / 0 failed**
- [x] `dotnet build -c Release`: 0 warnings, 0 errors
- [x] Golden argv tests incl. a composite test pinning the fixed flag order (mutation-verified: reordering two flag blocks fails it)
- [x] Headless screen tests for the popup checkboxes, link-originals, the fuzz caveat and the redirect note — each mutation-verified by breaking its binding
- [x] Opt-in screenshot capture of the new panel (`DJIEMBED_CAPTURE_DIR`), skipped in CI
- [ ] Manual check on real Windows: panel renders, options reach the run, redirect note appears

Follow-ups filed rather than folded in: #333, #334, #335, #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tEiXZHSThdF9BB9Gxzi9S