### PR TITLE
feat(gui): Embed telemetry curated options (M3d)

### DIFF
--- a/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
+++ b/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
@@ -244,7 +244,7 @@ TDD throughout; red before green.
   but `embed` does not, a folder whose videos live only in subfolders passes the
   mode guard, embeds nothing, and reports "✅ Done" with a "No MP4 files found"
   warning (`embedder.py:588-592` — a warning, not an error, so `ok` stays true).
-  Filed as a `type:gui` issue alongside #333: both share one root cause (a
+  Filed as **#338**, alongside #333: both share one root cause (a
   recursive folder scan feeding commands that are non-recursive or only
   opt-in recursive) and should be fixed once, together, not patched inside an
   options PR.

--- a/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
+++ b/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
@@ -84,7 +84,12 @@ panels' labels, so the same stance reads the same way in every mode.
 
 **Record the launch point** is `--extract-home` with a plain-language subtitle:
 where the aircraft took off — often the operator's home — written only to the
-`.json` sidecar, never into the video. It sits in the curated zone rather than
+`.json` sidecar, never as a separate tag in the video, and pointing at Privacy
+as the control that governs the location *in* the video. That last clause
+matters: `first_gps` is always written into the video as a `location` tag
+(`embedder.py:481-490`), and on a clip that starts recording on the ground it
+is the takeoff point to within a few metres — so leaving this box unticked is
+not by itself a privacy measure. It sits in the curated zone rather than
 Advanced because it is a privacy decision, and privacy decisions should not be
 discoverable only by expanding "Advanced".
 
@@ -118,8 +123,21 @@ is set — but opens a **folder** picker, reusing the existing `FolderPicking`
 helper rather than the map modes' save-file picker. Its empty-state text reads
 "(a 'processed' folder inside the source folder)".
 
-The ExifTool row carries a one-line hint that it needs ExifTool installed, and
-points at the Setup mode.
+The ExifTool row carries a hint saying it writes GPS tags with ExifTool as well
+as ffmpeg, and that Embed needs ExifTool installed **either way** — the CLI's
+`check_dependencies()` probes ffmpeg and exiftool unconditionally
+(`utilities.py:469-535`) and refuses to run without both, so a hint reading as
+"leave it unticked and skip installing ExifTool" would earn the user a failed
+run. It points at the Setup mode, which is where that gets resolved.
+
+It also carries a **conditional note**, shown only when ExifTool is ticked *and*
+the container is MKV: *"ExifTool can't write MKV — this does nothing while MKV
+is selected."* ExifTool cannot write Matroska (`exiftool -listwf` lists MP4/MOV,
+not MKV), `embed_metadata_exiftool` swallows the failure (no `check=True`, and
+the captured stderr is dropped), and `embedder.py:735` discards the `False` it
+returns — so the run reports success having written no tags. Nothing can surface
+this at runtime; a pre-run note is the only place it can be said. Same shape as
+the launch-point note: a real bool on the options VM, assertable headless.
 
 ## Defaults invariant
 

--- a/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
+++ b/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
@@ -1,0 +1,262 @@
+# GUI 2.0 — M3d: Embed telemetry curated options + Advanced expander
+
+**Parent spec:** `docs/superpowers/specs/2026-07-18-gui-full-workspace-design.md`
+(GUI 2.0 full-workspace design; this is the M3d milestone slice, and the last
+one in the M3 arc.)
+
+**Predecessors:** M3a shipped `CommandBuilder` (per-mode argv, one source of
+truth for run + strip) and the live CLI transparency strip. M3b and M3c gave
+**Flight map** and **Photo map** their curated options panels and set the
+pattern this slice follows.
+
+## Goal
+
+Give the **Embed telemetry** mode a curated options panel between the MODE strip
+and the ACTION button, plus an Advanced expander. Every control maps to an
+existing `embed` CLI flag; the typed option state flows through `CommandBuilder`
+into both the executed run and the live CLI strip. No new CLI features — M3d
+surfaces capability that already exists.
+
+## Context: the real `embed` flag surface
+
+`embed` (`src/dji_metadata_embedder/cli.py:252-294`) accepts: `directory` (from
+the Source picker), `-o/--output` **DIR**, `--overwrite`, `--exiftool`,
+`--dat PATH`, `--dat-auto`, `--audio-sidecar`, `--redact`
+(`none`/`drop`/`fuzz`, default `none`), `--container` (`mp4`/`mkv`, default
+`mp4`), `--extract-home`, plus `--progress`/`-v`/`-q`.
+
+Differences from the two map modes that shape this slice:
+
+- **No `-r/--recursive` at all.** `embed` processes one directory level. There is
+  therefore no "Include subfolders" control — the first curated toggle both map
+  panels open with is simply absent here.
+- **`--redact` is three-valued** (`none`/`drop`/`fuzz`), where both map commands
+  accept only `none`/`fuzz`. `drop` is not a value the map modes declined to
+  surface; it is one their commands would **reject**.
+- **`-o/--output` is a directory**, not a file. `photomap`/`flightmap` take an
+  output *file* and needed a save-file picker; `embed` reuses the existing folder
+  picker. Default output is `<folder>/processed/`
+  (`src/dji_metadata_embedder/embedder.py:163-164`).
+- **No preview.** Embed produces videos, not HTML, so `PrimePreviewAsync` never
+  runs for this mode and the done **card** (output directory + warnings) is the
+  terminal state. Unchanged by M3d.
+
+## Amendments to the parent spec's curation table
+
+The 2026-07-18 spec proposed, for Embed: curated *privacy, container, extract
+HOME point*; Advanced *audio sidecar, ExifTool GPS injection, DAT log (+auto),
+overwrite, output*. Two entries are amended here, decided during the M3d
+brainstorm:
+
+1. **`--overwrite` is dropped from the GUI entirely — it stays CLI-only.** It
+   rewrites the original videos in place and is the only irreversible flag in
+   the product. A GUI whose premise is "drop a folder, press the button" must
+   not put one-click destruction of the user's originals behind a checkbox, and
+   a confirmation modal would be the app's first modal built solely to make a
+   dangerous option survivable. The CLI strip still teaches the command, so a
+   user who genuinely wants in-place embedding copies the line and adds the flag
+   deliberately. **The GUI always writes copies.**
+2. **`--dat PATH` is dropped; only `--dat-auto` is surfaced.** Pointing at one
+   specific DAT file is a per-file operation in a folder-shaped GUI, and it would
+   add a second untestable picker handler (the gap already filed as #335) plus a
+   mutual-exclusion rule against `--dat-auto`. The auto flag covers the realistic
+   case: DAT logs pulled off the aircraft into the same folder as the videos.
+
+## Curated controls (always visible when Embed telemetry is selected)
+
+| Control | Shape | Default | argv effect |
+|---|---|---|---|
+| **Video container** | `ComboBox` (2) | MP4 (most compatible) | `--container mkv` when MKV; omit for MP4 |
+| **Privacy** | `ComboBox` (3) | Keep exact locations | `--redact fuzz` / `--redact drop`; omit when Keep |
+| **Record the launch point in the sidecar** | `CheckBox` | off | `--extract-home` when on |
+
+**Video container** labels the trade-off rather than the format:
+"MP4 (most compatible)" and "MKV (keeps DJI data streams)". The MKV note matters
+— the mp4 muxer drops DJI `djmd`/`dbgi` data streams, which is exactly the
+telemetry the ExifTool extractor (#206) reads back.
+
+**Privacy** offers "Keep exact locations" (omit), "Fuzz to ~100 m" (`fuzz`), and
+"Remove GPS entirely" (`drop`). The first two labels are word-for-word the map
+panels' labels, so the same stance reads the same way in every mode.
+
+**Record the launch point** is `--extract-home` with a plain-language subtitle:
+where the aircraft took off — often the operator's home — written only to the
+`.json` sidecar, never into the video. It sits in the curated zone rather than
+Advanced because it is a privacy decision, and privacy decisions should not be
+discoverable only by expanding "Advanced".
+
+### Launch-point / privacy interaction note
+
+`apply_redaction` (`src/dji_metadata_embedder/utilities.py:337-341`) redacts
+`home` alongside the coordinates. With **Remove GPS entirely** the extracted home
+point is emitted as `"home": null` (`embedder.py:756-763` writes the key as a
+marker whenever extraction was requested). So the two controls can be set to a
+combination that does nothing useful, and the panel says so in a quiet note under
+the checkbox:
+
+> This privacy stance writes the launch point as empty.
+
+Shown only when Privacy is **Remove GPS entirely** *and* the checkbox is ticked.
+Like M3c's fuzz caveat, it is a real bool property on the options VM (not a XAML
+multi-binding) so it is assertable headless.
+
+## Advanced expander (collapsed by default)
+
+| Control | Shape | Default | argv effect |
+|---|---|---|---|
+| **Also write GPS with ExifTool** | `CheckBox` | off | `--exiftool` when on |
+| **Mux .m4a audio sidecar (DJI Neo 2)** | `CheckBox` | off | `--audio-sidecar` when on |
+| **Merge DAT flight logs found beside the videos** | `CheckBox` | off | `--dat-auto` when on |
+| **Save copies to** | folder picker (path text + Choose… + "Use default") | empty (→ `processed/`) | `--output DIR` when set |
+
+"Save copies to" reuses M3b/M3c's clear-output affordance verbatim — the
+`ClearOutputCommand` plus a "Use default" button visible only while an override
+is set — but opens a **folder** picker, reusing the existing `FolderPicking`
+helper rather than the map modes' save-file picker. Its empty-state text reads
+"(a 'processed' folder inside the source folder)".
+
+The ExifTool row carries a one-line hint that it needs ExifTool installed, and
+points at the Setup mode.
+
+## Defaults invariant
+
+With nothing touched, the Embed argv is **`embed <folder>`** — byte-identical to
+what M3a's `CommandBuilder.Build(Embed, folder)` produces today, and the only
+mode whose default argv carries no flags at all. Options only *add* flags.
+
+Fully loaded, the fixed flag order (mirroring panel order, curated before
+Advanced) is:
+
+```
+embed <folder> --redact fuzz --container mkv --extract-home \
+      --exiftool --audio-sidecar --dat-auto --output <dir>
+```
+
+`CommandBuilder` still omits `--progress jsonl`; `DjiEmbedRunner` appends it at
+execution. The strip shows the human form with program name `dji-embed` and a
+`<folder>` placeholder before a folder is picked.
+
+## Styling constraint
+
+All controls are the **standard Avalonia / SukiUI themed controls**
+(`ComboBox`, `CheckBox`, `TextBox`, `Expander`) inheriting the app theme's
+default appearance in light and dark, with no bespoke restyling. Layout spacing
+and labels are ours; control chrome stays themed default.
+
+Known build gotcha carried from M3b: `TextBox.Watermark` is `[Obsolete]`
+(AVLN5001) in this Avalonia — use `PlaceholderText`.
+
+## Architecture
+
+Mirrors M3b/M3c's seam layout.
+
+- **`ViewModels/EmbedOptions.cs`** — an immutable record of typed option state
+  (`Privacy`, `Container`, `ExtractHome`, `UseExifTool`, `AudioSidecar`,
+  `DatAuto`, `Output`) with a `Defaults` value, plus a new
+  **`EmbedPrivacy { Keep, Fuzz, Drop }`** enum. `Container` is the CLI key
+  string (`"mp4"`/`"mkv"`), following `TileStyle` in the map option records.
+- **`ViewModels/EmbedOptionsViewModel.cs`** — `[ObservableProperty]` per control,
+  bound to the panel; `ToOptions()` snapshots it into `EmbedOptions`. Exposes the
+  launch-point note bool and the `ClearOutputCommand`. Declares the one-line
+  `EmbedPrivacyChoice(string Label, EmbedPrivacy Value)` display record and a
+  `ContainerChoice(string Label, string Key)` list.
+- **`Services/CommandBuilder.cs`** — new pure overload
+  `Embed(string folder, EmbedOptions opts)`. The existing `Build(kind, folder)`
+  routes its Embed arm through `Embed(folder, EmbedOptions.Defaults)`, so M3a's
+  default-behavior golden tests are unchanged.
+- **`ViewModels/WorkspaceViewModel.cs`** — an `EmbedOptions` property; a new
+  `IsEmbedMode` computed property notified alongside `IsFlightMapMode` /
+  `IsPhotoMapMode`; the Embed `RunAsync` branch and `CommandPreview` both build
+  argv via `CommandBuilder.Embed(folder, EmbedOptions.ToOptions())`; the strip
+  recomputes on the options VM's `PropertyChanged` (same subscription pattern as
+  `FlightOptions` / `PhotoOptions`).
+- **`Views/WorkspaceView.axaml`** — an `EmbedOptionsPanel` border in the existing
+  OPTIONS zone, `IsVisible="{Binding IsEmbedMode}"`, with its own collapsed
+  Advanced `Expander`.
+
+### Why a separate privacy enum
+
+`MapPrivacy { Keep, Fuzz }` stays exactly as it is. Embed gets its own
+`EmbedPrivacy { Keep, Fuzz, Drop }` rather than a `Drop` member being added to
+the shared enum, because `flightmap`/`photomap` accept only `none|fuzz`
+(`cli.py:567-570`, `cli.py:751-755`): a shared three-valued enum would make it
+possible to build a map argv the CLI rejects. Each mode's enum stays total over
+what its own command accepts. The cost is one 1-line display record — a generic
+`PrivacyChoice<T>` is not worth the friction it causes in compiled XAML
+bindings.
+
+This follows the same judgment recorded in M3c: share what is genuinely
+identical (`TileChoice`, extracted because both map modes take the same
+`--tile-style` keys), keep separate what merely looks similar (the two options
+ViewModels, deliberately not given a shared base class).
+
+Runner, strict-success rule, cancellation, and the done card all carry over
+unchanged.
+
+## Behavior notes
+
+- **Persistence:** in-memory VM state only — no disk persistence (respects the
+  "no settings dialog; only MRU + window bounds" rule). Options survive mode
+  switches while the app is open; a fresh launch starts at defaults.
+- **Mode switch:** switching away from Embed hides the panel; switching back
+  shows it with state intact. Only one options panel is visible at a time.
+- **Path-valued option resets on a folder change.** `SetFolderAsync` already
+  clears `FlightOptions.Output` and `PhotoOptions.Output`; `EmbedOptions.Output`
+  joins them. An absolute output directory chosen for folder A must not silently
+  collect folder B's copies. Every other option deliberately survives a folder
+  change.
+- **Embed with no videos:** the existing `Embed when !contents.HasVideos` guard
+  is unchanged; options do not affect it.
+
+## Testing
+
+TDD throughout; red before green.
+
+- **Golden argv** (`CommandBuilderTests`): defaults (`embed <f>`, no flags);
+  each privacy value (`fuzz`, `drop`, Keep omits); `--container mkv` with MP4
+  omitting; each Advanced flag alone; a composite asserting the full fixed order;
+  an output path with spaces (display quoting).
+- **Options VM** (`EmbedOptionsViewModelTests`): default values; `ToOptions()`
+  mapping per control; the launch-point note bool is true only when **Drop** and
+  **ExtractHome** are both set (and false for Fuzz+ExtractHome, and for
+  Drop alone); `ClearOutputCommand` resets Output.
+- **Live preview** (`WorkspaceViewModelTests`): `CommandPreview` updates when an
+  embed option changes; reflects Embed argv when that mode is selected;
+  `IsEmbedMode` flips and notifies on mode change; `EmbedOptions.Output` clears
+  on a folder change; the run's recorded argv (via `FakeCli.WriteArgsRecorder`)
+  equals what the strip shows.
+- **Screen** (`AvaloniaFact`): Embed renders the options panel with Advanced
+  collapsed; the map modes do not render the embed panel (and vice versa).
+  Per the #328 gotcha, any button assertion checks
+  `Assert.Same(vm.SomeCommand, button.Command)` — a `Button` with a **null**
+  `Command` still reports `IsEffectivelyEnabled == true`, so asserting
+  enabled-ness proves nothing about a binding.
+- **Optional capture** (opt-in via `DJIEMBED_CAPTURE_DIR`): follows M3c's
+  screenshot test, including the interleaved
+  `ForceRenderTimerTick()`/`RunJobs()`/`UpdateLayout()` settling the `Expander`
+  animation needs.
+
+## Out of scope (M3d)
+
+- `--overwrite` and `--dat PATH` — CLI-only by the decisions above.
+- `-v`/`-q` (execution detail; `--progress jsonl` forces quiet anyway).
+- The **nested-videos hollow success**: because the GUI's folder scan recurses
+  but `embed` does not, a folder whose videos live only in subfolders passes the
+  mode guard, embeds nothing, and reports "✅ Done" with a "No MP4 files found"
+  warning (`embedder.py:588-592` — a warning, not an error, so `ok` stays true).
+  Filed as a `type:gui` issue alongside #333: both share one root cause (a
+  recursive folder scan feeding commands that are non-recursive or only
+  opt-in recursive) and should be fixed once, together, not patched inside an
+  options PR.
+- Convert/Verify options and footprints (M4).
+- Any new CLI flag, or changes to the `--progress jsonl` contract.
+- Persisting options to disk.
+
+## Milestone placement
+
+M3d is one releasable milestone / one PR, and **completes the M3 arc** (M3a,
+M3b, M3c and issue #328 done). Release remains **held** per the small-userbase
+call: M3d rides the next version bump together with the already-merged #327
+playback fix, M3a, M3b, #328 and M3c. A manual UI test plan covering that whole
+held batch exists locally at
+`docs/superpowers/plans/2026-07-20-m3-manual-ui-test-plan.md`.

--- a/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
+++ b/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
@@ -60,7 +60,10 @@ brainstorm:
    specific DAT file is a per-file operation in a folder-shaped GUI, and it would
    add a second untestable picker handler (the gap already filed as #335) plus a
    mutual-exclusion rule against `--dat-auto`. The auto flag covers the realistic
-   case: DAT logs pulled off the aircraft into the same folder as the videos.
+   case: DAT logs pulled off the aircraft into the video folder **and named after
+   the videos** — `embedder.py:632-641` tries `<video>.DAT` and then globs
+   `<stem>*.DAT`, so co-location alone is not enough, and the panel must say so
+   rather than promising a merge a stray `FLY042.DAT` will never get.
 
 ## Curated controls (always visible when Embed telemetry is selected)
 
@@ -106,7 +109,7 @@ multi-binding) so it is assertable headless.
 |---|---|---|---|
 | **Also write GPS with ExifTool** | `CheckBox` | off | `--exiftool` when on |
 | **Mux .m4a audio sidecar (DJI Neo 2)** | `CheckBox` | off | `--audio-sidecar` when on |
-| **Merge DAT flight logs found beside the videos** | `CheckBox` | off | `--dat-auto` when on |
+| **Merge DAT flight logs named after the videos** | `CheckBox` | off | `--dat-auto` when on |
 | **Save copies to** | folder picker (path text + Choose… + "Use default") | empty (→ `processed/`) | `--output DIR` when set |
 
 "Save copies to" reuses M3b/M3c's clear-output affordance verbatim — the
@@ -122,10 +125,13 @@ points at the Setup mode.
 
 With nothing touched, the Embed argv is **`embed <folder>`** — byte-identical to
 what M3a's `CommandBuilder.Build(Embed, folder)` produces today, and the only
-mode whose default argv carries no flags at all. Options only *add* flags.
+folder-taking mode whose default argv carries no flags at all (`doctor` is
+flagless too, but takes no folder). Options only *add* flags.
 
-Fully loaded, the fixed flag order (mirroring panel order, curated before
-Advanced) is:
+Fully loaded, the fixed flag order is curated-before-Advanced, and within the
+curated group `--redact` precedes `--container` — the panel puts container
+first because it is the less loaded choice to meet, while the argv keeps
+privacy first. The order is fixed for golden tests either way:
 
 ```
 embed <folder> --redact fuzz --container mkv --extract-home \

--- a/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
+++ b/docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md
@@ -150,22 +150,31 @@ Known build gotcha carried from M3b: `TextBox.Watermark` is `[Obsolete]`
 
 Mirrors M3b/M3c's seam layout.
 
-- **`ViewModels/EmbedOptions.cs`** — an immutable record of typed option state
-  (`Privacy`, `Container`, `ExtractHome`, `UseExifTool`, `AudioSidecar`,
+**Naming.** The record is mode-qualified and the ViewModel property is short,
+following the siblings (`FlightMapOptions` → `vm.FlightOptions`,
+`PhotoMapOptions` → `vm.PhotoOptions`): the record is
+**`EmbedTelemetryOptions`** and the property is **`vm.EmbedOptions`**. An
+`EmbedOptions` record would collide with that property name.
+
+- **`ViewModels/EmbedTelemetryOptions.cs`** — an immutable record of typed option
+  state (`Privacy`, `Container`, `ExtractHome`, `UseExifTool`, `AudioSidecar`,
   `DatAuto`, `Output`) with a `Defaults` value, plus a new
   **`EmbedPrivacy { Keep, Fuzz, Drop }`** enum. `Container` is the CLI key
   string (`"mp4"`/`"mkv"`), following `TileStyle` in the map option records.
-- **`ViewModels/EmbedOptionsViewModel.cs`** — `[ObservableProperty]` per control,
-  bound to the panel; `ToOptions()` snapshots it into `EmbedOptions`. Exposes the
-  launch-point note bool and the `ClearOutputCommand`. Declares the one-line
+- **`ViewModels/EmbedTelemetryOptionsViewModel.cs`** — `[ObservableProperty]` per
+  control, bound to the panel; `ToOptions()` snapshots it into
+  `EmbedTelemetryOptions`. Exposes the launch-point note bool and the
+  `ClearOutputCommand`. Declares the one-line
   `EmbedPrivacyChoice(string Label, EmbedPrivacy Value)` display record and a
   `ContainerChoice(string Label, string Key)` list.
 - **`Services/CommandBuilder.cs`** — new pure overload
-  `Embed(string folder, EmbedOptions opts)`. The existing `Build(kind, folder)`
-  routes its Embed arm through `Embed(folder, EmbedOptions.Defaults)`, so M3a's
-  default-behavior golden tests are unchanged.
-- **`ViewModels/WorkspaceViewModel.cs`** — an `EmbedOptions` property; a new
-  `IsEmbedMode` computed property notified alongside `IsFlightMapMode` /
+  `Embed(string folder, EmbedTelemetryOptions opts)`. The existing
+  `Build(kind, folder)` routes its Embed arm through
+  `Embed(folder, EmbedTelemetryOptions.Defaults)`, so M3a's default-behavior
+  golden tests are unchanged.
+- **`ViewModels/WorkspaceViewModel.cs`** — an `EmbedOptions` property of type
+  `EmbedTelemetryOptionsViewModel`; a new `IsEmbedMode` computed property
+  notified alongside `IsFlightMapMode` /
   `IsPhotoMapMode`; the Embed `RunAsync` branch and `CommandPreview` both build
   argv via `CommandBuilder.Embed(folder, EmbedOptions.ToOptions())`; the strip
   recomputes on the options VM's `PropertyChanged` (same subscription pattern as

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -327,4 +327,113 @@ public class CommandBuilderTests
              "--format", "all", "--title", "T", "--output", "/o.html"],
             CommandBuilder.PhotoMap("/x", opts));
     }
+
+    // M3d: Embed(folder, opts) is the option-aware argv builder. Embed is the
+    // only mode whose defaults carry NO flags at all, so the defaults test is
+    // also the guard that no option leaks in at its default value.
+    [Fact]
+    public void Embed_defaults_match_the_m3a_bare_form()
+    {
+        string[] expected = ["embed", "/x"];
+        Assert.Equal(expected,
+            CommandBuilder.Embed("/x", EmbedTelemetryOptions.Defaults));
+    }
+
+    [Fact]
+    public void Embed_build_delegates_to_the_options_overload()
+    {
+        Assert.Equal(
+            CommandBuilder.Embed("/x", EmbedTelemetryOptions.Defaults),
+            CommandBuilder.Build(WorkspaceModeKind.Embed, "/x"));
+    }
+
+    [Theory]
+    [InlineData(EmbedPrivacy.Fuzz, "fuzz")]
+    [InlineData(EmbedPrivacy.Drop, "drop")]
+    public void Embed_passes_a_non_default_privacy_stance(
+        EmbedPrivacy privacy, string value)
+    {
+        var argv = CommandBuilder.Embed("/x",
+            EmbedTelemetryOptions.Defaults with { Privacy = privacy });
+        Assert.Equal(["embed", "/x", "--redact", value], argv);
+    }
+
+    [Fact]
+    public void Embed_omits_redact_when_locations_are_kept()
+    {
+        Assert.DoesNotContain("--redact",
+            CommandBuilder.Embed("/x", EmbedTelemetryOptions.Defaults));
+    }
+
+    [Fact]
+    public void Embed_passes_the_mkv_container_and_omits_the_default_mp4()
+    {
+        var argv = CommandBuilder.Embed("/x",
+            EmbedTelemetryOptions.Defaults with { Container = "mkv" });
+        Assert.Equal(["embed", "/x", "--container", "mkv"], argv);
+        Assert.DoesNotContain("--container",
+            CommandBuilder.Embed("/x", EmbedTelemetryOptions.Defaults));
+    }
+
+    [Fact]
+    public void Embed_passes_extract_home()
+    {
+        var argv = CommandBuilder.Embed("/x",
+            EmbedTelemetryOptions.Defaults with { ExtractHome = true });
+        Assert.Equal(["embed", "/x", "--extract-home"], argv);
+    }
+
+    [Fact]
+    public void Embed_passes_each_advanced_flag()
+    {
+        Assert.Equal(["embed", "/x", "--exiftool"], CommandBuilder.Embed("/x",
+            EmbedTelemetryOptions.Defaults with { UseExifTool = true }));
+        Assert.Equal(["embed", "/x", "--audio-sidecar"], CommandBuilder.Embed("/x",
+            EmbedTelemetryOptions.Defaults with { AudioSidecar = true }));
+        Assert.Equal(["embed", "/x", "--dat-auto"], CommandBuilder.Embed("/x",
+            EmbedTelemetryOptions.Defaults with { DatAuto = true }));
+    }
+
+    [Fact]
+    public void Embed_passes_a_trimmed_output_directory()
+    {
+        var argv = CommandBuilder.Embed("/x",
+            EmbedTelemetryOptions.Defaults with { Output = "  /out/copies  " });
+        // Trimmed, not quoted: quoting belongs to CommandLine.Format (the
+        // strip); argv elements reach the process verbatim.
+        Assert.Equal(["embed", "/x", "--output", "/out/copies"], argv);
+    }
+
+    [Fact]
+    public void Embed_ignores_a_blank_output()
+    {
+        Assert.Equal(["embed", "/x"], CommandBuilder.Embed("/x",
+            EmbedTelemetryOptions.Defaults with { Output = "   " }));
+    }
+
+    [Fact]
+    public void Embed_never_offers_overwrite()
+    {
+        // --overwrite is CLI-only by design (M3d spec): it rewrites the
+        // originals in place and must not be reachable from the GUI.
+        var everything = new EmbedTelemetryOptions(
+            Privacy: EmbedPrivacy.Drop, Container: "mkv", ExtractHome: true,
+            UseExifTool: true, AudioSidecar: true, DatAuto: true,
+            Output: "/out/copies");
+        Assert.DoesNotContain("--overwrite", CommandBuilder.Embed("/x", everything));
+    }
+
+    [Fact]
+    public void Embed_all_options_compose_in_a_stable_order()
+    {
+        var opts = new EmbedTelemetryOptions(
+            Privacy: EmbedPrivacy.Fuzz, Container: "mkv", ExtractHome: true,
+            UseExifTool: true, AudioSidecar: true, DatAuto: true,
+            Output: "/out/copies");
+        Assert.Equal(
+            ["embed", "/x", "--redact", "fuzz", "--container", "mkv",
+             "--extract-home", "--exiftool", "--audio-sidecar", "--dat-auto",
+             "--output", "/out/copies"],
+            CommandBuilder.Embed("/x", opts));
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -332,6 +332,8 @@ public class CommandBuilderTests
     // only folder-taking mode whose defaults carry NO flags at all, so the
     // defaults test is also the guard that no option leaks in at its default
     // value.
+
+    // Every option switched on; shared by the two CLI-only guards below.
     private static readonly EmbedTelemetryOptions EverythingOn = new(
         Privacy: EmbedPrivacy.Drop, Container: "mkv", ExtractHome: true,
         UseExifTool: true, AudioSidecar: true, DatAuto: true,

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -329,8 +329,14 @@ public class CommandBuilderTests
     }
 
     // M3d: Embed(folder, opts) is the option-aware argv builder. Embed is the
-    // only mode whose defaults carry NO flags at all, so the defaults test is
-    // also the guard that no option leaks in at its default value.
+    // only folder-taking mode whose defaults carry NO flags at all, so the
+    // defaults test is also the guard that no option leaks in at its default
+    // value.
+    private static readonly EmbedTelemetryOptions EverythingOn = new(
+        Privacy: EmbedPrivacy.Drop, Container: "mkv", ExtractHome: true,
+        UseExifTool: true, AudioSidecar: true, DatAuto: true,
+        Output: "/out/copies");
+
     [Fact]
     public void Embed_defaults_match_the_m3a_bare_form()
     {
@@ -416,11 +422,7 @@ public class CommandBuilderTests
     {
         // --overwrite is CLI-only by design (M3d spec): it rewrites the
         // originals in place and must not be reachable from the GUI.
-        var everything = new EmbedTelemetryOptions(
-            Privacy: EmbedPrivacy.Drop, Container: "mkv", ExtractHome: true,
-            UseExifTool: true, AudioSidecar: true, DatAuto: true,
-            Output: "/out/copies");
-        Assert.DoesNotContain("--overwrite", CommandBuilder.Embed("/x", everything));
+        Assert.DoesNotContain("--overwrite", CommandBuilder.Embed("/x", EverythingOn));
     }
 
     [Fact]
@@ -428,20 +430,14 @@ public class CommandBuilderTests
     {
         // --dat PATH is CLI-only by design (M3d spec): pointing at one file
         // does not fit a folder-shaped GUI. Only --dat-auto is surfaced.
-        var everything = new EmbedTelemetryOptions(
-            Privacy: EmbedPrivacy.Drop, Container: "mkv", ExtractHome: true,
-            UseExifTool: true, AudioSidecar: true, DatAuto: true,
-            Output: "/out/copies");
-        Assert.DoesNotContain("--dat", CommandBuilder.Embed("/x", everything));
+        // (collection DoesNotContain is element-wise, so --dat-auto does not trip it)
+        Assert.DoesNotContain("--dat", CommandBuilder.Embed("/x", EverythingOn));
     }
 
     [Fact]
     public void Embed_all_options_compose_in_a_stable_order()
     {
-        var opts = new EmbedTelemetryOptions(
-            Privacy: EmbedPrivacy.Fuzz, Container: "mkv", ExtractHome: true,
-            UseExifTool: true, AudioSidecar: true, DatAuto: true,
-            Output: "/out/copies");
+        var opts = EverythingOn with { Privacy = EmbedPrivacy.Fuzz };
         Assert.Equal(
             ["embed", "/x", "--redact", "fuzz", "--container", "mkv",
              "--extract-home", "--exiftool", "--audio-sidecar", "--dat-auto",

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -424,6 +424,18 @@ public class CommandBuilderTests
     }
 
     [Fact]
+    public void Embed_never_offers_a_dat_file_path()
+    {
+        // --dat PATH is CLI-only by design (M3d spec): pointing at one file
+        // does not fit a folder-shaped GUI. Only --dat-auto is surfaced.
+        var everything = new EmbedTelemetryOptions(
+            Privacy: EmbedPrivacy.Drop, Container: "mkv", ExtractHome: true,
+            UseExifTool: true, AudioSidecar: true, DatAuto: true,
+            Output: "/out/copies");
+        Assert.DoesNotContain("--dat", CommandBuilder.Embed("/x", everything));
+    }
+
+    [Fact]
     public void Embed_all_options_compose_in_a_stable_order()
     {
         var opts = new EmbedTelemetryOptions(

--- a/gui/DjiEmbed.Gui.Tests/EmbedTelemetryOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/EmbedTelemetryOptionsViewModelTests.cs
@@ -34,6 +34,13 @@ public class EmbedTelemetryOptionsViewModelTests
     }
 
     [Fact]
+    public void Containers_offer_only_the_two_keys_the_embed_cli_accepts()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel();
+        Assert.Equal(["mp4", "mkv"], vm.Containers.Select(c => c.Key));
+    }
+
+    [Fact]
     public void ToOptions_reflects_every_mutated_control()
     {
         var vm = new EmbedTelemetryOptionsViewModel
@@ -99,7 +106,7 @@ public class EmbedTelemetryOptionsViewModelTests
     }
 
     [Fact]
-    public void Clear_output_resets_to_the_source_folder()
+    public void Clear_output_resets_to_the_processed_folder_default()
     {
         var vm = new EmbedTelemetryOptionsViewModel { Output = "/out/copies" };
         vm.ClearOutputCommand.Execute(null);

--- a/gui/DjiEmbed.Gui.Tests/EmbedTelemetryOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/EmbedTelemetryOptionsViewModelTests.cs
@@ -105,6 +105,40 @@ public class EmbedTelemetryOptionsViewModelTests
             n => n == nameof(EmbedTelemetryOptionsViewModel.ShowsHomeEmptiedNote)));
     }
 
+    // ExifTool cannot write Matroska (`exiftool -listwf` lists MP4/MOV, not
+    // MKV) and embedder.py:735 discards the failed call's return value, so
+    // ExifTool + MKV writes no tags and still reports success. The panel says
+    // so at the moment of the choice, like the home note above.
+    [Fact]
+    public void Exiftool_mkv_note_shows_only_when_exiftool_meets_mkv()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel();
+        Assert.False(vm.ShowsExifToolMkvNote);          // MP4, no ExifTool
+
+        vm.UseExifTool = true;
+        Assert.False(vm.ShowsExifToolMkvNote);          // MP4 + ExifTool works
+
+        vm.SelectedContainer = vm.Containers.Single(c => c.Key == "mkv");
+        Assert.True(vm.ShowsExifToolMkvNote);           // MKV + ExifTool = no-op
+
+        vm.UseExifTool = false;
+        Assert.False(vm.ShowsExifToolMkvNote);          // MKV alone is fine
+    }
+
+    [Fact]
+    public void Exiftool_mkv_note_notifies_on_both_of_its_inputs()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel();
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+
+        vm.UseExifTool = true;
+        vm.SelectedContainer = vm.Containers.Single(c => c.Key == "mkv");
+
+        Assert.Equal(2, notified.Count(
+            n => n == nameof(EmbedTelemetryOptionsViewModel.ShowsExifToolMkvNote)));
+    }
+
     [Fact]
     public void Clear_output_resets_to_the_processed_folder_default()
     {

--- a/gui/DjiEmbed.Gui.Tests/EmbedTelemetryOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/EmbedTelemetryOptionsViewModelTests.cs
@@ -1,0 +1,108 @@
+using DjiEmbed.Gui.ViewModels;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class EmbedTelemetryOptionsViewModelTests
+{
+    [Fact]
+    public void Defaults_match_the_embed_options_defaults()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel();
+        Assert.Equal(EmbedTelemetryOptions.Defaults, vm.ToOptions());
+    }
+
+    [Fact]
+    public void Default_selections_are_mp4_and_keep_with_nothing_ticked()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel();
+        Assert.Equal("mp4", vm.SelectedContainer.Key);
+        Assert.Equal(EmbedPrivacy.Keep, vm.SelectedPrivacy.Value);
+        Assert.False(vm.ExtractHome);
+        Assert.False(vm.UseExifTool);
+        Assert.False(vm.AudioSidecar);
+        Assert.False(vm.DatAuto);
+        Assert.Equal("", vm.Output);
+    }
+
+    [Fact]
+    public void Privacy_offers_all_three_stances_the_embed_cli_accepts()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel();
+        Assert.Equal(
+            [EmbedPrivacy.Keep, EmbedPrivacy.Fuzz, EmbedPrivacy.Drop],
+            vm.PrivacyOptions.Select(p => p.Value));
+    }
+
+    [Fact]
+    public void ToOptions_reflects_every_mutated_control()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel
+        {
+            ExtractHome = true,
+            UseExifTool = true,
+            AudioSidecar = true,
+            DatAuto = true,
+            Output = "/out/copies",
+        };
+        vm.SelectedContainer = vm.Containers.Single(c => c.Key == "mkv");
+        vm.SelectedPrivacy =
+            vm.PrivacyOptions.Single(p => p.Value == EmbedPrivacy.Drop);
+
+        Assert.Equal(new EmbedTelemetryOptions(
+            Privacy: EmbedPrivacy.Drop,
+            Container: "mkv",
+            ExtractHome: true,
+            UseExifTool: true,
+            AudioSidecar: true,
+            DatAuto: true,
+            Output: "/out/copies"), vm.ToOptions());
+    }
+
+    // apply_redaction (utilities.py) redacts `home` with everything else, so
+    // Drop + ExtractHome writes "home": null — a combination that looks like
+    // it does something and does not. The panel says so at the moment of the
+    // choice.
+    [Fact]
+    public void Home_emptied_note_shows_only_when_dropping_and_extracting()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel();
+        Assert.False(vm.ShowsHomeEmptiedNote);          // Keep, not extracting
+
+        vm.ExtractHome = true;
+        Assert.False(vm.ShowsHomeEmptiedNote);          // Keep + extracting
+
+        vm.SelectedPrivacy =
+            vm.PrivacyOptions.Single(p => p.Value == EmbedPrivacy.Fuzz);
+        Assert.False(vm.ShowsHomeEmptiedNote);          // Fuzz still records one
+
+        vm.SelectedPrivacy =
+            vm.PrivacyOptions.Single(p => p.Value == EmbedPrivacy.Drop);
+        Assert.True(vm.ShowsHomeEmptiedNote);           // Drop + extracting
+
+        vm.ExtractHome = false;
+        Assert.False(vm.ShowsHomeEmptiedNote);          // Drop, nothing to empty
+    }
+
+    [Fact]
+    public void Home_emptied_note_notifies_on_both_of_its_inputs()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel();
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+
+        vm.SelectedPrivacy =
+            vm.PrivacyOptions.Single(p => p.Value == EmbedPrivacy.Drop);
+        vm.ExtractHome = true;
+
+        Assert.Equal(2, notified.Count(
+            n => n == nameof(EmbedTelemetryOptionsViewModel.ShowsHomeEmptiedNote)));
+    }
+
+    [Fact]
+    public void Clear_output_resets_to_the_source_folder()
+    {
+        var vm = new EmbedTelemetryOptionsViewModel { Output = "/out/copies" };
+        vm.ClearOutputCommand.Execute(null);
+        Assert.Equal("", vm.Output);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -256,6 +256,57 @@ public class ScreenshotCaptureTests
         Capture(window, Path.Combine(dir!, "workspace-photo-options-advanced.png"));
     }
 
+    /// <summary>
+    /// The Embed telemetry curated options (M3d): once at its defaults with
+    /// Advanced closed — the state a novice actually meets — and once with
+    /// Advanced open, "Remove GPS entirely" chosen and the launch point
+    /// ticked, the only state that renders the emptied-home note and the
+    /// "Use default" reset.
+    /// </summary>
+    [AvaloniaFact]
+    public void Captures_embed_options_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture the Embed options.");
+        Directory.CreateDirectory(dir!);
+
+        var vm = new WorkspaceViewModel(
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
+        vm.SelectedFolder = @"C:\Users\demo\Videos\flight";
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        view.DataContext = vm;
+        // Taller than the app's 720: the point of this capture is to review
+        // the whole panel at once, which the real window scrolls to reach.
+        CaptureView(view, Path.Combine(dir!, "workspace-embed-options.png"),
+            height: 1100);
+
+        vm.EmbedOptions.SelectedPrivacy = vm.EmbedOptions.PrivacyOptions
+            .Single(p => p.Value == EmbedPrivacy.Drop);
+        vm.EmbedOptions.ExtractHome = true;
+        vm.EmbedOptions.DatAuto = true;
+        vm.EmbedOptions.Output = @"C:\Users\demo\Desktop\embedded";
+        var opened = new WorkspaceView { WebViewGate = static () => false };
+        opened.DataContext = vm;
+        var window = new Window { Width = 1140, Height = 1400, Content = opened };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        opened.FindControl<Expander>("EmbedAdvanced")!.IsExpanded = true;
+        // The expander reveals its content with an animation; without
+        // advancing the headless render clock the capture catches it
+        // half-open and the Advanced rows are clipped away. Interleaved
+        // ticks are required — one big tick count does NOT settle it.
+        for (var i = 0; i < 80; i++)
+        {
+            AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+        Capture(window, Path.Combine(dir!, "workspace-embed-options-advanced.png"));
+    }
+
     private static void CaptureView(
         Control view, string outPath, double width = 1140, double height = 720) =>
         Capture(new Window { Width = width, Height = height, Content = view },

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -587,6 +587,35 @@ public class WorkspaceScreenTests
         Assert.False(note.IsEffectivelyVisible);
     }
 
+    // The Advanced expander's counterpart to the home note: ExifTool can't
+    // write MKV, and the curated container combo sits three rows above, so
+    // the no-op pair is two clicks away. Proves the IsVisible binding path.
+    [AvaloniaFact]
+    public void Exiftool_mkv_note_appears_only_when_exiftool_meets_mkv()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var note = window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "ExifToolMkvNote");
+        Assert.False(note.IsEffectivelyVisible);   // defaults: MP4, no ExifTool
+
+        vm.EmbedOptions.UseExifTool = true;
+        vm.EmbedOptions.SelectedContainer =
+            vm.EmbedOptions.Containers.Single(c => c.Key == "mkv");
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(note.IsEffectivelyVisible);
+
+        vm.EmbedOptions.UseExifTool = false;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.False(note.IsEffectivelyVisible);
+    }
+
     // Driven from the CONTROL side on purpose: the note test above mutates
     // SelectedPrivacy on the ViewModel and so never exercises the combo's
     // binding. A wrong-object ItemsSource compiles, renders a plausible

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -586,4 +586,34 @@ public class WorkspaceScreenTests
         window.UpdateLayout();
         Assert.False(note.IsEffectivelyVisible);
     }
+
+    // Driven from the CONTROL side on purpose: the note test above mutates
+    // SelectedPrivacy on the ViewModel and so never exercises the combo's
+    // binding. A wrong-object ItemsSource compiles, renders a plausible
+    // list, and silently cannot round-trip a selection.
+    [AvaloniaFact]
+    public void Embed_combo_boxes_round_trip_a_selection_into_the_argv()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var privacy = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "EmbedPrivacyCombo");
+        Assert.Same(vm.EmbedOptions.PrivacyOptions, privacy.ItemsSource);
+        privacy.SelectedItem = vm.EmbedOptions.PrivacyOptions
+            .Single(p => p.Value == EmbedPrivacy.Drop);
+
+        var container = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "ContainerCombo");
+        Assert.Same(vm.EmbedOptions.Containers, container.ItemsSource);
+        container.SelectedItem =
+            vm.EmbedOptions.Containers.Single(c => c.Key == "mkv");
+
+        Dispatcher.UIThread.RunJobs();
+        Assert.Contains("--redact drop", vm.CommandPreview);
+        Assert.Contains("--container mkv", vm.CommandPreview);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -482,4 +482,108 @@ public class WorkspaceScreenTests
         Assert.False(vm.PhotoOptions.LinkOriginals);
         Assert.DoesNotContain("--link-originals", vm.CommandPreview);
     }
+
+    [AvaloniaFact]
+    public void Embed_mode_shows_its_options_panel_with_advanced_collapsed()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "EmbedOptionsPanel");
+        Assert.True(panel.IsEffectivelyVisible);
+        var advanced = window.GetVisualDescendants().OfType<Expander>()
+            .Single(e => e.Name == "EmbedAdvanced");
+        Assert.False(advanced.IsExpanded);
+        // All three options panels are mutually exclusive.
+        Assert.False(window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "FlightOptionsPanel").IsEffectivelyVisible);
+        Assert.False(window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "PhotoOptionsPanel").IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Flight_map_mode_hides_the_embed_options_panel()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "EmbedOptionsPanel");
+        Assert.False(panel.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Embed_checkboxes_bind_to_their_own_options_view_model()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var home = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "ExtractHomeCheck");
+        Assert.False(home.IsChecked);
+        home.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.EmbedOptions.ExtractHome);
+        Assert.Contains("--extract-home", vm.CommandPreview);
+
+        // A wrong-OBJECT binding (e.g. PhotoOptions.X in this panel) compiles
+        // fine, so assert the flag actually lands in the Embed argv.
+        var dat = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "DatAutoCheck");
+        dat.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.EmbedOptions.DatAuto);
+        Assert.Contains("--dat-auto", vm.CommandPreview);
+    }
+
+    [AvaloniaFact]
+    public void Embed_clear_output_button_is_bound_to_its_command()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        vm.EmbedOptions.Output = "/out/copies";
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var clear = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ClearEmbedOutputButton");
+        // A Button with a NULL Command still reports IsEffectivelyEnabled ==
+        // true, so identity is the only assertion that proves the binding.
+        Assert.Same(vm.EmbedOptions.ClearOutputCommand, clear.Command);
+    }
+
+    // The one privacy-relevant message in this panel: "Remove GPS entirely"
+    // empties the launch point the checkbox just asked for. Proves the
+    // IsVisible binding path, not just the ViewModel property behind it.
+    [AvaloniaFact]
+    public void Home_emptied_note_appears_only_when_dropping_and_extracting()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var note = window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "HomeEmptiedNote");
+        Assert.False(note.IsEffectivelyVisible);   // defaults: Keep, no home
+
+        vm.EmbedOptions.ExtractHome = true;
+        vm.EmbedOptions.SelectedPrivacy = vm.EmbedOptions.PrivacyOptions
+            .Single(p => p.Value == EmbedPrivacy.Drop);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(note.IsEffectivelyVisible);
+
+        vm.EmbedOptions.ExtractHome = false;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.False(note.IsEffectivelyVisible);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -947,6 +947,88 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Contains(nameof(WorkspaceViewModel.IsPhotoMapMode), notified);
     }
 
+    // M3d: Embed options flow through the run and the live strip.
+    [Fact]
+    public async Task Embed_options_reach_the_embed_argv()
+    {
+        var argsFile = Path.Combine(_dir, "args-embed-opt.txt");
+        var cli = FakeCli.WriteArgsRecorder(_dir, argsFile,
+        [
+            """{"v": 1, "event": "start", "command": "embed", "total": 1}""",
+            """{"v": 1, "event": "result", "ok": true, "outputs": ["/footage/processed"], "summary": {}}""",
+        ]);
+        var vm = Vm(cli);
+        vm.EmbedOptions.SelectedPrivacy = vm.EmbedOptions.PrivacyOptions
+            .Single(p => p.Value == EmbedPrivacy.Drop);
+        vm.EmbedOptions.SelectedContainer =
+            vm.EmbedOptions.Containers.Single(c => c.Key == "mkv");
+        vm.EmbedOptions.DatAuto = true;
+        await vm.SetFolderAsync(MakeFolder(videos: true));
+        Assert.Equal(WorkspaceModeKind.Embed, vm.SelectedMode.Kind);
+
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Equal(FlowStep.Done, vm.Step);
+        var argv = File.ReadAllText(argsFile);
+        Assert.Contains("--redact drop", argv);
+        Assert.Contains("--container mkv", argv);
+        Assert.Contains("--dat-auto", argv);
+        Assert.DoesNotContain("--overwrite", argv);
+    }
+
+    [Fact]
+    public void Command_preview_reflects_embed_options()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Assert.Equal("dji-embed embed <folder>", vm.CommandPreview);
+        vm.EmbedOptions.ExtractHome = true;
+        Assert.Contains("--extract-home", vm.CommandPreview);
+        vm.EmbedOptions.UseExifTool = true;
+        Assert.Contains("--exiftool", vm.CommandPreview);
+    }
+
+    [Fact]
+    public void Changing_an_embed_option_notifies_command_preview()
+    {
+        var vm = Vm("unused");
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.EmbedOptions.AudioSidecar = true;
+        Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
+    }
+
+    [Fact]
+    public void Only_embed_mode_reports_the_embed_options_panel_visible()
+    {
+        var vm = Vm("unused");   // default mode Flight map
+        Assert.False(vm.IsEmbedMode);
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Assert.True(vm.IsEmbedMode);
+        Assert.False(vm.IsFlightMapMode);
+        Assert.False(vm.IsPhotoMapMode);
+        Assert.Contains(nameof(WorkspaceViewModel.IsEmbedMode), notified);
+    }
+
+    [Fact]
+    public async Task A_new_folder_clears_the_embed_output_but_keeps_other_options()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(videos: true));
+        vm.EmbedOptions.Output = Path.Combine(_dir, "copies");
+        vm.EmbedOptions.SelectedContainer =
+            vm.EmbedOptions.Containers.Single(c => c.Key == "mkv");
+        vm.EmbedOptions.ExtractHome = true;
+
+        await vm.SetFolderAsync(MakeFolder(videos: true));
+
+        Assert.Equal("", vm.EmbedOptions.Output);
+        Assert.Equal("mkv", vm.EmbedOptions.SelectedContainer.Key);
+        Assert.True(vm.EmbedOptions.ExtractHome);
+    }
+
     // Branch review finding: photomap writes each pin's href RELATIVE to the
     // HTML file, so a "Save map to" redirected outside the source folder
     // silently breaks every "open the original" link — and with it the 360°

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -1139,6 +1139,42 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.False(vm.PhotoOptions.ShowCamera);
     }
 
+    // The ✕ next to the folder path removes the folder, so an absolute output
+    // override chosen for it no longer has an owner — without this the idle
+    // strip advertises a path from a folder that is no longer selected.
+    [Fact]
+    public async Task Clearing_the_folder_clears_every_save_override()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        vm.FlightOptions.Output = Path.Combine(_dir, "flightmap.html");
+        vm.PhotoOptions.Output = Path.Combine(_dir, "photomap.html");
+        vm.EmbedOptions.Output = Path.Combine(_dir, "copies");
+
+        vm.ClearFolderCommand.Execute(null);
+
+        Assert.Equal("", vm.FlightOptions.Output);
+        Assert.Equal("", vm.PhotoOptions.Output);
+        Assert.Equal("", vm.EmbedOptions.Output);
+    }
+
+    // The reset is only half the fix: the strip has to be told to recompute,
+    // or the cleared path stays on screen as text.
+    [Fact]
+    public async Task Clearing_the_folder_refreshes_the_command_strip()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        vm.FlightOptions.Output = Path.Combine(_dir, "flightmap.html");
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+
+        vm.ClearFolderCommand.Execute(null);
+
+        Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
+        Assert.Equal("dji-embed flightmap <folder> -r", vm.CommandPreview);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -1175,6 +1175,50 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Equal("dji-embed flightmap <folder> -r", vm.CommandPreview);
     }
 
+    // Review finding: ✕ after a finished run nulled the preview but left
+    // Step == Done, so ShowDoneCard stayed true — the run's outputs and
+    // warnings listed with no folder selected and no drop hero behind them.
+    // That is the same failure the ResetPreview comment cites; the reset just
+    // stopped one property short. Synthetic Done, as in the GoHome sibling
+    // above: the bug is in the reset, not in how Done was reached.
+    [Fact]
+    public async Task Clearing_the_folder_after_a_run_returns_to_the_hero()
+    {
+        var vm = Vm("unused");
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        vm.Outputs.Add("C:\\out\\flightmap.html");
+        vm.Warnings.Add("something from the run just finished");
+        vm.Step = FlowStep.Done;
+
+        vm.ClearFolderCommand.Execute(null);
+
+        Assert.True(vm.ShowIdle);
+        Assert.False(vm.ShowDoneCard);
+        Assert.Empty(vm.Outputs);
+        Assert.Empty(vm.Warnings);
+    }
+
+    // SetFolderAsync is inert mid-run; ✕ was not, so it could yank the folder
+    // out from under a running job — and once it also cleared the three
+    // output overrides, a mid-run ✕ silently discarded those too.
+    [Fact]
+    public async Task Clearing_the_folder_is_inert_while_a_run_is_in_flight()
+    {
+        var vm = Vm("unused");
+        var folder = MakeFolder(srt: true);
+        await vm.SetFolderAsync(folder);
+        vm.FlightOptions.Output = Path.Combine(_dir, "flightmap.html");
+        vm.EmbedOptions.Output = Path.Combine(_dir, "copies");
+        vm.Step = FlowStep.Running;
+
+        vm.ClearFolderCommand.Execute(null);
+
+        Assert.Equal(folder, vm.SelectedFolder);
+        Assert.Equal(Path.Combine(_dir, "flightmap.html"), vm.FlightOptions.Output);
+        Assert.Equal(Path.Combine(_dir, "copies"), vm.EmbedOptions.Output);
+        Assert.Equal(FlowStep.Running, vm.Step);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -139,8 +139,9 @@ public static class CommandBuilder
     /// <summary>
     /// The Embed telemetry argv from typed <paramref name="opts"/> (GUI 2.0
     /// spec, M3d). Flags are omitted at their defaults so an untouched run
-    /// reads <c>embed &lt;folder&gt;</c>, exactly like M3a — the only mode
-    /// whose default argv carries no flags. Order is fixed for golden tests.
+    /// reads <c>embed &lt;folder&gt;</c>, exactly like M3a — the only
+    /// folder-taking mode whose default argv carries no flags. Order is fixed
+    /// for golden tests.
     /// No <c>--progress</c>: the runner appends that. No <c>--overwrite</c>
     /// and no <c>--dat</c>: both are CLI-only by design, the first because it
     /// destroys the originals, the second because a per-file picker does not
@@ -149,10 +150,18 @@ public static class CommandBuilder
     public static string[] Embed(string folder, EmbedTelemetryOptions opts)
     {
         var args = new List<string> { "embed", folder };
-        if (opts.Privacy != EmbedPrivacy.Keep)
+        var redact = opts.Privacy switch
+        {
+            EmbedPrivacy.Keep => null,
+            EmbedPrivacy.Fuzz => "fuzz",
+            EmbedPrivacy.Drop => "drop",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(opts), opts.Privacy, null),
+        };
+        if (redact is not null)
         {
             args.Add("--redact");
-            args.Add(opts.Privacy == EmbedPrivacy.Fuzz ? "fuzz" : "drop");
+            args.Add(redact);
         }
         if (opts.Container != EmbedTelemetryOptions.Defaults.Container)
         {

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -23,7 +23,7 @@ public static class CommandBuilder
     {
         WorkspaceModeKind.FlightMap => FlightMap(folder!, FlightMapOptions.Defaults),
         WorkspaceModeKind.PhotoMap => PhotoMap(folder!, PhotoMapOptions.Defaults),
-        WorkspaceModeKind.Embed => ["embed", folder!],
+        WorkspaceModeKind.Embed => Embed(folder!, EmbedTelemetryOptions.Defaults),
         WorkspaceModeKind.Setup => ["doctor"],
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
     };
@@ -126,6 +126,54 @@ public static class CommandBuilder
         {
             args.Add("--title");
             args.Add(title);
+        }
+        var output = opts.Output.Trim();
+        if (output.Length > 0)
+        {
+            args.Add("--output");
+            args.Add(output);
+        }
+        return args.ToArray();
+    }
+
+    /// <summary>
+    /// The Embed telemetry argv from typed <paramref name="opts"/> (GUI 2.0
+    /// spec, M3d). Flags are omitted at their defaults so an untouched run
+    /// reads <c>embed &lt;folder&gt;</c>, exactly like M3a — the only mode
+    /// whose default argv carries no flags. Order is fixed for golden tests.
+    /// No <c>--progress</c>: the runner appends that. No <c>--overwrite</c>
+    /// and no <c>--dat</c>: both are CLI-only by design, the first because it
+    /// destroys the originals, the second because a per-file picker does not
+    /// fit a folder-shaped GUI.
+    /// </summary>
+    public static string[] Embed(string folder, EmbedTelemetryOptions opts)
+    {
+        var args = new List<string> { "embed", folder };
+        if (opts.Privacy != EmbedPrivacy.Keep)
+        {
+            args.Add("--redact");
+            args.Add(opts.Privacy == EmbedPrivacy.Fuzz ? "fuzz" : "drop");
+        }
+        if (opts.Container != EmbedTelemetryOptions.Defaults.Container)
+        {
+            args.Add("--container");
+            args.Add(opts.Container);
+        }
+        if (opts.ExtractHome)
+        {
+            args.Add("--extract-home");
+        }
+        if (opts.UseExifTool)
+        {
+            args.Add("--exiftool");
+        }
+        if (opts.AudioSidecar)
+        {
+            args.Add("--audio-sidecar");
+        }
+        if (opts.DatAuto)
+        {
+            args.Add("--dat-auto");
         }
         var output = opts.Output.Trim();
         if (output.Length > 0)

--- a/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptions.cs
@@ -34,12 +34,11 @@ public enum EmbedPrivacy
 /// (<c>--extract-home</c>). Never written into the video, and redacted along
 /// with everything else — <see cref="EmbedPrivacy.Drop"/> empties it.</param>
 /// <param name="UseExifTool">Also write GPS metadata with ExifTool
-/// (<c>--exiftool</c>) — the one field whose name does not mirror its
-/// flag.</param>
-/// <param name="DatAuto">Scan for DAT flight logs sitting beside the videos
-/// and merge each match (<c>--dat-auto</c>). This is the whole DAT story in
-/// the GUI: <c>--dat PATH</c>, which names one log for one video, stays
-/// CLI-only.</param>
+/// (the flag is <c>--exiftool</c>, not <c>--use-exiftool</c>).</param>
+/// <param name="DatAuto">Scan for a DAT flight log sitting beside each video
+/// and merge whichever one matches (<c>--dat-auto</c>). This is the whole DAT
+/// story in the GUI: <c>--dat PATH</c>, which forces a single log onto every
+/// video in the folder, stays CLI-only.</param>
 /// <param name="Output">Destination directory for the copies; empty means the
 /// CLI default, a <c>processed</c> folder inside the source folder.</param>
 public sealed record EmbedTelemetryOptions(

--- a/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptions.cs
@@ -1,0 +1,55 @@
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>
+/// What happens to GPS coordinates on the way into the copies. Deliberately
+/// NOT <see cref="MapPrivacy"/>: <c>embed --redact</c> accepts
+/// <c>none|drop|fuzz</c>, while <c>flightmap</c>/<c>photomap</c> accept only
+/// <c>none|fuzz</c> and would reject <c>drop</c>. One enum per command keeps
+/// each mode total over what its own CLI accepts.
+/// </summary>
+public enum EmbedPrivacy
+{
+    /// <summary>Coordinates pass through untouched (flag omitted).</summary>
+    Keep,
+
+    /// <summary>Coarsened to ~100 m (<c>--redact fuzz</c>).</summary>
+    Fuzz,
+
+    /// <summary>Removed entirely (<c>--redact drop</c>).</summary>
+    Drop,
+}
+
+/// <summary>
+/// Immutable, typed state for an Embed telemetry run (GUI 2.0 spec, M3d). It
+/// is the single input to <see cref="Services.CommandBuilder.Embed"/>, so the
+/// argv is a pure function of this record — golden-testable. Every field maps
+/// to an existing <c>embed</c> flag; the defaults reproduce M3a's bare argv.
+/// <c>--overwrite</c> and <c>--dat PATH</c> are deliberately absent: both stay
+/// CLI-only per the M3d spec.
+/// </summary>
+/// <param name="Container">A CLI container key: <c>mp4</c> (default) or
+/// <c>mkv</c>, which preserves the DJI djmd/dbgi data streams the mp4 muxer
+/// drops.</param>
+/// <param name="ExtractHome">Write the launch point into the JSON sidecar
+/// (<c>--extract-home</c>). Never written into the video, and redacted along
+/// with everything else — <see cref="EmbedPrivacy.Drop"/> empties it.</param>
+/// <param name="Output">Destination directory for the copies; empty means the
+/// CLI default, a <c>processed</c> folder inside the source folder.</param>
+public sealed record EmbedTelemetryOptions(
+    EmbedPrivacy Privacy,
+    string Container,
+    bool ExtractHome,
+    bool UseExifTool,
+    bool AudioSidecar,
+    bool DatAuto,
+    string Output)
+{
+    public static readonly EmbedTelemetryOptions Defaults = new(
+        Privacy: EmbedPrivacy.Keep,
+        Container: "mp4",
+        ExtractHome: false,
+        UseExifTool: false,
+        AudioSidecar: false,
+        DatAuto: false,
+        Output: "");
+}

--- a/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptions.cs
@@ -33,6 +33,13 @@ public enum EmbedPrivacy
 /// <param name="ExtractHome">Write the launch point into the JSON sidecar
 /// (<c>--extract-home</c>). Never written into the video, and redacted along
 /// with everything else — <see cref="EmbedPrivacy.Drop"/> empties it.</param>
+/// <param name="UseExifTool">Also write GPS metadata with ExifTool
+/// (<c>--exiftool</c>) — the one field whose name does not mirror its
+/// flag.</param>
+/// <param name="DatAuto">Scan for DAT flight logs sitting beside the videos
+/// and merge each match (<c>--dat-auto</c>). This is the whole DAT story in
+/// the GUI: <c>--dat PATH</c>, which names one log for one video, stays
+/// CLI-only.</param>
 /// <param name="Output">Destination directory for the copies; empty means the
 /// CLI default, a <c>processed</c> folder inside the source folder.</param>
 public sealed record EmbedTelemetryOptions(

--- a/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptionsViewModel.cs
@@ -77,6 +77,22 @@ public partial class EmbedTelemetryOptionsViewModel : ViewModelBase
     partial void OnExtractHomeChanged(bool value) =>
         OnPropertyChanged(nameof(ShowsHomeEmptiedNote));
 
+    /// <summary>
+    /// True when ExifTool is requested but the chosen container makes it a
+    /// no-op. ExifTool cannot write Matroska (<c>exiftool -listwf</c> lists
+    /// MP4/MOV, not MKV), and <c>embedder.py:735</c> discards the failed
+    /// call's return value — so the run reports success and writes no tags.
+    /// A real property (not a XAML multi-binding) so it is assertable headless.
+    /// </summary>
+    public bool ShowsExifToolMkvNote =>
+        UseExifTool && SelectedContainer.Key == "mkv";
+
+    partial void OnUseExifToolChanged(bool value) =>
+        OnPropertyChanged(nameof(ShowsExifToolMkvNote));
+
+    partial void OnSelectedContainerChanged(ContainerChoice value) =>
+        OnPropertyChanged(nameof(ShowsExifToolMkvNote));
+
     public EmbedTelemetryOptions ToOptions() => new(
         Privacy: SelectedPrivacy.Value,
         Container: SelectedContainer.Key,

--- a/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptionsViewModel.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>A selectable output container: a label over a CLI key.</summary>
+public sealed record ContainerChoice(string Label, string Key);
+
+/// <summary>A selectable privacy stance: a label over an <see cref="EmbedPrivacy"/>.
+/// Separate from <see cref="PrivacyChoice"/>, which wraps <see cref="MapPrivacy"/>
+/// and so cannot express the third stance <c>embed --redact</c> accepts.</summary>
+public sealed record EmbedPrivacyChoice(string Label, EmbedPrivacy Value);
+
+/// <summary>
+/// Observable control state for the Embed telemetry options panel (GUI 2.0
+/// spec, M3d). Bound directly to the SukiUI-themed controls;
+/// <see cref="ToOptions"/> snapshots it into the immutable
+/// <see cref="EmbedTelemetryOptions"/> the builder consumes. Lives on
+/// <see cref="WorkspaceViewModel"/>; in-memory only.
+/// </summary>
+public partial class EmbedTelemetryOptionsViewModel : ViewModelBase
+{
+    public IReadOnlyList<ContainerChoice> Containers { get; } =
+    [
+        new("MP4 (most compatible)", "mp4"),
+        new("MKV (keeps DJI data streams)", "mkv"),
+    ];
+
+    public IReadOnlyList<EmbedPrivacyChoice> PrivacyOptions { get; } =
+    [
+        new("Keep exact locations", EmbedPrivacy.Keep),
+        new("Fuzz to ~100 m", EmbedPrivacy.Fuzz),
+        new("Remove GPS entirely", EmbedPrivacy.Drop),
+    ];
+
+    [ObservableProperty]
+    public partial ContainerChoice SelectedContainer { get; set; }
+
+    [ObservableProperty]
+    public partial EmbedPrivacyChoice SelectedPrivacy { get; set; }
+
+    [ObservableProperty]
+    public partial bool ExtractHome { get; set; }
+
+    [ObservableProperty]
+    public partial bool UseExifTool { get; set; }
+
+    [ObservableProperty]
+    public partial bool AudioSidecar { get; set; }
+
+    [ObservableProperty]
+    public partial bool DatAuto { get; set; }
+
+    [ObservableProperty]
+    public partial string Output { get; set; } = "";
+
+    public EmbedTelemetryOptionsViewModel()
+    {
+        SelectedContainer = Containers[0];
+        SelectedPrivacy = PrivacyOptions[0];
+    }
+
+    /// <summary>
+    /// True when the launch point is requested but the privacy stance empties
+    /// it. <c>apply_redaction</c> (<c>utilities.py</c>) redacts <c>home</c>
+    /// alongside the coordinates, so <c>drop</c> writes <c>"home": null</c> —
+    /// the option looks active and achieves nothing. A real property (not a
+    /// XAML multi-binding) so it is assertable headless.
+    /// </summary>
+    public bool ShowsHomeEmptiedNote =>
+        SelectedPrivacy.Value == EmbedPrivacy.Drop && ExtractHome;
+
+    partial void OnSelectedPrivacyChanged(EmbedPrivacyChoice value) =>
+        OnPropertyChanged(nameof(ShowsHomeEmptiedNote));
+
+    partial void OnExtractHomeChanged(bool value) =>
+        OnPropertyChanged(nameof(ShowsHomeEmptiedNote));
+
+    public EmbedTelemetryOptions ToOptions() => new(
+        Privacy: SelectedPrivacy.Value,
+        Container: SelectedContainer.Key,
+        ExtractHome: ExtractHome,
+        UseExifTool: UseExifTool,
+        AudioSidecar: AudioSidecar,
+        DatAuto: DatAuto,
+        Output: Output);
+
+    /// <summary>Reset the output override back to the default (a
+    /// <c>processed</c> folder inside the source folder).</summary>
+    [RelayCommand]
+    private void ClearOutput() => Output = "";
+}

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -286,6 +286,15 @@ public partial class WorkspaceViewModel : FlowViewModel
         SelectedFolder = null;
         SuggestedMode = null;
         ExistingMaps.Clear();
+        // The same ownership rule SetFolderAsync explains: an output override
+        // belongs to the folder it was chosen for, and removing the folder
+        // leaves it with no owner at all. The strip is where that shows —
+        // it would go on advertising `--output <path>` beside the `<folder>`
+        // placeholder. (SelectedFolder = null above already re-raises
+        // CommandPreview, so the cleared text refreshes on screen.)
+        FlightOptions.Output = "";
+        PhotoOptions.Output = "";
+        EmbedOptions.Output = "";
         // A map browsed out of that folder can't outlive it: without this the
         // pane keeps rendering it with no folder and no drop hero behind it.
         ResetPreview();

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -186,9 +186,9 @@ public partial class WorkspaceViewModel : FlowViewModel
         {
             var folder = SelectedFolder
                 ?? (SelectedMode.NeedsFolder ? "<folder>" : null);
-            // folder! is safe for every arm below: each of those modes has
-            // NeedsFolder true, so the line above yields the "<folder>"
-            // placeholder (never null) when no folder is picked.
+            // folder! is safe in the three explicit arms below: each of those
+            // modes has NeedsFolder true, so the line above yields the
+            // "<folder>" placeholder (never null) when no folder is picked.
             var argv = SelectedMode.Kind switch
             {
                 WorkspaceModeKind.FlightMap =>
@@ -271,8 +271,8 @@ public partial class WorkspaceViewModel : FlowViewModel
         // belongs to the folder it was chosen for — carried to a new folder it
         // either overwrites that folder's outputs or writes nowhere the new
         // folder shows. Every other option (tile style, privacy, container,
-        // popup fields, ...) is deliberately app-session state that survives a
-        // folder change (GUI 2.0 spec).
+        // popup fields, title, timezone, ...) is deliberately app-session
+        // state that survives a folder change (GUI 2.0 spec).
         FlightOptions.Output = "";
         PhotoOptions.Output = "";
         EmbedOptions.Output = "";
@@ -290,8 +290,10 @@ public partial class WorkspaceViewModel : FlowViewModel
         // belongs to the folder it was chosen for, and removing the folder
         // leaves it with no owner at all. The strip is where that shows —
         // it would go on advertising `--output <path>` beside the `<folder>`
-        // placeholder. (SelectedFolder = null above already re-raises
-        // CommandPreview, so the cleared text refreshes on screen.)
+        // placeholder. (Each Output setter raises through the ctor's options
+        // subscription, so the strip repaints with the cleared value. The
+        // SelectedFolder raise above fires before these lines and still sees
+        // the old path.)
         FlightOptions.Output = "";
         PhotoOptions.Output = "";
         EmbedOptions.Output = "";

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -41,6 +41,8 @@ public partial class WorkspaceViewModel : FlowViewModel
             OnPropertyChanged(nameof(CommandPreview));
             OnPropertyChanged(nameof(PhotoLinksCannotReachOriginals));
         };
+        EmbedOptions.PropertyChanged += (_, _) =>
+            OnPropertyChanged(nameof(CommandPreview));
     }
 
     /// <summary>Curated option state for the Flight map mode (M3b). Feeds both
@@ -50,6 +52,10 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Curated option state for the Photo map mode (M3c). Feeds both
     /// the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
     public PhotoMapOptionsViewModel PhotoOptions { get; } = new();
+
+    /// <summary>Curated option state for the Embed telemetry mode (M3d). Feeds
+    /// both the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
+    public EmbedTelemetryOptionsViewModel EmbedOptions { get; } = new();
 
     public IReadOnlyList<WorkspaceMode> Modes => WorkspaceMode.All;
 
@@ -120,6 +126,9 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Whether the Photo map options panel applies to the current mode.</summary>
     public bool IsPhotoMapMode => SelectedMode.Kind == WorkspaceModeKind.PhotoMap;
 
+    /// <summary>Whether the Embed telemetry options panel applies to the current mode.</summary>
+    public bool IsEmbedMode => SelectedMode.Kind == WorkspaceModeKind.Embed;
+
     /// <summary>
     /// True when a Photo map's "Save map to" override would leave the pins
     /// unable to find the original photos. <c>photomap --link-originals</c>
@@ -177,15 +186,17 @@ public partial class WorkspaceViewModel : FlowViewModel
         {
             var folder = SelectedFolder
                 ?? (SelectedMode.NeedsFolder ? "<folder>" : null);
-            // folder! is safe for the map modes: their NeedsFolder is true, so
-            // the line above yields the "<folder>" placeholder (never null)
-            // when no folder is picked.
+            // folder! is safe for every arm below: each of those modes has
+            // NeedsFolder true, so the line above yields the "<folder>"
+            // placeholder (never null) when no folder is picked.
             var argv = SelectedMode.Kind switch
             {
                 WorkspaceModeKind.FlightMap =>
                     CommandBuilder.FlightMap(folder!, FlightOptions.ToOptions()),
                 WorkspaceModeKind.PhotoMap =>
                     CommandBuilder.PhotoMap(folder!, PhotoOptions.ToOptions()),
+                WorkspaceModeKind.Embed =>
+                    CommandBuilder.Embed(folder!, EmbedOptions.ToOptions()),
                 _ => CommandBuilder.Build(SelectedMode.Kind, folder),
             };
             return CommandLine.Format("dji-embed", argv);
@@ -206,6 +217,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(CommandPreview));
         OnPropertyChanged(nameof(IsFlightMapMode));
         OnPropertyChanged(nameof(IsPhotoMapMode));
+        OnPropertyChanged(nameof(IsEmbedMode));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -255,13 +267,15 @@ public partial class WorkspaceViewModel : FlowViewModel
         // warnings must not frame a map that was already sitting here.
         Outputs.Clear();
         Warnings.Clear();
-        // An absolute "Save map to" override belongs to the folder it was
-        // chosen for — carried to a new folder it either overwrites that
-        // folder's map or writes nowhere the new folder shows. Every other
-        // option (tile style, privacy, popup fields, ...) is deliberately
-        // app-session state that survives a folder change (GUI 2.0 spec).
+        // An absolute output override ("Save map to", "Save copies to")
+        // belongs to the folder it was chosen for — carried to a new folder it
+        // either overwrites that folder's outputs or writes nowhere the new
+        // folder shows. Every other option (tile style, privacy, container,
+        // popup fields, ...) is deliberately app-session state that survives a
+        // folder change (GUI 2.0 spec).
         FlightOptions.Output = "";
         PhotoOptions.Output = "";
+        EmbedOptions.Output = "";
         ResetPreview();
         Step = FlowStep.Pick;
     }
@@ -469,7 +483,7 @@ public partial class WorkspaceViewModel : FlowViewModel
             case WorkspaceModeKind.Embed:
                 await ExecuteFlowAsync(() => RunStepAsync(
                     "Embedding flight data into new copies…",
-                    CommandBuilder.Build(SelectedMode.Kind, folder)));
+                    CommandBuilder.Embed(folder, EmbedOptions.ToOptions())));
                 return;
         }
     }

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -283,8 +283,11 @@ public partial class WorkspaceViewModel : FlowViewModel
     [RelayCommand]
     private void ClearFolder()
     {
-        // Inert mid-run, exactly as SetFolderAsync is: pulling the folder out
-        // from under a running job would also discard the output overrides.
+        // Inert once the flow proper is running: pulling the folder out from
+        // under a running job would also discard the output overrides. This
+        // covers only Step == Running — a run's folder scan happens BEFORE
+        // ExecuteFlowAsync sets that, and that earlier window is closed on
+        // the other side, by RunAsync's ownership re-check after the scan.
         if (Step == FlowStep.Running)
         {
             return;
@@ -464,6 +467,14 @@ public partial class WorkspaceViewModel : FlowViewModel
             return;
         }
         var contents = await Task.Run(() => FolderInspector.Inspect(folder));
+        // The scan runs before ExecuteFlowAsync sets Step = Running, so the
+        // folder can be cleared or replaced underneath us while it is in
+        // flight. The newest pick owns the state — same rule SetFolderAsync
+        // applies to itself — so a run whose folder is gone just stops.
+        if (SelectedFolder != folder)
+        {
+            return;
+        }
         // Reset only now, past the awaited scan: clearing the preview any
         // earlier flashes the stale done card while a live map is still up.
         ResetPreview();

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -283,6 +283,12 @@ public partial class WorkspaceViewModel : FlowViewModel
     [RelayCommand]
     private void ClearFolder()
     {
+        // Inert mid-run, exactly as SetFolderAsync is: pulling the folder out
+        // from under a running job would also discard the output overrides.
+        if (Step == FlowStep.Running)
+        {
+            return;
+        }
         SelectedFolder = null;
         SuggestedMode = null;
         ExistingMaps.Clear();
@@ -300,6 +306,12 @@ public partial class WorkspaceViewModel : FlowViewModel
         // A map browsed out of that folder can't outlive it: without this the
         // pane keeps rendering it with no folder and no drop hero behind it.
         ResetPreview();
+        // Nor can a finished run's results: without these, ✕ after a run left
+        // Step == Done with the preview nulled, which is precisely the
+        // done-card state — outputs and warnings listed over no folder.
+        Outputs.Clear();
+        Warnings.Clear();
+        Step = FlowStep.Pick;
     }
 
     [RelayCommand]

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -13,23 +13,42 @@ namespace DjiEmbed.Gui.Views;
 /// </summary>
 internal static class FolderPicking
 {
-    internal static async Task ChooseAsync(
-        Control anchor, Func<string, Task> onFolder)
+    private static async Task<string?> PickFolderAsync(Control anchor, string title)
     {
         if (TopLevel.GetTopLevel(anchor) is not { } top)
         {
-            return;
+            return null;
         }
         var folders = await top.StorageProvider.OpenFolderPickerAsync(
             new FolderPickerOpenOptions
             {
                 AllowMultiple = false,
-                Title = "Choose the folder with your footage",
+                Title = title,
             });
-        var path = folders.FirstOrDefault()?.TryGetLocalPath();
-        if (path is not null)
+        return folders.FirstOrDefault()?.TryGetLocalPath();
+    }
+
+    internal static async Task ChooseAsync(
+        Control anchor, Func<string, Task> onFolder)
+    {
+        if (await PickFolderAsync(anchor, "Choose the folder with your footage")
+            is { } path)
         {
             await onFolder(path);
+        }
+    }
+
+    /// <summary>
+    /// Pick a destination directory. Embed's <c>-o</c> is a directory, not a
+    /// file, so it reuses the folder picker rather than
+    /// <see cref="SaveMapAsync"/>'s save-file dialog.
+    /// </summary>
+    internal static async Task ChooseFolderAsync(
+        Control anchor, Action<string> onPath, string title)
+    {
+        if (await PickFolderAsync(anchor, title) is { } path)
+        {
+            onPath(path);
         }
     }
 

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -39,11 +39,11 @@ internal static class FolderPicking
     }
 
     /// <summary>
-    /// Pick a destination directory. Embed's <c>-o</c> is a directory, not a
-    /// file, so it reuses the folder picker rather than
-    /// <see cref="SaveMapAsync"/>'s save-file dialog.
+    /// Pick a destination directory for a command's output. Embed's
+    /// <c>-o</c> is a directory, not a file, so it reuses the folder picker
+    /// rather than <see cref="SaveMapAsync"/>'s save-file dialog.
     /// </summary>
-    internal static async Task ChooseFolderAsync(
+    internal static async Task ChooseOutputFolderAsync(
         Control anchor, Action<string> onPath, string title)
     {
         if (await PickFolderAsync(anchor, title) is { } path)

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -408,6 +408,116 @@
                         </StackPanel>
                     </Border>
 
+                    <Border Name="EmbedOptionsPanel"
+                            IsVisible="{Binding IsEmbedMode}">
+                        <StackPanel>
+                            <TextBlock Classes="zone" Text="OPTIONS" />
+                            <suki:GlassCard Padding="14">
+                                <StackPanel Spacing="12">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Video container" Opacity="0.7"
+                                                   FontSize="12" />
+                                        <ComboBox Name="ContainerCombo"
+                                                  HorizontalAlignment="Stretch"
+                                                  ItemsSource="{Binding EmbedOptions.Containers}"
+                                                  SelectedItem="{Binding EmbedOptions.SelectedContainer}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:ContainerChoice">
+                                                    <TextBlock Text="{Binding Label}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Privacy" Opacity="0.7"
+                                                   FontSize="12" />
+                                        <ComboBox Name="EmbedPrivacyCombo"
+                                                  HorizontalAlignment="Stretch"
+                                                  ItemsSource="{Binding EmbedOptions.PrivacyOptions}"
+                                                  SelectedItem="{Binding EmbedOptions.SelectedPrivacy}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:EmbedPrivacyChoice">
+                                                    <TextBlock Text="{Binding Label}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <CheckBox Name="ExtractHomeCheck"
+                                                  IsChecked="{Binding EmbedOptions.ExtractHome}"
+                                                  Content="Record the launch point in the sidecar" />
+                                        <TextBlock Text="Where the aircraft took off — often your home. Written only to the .json file, never into the video."
+                                                   TextWrapping="Wrap"
+                                                   Opacity="0.5" FontSize="11" />
+                                        <TextBlock Name="HomeEmptiedNote"
+                                                   Text="This privacy stance writes the launch point as empty."
+                                                   IsVisible="{Binding EmbedOptions.ShowsHomeEmptiedNote}"
+                                                   TextWrapping="Wrap"
+                                                   Opacity="0.5" FontSize="11" />
+                                    </StackPanel>
+
+                                    <Expander Name="EmbedAdvanced" Header="Advanced"
+                                              IsExpanded="False">
+                                        <StackPanel Spacing="12" Margin="0,8,0,0">
+                                            <StackPanel Spacing="4">
+                                                <CheckBox Name="ExifToolCheck"
+                                                          IsChecked="{Binding EmbedOptions.UseExifTool}"
+                                                          Content="Also write GPS with ExifTool" />
+                                                <TextBlock Text="Needs ExifTool installed — the Setup mode checks for it."
+                                                           TextWrapping="Wrap"
+                                                           Opacity="0.5" FontSize="11" />
+                                            </StackPanel>
+
+                                            <CheckBox Name="AudioSidecarCheck"
+                                                      IsChecked="{Binding EmbedOptions.AudioSidecar}"
+                                                      Content="Mux .m4a audio sidecar (DJI Neo 2)" />
+
+                                            <CheckBox Name="DatAutoCheck"
+                                                      IsChecked="{Binding EmbedOptions.DatAuto}"
+                                                      Content="Merge DAT flight logs found beside the videos" />
+
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="Save copies to" Opacity="0.7"
+                                                           FontSize="12" />
+                                                <DockPanel>
+                                                    <Button DockPanel.Dock="Right"
+                                                            Margin="8,0,0,0"
+                                                            Name="ChooseEmbedOutputButton"
+                                                            Click="OnChooseEmbedOutputClick">
+                                                        <TextBlock Text="Choose…" FontSize="12" />
+                                                    </Button>
+                                                    <Button DockPanel.Dock="Right"
+                                                            Margin="8,0,0,0"
+                                                            Name="ClearEmbedOutputButton"
+                                                            Command="{Binding EmbedOptions.ClearOutputCommand}"
+                                                            IsVisible="{Binding EmbedOptions.Output,
+                                                                Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                            ToolTip.Tip="Reset to the source folder">
+                                                        <TextBlock Text="Use default" FontSize="12" />
+                                                    </Button>
+                                                    <Panel VerticalAlignment="Center">
+                                                        <TextBlock Text="(a 'processed' folder inside the source folder)"
+                                                                   IsVisible="{Binding EmbedOptions.Output,
+                                                                       Converter={x:Static StringConverters.IsNullOrEmpty}}"
+                                                                   TextWrapping="Wrap"
+                                                                   Opacity="0.5" FontSize="12" />
+                                                        <TextBlock Text="{Binding EmbedOptions.Output}"
+                                                                   IsVisible="{Binding EmbedOptions.Output,
+                                                                       Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                                   TextTrimming="CharacterEllipsis"
+                                                                   Opacity="0.8" FontSize="12" />
+                                                    </Panel>
+                                                </DockPanel>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Expander>
+                                </StackPanel>
+                            </suki:GlassCard>
+                        </StackPanel>
+                    </Border>
+
                     <TextBlock Classes="zone" Text="ACTION" />
                     <Button Name="RunButton" Classes="Flat"
                             HorizontalAlignment="Stretch"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -474,9 +474,14 @@
                                                       IsChecked="{Binding EmbedOptions.AudioSidecar}"
                                                       Content="Mux .m4a audio sidecar (DJI Neo 2)" />
 
-                                            <CheckBox Name="DatAutoCheck"
-                                                      IsChecked="{Binding EmbedOptions.DatAuto}"
-                                                      Content="Merge DAT flight logs found beside the videos" />
+                                            <StackPanel Spacing="4">
+                                                <CheckBox Name="DatAutoCheck"
+                                                          IsChecked="{Binding EmbedOptions.DatAuto}"
+                                                          Content="Merge DAT flight logs named after the videos" />
+                                                <TextBlock Text="A log is used when its name starts with the video's — DJI_0001.DAT beside DJI_0001.MP4."
+                                                           TextWrapping="Wrap"
+                                                           Opacity="0.5" FontSize="11" />
+                                            </StackPanel>
 
                                             <StackPanel Spacing="4">
                                                 <TextBlock Text="Save copies to" Opacity="0.7"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -448,7 +448,7 @@
                                         <CheckBox Name="ExtractHomeCheck"
                                                   IsChecked="{Binding EmbedOptions.ExtractHome}"
                                                   Content="Record the launch point in the sidecar" />
-                                        <TextBlock Text="Where the aircraft took off — often your home. Written only to the .json file, never into the video."
+                                        <TextBlock Text="Where the aircraft took off — often your home. Written only to the .json file, never as a separate tag in the video — use Privacy above to control the location in the video itself."
                                                    TextWrapping="Wrap"
                                                    Opacity="0.5" FontSize="11" />
                                         <TextBlock Name="HomeEmptiedNote"
@@ -466,6 +466,11 @@
                                                           IsChecked="{Binding EmbedOptions.UseExifTool}"
                                                           Content="Also write GPS with ExifTool" />
                                                 <TextBlock Text="Writes GPS tags with ExifTool as well as ffmpeg. Embed needs ExifTool installed either way — the Setup mode checks for it."
+                                                           TextWrapping="Wrap"
+                                                           Opacity="0.5" FontSize="11" />
+                                                <TextBlock Name="ExifToolMkvNote"
+                                                           Text="ExifTool can't write MKV — this does nothing while MKV is selected."
+                                                           IsVisible="{Binding EmbedOptions.ShowsExifToolMkvNote}"
                                                            TextWrapping="Wrap"
                                                            Opacity="0.5" FontSize="11" />
                                             </StackPanel>

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -465,7 +465,7 @@
                                                 <CheckBox Name="ExifToolCheck"
                                                           IsChecked="{Binding EmbedOptions.UseExifTool}"
                                                           Content="Also write GPS with ExifTool" />
-                                                <TextBlock Text="Needs ExifTool installed — the Setup mode checks for it."
+                                                <TextBlock Text="Writes GPS tags with ExifTool as well as ffmpeg. Embed needs ExifTool installed either way — the Setup mode checks for it."
                                                            TextWrapping="Wrap"
                                                            Opacity="0.5" FontSize="11" />
                                             </StackPanel>
@@ -499,7 +499,7 @@
                                                             Command="{Binding EmbedOptions.ClearOutputCommand}"
                                                             IsVisible="{Binding EmbedOptions.Output,
                                                                 Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                                            ToolTip.Tip="Reset to the source folder">
+                                                            ToolTip.Tip="Reset to the default 'processed' folder">
                                                         <TextBlock Text="Use default" FontSize="12" />
                                                     </Button>
                                                     <Panel VerticalAlignment="Center">

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -138,7 +138,7 @@ public partial class WorkspaceView : UserControl
     {
         if (DataContext is WorkspaceViewModel vm)
         {
-            await FolderPicking.ChooseFolderAsync(
+            await FolderPicking.ChooseOutputFolderAsync(
                 this, p => vm.EmbedOptions.Output = p,
                 "Choose where to save the embedded copies");
         }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -134,6 +134,16 @@ public partial class WorkspaceView : UserControl
         }
     }
 
+    private async void OnChooseEmbedOutputClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is WorkspaceViewModel vm)
+        {
+            await FolderPicking.ChooseFolderAsync(
+                this, p => vm.EmbedOptions.Output = p,
+                "Choose where to save the embedded copies");
+        }
+    }
+
     private async void OnCopyDetailsClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is FlowViewModel vm)


### PR DESCRIPTION
Completes the **M3 arc**: Embed telemetry was the last mode still running a bare, unconfigurable `dji-embed embed <folder>`. It now has a curated options panel and an Advanced expander, matching Flight map (M3b) and Photo map (M3c).

Spec: `docs/superpowers/specs/2026-07-20-gui-m3d-embed-options-design.md`

## What the panel offers

**Curated:** Video container (MP4 / MKV) · Privacy (Keep exact locations / Fuzz to ~100 m / Remove GPS entirely) · "Record the launch point in the sidecar".

**Advanced (collapsed):** ExifTool GPS · .m4a audio sidecar (DJI Neo 2) · DAT auto-merge · "Save copies to" with a folder picker and a "Use default" reset.

Everything flows through `CommandBuilder.Embed` into **both** the executed run and the live CLI strip.

## Defaults invariant

Untouched, the strip reads exactly `dji-embed embed <folder>` — no flags. Embed is the only folder-taking mode whose defaults carry none. Pinned at three layers: the builder golden, the options-VM defaults, and an exact-string assert on the strip.

## Two deliberate exclusions

- **`--overwrite` stays CLI-only.** It rewrites the original videos in place — the only irreversible flag in the product. A GUI whose premise is "drop a folder, press the button" should not put one-click destruction of the user's originals behind a checkbox. The strip still teaches the command for anyone who wants it.
- **`--dat PATH` stays CLI-only**; only `--dat-auto` is surfaced. Pointing at one file is a per-file operation in a folder-shaped GUI, and it would add a second untestable picker handler (#335).

`EmbedPrivacy` is a separate enum rather than a third member on the shared `MapPrivacy`, because `flightmap`/`photomap` accept only `none|fuzz` and would **reject** `drop`.

## Defects the reviews caught (all fixed here, with failing tests first)

- **The privacy ternary failed toward the destructive value.** `Privacy == Fuzz ? "fuzz" : "drop"` meant a future fourth stance would silently emit `--redact drop` — coordinates erased, no compile error, no test failure. Now a total switch.
- **`ClearFolder` leaked state twice.** It left all three save-overrides set, so the idle strip advertised an absolute `--output` path beside the `<folder>` placeholder; and it never reset `Step`, so the ✕ after a finished run showed the previous run's done card with no folder selected.
- **A run could outlive the folder it belonged to.** `RunAsync`'s pre-scan runs before `Step` becomes `Running`, so both mid-run guards were open during it — long enough to clear the folder and have the run resume with the override the user just discarded, writing copies to the wrong place.
- **Two panel strings promised things the CLI does not do.** `--dat-auto` needs the log *named after* the video, not merely sitting beside it; and ExifTool is a hard prerequisite of every embed run, not just of the checkbox — the old hint read as permission to skip installing it.
- **ExifTool + MKV is a silent no-op.** ExifTool cannot write Matroska, `embed_metadata_exiftool` swallows the failure, and its caller discards the `False` — so the run reports success having written nothing. The panel now warns in exactly that combination. This one was two clicks away, since the curated MKV option recommends itself for DJI telemetry.

## Filed rather than patched in

- **#339** — the CLI's missing-DAT silence (the audio-sidecar branch twenty lines below warns for the identical miss).
- **#340** — the left column stays live during a run, so the strip can diverge from what is executing; plus the `FolderInspector` seam that would make the race testable.
- **#338** — nested videos make Embed report a hollow success (shares a root cause with #333).

## Verification

`dotnet test gui/DjiEmbed.Gui.sln --configuration Release` → **301 passed / 10 skipped / 0 failed, 0 warnings.**

Built TDD throughout, subagent-driven: every task through an independent spec review and a code-quality review, then a whole-branch review by fresh eyes — which is what found the ExifTool/MKV no-op and the pre-`Running` window. Binding tests were mutation-verified (a wrong-object `ItemsSource` renders a plausible list with "Remove GPS entirely" simply absent).

Release stays **held** per the small-userbase call: this rides the next version bump with #327, M3a, M3b, #328 and M3c. A manual UI test plan for that whole batch exists locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013462EMyRam43EMzhYFm6ia