### PR TITLE
feat(geo): photomap hover previews become a viewer-side toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet._
+### Changed
+
+- Photo map hover previews are now opt-in ([#345]): pins go straight to the
+  click popup, and a "Hover previews" toggle in the map's top-right corner
+  (mouse devices only, remembered by the browser) restores the thumbnail
+  preview for skimming. Previously the preview was always on, which meant
+  interacting with a pin twice to reach its details and link.
+
+[#345]: https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/345
 
 ## [1.27.0] - 2026-07-20
 

--- a/docs/superpowers/specs/2026-07-21-photomap-hover-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-21-photomap-hover-toggle-design.md
@@ -1,0 +1,62 @@
+# Photomap: hover previews become a viewer-side toggle (issue #345)
+
+**Status:** approved 2026-07-21 (maintainer chose "viewer: in-map toggle" over
+an author-side CLI flag or both).
+
+## Problem
+
+Since #273, photomap pins show a sticky hover tooltip (thumbnail + filename)
+on mouse devices, and the full popup — details and the link to the original /
+360° viewer — still needs a click. On a mouse device the user therefore
+interacts with a pin **twice** to get anywhere. The preview is great for
+skimming a large map, but as the default it adds a step to the most common
+action: opening a photo.
+
+## Decision
+
+The map itself grows a small **"Hover previews"** toggle, default **OFF**.
+The map author's surface does not change: no CLI flag, no GUI panel row —
+every regenerated map simply behaves this way, and anyone the map is shared
+with gets the same choice.
+
+## Design
+
+1. **Control.** A custom Leaflet-style control (top-right, stacking with the
+   existing photos/panos legend when present): a label + checkbox reading
+   "Hover previews", styled like a `leaflet-control` card. Rendered **only
+   when the device really hovers** (`!TOUCH`, the #295 capability check) —
+   touch never had tooltips and must not gain a dead toggle.
+2. **Default OFF.** Markers bind only the click popup at creation. A
+   `setHoverPreviews(on)` function binds the existing #273 sticky tooltip
+   (`buildTooltip`, `{ sticky: true, direction: 'top' }`) to every marker,
+   or unbinds it; the marker loop keeps `(marker, feature)` pairs so the
+   toggle can rebind lazily.
+3. **Persistence.** `localStorage` key `djiembed-photomap-hover` (`'1'` =
+   on), read at load to set the initial checkbox state and binding. All
+   localStorage access is wrapped in try/catch — Safari private mode and
+   file:// contexts can throw — and failure silently means "not remembered".
+4. **Unchanged:** the tooltip content and CSS (#273), the touch tap-target
+   handling (#295), the click popup, the pano viewer, flightmap (it has no
+   hover previews), and the CLI/GUI surfaces.
+
+## Docs & changelog
+
+- `docs/user_guide.md` hover paragraph: previews are off by default; the
+  toggle sits in the map's top-right corner and is remembered by the
+  browser; phones/tablets still skip previews entirely.
+- CHANGELOG entry under Changed (default behaviour change for mouse users).
+
+## Testing
+
+String-level tests in `tests/test_geo_photomap_html.py`, same style as the
+existing #273/#295 pins (which move to the new shape rather than being
+deleted):
+
+- the control markup exists and is created only under `!TOUCH`;
+- markers do NOT bind tooltips unconditionally at creation (default off);
+- `setHoverPreviews` both binds and unbinds;
+- the `djiembed-photomap-hover` localStorage key is present and guarded;
+- `buildTooltip` content pins (#273) unchanged.
+
+Manual E2E with the Playwright browser on a real generated map: default no
+tooltip on hover; toggle on → tooltip appears; reload → remembered.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -104,10 +104,12 @@ The command scans the whole directory in one pass, so even large archives
 scan quickly (ExifTool must be installed — `dji-embed doctor` checks this).
 The HTML map clusters nearby shots into an expandable numbered marker so a
 dense session doesn't turn into a wall of overlapping pins; clicking a photo
-shows its EXIF thumbnail, filename, timestamp, altitude, and camera settings,
-and hovering a marker previews the thumbnail and filename without clicking.
-On phones and tablets there is no hover, so the map skips the previews and
-gives every pin a larger tap target instead — one tap opens the photo popup.
+shows its EXIF thumbnail, filename, timestamp, altitude, and camera settings.
+A **Hover previews** toggle in the map's top-right corner (off by default)
+adds a thumbnail-and-filename preview on mouse-over for skimming large maps;
+the browser remembers your choice. On phones and tablets there is no hover,
+so the map skips the toggle and previews entirely and gives every pin a
+larger tap target instead — one tap opens the photo popup.
 Sharing the map? `--popup-fields` chooses what the popups disclose (`none`,
 or a comma list of `name`, `timestamp`, `camera`, `altitude`); excluded
 details are left out of the HTML file entirely.

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -118,6 +118,9 @@ _TEMPLATE = """<!DOCTYPE html>
   .photo-popup img {{ max-width: 260px; display: block; margin-bottom: 4px; }}
   .photo-popup .photo-credit {{ opacity: .75; font-size: 90%; }}
   .photo-tooltip img {{ max-width: 160px; display: block; margin-bottom: 2px; }}
+  /* The hover-previews toggle (issue #345) borrows the layer-control card. */
+  .hover-control {{ padding: 5px 8px; font: 12px/1.4 sans-serif; }}
+  .hover-control label {{ cursor: pointer; user-select: none; }}
   /* Per-type markers (issue #283): blue dot = photo, orange dot = 360 pano.
      The same classes render the swatches in the layer-control legend, and
      the cluster tints derive from the same two custom properties. */
@@ -338,8 +341,7 @@ function buildPopup(f) {
 
 // Hover preview (issue #273): thumbnail + filename in a sticky tooltip so a
 // map can be skimmed without clicking every pin. Thumb-less points fall back
-// to a filename-only tooltip. Bound only when the device really hovers
-// (issue #295) — on touch the tooltip hijacked the first tap and hid the pin.
+// to a filename-only tooltip.
 function buildTooltip(f) {
   const p = f.properties || {};
   let html = '<div class="photo-tooltip">';
@@ -350,15 +352,36 @@ function buildTooltip(f) {
   return html;
 }
 
+// Hover previews are opt-in (issue #345): as the default they added a second
+// interaction before the popup's details and link. A small control (mouse
+// devices only — touch never had tooltips, #295) restores #273's skimming
+// tooltips, and the choice is remembered per browser. localStorage can throw
+// (Safari private mode, file://), so failing to remember is silent.
+const HOVER_KEY = 'djiembed-photomap-hover';
+const readHoverPref = () => {
+  try { return localStorage.getItem(HOVER_KEY) === '1'; } catch (e) { return false; }
+};
+const writeHoverPref = on => {
+  try { localStorage.setItem(HOVER_KEY, on ? '1' : '0'); } catch (e) {}
+};
+const allMarkers = [];
+function setHoverPreviews(on) {
+  for (const [marker, f] of allMarkers) {
+    if (on) {
+      marker.bindTooltip(() => buildTooltip(f), { sticky: true, direction: 'top' });
+    } else {
+      marker.unbindTooltip();
+    }
+  }
+}
+
 for (const f of points) {
   const c = f.geometry.coordinates;                  // [lon, lat, alt]
   latlngs.push([c[1], c[0]]);
   const pano = isPano(f);
   const marker = L.marker([c[1], c[0]], { icon: pano ? panoIcon : photoIcon })
     .bindPopup(() => buildPopup(f), { maxWidth: 300 });
-  if (!TOUCH) {
-    marker.bindTooltip(() => buildTooltip(f), { sticky: true, direction: 'top' });
-  }
+  allMarkers.push([marker, f]);
   (pano ? panoMarkers : photoMarkers).push(marker);
 }
 photoCluster.addLayers(photoMarkers);
@@ -373,6 +396,27 @@ if (photoMarkers.length && panoMarkers.length) {
     '<span class="photo-pin pin-pano pin-swatch"></span>360° panoramas':
       panoCluster
   }, { collapsed: false }).addTo(map);
+}
+if (!TOUCH) {
+  const HoverControl = L.Control.extend({
+    onAdd() {
+      const div = L.DomUtil.create(
+        'div', 'leaflet-control-layers hover-control');
+      div.innerHTML =
+        '<label><input type="checkbox" id="hover-toggle"> Hover previews</label>';
+      // Without this, a click on the checkbox also pans/zooms the map.
+      L.DomEvent.disableClickPropagation(div);
+      return div;
+    }
+  });
+  new HoverControl({ position: 'topright' }).addTo(map);
+  const hoverToggle = document.getElementById('hover-toggle');
+  hoverToggle.checked = readHoverPref();
+  if (hoverToggle.checked) setHoverPreviews(true);
+  hoverToggle.addEventListener('change', () => {
+    setHoverPreviews(hoverToggle.checked);
+    writeHoverPref(hoverToggle.checked);
+  });
 }
 if (latlngs.length > 1) {
   map.fitBounds(L.latLngBounds(latlngs).pad(0.1), { maxZoom: 17 });

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -117,12 +117,48 @@ def _tooltip_builder(html: str) -> str:
     return match.group(1)
 
 
-def test_html_markers_bind_hover_tooltip():
-    # Hover preview (issue #273): every marker gets a sticky tooltip so the
-    # map can be skimmed without clicking each pin.
+def test_html_hover_previews_are_off_by_default():
+    # Issue #345: hovering used to add a second interaction before the
+    # popup's details and link. Markers now bind only the click popup at
+    # creation; the tooltip binding lives solely in the opt-in toggle path.
     html = photos_to_html(POINTS, title="t")
-    assert "bindTooltip(" in html
-    assert "sticky: true" in html
+    # The dot keeps `unbindTooltip(` from matching as a substring.
+    assert html.count(".bindTooltip(") == 1
+    match = re.search(
+        r"function setHoverPreviews\(on\) \{(.*?)\n\}", html, re.DOTALL)
+    assert match, "setHoverPreviews function not found"
+    assert ".bindTooltip(" in match.group(1)
+
+
+def test_html_hover_toggle_binds_and_unbinds():
+    # Turning the toggle on restores exactly the #273 sticky tooltips;
+    # turning it off removes them again.
+    html = photos_to_html(POINTS, title="t")
+    match = re.search(
+        r"function setHoverPreviews\(on\) \{(.*?)\n\}", html, re.DOTALL)
+    assert match
+    body = match.group(1)
+    assert "bindTooltip(" in body
+    assert "sticky: true" in body
+    assert "unbindTooltip(" in body
+
+
+def test_html_hover_toggle_control_only_on_hover_devices():
+    # The control is a small Leaflet-style card labelled "Hover previews".
+    # Touch never had tooltips (#295), so it must not gain a dead toggle.
+    html = photos_to_html(POINTS, title="t")
+    assert "Hover previews" in html
+    assert re.search(r"if \(!TOUCH\) \{[\s\S]{0,700}Hover previews", html)
+
+
+def test_html_hover_preference_is_remembered_and_guarded():
+    # The choice persists per browser; localStorage can throw (Safari
+    # private mode, file://), so every access sits inside a try.
+    html = photos_to_html(POINTS, title="t")
+    assert "djiembed-photomap-hover" in html
+    assert "localStorage.getItem" in html
+    assert "localStorage.setItem" in html
+    assert "catch" in html
 
 
 def test_html_tooltip_shows_thumbnail_and_escaped_name():
@@ -294,13 +330,15 @@ def test_html_pano_cluster_anchor_offset_against_occlusion():
 # the tap meant for it. Touch gets no tooltips and a larger tap target instead.
 
 
-def test_html_touch_devices_detected_and_skip_hover_tooltips():
+def test_html_touch_devices_detected_and_skip_hover_previews():
     html = photos_to_html(PANO_POINTS, title="t")
     # Capability detection, not UA sniffing: no hover / coarse pointer.
     assert "matchMedia" in html
     assert "hover: none" in html
-    # Tooltip binding is gated on the touch check; popups stay unconditional.
-    assert re.search(r"if \(!TOUCH\)[\s\S]{0,120}bindTooltip\(", html)
+    # The hover-previews control (#345) is gated on the touch check —
+    # touch devices get neither tooltips nor the toggle. Popups stay
+    # unconditional.
+    assert re.search(r"if \(!TOUCH\) \{[\s\S]{0,700}Hover previews", html)
     assert "bindPopup(" in html
 
 


### PR DESCRIPTION
Closes #345. Spec (first commit): `docs/superpowers/specs/2026-07-21-photomap-hover-toggle-design.md` — maintainer chose the viewer-side toggle over an author-side CLI flag.

## What changes

Photomap's #273 hover preview (thumbnail + filename tooltip) is no longer the default. Pins go straight to the click popup — one interaction to the details and link. A small Leaflet-style **"Hover previews"** control in the map's top-right corner restores the skimming tooltips for whoever wants them, and the choice is remembered per browser (`localStorage`, guarded with try/catch for Safari private mode and `file://`).

- **Mouse devices only:** the control is gated on the same `!TOUCH` capability check as #295 — touch never had tooltips and doesn't gain a dead toggle. Touch behaviour (bigger tap targets, tap = popup) is unchanged.
- **No CLI flag, no GUI panel row:** the map author's surface is untouched; every regenerated map simply behaves this way, and anyone the map is shared with gets the same choice.
- Tooltip content/CSS, the click popup, the pano viewer and flightmap are all unchanged.

## Verification

- String-level tests (5 new/moved pins in `test_geo_photomap_html.py`, watched RED first): default-off (the only `.bindTooltip(` lives in the toggle path), bind-and-unbind, control gated on `!TOUCH`, storage key present and guarded; the #273 tooltip-content pins are untouched. Suite: 669 passed, ruff + mypy clean.
- Live E2E with a real Chromium (Playwright MCP) on a generated map: fresh load → toggle unchecked, hover shows nothing; toggle on → sticky tooltip with the filename appears; reload → remembered and active; toggle off → tooltips unbind and the open one fades out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XuoE5YY4z8jFGhSQXPrNZ
