### PR TITLE
fix(gui): recursion-mismatch guards and busy gating

### DIFF
--- a/docs/superpowers/specs/2026-07-21-gui-recursion-mismatch-and-busy-gating-design.md
+++ b/docs/superpowers/specs/2026-07-21-gui-recursion-mismatch-and-busy-gating-design.md
@@ -1,0 +1,140 @@
+# GUI: recursion-mismatch guards and busy gating (issues #333, #338, #340)
+
+**Status:** approved 2026-07-21 (design discussed and accepted in session; option
+"block with guidance" chosen by the maintainer).
+
+## Problem
+
+Three shipped defects share two root causes:
+
+1. **A recursive folder scan feeds commands that are not recursive.**
+   `FolderInspector.Inspect` always scans subfolders, so the workspace's
+   pre-flight guards pass whenever media exists *anywhere* under the picked
+   folder — but `embed` reads one directory level only, and
+   `flightmap`/`photomap` recurse only with `-r` ("Include subfolders").
+   Result: the CLI's `-r`-flavoured error surfaces in a GUI that has a toggle
+   for exactly that (#333), and Embed reports a hollow "✅ Done" over a
+   zero-file warning run (#338).
+2. **Work outlives the UI state that owns it.** The left column stays live
+   during a run (the CLI transparency strip can repaint to show flags the
+   running process does not have), and there is a pre-`Running` window during
+   the folder scan where the clear/replace guards are open (#340).
+
+## Decision
+
+Block mismatched runs **before** they start, with guidance in GUI language;
+freeze the left column for the whole run, starting at the first line of
+`RunAsync`; make the scan injectable so the busy window is testable.
+
+## 1. Depth-aware `FolderInspector`
+
+`FolderContents` grows three flags, computed in the **same single
+enumeration** (no second I/O pass):
+
+```csharp
+public sealed record FolderContents(
+    bool HasFlightLogs, bool HasPhotos, bool HasVideos,
+    bool HasTopLevelFlightLogs, bool HasTopLevelPhotos, bool HasTopLevelVideos,
+    DateTime? NewestFlightLogUtc, DateTime? NewestPhotoUtc);
+```
+
+A file is top-level when its parent directory equals the inspected folder
+(path-compare the directory name `Path.GetDirectoryName(file)` against the
+normalised root; `Path.TrimEndingDirectorySeparator` both sides,
+`OrdinalIgnoreCase` — same-volume enumeration returns consistent casing, and
+this comparison only ever runs on strings produced by one
+`Directory.EnumerateFiles` call over one root).
+
+Unchanged on purpose:
+
+- The `#328` per-kind newest-write timestamps stay **recursive**. Freshness
+  semantics shipped that way; not touched here.
+- The scan still has no early exit (timestamps need every file).
+
+## 2. Guards match the command's reach (#333, #338)
+
+In `WorkspaceViewModel.RunAsync`, each mode's guard reads the flag matching
+what the command will actually read:
+
+| Mode | Toggle | Guard requires | On "media only deeper" | On "no media at all" |
+|---|---|---|---|---|
+| Flight map | Include subfolders ON | `HasFlightLogs` | n/a (reachable) | existing message, "subfolders are included automatically" clause kept |
+| Flight map | OFF | `HasTopLevelFlightLogs` | "Those flight logs are in subfolders — turn on **Include subfolders**." | existing message **without** the subfolders clause |
+| Photo map | ON | `HasPhotos` | n/a | existing message, clause kept |
+| Photo map | OFF | `HasTopLevelPhotos` | "Those photos are in subfolders — turn on **Include subfolders**." | existing message without the clause |
+| Embed | (no toggle) | `HasTopLevelVideos` | "The videos are in subfolders, and Embed reads only the folder you pick — pick the subfolder that holds the videos." | existing message |
+
+Notes:
+
+- The existing not-found messages currently always say "subfolders are
+  included automatically" — untrue when the toggle is off. The clause becomes
+  conditional on the mode's recursive setting.
+- All guidance goes through the existing `Fail(...)` failure card; no new UI
+  element.
+- Mode-suggestion chips stay anywhere-based: the option defaults have
+  recursion ON, so suggestions remain honest, and a subfolder-only Embed
+  suggestion now lands on guidance instead of a hollow success.
+
+## 3. Busy from the first line of `RunAsync` (#340 §2)
+
+New observable `IsBusy` on `WorkspaceViewModel`:
+
+- Set `true` at the top of `RunAsync`, cleared in a `finally` around the whole
+  body — it spans the folder scan **and** the run (`Step == Running` starts
+  later, inside `ExecuteFlowAsync`).
+- `ClearFolder`, `SetFolderAsync` and the existing-map open path gate on
+  `IsBusy` instead of `Step == FlowStep.Running`.
+- The post-scan `SelectedFolder != folder` ownership re-check **stays** as
+  defence in depth; its test keeps passing.
+- `RunSetupAsync` (doctor) runs under the same flag — `RunAsync` is the single
+  entry point, so the `finally` covers it.
+- `SelectedMode` is a bare observable property (no command to gate), so
+  `RunAsync` additionally captures the mode **and** its options snapshot
+  before the awaited scan and uses only the captures afterwards — a mid-scan
+  mode or option change (programmatic or otherwise) cannot pair folder A with
+  mode/options B. The disabled strip (§4) closes the UI path; the captures
+  close the ViewModel path.
+
+## 4. Left column frozen while busy (#340 §1)
+
+`WorkspaceView.axaml`: bind `IsEnabled` of the folder card (SOURCE), the mode
+strip (MODE) and the options container (OPTIONS) to `!IsBusy`. The strip's
+promise — what is shown is what runs — holds for the duration of a run because
+nothing that feeds it can change. The strip's Copy button stays enabled.
+
+## 5. Injection seam (#340 §3)
+
+`WorkspaceViewModel` gains an optional ctor parameter following the existing
+`cliResolver`/`previewAvailable` pattern:
+
+```csharp
+Func<string, FolderContents>? folderInspector = null   // defaults to FolderInspector.Inspect
+```
+
+Both scan sites (`SetFolderAsync`, `RunAsync`) call it. Tests wrap it in a
+gate (e.g. block on a `TaskCompletionSource` inside `Task.Run`) to hold the
+scan open and prove mid-scan interactions are inert.
+
+## Out of scope (recorded decisions)
+
+- **CLI `embed` semantics unchanged:** zero matching MP4s remains a warning
+  with `ok: true` and exit 0. Scripts depend on exit codes; the
+  recursion mismatch is a GUI concept and is now caught before the CLI runs.
+- **#328 freshness stays recursive** (see §1).
+- No auto-fix buttons (flip-the-toggle-and-rerun was considered and rejected:
+  two different behaviours for map vs Embed, more code for marginal benefit).
+
+## Testing
+
+TDD throughout (current GUI suite: 318).
+
+- `FolderInspectorTests`: per-kind top-level vs nested-only vs both fixtures.
+- `WorkspaceViewModelTests`: guard matrix per mode × toggle state ×
+  media depth — blocked runs never invoke the CLI (FakeCli not called), and
+  each guidance string is pinned.
+- Busy window via the seam: while the scan is held open, `ClearFolder` and
+  `SetFolderAsync` are inert, and a mid-scan `SelectedMode`/option change does
+  not alter the executed argv (captures win); `IsBusy` raises change
+  notifications.
+- View-level (headless): folder card, mode strip and options container are
+  disabled while a run is in flight and re-enable after.

--- a/gui/DjiEmbed.Gui.Tests/ExistingMapFinderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ExistingMapFinderTests.cs
@@ -26,6 +26,7 @@ public class ExistingMapFinderTests : IDisposable
     private static FolderContents Contents(
         DateTime? newestFlightLog = null, DateTime? newestPhoto = null) =>
         new(newestFlightLog is not null, newestPhoto is not null, false,
+            newestFlightLog is not null, newestPhoto is not null, false,
             newestFlightLog, newestPhoto);
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FolderInspectorTests.cs
@@ -171,6 +171,32 @@ public class FolderInspectorTests : IDisposable
     }
 
     [Fact]
+    public void Distinguishes_top_level_media_from_nested_only()
+    {
+        Touch("DJI_0001.SRT");
+        Touch("sub", "IMG_0001.JPG");
+        Touch("sub", "DJI_0001.MP4");
+
+        var c = FolderInspector.Inspect(_dir);
+
+        Assert.True(c.HasTopLevelFlightLogs);
+        Assert.True(c.HasPhotos);
+        Assert.False(c.HasTopLevelPhotos);
+        Assert.True(c.HasVideos);
+        Assert.False(c.HasTopLevelVideos);
+    }
+
+    [Fact]
+    public void Trailing_separator_on_the_picked_folder_does_not_break_top_level()
+    {
+        Touch("IMG_0001.JPG");
+
+        var c = FolderInspector.Inspect(_dir + Path.DirectorySeparatorChar);
+
+        Assert.True(c.HasTopLevelPhotos);
+    }
+
+    [Fact]
     public void A_kind_that_is_absent_has_no_timestamp()
     {
         Touch("IMG_1.JPG");

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -939,4 +939,59 @@ public class WorkspaceScreenTests
         Assert.Contains("--redact drop", vm.CommandPreview);
         Assert.Contains("--container mkv", vm.CommandPreview);
     }
+
+    // #340: the CLI strip's promise — what is shown is what runs — only
+    // holds if nothing that feeds it can change during a run. SOURCE, MODE
+    // and the options panels freeze; the strip's Copy button does not
+    // (what it copies IS what is running).
+    [AvaloniaFact]
+    public async Task Left_column_freezes_while_a_run_is_in_flight()
+    {
+        var dir = Directory.CreateTempSubdirectory("djiembed-screen-busy").FullName;
+        try
+        {
+            var cli = FakeCli.WriteEventStream(dir,
+            [
+                """{"v": 1, "event": "start", "command": "flightmap", "total": 1}""",
+                """{"v": 1, "event": "result", "ok": true, "outputs": ["flightmap.html"], "summary": {}}""",
+            ]);
+            var gate = new TaskCompletionSource();
+            Func<string, FolderContents> inspect = _ => new FolderContents(
+                true, false, false, true, false, false, null, null);
+            var vm = new WorkspaceViewModel(cli, new DjiEmbedRunner(),
+                new FakeMapServer(null), () => { },
+                previewAvailable: static () => false,
+                folderInspector: d => inspect(d));
+            var window = ShowWorkspace(vm);
+            await vm.SetFolderAsync(dir);
+            inspect = _ =>
+            {
+                gate.Task.Wait();
+                return new FolderContents(
+                    true, false, false, true, false, false, null, null);
+            };
+
+            var run = vm.RunCommand.ExecuteAsync(null);
+            Dispatcher.UIThread.RunJobs();
+
+            var byName = (string name) => window.GetVisualDescendants()
+                .OfType<Control>().Single(c => c.Name == name);
+            Assert.False(byName("SourceCard").IsEnabled);
+            Assert.False(byName("ModeCard").IsEnabled);
+            Assert.False(byName("FlightOptionsPanel").IsEnabled);
+            Assert.False(byName("PhotoOptionsPanel").IsEnabled);
+            Assert.False(byName("EmbedOptionsPanel").IsEnabled);
+            Assert.True(byName("CopyCommandButton").IsEffectivelyEnabled);
+
+            gate.SetResult();
+            await run;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(byName("SourceCard").IsEnabled);
+            Assert.True(byName("ModeCard").IsEnabled);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -143,13 +143,27 @@ public class WorkspaceViewModelTests : IDisposable
     }
 
     [Fact]
-    public async Task Folder_drop_while_running_is_ignored()
+    public async Task Folder_drop_during_a_run_is_ignored()
     {
-        var vm = Vm("unused");
-        vm.Step = FlowStep.Running;
+        var cli = FakeCli.WriteEventStream(_dir, FlightmapStream);
+        Func<string, FolderContents> inspect =
+            _ => Contents(logs: true, topLogs: true);
+        var vm = Vm(cli, folderInspector: dir => inspect(dir));
+        var folder = MakeFolder(srt: true);
+        await vm.SetFolderAsync(folder);
+        var gate = new TaskCompletionSource();
+        inspect = _ =>
+        {
+            gate.Task.Wait();
+            return Contents(logs: true, topLogs: true);
+        };
+        var run = vm.RunCommand.ExecuteAsync(null);
+
         await vm.SetFolderAsync(MakeFolder(photos: true));
-        Assert.Null(vm.SelectedFolder);
-        Assert.Equal(FlowStep.Running, vm.Step);
+
+        Assert.Equal(folder, vm.SelectedFolder);
+        gate.SetResult();
+        await run;
     }
 
     private static readonly string[] FlightmapStream =
@@ -312,6 +326,69 @@ public class WorkspaceViewModelTests : IDisposable
         var argv = File.ReadAllLines(argsFile);
         Assert.Equal("flightmap", argv[0]);
         Assert.DoesNotContain("-r", argv);
+    }
+
+    // #340: the run's folder scan happens before ExecuteFlowAsync sets
+    // Step = Running, and that window used to leave every guard open. A
+    // run is busy from its first line, and it owns the inputs it captured.
+    [Fact]
+    public async Task The_whole_run_is_busy_from_its_first_line()
+    {
+        var cli = FakeCli.WriteEventStream(_dir, FlightmapStream);
+        Func<string, FolderContents> inspect =
+            _ => Contents(logs: true, topLogs: true);
+        var vm = Vm(cli, folderInspector: dir => inspect(dir));
+        var folder = MakeFolder(srt: true);
+        await vm.SetFolderAsync(folder);
+
+        var gate = new TaskCompletionSource();
+        inspect = _ =>
+        {
+            gate.Task.Wait();
+            return Contents(logs: true, topLogs: true);
+        };
+        var run = vm.RunCommand.ExecuteAsync(null);
+
+        Assert.True(vm.IsBusy);
+        vm.ClearFolderCommand.Execute(null);
+        Assert.Equal(folder, vm.SelectedFolder);      // inert while busy
+        await vm.SetFolderAsync("Z:/other");
+        Assert.Equal(folder, vm.SelectedFolder);      // inert while busy
+        Assert.False(vm.OpenExistingMapCommand.CanExecute(null));
+
+        gate.SetResult();
+        await run;
+        Assert.False(vm.IsBusy);
+        Assert.Equal(FlowStep.Done, vm.Step);
+    }
+
+    [Fact]
+    public async Task Mid_scan_edits_do_not_alter_the_executed_argv()
+    {
+        var argsFile = Path.Combine(_dir, "args-midscan.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, FlightmapStream);
+        Func<string, FolderContents> inspect =
+            _ => Contents(logs: true, topLogs: true);
+        var vm = Vm(cli, folderInspector: dir => inspect(dir));
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+
+        var gate = new TaskCompletionSource();
+        inspect = _ =>
+        {
+            gate.Task.Wait();
+            return Contents(logs: true, topLogs: true);
+        };
+        var run = vm.RunCommand.ExecuteAsync(null);
+        // The strip promised `flightmap <folder> -r` at press time; these
+        // edits arrive while the scan is still in flight.
+        vm.FlightOptions.Recursive = false;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        gate.SetResult();
+        await run;
+
+        var argv = File.ReadAllLines(argsFile);
+        Assert.Equal("flightmap", argv[0]);
+        Assert.Contains("-r", argv);
     }
 
     [Fact]
@@ -1019,7 +1096,13 @@ public class WorkspaceViewModelTests : IDisposable
     [Fact]
     public async Task The_open_command_is_disabled_while_a_run_is_in_flight()
     {
-        var vm = PreviewingVm();
+        var gate = new TaskCompletionSource();
+        Func<string, FolderContents> inspect =
+            _ => Contents(logs: true, topLogs: true);
+        var cli = FakeCli.WriteEventStream(_dir, FlightmapStream);
+        var vm = Vm(cli, mapServer: new FakeMapServer(FakeUrl),
+            previewAvailable: static () => true,
+            folderInspector: dir => inspect(dir));
         await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
         var map = vm.ExistingMaps[0];
         Assert.True(vm.OpenExistingMapCommand.CanExecute(map));
@@ -1028,11 +1111,18 @@ public class WorkspaceViewModelTests : IDisposable
         // told to, so assert the telling too.
         var notified = false;
         vm.OpenExistingMapCommand.CanExecuteChanged += (_, _) => notified = true;
+        inspect = _ =>
+        {
+            gate.Task.Wait();
+            return Contents(logs: true, topLogs: true);
+        };
 
-        vm.Step = FlowStep.Running;
+        var run = vm.RunCommand.ExecuteAsync(null);
 
         Assert.False(vm.OpenExistingMapCommand.CanExecute(map));
         Assert.True(notified);
+        gate.SetResult();
+        await run;
     }
 
     [Fact]
@@ -1480,19 +1570,29 @@ public class WorkspaceViewModelTests : IDisposable
     [Fact]
     public async Task Clearing_the_folder_is_inert_while_a_run_is_in_flight()
     {
-        var vm = Vm("unused");
+        var cli = FakeCli.WriteEventStream(_dir, FlightmapStream);
+        Func<string, FolderContents> inspect =
+            _ => Contents(logs: true, topLogs: true);
+        var vm = Vm(cli, folderInspector: dir => inspect(dir));
         var folder = MakeFolder(srt: true);
         await vm.SetFolderAsync(folder);
         vm.FlightOptions.Output = Path.Combine(_dir, "flightmap.html");
         vm.EmbedOptions.Output = Path.Combine(_dir, "copies");
-        vm.Step = FlowStep.Running;
+        var gate = new TaskCompletionSource();
+        inspect = _ =>
+        {
+            gate.Task.Wait();
+            return Contents(logs: true, topLogs: true);
+        };
+        var run = vm.RunCommand.ExecuteAsync(null);
 
         vm.ClearFolderCommand.Execute(null);
 
         Assert.Equal(folder, vm.SelectedFolder);
         Assert.Equal(Path.Combine(_dir, "flightmap.html"), vm.FlightOptions.Output);
         Assert.Equal(Path.Combine(_dir, "copies"), vm.EmbedOptions.Output);
-        Assert.Equal(FlowStep.Running, vm.Step);
+        gate.SetResult();
+        await run;
     }
 
     private sealed class ThrowingMapServer : IMapServer

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -12,7 +12,9 @@ public class WorkspaceViewModelTests : IDisposable
 
     private string MakeFolder(
         bool srt = false, bool photos = false, bool videos = false,
-        bool flightMap = false, bool photoMap = false)
+        bool flightMap = false, bool photoMap = false,
+        bool nestedSrt = false, bool nestedPhotos = false,
+        bool nestedVideos = false)
     {
         var folder = Path.Combine(_dir, "footage-" + Guid.NewGuid().ToString("N")[..6]);
         Directory.CreateDirectory(folder);
@@ -21,6 +23,14 @@ public class WorkspaceViewModelTests : IDisposable
         if (videos) File.WriteAllText(Path.Combine(folder, "DJI_0001.MP4"), "");
         if (flightMap) File.WriteAllText(Path.Combine(folder, "flightmap.html"), "");
         if (photoMap) File.WriteAllText(Path.Combine(folder, "photomap.html"), "");
+        if (nestedSrt || nestedPhotos || nestedVideos)
+        {
+            var sub = Directory.CreateDirectory(
+                Path.Combine(folder, "trip")).FullName;
+            if (nestedSrt) File.WriteAllText(Path.Combine(sub, "DJI_0002.SRT"), "");
+            if (nestedPhotos) File.WriteAllText(Path.Combine(sub, "IMG_2.JPG"), "");
+            if (nestedVideos) File.WriteAllText(Path.Combine(sub, "DJI_0002.MP4"), "");
+        }
         return folder;
     }
 
@@ -219,6 +229,89 @@ public class WorkspaceViewModelTests : IDisposable
         await vm.RunCommand.ExecuteAsync(null);
         Assert.Equal(FlowStep.Done, vm.Step);
         Assert.Contains("--link-originals", File.ReadAllText(argsFile));
+    }
+
+    // #333/#338: the folder scan is recursive, but embed reads one level
+    // and the map commands recurse only with -r. When the media is out of
+    // the selected command's reach the run must not start, and the message
+    // must speak GUI ("Include subfolders"), not CLI ("-r").
+    [Fact]
+    public async Task Flight_map_without_subfolders_blocks_nested_only_logs_with_guidance()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.SetFolderAsync(MakeFolder(nestedSrt: true));
+        vm.FlightOptions.Recursive = false;
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(
+            "Those flight logs are in subfolders — turn on Include subfolders.",
+            vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Photo_map_without_subfolders_blocks_nested_only_photos_with_guidance()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.SetFolderAsync(MakeFolder(nestedPhotos: true));
+        vm.PhotoOptions.Recursive = false;
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(
+            "Those photos are in subfolders — turn on Include subfolders.",
+            vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Embed_blocks_nested_only_videos_instead_of_a_hollow_success()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.SetFolderAsync(MakeFolder(nestedVideos: true));  // suggests Embed
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(
+            "The videos are in subfolders, and Embed reads only the folder "
+            + "you pick — pick the subfolder that holds the videos.",
+            vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Not_found_message_drops_the_subfolders_clause_when_the_toggle_is_off()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.FlightMap);
+        vm.FlightOptions.Recursive = false;
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.DoesNotContain("subfolders are included", vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Not_found_message_keeps_the_subfolders_clause_when_the_toggle_is_on()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.FlightMap);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Contains("subfolders are included automatically", vm.ErrorMessage);
+    }
+
+    // Positive control for the new guards: top-level media with the toggle
+    // off is within reach, so the run proceeds (and stays non-recursive).
+    [Fact]
+    public async Task Flight_map_without_subfolders_still_runs_on_top_level_logs()
+    {
+        var argsFile = Path.Combine(_dir, "args-fm-toponly.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, FlightmapStream);
+        var vm = Vm(cli);
+        await vm.SetFolderAsync(MakeFolder(srt: true, nestedSrt: true));
+        vm.FlightOptions.Recursive = false;
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        var argv = File.ReadAllLines(argsFile);
+        Assert.Equal("flightmap", argv[0]);
+        Assert.DoesNotContain("-r", argv);
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -30,10 +30,31 @@ public class WorkspaceViewModelTests : IDisposable
     // deterministic on every OS.
     private static WorkspaceViewModel Vm(
         string? cli, Func<string?>? cliResolver = null,
-        IMapServer? mapServer = null, Func<bool>? previewAvailable = null) =>
+        IMapServer? mapServer = null, Func<bool>? previewAvailable = null,
+        Func<string, FolderContents>? folderInspector = null) =>
         new(cli, new DjiEmbedRunner(), mapServer ?? new FakeMapServer(null),
             () => { }, cliResolver,
-            previewAvailable ?? (static () => false));
+            previewAvailable ?? (static () => false),
+            folderInspector);
+
+    private static FolderContents Contents(
+        bool logs = false, bool photos = false, bool videos = false,
+        bool topLogs = false, bool topPhotos = false, bool topVideos = false) =>
+        new(logs, photos, videos, topLogs, topPhotos, topVideos, null, null);
+
+    [Fact]
+    public async Task Folder_scans_go_through_the_injected_inspector()
+    {
+        var inspected = new List<string>();
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"), folderInspector: dir =>
+        {
+            inspected.Add(dir);
+            return Contents(photos: true, topPhotos: true);
+        });
+        await vm.SetFolderAsync("Z:/nowhere");           // scan site 1
+        await vm.RunCommand.ExecuteAsync(null);          // scan site 2
+        Assert.Equal(["Z:/nowhere", "Z:/nowhere"], inspected);
+    }
 
     [Fact]
     public void Starts_idle_with_flight_map_selected_and_no_folder()

--- a/gui/DjiEmbed.Gui/Services/FolderInspector.cs
+++ b/gui/DjiEmbed.Gui/Services/FolderInspector.cs
@@ -5,6 +5,7 @@ namespace DjiEmbed.Gui.Services;
 
 public sealed record FolderContents(
     bool HasFlightLogs, bool HasPhotos, bool HasVideos,
+    bool HasTopLevelFlightLogs, bool HasTopLevelPhotos, bool HasTopLevelVideos,
     DateTime? NewestFlightLogUtc, DateTime? NewestPhotoUtc);
 
 /// <summary>
@@ -22,6 +23,16 @@ public static class FolderInspector
         var hasVideos = false;
         DateTime? newestFlightLog = null;
         DateTime? newestPhoto = null;
+        // Per-kind top-level presence: embed reads one directory level and
+        // the map commands recurse only with -r, so the pre-flight guards
+        // need "is it where this command will look", not just "is it
+        // anywhere" (#333, #338). The walk echoes the directory argument as
+        // each file's prefix, so a plain string compare against the
+        // trimmed root is exact.
+        var root = Path.TrimEndingDirectorySeparator(directory);
+        var topFlightLogs = false;
+        var topPhotos = false;
+        var topVideos = false;
         // No early exit: the newest write time is only known once every
         // file has been seen. IgnoreInaccessible keeps an unreadable
         // subfolder from throwing out of the (async void) folder pick.
@@ -37,24 +48,31 @@ public static class FolderInspector
                      }))
         {
             var ext = Path.GetExtension(file);
+            var topLevel = string.Equals(
+                Path.GetDirectoryName(file), root,
+                StringComparison.OrdinalIgnoreCase);
             if (ext.Equals(".srt", StringComparison.OrdinalIgnoreCase))
             {
                 newestFlightLog = Newer(newestFlightLog, File.GetLastWriteTimeUtc(file));
+                topFlightLogs |= topLevel;
             }
             else if (ext.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
                      || ext.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
                      || ext.Equals(".dng", StringComparison.OrdinalIgnoreCase))
             {
                 newestPhoto = Newer(newestPhoto, File.GetLastWriteTimeUtc(file));
+                topPhotos |= topLevel;
             }
             else if (ext.Equals(".mp4", StringComparison.OrdinalIgnoreCase)
                      || ext.Equals(".mov", StringComparison.OrdinalIgnoreCase))
             {
                 hasVideos = true;
+                topVideos |= topLevel;
             }
         }
         return new FolderContents(
             newestFlightLog is not null, newestPhoto is not null, hasVideos,
+            topFlightLogs, topPhotos, topVideos,
             newestFlightLog, newestPhoto);
     }
 

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -86,6 +86,19 @@ public partial class WorkspaceViewModel : FlowViewModel
     [ObservableProperty]
     public partial bool AllGood { get; set; }
 
+    /// <summary>
+    /// True from the first line of a run to its last — including the folder
+    /// scan that precedes <see cref="FlowViewModel.Step"/> becoming
+    /// <see cref="FlowStep.Running"/> (#340). Everything that feeds a run
+    /// (folder, mode, options) freezes on this, so the CLI strip's promise
+    /// — what is shown is what runs — holds for the whole run.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsBusy { get; private set; }
+
+    partial void OnIsBusyChanged(bool value) =>
+        OpenExistingMapCommand.NotifyCanExecuteChanged();
+
     public ObservableCollection<SetupItem> SetupItems { get; } = [];
 
     /// <summary>Maps this folder already had when it was picked (#328) —
@@ -246,7 +259,7 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// </summary>
     public async Task SetFolderAsync(string folder)
     {
-        if (Step == FlowStep.Running)
+        if (IsBusy)
         {
             return;
         }
@@ -298,12 +311,11 @@ public partial class WorkspaceViewModel : FlowViewModel
     [RelayCommand]
     private void ClearFolder()
     {
-        // Inert once the flow proper is running: pulling the folder out from
-        // under a running job would also discard the output overrides. This
-        // covers only Step == Running — a run's folder scan happens BEFORE
-        // ExecuteFlowAsync sets that, and that earlier window is closed on
-        // the other side, by RunAsync's ownership re-check after the scan.
-        if (Step == FlowStep.Running)
+        // Inert while a run is in flight: pulling the folder out from under
+        // a running job would also discard the output overrides. IsBusy
+        // spans the run's folder scan too, and RunAsync's ownership
+        // re-check after the scan stays as defence in depth.
+        if (IsBusy)
         {
             return;
         }
@@ -347,7 +359,7 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>A run owns the preview pane while it is in flight. Private:
     /// it raises no PropertyChanged, so nothing may bind it — a button gets
     /// this gate from the command's own CanExecute.</summary>
-    private bool CanOpenExistingMap => Step != FlowStep.Running;
+    private bool CanOpenExistingMap => !IsBusy;
 
     /// <summary>
     /// Show a map the folder already had, in the pane a finished run would
@@ -464,6 +476,22 @@ public partial class WorkspaceViewModel : FlowViewModel
     [RelayCommand(CanExecute = nameof(CanRun))]
     private async Task RunAsync()
     {
+        // Busy for the run's entire lifetime, from before the folder scan:
+        // AsyncRelayCommand only covers the button, and Step only turns
+        // Running later, inside ExecuteFlowAsync (#340).
+        IsBusy = true;
+        try
+        {
+            await RunCoreAsync();
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task RunCoreAsync()
+    {
         CliPath ??= _cliResolver?.Invoke();
         if (!EnsureCli())
         {
@@ -471,7 +499,11 @@ public partial class WorkspaceViewModel : FlowViewModel
         }
         SetupItems.Clear();
         AllGood = false;
-        if (SelectedMode.Kind == WorkspaceModeKind.Setup)
+        // Captured with the folder and options below: SelectedMode is a
+        // bare bindable property, so only captures guarantee a mid-scan
+        // change cannot pair this run's folder with another mode.
+        var mode = SelectedMode;
+        if (mode.Kind == WorkspaceModeKind.Setup)
         {
             ResetPreview();
             await RunSetupAsync();
@@ -503,7 +535,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         // the map commands recurse only with -r — so each guard asks "is
         // the media where THIS command will look" (#333, #338), and the
         // guidance names the panel's own controls, never the CLI's flags.
-        switch (SelectedMode.Kind)
+        switch (mode.Kind)
         {
             case WorkspaceModeKind.FlightMap
                 when !(flight.Recursive

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -481,6 +481,12 @@ public partial class WorkspaceViewModel : FlowViewModel
         {
             return;
         }
+        // Option snapshots are taken BEFORE the awaited scan: the strip
+        // shows this exact command when the button is pressed, and a run
+        // owns what it showed — a mid-scan edit must not repair into it.
+        var flight = FlightOptions.ToOptions();
+        var photo = PhotoOptions.ToOptions();
+        var embed = EmbedOptions.ToOptions();
         var contents = await Task.Run(() => _inspectFolder(folder));
         // The scan runs before ExecuteFlowAsync sets Step = Running, so the
         // folder can be cleared or replaced underneath us while it is in
@@ -493,24 +499,40 @@ public partial class WorkspaceViewModel : FlowViewModel
         // Reset only now, past the awaited scan: clearing the preview any
         // earlier flashes the stale done card while a live map is still up.
         ResetPreview();
+        // The scan is recursive, but embed reads one directory level and
+        // the map commands recurse only with -r — so each guard asks "is
+        // the media where THIS command will look" (#333, #338), and the
+        // guidance names the panel's own controls, never the CLI's flags.
         switch (SelectedMode.Kind)
         {
-            case WorkspaceModeKind.FlightMap when !contents.HasFlightLogs:
-                Fail("No drone flight logs (.SRT) were found in that folder. "
-                     + "Pick the folder that contains your footage — "
-                     + "subfolders are included automatically.");
+            case WorkspaceModeKind.FlightMap
+                when !(flight.Recursive
+                    ? contents.HasFlightLogs : contents.HasTopLevelFlightLogs):
+                Fail(contents.HasFlightLogs
+                    ? "Those flight logs are in subfolders — turn on "
+                      + "Include subfolders."
+                    : "No drone flight logs (.SRT) were found in that "
+                      + "folder. Pick the folder that contains your footage"
+                      + (flight.Recursive
+                          ? " — subfolders are included automatically." : "."));
                 return;
             case WorkspaceModeKind.FlightMap:
                 await ExecuteFlowAsync(async () =>
                     await RunStepAsync(
                         "Mapping your flights…",
-                        CommandBuilder.FlightMap(folder, FlightOptions.ToOptions()))
+                        CommandBuilder.FlightMap(folder, flight))
                     && await PrimePreviewAsync());
                 return;
-            case WorkspaceModeKind.PhotoMap when !contents.HasPhotos:
-                Fail("No photos were found in that folder. Pick the folder "
-                     + "that contains your pictures — subfolders are "
-                     + "included automatically.");
+            case WorkspaceModeKind.PhotoMap
+                when !(photo.Recursive
+                    ? contents.HasPhotos : contents.HasTopLevelPhotos):
+                Fail(contents.HasPhotos
+                    ? "Those photos are in subfolders — turn on "
+                      + "Include subfolders."
+                    : "No photos were found in that folder. Pick the folder "
+                      + "that contains your pictures"
+                      + (photo.Recursive
+                          ? " — subfolders are included automatically." : "."));
                 return;
             case WorkspaceModeKind.PhotoMap:
                 // --link-originals defaults on: it's what powers the embedded
@@ -521,18 +543,25 @@ public partial class WorkspaceViewModel : FlowViewModel
                 await ExecuteFlowAsync(async () =>
                     await RunStepAsync(
                         "Mapping your photos…",
-                        CommandBuilder.PhotoMap(folder, PhotoOptions.ToOptions()))
+                        CommandBuilder.PhotoMap(folder, photo))
                     && await PrimePreviewAsync());
                 return;
-            case WorkspaceModeKind.Embed when !contents.HasVideos:
-                Fail("No videos (.MP4) were found in that folder. Pick the "
-                     + "folder that holds the drone videos together with "
-                     + "their .SRT flight logs.");
+            case WorkspaceModeKind.Embed when !contents.HasTopLevelVideos:
+                // embed has no recursive form at all, so subfolder-only
+                // videos would end as a "Done" card over a zero-file
+                // warning run (#338) — say so before spending the run.
+                Fail(contents.HasVideos
+                    ? "The videos are in subfolders, and Embed reads only "
+                      + "the folder you pick — pick the subfolder that "
+                      + "holds the videos."
+                    : "No videos (.MP4) were found in that folder. Pick the "
+                      + "folder that holds the drone videos together with "
+                      + "their .SRT flight logs.");
                 return;
             case WorkspaceModeKind.Embed:
                 await ExecuteFlowAsync(() => RunStepAsync(
                     "Embedding flight data into new copies…",
-                    CommandBuilder.Embed(folder, EmbedOptions.ToOptions())));
+                    CommandBuilder.Embed(folder, embed)));
                 return;
         }
     }

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -22,11 +22,13 @@ public partial class WorkspaceViewModel : FlowViewModel
     private readonly Action _openCliDiscovery;
     private readonly Func<string?>? _cliResolver;
     private readonly Func<bool> _previewAvailable;
+    private readonly Func<string, FolderContents> _inspectFolder;
 
     public WorkspaceViewModel(string? cli, DjiEmbedRunner runner,
         IMapServer mapServer, Action openCliDiscovery,
         Func<string?>? cliResolver = null,
-        Func<bool>? previewAvailable = null)
+        Func<bool>? previewAvailable = null,
+        Func<string, FolderContents>? folderInspector = null)
         : base(cli, runner, static () => { })
     {
         _mapServer = mapServer;
@@ -34,6 +36,10 @@ public partial class WorkspaceViewModel : FlowViewModel
         _cliResolver = cliResolver;
         _previewAvailable = previewAvailable
             ?? (static () => WebViewSupport.IsLikelyAvailable);
+        // The folder scan is injectable (#340): FolderInspector is static
+        // and deliberately has no early exit, so only a seam lets a test
+        // hold a scan open and prove the busy window is closed.
+        _inspectFolder = folderInspector ?? FolderInspector.Inspect;
         FlightOptions.PropertyChanged += (_, _) =>
             OnPropertyChanged(nameof(CommandPreview));
         PhotoOptions.PropertyChanged += (_, _) =>
@@ -249,7 +255,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         // and the map probe that depends on its timestamps.
         var scan = await Task.Run(() =>
         {
-            var contents = FolderInspector.Inspect(folder);
+            var contents = _inspectFolder(folder);
             return (contents, maps: ExistingMapFinder.Find(folder, contents));
         });
         // A second pick can land while this scan is in flight; the newest
@@ -475,7 +481,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         {
             return;
         }
-        var contents = await Task.Run(() => FolderInspector.Inspect(folder));
+        var contents = await Task.Run(() => _inspectFolder(folder));
         // The scan runs before ExecuteFlowAsync sets Step = Running, so the
         // folder can be cleared or replaced underneath us while it is in
         // flight. The newest pick owns the state — same rule SetFolderAsync

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -50,7 +50,12 @@
 
                 <StackPanel>
                     <TextBlock Classes="zone" Text="SOURCE" Margin="2,0,0,6" />
-                    <suki:GlassCard Padding="14">
+                    <!-- SOURCE, MODE and the options panels freeze while a
+                         run is in flight (#340): the CLI strip's promise is
+                         "what is shown is what runs", so nothing that feeds
+                         it may change until the run ends. -->
+                    <suki:GlassCard Name="SourceCard" Padding="14"
+                                    IsEnabled="{Binding !IsBusy}">
                         <StackPanel Spacing="10">
                             <Border Name="DropZone" DragDrop.AllowDrop="True"
                                     CornerRadius="10">
@@ -93,7 +98,8 @@
                     </suki:GlassCard>
 
                     <TextBlock Classes="zone" Text="MODE" />
-                    <suki:GlassCard Padding="8">
+                    <suki:GlassCard Name="ModeCard" Padding="8"
+                                    IsEnabled="{Binding !IsBusy}">
                         <StackPanel Spacing="6">
                             <ListBox Name="ModeStrip"
                                      ItemsSource="{Binding Modes}"
@@ -161,7 +167,8 @@
                     </Border>
 
                     <Border Name="FlightOptionsPanel"
-                            IsVisible="{Binding IsFlightMapMode}">
+                            IsVisible="{Binding IsFlightMapMode}"
+                            IsEnabled="{Binding !IsBusy}">
                         <StackPanel>
                             <TextBlock Classes="zone" Text="OPTIONS" />
                             <suki:GlassCard Padding="14">
@@ -283,7 +290,8 @@
                     </Border>
 
                     <Border Name="PhotoOptionsPanel"
-                            IsVisible="{Binding IsPhotoMapMode}">
+                            IsVisible="{Binding IsPhotoMapMode}"
+                            IsEnabled="{Binding !IsBusy}">
                         <StackPanel>
                             <TextBlock Classes="zone" Text="OPTIONS" />
                             <suki:GlassCard Padding="14">
@@ -421,7 +429,8 @@
                     </Border>
 
                     <Border Name="EmbedOptionsPanel"
-                            IsVisible="{Binding IsEmbedMode}">
+                            IsVisible="{Binding IsEmbedMode}"
+                            IsEnabled="{Binding !IsBusy}">
                         <StackPanel>
                             <TextBlock Classes="zone" Text="OPTIONS" />
                             <suki:GlassCard Padding="14">


### PR DESCRIPTION
Closes #333, closes #338, closes #340.

Design spec (first commit): `docs/superpowers/specs/2026-07-21-gui-recursion-mismatch-and-busy-gating-design.md` — approved in session 2026-07-21.

## The two root causes, fixed once

**1. A recursive folder scan fed commands that are not recursive (#333, #338).**
- `FolderInspector` now also reports per-kind **top-level** presence, in the same single pass (`FolderContents` grows `HasTopLevelFlightLogs/Photos/Videos`; the #328 timestamps stay recursive).
- Each pre-flight guard asks "is the media where *this* command will look": Flight/Photo map honour the **Include subfolders** toggle; Embed requires top-level videos. Out-of-reach media blocks the run with guidance in GUI language — *"Those photos are in subfolders — turn on Include subfolders."* / *"The videos are in subfolders, and Embed reads only the folder you pick — pick the subfolder that holds the videos."* — instead of the CLI's `-r` error (#333) or a hollow ✅ over a zero-file warning run (#338).
- The not-found messages only claim "subfolders are included automatically" when the toggle makes it true.

**2. Work outlived the UI state that owns it (#340).**
- New `IsBusy` spans a run from its **first line** — including the folder scan that precedes `Step == Running`. The clear/drop guards and the existing-map command key on it.
- `RunAsync` captures mode + option snapshots **before** the awaited scan, so a mid-scan edit can never pair folder A with mode/options B; the post-scan folder ownership re-check stays as defence in depth.
- SOURCE, MODE and the three options panels bind `IsEnabled` to `!IsBusy` — the CLI transparency strip can no longer repaint over a live process. The strip's Copy button stays enabled.
- The folder scan is injectable (`folderInspector` ctor parameter, same pattern as `cliResolver`), which is what makes the busy window testable at all.

## Tests

12 new (suite 328 → 340 total, 0 failed): depth-flag units, the full guard matrix with pinned guidance strings plus a positive control proving top-level media still runs non-recursively, gated-scan busy-window tests (mid-scan clear/drop/mode+option edits are inert or ignored, executed argv is the one the strip showed), and a headless view test that the left column freezes and re-enables while Copy stays live. Three existing tests that faked a run via the `Step` setter now drive a real gated run.

CLI `embed` exit semantics deliberately unchanged (scripts rely on them) — recorded in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XuoE5YY4z8jFGhSQXPrNZ