### PR TITLE
test(gui): close the #334/#335/#336 test-debt trio

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/ExistingMapFinderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ExistingMapFinderTests.cs
@@ -34,6 +34,17 @@ public class ExistingMapFinderTests : IDisposable
         Assert.Empty(ExistingMapFinder.Find(_dir, Contents()));
     }
 
+    // Only the CLI's default output names count (#328 spec): a map renamed
+    // or redirected by "Save map to" is deliberately out of scope, so an
+    // arbitrary .html must never surface as an existing map.
+    [Fact]
+    public void A_non_default_html_name_is_not_an_existing_map()
+    {
+        Map("myflight.html", Recent);
+
+        Assert.Empty(ExistingMapFinder.Find(_dir, Contents()));
+    }
+
     [Fact]
     public void Finds_the_flight_map_with_its_title_and_path()
     {

--- a/gui/DjiEmbed.Gui.Tests/FakeCli.cs
+++ b/gui/DjiEmbed.Gui.Tests/FakeCli.cs
@@ -73,6 +73,33 @@ internal static class FakeCli
             + EchoLinesSh(stdoutLines) + "exit 0\n");
     }
 
+    /// <summary>
+    /// Like <see cref="WriteArgsRecorder"/>, but records ONE ARGUMENT PER
+    /// LINE so argument boundaries survive — <c>%*</c>/<c>"$@"</c> joined
+    /// with spaces cannot tell <c>--title "My Trip"</c> from two arguments.
+    /// For tests that compare the full argv sequence (#334).
+    /// </summary>
+    internal static string WriteArgvLinesRecorder(string dir, string argsFile,
+        IEnumerable<string> stdoutLines)
+    {
+        if (IsWindows)
+        {
+            // Redirect-first (`>> "f" echo x`), or an argument ending in a
+            // digit would turn `echo x2>> f` into a stream-2 redirect.
+            return WriteScript(dir, "@echo off\r\n"
+                + ":argloop\r\n"
+                + "if \"%~1\"==\"\" goto argdone\r\n"
+                + $">> \"{argsFile}\" echo %~1\r\n"
+                + "shift\r\n"
+                + "goto argloop\r\n"
+                + ":argdone\r\n"
+                + EchoLinesCmd(stdoutLines) + "exit /b 0\r\n");
+        }
+        return WriteScript(dir, "#!/bin/sh\n"
+            + $"for a in \"$@\"; do printf '%s\\n' \"$a\" >> '{argsFile}'; done\n"
+            + EchoLinesSh(stdoutLines) + "exit 0\n");
+    }
+
     private static string EchoLinesCmd(IEnumerable<string> lines) =>
         string.Concat(lines.Select(l =>
             "echo " + l.Replace("\"", "\"\"") + "\r\n"));

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -205,6 +205,89 @@ public class WorkspaceScreenTests
         Assert.False(panel.IsEffectivelyVisible);
     }
 
+    // #336: the Flight panel had zero interactive-control binding tests.
+    // Compiled bindings catch a mistyped property PATH at build time; the
+    // surviving failure modes are a control bound to the wrong OBJECT
+    // (PhotoOptions.Recursive here compiles fine) or a dropped binding
+    // attribute — so flip every control from the CONTROL side and assert its
+    // own options VM moved, and the strip with it.
+    [AvaloniaFact]
+    public void Flight_map_controls_bind_to_the_flight_options_view_model()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+
+        var recursive = window.GetVisualDescendants().OfType<ToggleSwitch>()
+            .Single(t => t.Name == "FlightRecursiveToggle");
+        Assert.True(recursive.IsChecked);
+        recursive.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.FlightOptions.Recursive);
+        Assert.DoesNotContain(" -r", vm.CommandPreview);
+
+        var style = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "FlightStyleCombo");
+        Assert.Same(vm.FlightOptions.TileStyles, style.ItemsSource);
+        style.SelectedItem =
+            vm.FlightOptions.TileStyles.Single(t => t.Key == "opentopomap");
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("opentopomap", vm.FlightOptions.SelectedTileStyle.Key);
+        Assert.Contains("--tile-style opentopomap", vm.CommandPreview);
+
+        var privacy = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "FlightPrivacyCombo");
+        Assert.Same(vm.FlightOptions.PrivacyOptions, privacy.ItemsSource);
+        privacy.SelectedItem = vm.FlightOptions.PrivacyOptions
+            .Single(p => p.Value == MapPrivacy.Fuzz);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(MapPrivacy.Fuzz, vm.FlightOptions.SelectedPrivacy.Value);
+        Assert.Contains("--redact fuzz", vm.CommandPreview);
+
+        var joinGap = window.GetVisualDescendants().OfType<Slider>()
+            .Single(s => s.Name == "JoinGapSlider");
+        joinGap.Value = 0;
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(0, vm.FlightOptions.JoinGap);
+        Assert.Contains("--join-gap 0", vm.CommandPreview);
+
+        var exportAll = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "FlightExportAllCheck");
+        exportAll.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.FlightOptions.ExportAll);
+        Assert.Contains("--format all", vm.CommandPreview);
+
+        var tz = window.GetVisualDescendants().OfType<TextBox>()
+            .Single(t => t.Name == "FlightTzBox");
+        tz.Text = "+02:00";
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("+02:00", vm.FlightOptions.TzOffset);
+        Assert.Contains("--tz-offset +02:00", vm.CommandPreview);
+
+        var title = window.GetVisualDescendants().OfType<TextBox>()
+            .Single(t => t.Name == "FlightTitleBox");
+        title.Text = "Alps";
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("Alps", vm.FlightOptions.Title);
+        Assert.Contains("--title Alps", vm.CommandPreview);
+    }
+
+    [AvaloniaFact]
+    public void Flight_map_clear_output_button_is_bound_to_its_command()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.FlightOptions.Output = "/out/map.html";
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var clear = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ClearOutputButton");
+        // A Button with a NULL Command still reports IsEffectivelyEnabled ==
+        // true, so identity is the only assertion that proves the binding.
+        Assert.Same(vm.FlightOptions.ClearOutputCommand, clear.Command);
+    }
+
     [AvaloniaFact]
     public async Task A_folder_with_an_existing_map_shows_the_already_here_panel()
     {
@@ -388,6 +471,85 @@ public class WorkspaceScreenTests
         Assert.Contains("--popup-fields", vm.CommandPreview);
     }
 
+    // #336, Photo panel: the controls the camera-checkbox test above does not
+    // reach — including the four popup checkboxes that were named but never
+    // driven. Cumulative unchecks walk --popup-fields down to one name, so
+    // every flip shows up in the strip, not just in the VM.
+    [AvaloniaFact]
+    public void Photo_map_controls_bind_to_the_photo_options_view_model()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var recursive = window.GetVisualDescendants().OfType<ToggleSwitch>()
+            .Single(t => t.Name == "PhotoRecursiveToggle");
+        Assert.True(recursive.IsChecked);
+        recursive.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.PhotoOptions.Recursive);
+        Assert.DoesNotContain(" -r", vm.CommandPreview);
+
+        var style = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "PhotoStyleCombo");
+        Assert.Same(vm.PhotoOptions.TileStyles, style.ItemsSource);
+        style.SelectedItem =
+            vm.PhotoOptions.TileStyles.Single(t => t.Key == "cyclosm");
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("cyclosm", vm.PhotoOptions.SelectedTileStyle.Key);
+        Assert.Contains("--tile-style cyclosm", vm.CommandPreview);
+
+        var privacy = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "PhotoPrivacyCombo");
+        Assert.Same(vm.PhotoOptions.PrivacyOptions, privacy.ItemsSource);
+        privacy.SelectedItem = vm.PhotoOptions.PrivacyOptions
+            .Single(p => p.Value == MapPrivacy.Fuzz);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(MapPrivacy.Fuzz, vm.PhotoOptions.SelectedPrivacy.Value);
+        Assert.Contains("--redact fuzz", vm.CommandPreview);
+
+        var checkboxes = window.GetVisualDescendants().OfType<CheckBox>().ToList();
+        var name = checkboxes.Single(c => c.Name == "PopupNameCheck");
+        name.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.PhotoOptions.ShowName);
+        Assert.Contains("--popup-fields timestamp,camera,altitude,credit",
+            vm.CommandPreview);
+
+        var time = checkboxes.Single(c => c.Name == "PopupTimeCheck");
+        time.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.PhotoOptions.ShowTimestamp);
+        Assert.Contains("--popup-fields camera,altitude,credit", vm.CommandPreview);
+
+        var altitude = checkboxes.Single(c => c.Name == "PopupAltitudeCheck");
+        altitude.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.PhotoOptions.ShowAltitude);
+        Assert.Contains("--popup-fields camera,credit", vm.CommandPreview);
+
+        var credit = checkboxes.Single(c => c.Name == "PopupCreditCheck");
+        credit.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.PhotoOptions.ShowCredit);
+        Assert.Contains("--popup-fields camera", vm.CommandPreview);
+
+        var exportAll = checkboxes.Single(c => c.Name == "PhotoExportAllCheck");
+        exportAll.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.PhotoOptions.ExportAll);
+        Assert.Contains("--format all", vm.CommandPreview);
+
+        var title = window.GetVisualDescendants().OfType<TextBox>()
+            .Single(t => t.Name == "PhotoTitleBox");
+        title.Text = "Beach";
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("Beach", vm.PhotoOptions.Title);
+        Assert.Contains("--title Beach", vm.CommandPreview);
+    }
+
     [AvaloniaFact]
     public void Photo_map_clear_output_button_is_bound_to_its_command()
     {
@@ -539,6 +701,34 @@ public class WorkspaceScreenTests
         Dispatcher.UIThread.RunJobs();
         Assert.True(vm.EmbedOptions.DatAuto);
         Assert.Contains("--dat-auto", vm.CommandPreview);
+    }
+
+    // #336, Embed panel: the two Advanced checkboxes that were named but
+    // never driven by the sibling test above.
+    [AvaloniaFact]
+    public void Embed_advanced_checkboxes_bind_to_the_embed_options_view_model()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var exiftool = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "ExifToolCheck");
+        Assert.False(exiftool.IsChecked);
+        exiftool.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.EmbedOptions.UseExifTool);
+        Assert.Contains("--exiftool", vm.CommandPreview);
+
+        var audio = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "AudioSidecarCheck");
+        Assert.False(audio.IsChecked);
+        audio.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.EmbedOptions.AudioSidecar);
+        Assert.Contains("--audio-sidecar", vm.CommandPreview);
     }
 
     [AvaloniaFact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input.Platform;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using DjiEmbed.Gui.Services;
@@ -176,6 +177,26 @@ public class WorkspaceScreenTests
         Assert.DoesNotContain("--progress", strip.Text);  // teaching form, not the machine flag
         Assert.Single(window.GetVisualDescendants().OfType<Button>(),
             b => b.Name == "CopyCommandButton");
+    }
+
+    // Manual plan §2.6 "Copy is exact": the strip's Copy button must put the
+    // preview on the clipboard byte-identically — a transformation on the way
+    // out would break the paste-into-a-terminal promise.
+    [AvaloniaFact]
+    public async Task Copy_command_puts_the_exact_preview_on_the_clipboard()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+
+        window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "CopyCommandButton")
+            .RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(
+                Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+
+        var copied = await window.Clipboard!.TryGetTextAsync();
+        Assert.Equal(vm.CommandPreview, copied);
+        Assert.Equal("dji-embed flightmap <folder> -r", copied);
     }
 
     // M3b: the Flight map options panel renders only for Flight map, with the

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -748,6 +748,89 @@ public class WorkspaceScreenTests
         Assert.Same(vm.EmbedOptions.ClearOutputCommand, clear.Command);
     }
 
+    // #335: the three Choose… click handlers differ only in which panel's
+    // Output they assign — a cross-wired copy-paste (Photo's button on the
+    // flight handler, say) keeps every other test green while the click
+    // lands in the wrong panel. The picker seams are pinned so no native
+    // dialog ever opens headless; the OTHER two outputs are asserted
+    // untouched because that is precisely the failure shape.
+    [AvaloniaFact]
+    public void Flight_choose_button_routes_the_picked_path_to_the_flight_output()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var view = (WorkspaceView)window.Content!;
+        var vm = (WorkspaceViewModel)view.DataContext!;
+        var titles = new List<string>();
+        view.SavePicker = (_, title, _) =>
+        {
+            titles.Add(title);
+            return Task.FromResult<string?>("/picked/flightmap.html");
+        };
+
+        window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ChooseOutputButton")
+            .RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(["Save the flight map as"], titles);
+        Assert.Equal("/picked/flightmap.html", vm.FlightOptions.Output);
+        Assert.Equal("", vm.PhotoOptions.Output);
+        Assert.Equal("", vm.EmbedOptions.Output);
+    }
+
+    [AvaloniaFact]
+    public void Photo_choose_button_routes_the_picked_path_to_the_photo_output()
+    {
+        var window = ShowWorkspace();
+        var view = (WorkspaceView)window.Content!;
+        var vm = (WorkspaceViewModel)view.DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var titles = new List<string>();
+        view.SavePicker = (_, title, _) =>
+        {
+            titles.Add(title);
+            return Task.FromResult<string?>("/picked/photomap.html");
+        };
+
+        window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ChoosePhotoOutputButton")
+            .RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(["Save the photo map as"], titles);
+        Assert.Equal("/picked/photomap.html", vm.PhotoOptions.Output);
+        Assert.Equal("", vm.FlightOptions.Output);
+        Assert.Equal("", vm.EmbedOptions.Output);
+    }
+
+    [AvaloniaFact]
+    public void Embed_choose_button_routes_the_picked_folder_to_the_embed_output()
+    {
+        var window = ShowWorkspace();
+        var view = (WorkspaceView)window.Content!;
+        var vm = (WorkspaceViewModel)view.DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Embed);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        // Embed's -o is a DIRECTORY, so this button must take the folder
+        // picker, never the save dialog — the decoy would betray it.
+        view.SavePicker = static (_, _, _) =>
+            Task.FromResult<string?>("/decoy/from-the-save-dialog.html");
+        view.OutputFolderPicker = static (_, _) =>
+            Task.FromResult<string?>("/picked/copies");
+
+        window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ChooseEmbedOutputButton")
+            .RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("/picked/copies", vm.EmbedOptions.Output);
+        Assert.Equal("", vm.FlightOptions.Output);
+        Assert.Equal("", vm.PhotoOptions.Output);
+    }
+
     // The one privacy-relevant message in this panel: "Remove GPS entirely"
     // empties the launch point the checkbox just asked for. Proves the
     // IsVisible binding path, not just the ViewModel property behind it.

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -212,6 +212,19 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Contains("folder", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
     }
 
+    // The mirror guard: the test above covers flightmap-on-photos, this one
+    // photomap-on-videos — the only wrong-content arm that had no test.
+    [Fact]
+    public async Task Photo_map_on_a_videos_folder_fails_before_launching_anything()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.SetFolderAsync(MakeFolder(videos: true));   // suggests Embed
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Contains("photos", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public async Task Setup_mode_parses_the_doctor_checklist()
     {

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -841,6 +841,32 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.False(vm.ShowDoneCard);
     }
 
+    // The fallback half of OpenExistingMapAsync's contract: no usable inline
+    // preview means the user's ask is answered by the browser — still through
+    // the map server, so the 360° pano viewer works — and never by preview
+    // state a webview-less pane could not render.
+    [Fact]
+    public async Task Existing_map_open_without_preview_goes_to_the_browser()
+    {
+        var server = new FakeMapServer(FakeUrl);
+        var vm = Vm("cli", mapServer: server,
+            previewAvailable: static () => false);
+        var launched = new List<string>();
+        vm.UrlLauncher = launched.Add;
+        await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
+        var map = Assert.Single(vm.ExistingMaps);
+
+        await vm.OpenExistingMapCommand.ExecuteAsync(map);
+
+        Assert.Equal([FakeUrl], launched);          // the browser answered the ask
+        Assert.Equal([map.Path], server.Requests);  // via the server, not file://
+        Assert.Null(vm.PreviewUrl);                 // and no preview state at all
+        Assert.Null(vm.PreviewPath);
+        Assert.False(vm.ShowPreview);
+        Assert.False(vm.PreviewUnavailable);        // a browsed map is not a degradation
+        Assert.True(vm.ShowIdle);
+    }
+
     [Fact]
     public async Task Picking_another_folder_drops_a_browsed_preview()
     {

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -1012,6 +1012,129 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Contains(nameof(WorkspaceViewModel.IsEmbedMode), notified);
     }
 
+    // #334: the CLI transparency strip's whole promise is that the command it
+    // shows IS the command the runner executes — the runner may append only
+    // the machine-only `--progress jsonl`. Argv-fragment tests and preview
+    // tests each cover one side; these pin the two sides to each other, one
+    // per mode, argv-to-argv (via SplitPreview) so CommandLine.Format's
+    // display quoting stays free to change.
+    private static void AssertStripEqualsExecutedArgv(
+        string preview, string argsFile)
+    {
+        var executed = File.ReadAllLines(argsFile);
+        Assert.Equal(["--progress", "jsonl"], executed[^2..]);
+        var shown = SplitPreview(preview);
+        Assert.Equal("dji-embed", shown[0]);
+        Assert.Equal(shown.Skip(1), executed[..^2]);
+    }
+
+    /// <summary>Splits the strip's display string back into an argv,
+    /// honouring the double quotes CommandLine.Format adds around arguments
+    /// with spaces. Deliberately test-side: the promise under test is about
+    /// the rendered string, whatever quoting produced it.</summary>
+    private static List<string> SplitPreview(string preview)
+    {
+        var tokens = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var inQuotes = false;
+        var hasToken = false;   // distinguishes "" (an empty argument) from nothing
+        foreach (var c in preview)
+        {
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                hasToken = true;
+            }
+            else if (char.IsWhiteSpace(c) && !inQuotes)
+            {
+                if (hasToken)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                    hasToken = false;
+                }
+            }
+            else
+            {
+                current.Append(c);
+                hasToken = true;
+            }
+        }
+        if (hasToken)
+        {
+            tokens.Add(current.ToString());
+        }
+        return tokens;
+    }
+
+    [Fact]
+    public async Task Flight_map_strip_equals_the_executed_argv()
+    {
+        var argsFile = Path.Combine(_dir, "argv-strip-fm.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, FlightmapStream);
+        var vm = Vm(cli);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        vm.FlightOptions.SelectedTileStyle =
+            vm.FlightOptions.TileStyles.Single(t => t.Key == "opentopomap");
+        vm.FlightOptions.SelectedPrivacy =
+            vm.FlightOptions.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
+        vm.FlightOptions.JoinGap = 0;
+        vm.FlightOptions.Title = "My Alps Trip";   // quoted in the strip
+        var preview = vm.CommandPreview;
+
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Equal(FlowStep.Done, vm.Step);
+        AssertStripEqualsExecutedArgv(preview, argsFile);
+    }
+
+    [Fact]
+    public async Task Photo_map_strip_equals_the_executed_argv()
+    {
+        var argsFile = Path.Combine(_dir, "argv-strip-pm.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, PhotomapStream);
+        var vm = Vm(cli);
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        Assert.Equal(WorkspaceModeKind.PhotoMap, vm.SelectedMode.Kind);
+        vm.PhotoOptions.SelectedTileStyle =
+            vm.PhotoOptions.TileStyles.Single(t => t.Key == "cyclosm");
+        vm.PhotoOptions.ShowName = false;    // forces a --popup-fields subset
+        vm.PhotoOptions.ShowCredit = false;
+        vm.PhotoOptions.ExportAll = true;
+        var preview = vm.CommandPreview;
+
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Equal(FlowStep.Done, vm.Step);
+        AssertStripEqualsExecutedArgv(preview, argsFile);
+    }
+
+    [Fact]
+    public async Task Embed_strip_equals_the_executed_argv()
+    {
+        var argsFile = Path.Combine(_dir, "argv-strip-em.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile,
+        [
+            """{"v": 1, "event": "start", "command": "embed", "total": 1}""",
+            """{"v": 1, "event": "result", "ok": true, "outputs": ["/footage/processed"], "summary": {}}""",
+        ]);
+        var vm = Vm(cli);
+        await vm.SetFolderAsync(MakeFolder(videos: true));
+        Assert.Equal(WorkspaceModeKind.Embed, vm.SelectedMode.Kind);
+        vm.EmbedOptions.SelectedPrivacy = vm.EmbedOptions.PrivacyOptions
+            .Single(p => p.Value == EmbedPrivacy.Fuzz);
+        vm.EmbedOptions.SelectedContainer =
+            vm.EmbedOptions.Containers.Single(c => c.Key == "mkv");
+        vm.EmbedOptions.ExtractHome = true;
+        vm.EmbedOptions.AudioSidecar = true;
+        var preview = vm.CommandPreview;
+
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Equal(FlowStep.Done, vm.Step);
+        AssertStripEqualsExecutedArgv(preview, argsFile);
+    }
+
     [Fact]
     public async Task A_new_folder_clears_the_embed_output_but_keeps_other_options()
     {

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -45,6 +45,15 @@ public partial class WorkspaceViewModel : FlowViewModel
             OnPropertyChanged(nameof(CommandPreview));
     }
 
+    /// <summary>
+    /// Opens a served map URL with the OS default handler — the user's
+    /// browser. A test seam in the <see cref="DjiEmbed.Gui.Views.WorkspaceView.WebViewGate"/>
+    /// mould, defaulting to the real launch, so headless tests can pin it
+    /// and assert the browser-fallback path without spawning anything.
+    /// </summary>
+    internal Action<string> UrlLauncher { get; set; } = static url =>
+        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+
     /// <summary>Curated option state for the Flight map mode (M3b). Feeds both
     /// the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
     public FlightMapOptionsViewModel FlightOptions { get; } = new();
@@ -557,7 +566,7 @@ public partial class WorkspaceViewModel : FlowViewModel
                 CliPath, path, CancellationToken.None);
             if (url is not null)
             {
-                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+                UrlLauncher(url);
                 return;
             }
         }

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -13,7 +13,13 @@ namespace DjiEmbed.Gui.Views;
 /// </summary>
 internal static class FolderPicking
 {
-    private static async Task<string?> PickFolderAsync(Control anchor, string title)
+    /// <summary>
+    /// Pick a directory, or <c>null</c> when the picker was dismissed.
+    /// Also serves as a command-output destination picker: Embed's
+    /// <c>-o</c> is a directory, not a file, so its Choose… button routes
+    /// here rather than to <see cref="PickSaveAsync"/>'s save dialog.
+    /// </summary>
+    internal static async Task<string?> PickFolderAsync(Control anchor, string title)
     {
         if (TopLevel.GetTopLevel(anchor) is not { } top)
         {
@@ -35,20 +41,6 @@ internal static class FolderPicking
             is { } path)
         {
             await onFolder(path);
-        }
-    }
-
-    /// <summary>
-    /// Pick a destination directory for a command's output. Embed's
-    /// <c>-o</c> is a directory, not a file, so it reuses the folder picker
-    /// rather than <see cref="SaveMapAsync"/>'s save-file dialog.
-    /// </summary>
-    internal static async Task ChooseOutputFolderAsync(
-        Control anchor, Action<string> onPath, string title)
-    {
-        if (await PickFolderAsync(anchor, title) is { } path)
-        {
-            onPath(path);
         }
     }
 
@@ -88,12 +80,14 @@ internal static class FolderPicking
     internal static void SetDragOver(Control zone, bool active) =>
         zone.Classes.Set("dragover", active);
 
-    internal static async Task SaveMapAsync(
-        Control anchor, Action<string> onPath, string title, string suggestedName)
+    /// <summary>Pick where to save a map's HTML, or <c>null</c> when the
+    /// dialog was dismissed.</summary>
+    internal static async Task<string?> PickSaveAsync(
+        Control anchor, string title, string suggestedName)
     {
         if (TopLevel.GetTopLevel(anchor) is not { } top)
         {
-            return;
+            return null;
         }
         var file = await top.StorageProvider.SaveFilePickerAsync(
             new FilePickerSaveOptions
@@ -106,10 +100,6 @@ internal static class FolderPicking
                     new FilePickerFileType("Web map") { Patterns = ["*.html"] },
                 ],
             });
-        var path = file?.TryGetLocalPath();
-        if (path is not null)
-        {
-            onPath(path);
-        }
+        return file?.TryGetLocalPath();
     }
 }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -167,7 +167,8 @@
                             <suki:GlassCard Padding="14">
                                 <StackPanel Spacing="12">
                                     <DockPanel>
-                                        <ToggleSwitch DockPanel.Dock="Right"
+                                        <ToggleSwitch Name="FlightRecursiveToggle"
+                                                      DockPanel.Dock="Right"
                                                       IsChecked="{Binding FlightOptions.Recursive}" />
                                         <TextBlock Text="Include subfolders"
                                                    VerticalAlignment="Center" />
@@ -176,7 +177,8 @@
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Map style" Opacity="0.7"
                                                    FontSize="12" />
-                                        <ComboBox HorizontalAlignment="Stretch"
+                                        <ComboBox Name="FlightStyleCombo"
+                                                  HorizontalAlignment="Stretch"
                                                   ItemsSource="{Binding FlightOptions.TileStyles}"
                                                   SelectedItem="{Binding FlightOptions.SelectedTileStyle}">
                                             <ComboBox.ItemTemplate>
@@ -190,7 +192,8 @@
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Privacy" Opacity="0.7"
                                                    FontSize="12" />
-                                        <ComboBox HorizontalAlignment="Stretch"
+                                        <ComboBox Name="FlightPrivacyCombo"
+                                                  HorizontalAlignment="Stretch"
                                                   ItemsSource="{Binding FlightOptions.PrivacyOptions}"
                                                   SelectedItem="{Binding FlightOptions.SelectedPrivacy}">
                                             <ComboBox.ItemTemplate>
@@ -209,7 +212,8 @@
                                             <TextBlock Text="Join split recordings within"
                                                        Opacity="0.7" FontSize="12" />
                                         </DockPanel>
-                                        <Slider Minimum="0" Maximum="60"
+                                        <Slider Name="JoinGapSlider"
+                                                Minimum="0" Maximum="60"
                                                 TickFrequency="1" IsSnapToTickEnabled="True"
                                                 Value="{Binding FlightOptions.JoinGap}" />
                                         <TextBlock Text="0 = keep split clips as separate flights"
@@ -219,20 +223,23 @@
                                     <Expander Name="FlightAdvanced" Header="Advanced"
                                               IsExpanded="False">
                                         <StackPanel Spacing="12" Margin="0,8,0,0">
-                                            <CheckBox IsChecked="{Binding FlightOptions.ExportAll}"
+                                            <CheckBox Name="FlightExportAllCheck"
+                                                      IsChecked="{Binding FlightOptions.ExportAll}"
                                                       Content="Also export KML + GeoJSON" />
 
                                             <StackPanel Spacing="4">
                                                 <TextBlock Text="Time zone of the clips"
                                                            Opacity="0.7" FontSize="12" />
-                                                <TextBox Text="{Binding FlightOptions.TzOffset}"
+                                                <TextBox Name="FlightTzBox"
+                                                         Text="{Binding FlightOptions.TzOffset}"
                                                          PlaceholderText="auto" />
                                             </StackPanel>
 
                                             <StackPanel Spacing="4">
                                                 <TextBlock Text="Map title" Opacity="0.7"
                                                            FontSize="12" />
-                                                <TextBox Text="{Binding FlightOptions.Title}"
+                                                <TextBox Name="FlightTitleBox"
+                                                         Text="{Binding FlightOptions.Title}"
                                                          PlaceholderText="(folder name)" />
                                             </StackPanel>
 
@@ -282,7 +289,8 @@
                             <suki:GlassCard Padding="14">
                                 <StackPanel Spacing="12">
                                     <DockPanel>
-                                        <ToggleSwitch DockPanel.Dock="Right"
+                                        <ToggleSwitch Name="PhotoRecursiveToggle"
+                                                      DockPanel.Dock="Right"
                                                       IsChecked="{Binding PhotoOptions.Recursive}" />
                                         <TextBlock Text="Include subfolders"
                                                    VerticalAlignment="Center" />
@@ -291,7 +299,8 @@
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Map style" Opacity="0.7"
                                                    FontSize="12" />
-                                        <ComboBox HorizontalAlignment="Stretch"
+                                        <ComboBox Name="PhotoStyleCombo"
+                                                  HorizontalAlignment="Stretch"
                                                   ItemsSource="{Binding PhotoOptions.TileStyles}"
                                                   SelectedItem="{Binding PhotoOptions.SelectedTileStyle}">
                                             <ComboBox.ItemTemplate>
@@ -305,7 +314,8 @@
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Privacy" Opacity="0.7"
                                                    FontSize="12" />
-                                        <ComboBox HorizontalAlignment="Stretch"
+                                        <ComboBox Name="PhotoPrivacyCombo"
+                                                  HorizontalAlignment="Stretch"
                                                   ItemsSource="{Binding PhotoOptions.PrivacyOptions}"
                                                   SelectedItem="{Binding PhotoOptions.SelectedPrivacy}">
                                             <ComboBox.ItemTemplate>
@@ -354,13 +364,15 @@
                                     <Expander Name="PhotoAdvanced" Header="Advanced"
                                               IsExpanded="False">
                                         <StackPanel Spacing="12" Margin="0,8,0,0">
-                                            <CheckBox IsChecked="{Binding PhotoOptions.ExportAll}"
+                                            <CheckBox Name="PhotoExportAllCheck"
+                                                      IsChecked="{Binding PhotoOptions.ExportAll}"
                                                       Content="Also export KML + GeoJSON" />
 
                                             <StackPanel Spacing="4">
                                                 <TextBlock Text="Map title" Opacity="0.7"
                                                            FontSize="12" />
-                                                <TextBox Text="{Binding PhotoOptions.Title}"
+                                                <TextBox Name="PhotoTitleBox"
+                                                         Text="{Binding PhotoOptions.Title}"
                                                          PlaceholderText="(folder name)" />
                                             </StackPanel>
 

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -23,6 +24,24 @@ public partial class WorkspaceView : UserControl
     /// </summary>
     internal Func<bool> WebViewGate { get; set; } =
         static () => WebViewSupport.IsLikelyAvailable;
+
+    /// <summary>
+    /// Save-file picking for the two map panels' Choose… buttons — a test
+    /// seam (#335) defaulting to the real save dialog, which cannot open
+    /// headless: (anchor, title, suggestedName) → the chosen path, or null
+    /// when dismissed.
+    /// </summary>
+    internal Func<Control, string, string, Task<string?>> SavePicker
+    { get; set; } = FolderPicking.PickSaveAsync;
+
+    /// <summary>
+    /// Folder picking for Embed's Choose… button (its <c>-o</c> is a
+    /// directory, not a file) — the same seam shape as
+    /// <see cref="SavePicker"/>: (anchor, title) → the chosen path, or
+    /// null when dismissed.
+    /// </summary>
+    internal Func<Control, string, Task<string?>> OutputFolderPicker
+    { get; set; } = FolderPicking.PickFolderAsync;
 
     public WorkspaceView()
     {
@@ -116,31 +135,31 @@ public partial class WorkspaceView : UserControl
 
     private async void OnChooseOutputClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is WorkspaceViewModel vm)
+        if (DataContext is WorkspaceViewModel vm
+            && await SavePicker(this, "Save the flight map as", "flightmap.html")
+                is { } path)
         {
-            await FolderPicking.SaveMapAsync(
-                this, p => vm.FlightOptions.Output = p,
-                "Save the flight map as", "flightmap.html");
+            vm.FlightOptions.Output = path;
         }
     }
 
     private async void OnChoosePhotoOutputClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is WorkspaceViewModel vm)
+        if (DataContext is WorkspaceViewModel vm
+            && await SavePicker(this, "Save the photo map as", "photomap.html")
+                is { } path)
         {
-            await FolderPicking.SaveMapAsync(
-                this, p => vm.PhotoOptions.Output = p,
-                "Save the photo map as", "photomap.html");
+            vm.PhotoOptions.Output = path;
         }
     }
 
     private async void OnChooseEmbedOutputClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is WorkspaceViewModel vm)
+        if (DataContext is WorkspaceViewModel vm
+            && await OutputFolderPicker(
+                this, "Choose where to save the embedded copies") is { } path)
         {
-            await FolderPicking.ChooseOutputFolderAsync(
-                this, p => vm.EmbedOptions.Output = p,
-                "Choose where to save the embedded copies");
+            vm.EmbedOptions.Output = path;
         }
     }
 


### PR DESCRIPTION
## What

Closes the three GUI test-debt issues in one slice, plus four uncovered corners found by the coverage audit that preceded it. 14 new tests; suite goes 301 → **315 passed, 0 failed** (verified twice: once by the implementing agent, once independently by the reviewing session).

### #334 — the strip equals the executed argv
One test per mode sets several non-default options (including a quoted `--title "My Alps Trip"`), runs against a new `FakeCli.WriteArgvLinesRecorder` (one argument per line — `%*`/`"$@"` space-joins can't preserve argument boundaries), asserts the executed argv ends `--progress jsonl`, strips it, and compares the remainder argv-to-argv against the tokenized strip. Display quoting stays free to change.

### #336 — control-binding tests
All 12 previously-unnamed options controls got `Name`s (no bindings touched — pure additions), and per-panel tests now flip every interactive control and assert both the VM property and the strip react. **Mutation-checked**: rewiring `FlightRecursiveToggle` to `PhotoOptions.Recursive` — the exact wrong-object slip the issue describes — compiled cleanly and was caught only by the new test.

### #335 — save-picker seams + routing
`WorkspaceView` gains `SavePicker` / `OutputFolderPicker` seams (the `WebViewGate` mould) defaulting to the real dialogs; `FolderPicking` simplifies from callbacks to return values with the two wrapper methods deleted. Routing tests click each Choose… button headless and assert the path lands in that panel's `Output` while the other two stay untouched — with dialog-title assertions so Flight↔Photo cross-wiring is caught twice over.

### Strays (from the coverage audit)
- photomap-on-a-videos-folder guard test (previously only the flightmap direction was tested)
- `ExistingMapFinder` ignores non-default filenames (`myflight.html`) — now asserted, was only true by construction
- `CopyCommandButton` puts exactly `CommandPreview` on the clipboard
- existing-map **Open** with WebView2 unavailable launches the served URL in the browser (needed one more seam: `UrlLauncher` on the view model)

### Deliberately unchanged
The join-gap hint ("0 = keep split clips…") stays always-visible: the M3b spec asks for `0` to be *labelled* as disabling the join, which the static hint satisfies; hiding it at non-zero would make 0's meaning undiscoverable.

### Known remaining (out of scope)
`FlowViewModel.OpenOutputCoreAsync` still calls `Process.Start` seamlessly, so the non-HTML fallback open remains untestable headless; Photo map's idle strip is still not pinned verbatim.

Closes #334
Closes #335
Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XuoE5YY4z8jFGhSQXPrNZ