### PR TITLE
feat(cli): extend --progress jsonl to convert, validate, and verify-sun

### DIFF
--- a/docs/PROGRESS_JSONL.md
+++ b/docs/PROGRESS_JSONL.md
@@ -1,7 +1,7 @@
 # `--progress jsonl` — machine-readable progress events
 
-`photomap`, `flightmap`, `embed`, `check`, and `doctor` accept
-`--progress jsonl`. In
+`photomap`, `flightmap`, `embed`, `check`, `doctor`, `convert`, `validate`,
+and `verify-sun` accept `--progress jsonl`. In
 this mode a command writes **one JSON object per line to stdout** and nothing
 else — human/informational output is suppressed, and warnings and log
 messages go to stderr. A non-zero exit code always means the run failed;
@@ -103,6 +103,36 @@ field, never by arrival order.
   code 0 (same reading rule as `embed`).
 - The opt-in online update check **never** runs under `--progress jsonl`;
   consent for going online stays interactive-only.
+
+### `convert`
+- Single-file mode: `start` carries `total: 1` and one `progress` event
+  fires for the input. Batch mode (`-b`): `start` has no `total` (the
+  directory is scanned inside the run); one `progress` event per candidate
+  file, `total` on the `progress` events.
+- Batch files whose telemetry cannot be read (`Mp4TelemetryError`) are
+  skipped with one `warning` each (`item` = file name); in single-file mode
+  the same failure is fatal (`error` event, non-zero exit).
+- `outputs` = absolute paths of every file written. `summary`:
+  `{"converted": N, "skipped": N, "format": "gpx"}`.
+
+### `validate`
+- No `progress` events; `start` has no `total`. One `warning` per issue
+  found. `outputs` is empty; `summary` is the full validation report
+  (`total_files`, `valid_pairs`, `issues`, `warnings`, `file_analyses`).
+- Findings are a report, not a command failure: a run with issues still
+  **exits 0** and ends in `result` with `"ok": true` — read
+  `summary.issues`. (Text mode keeps the non-zero `VALIDATION_ERROR` exit
+  for scripts.)
+- `--format json` cannot be combined with `--progress jsonl` (the `result`
+  summary already carries the full report).
+
+### `verify-sun`
+- No `progress` events. One `warning` per analysis flag (`night`,
+  `very_low_sun`, `sun_not_computable` — the flag name is the `message`).
+  Flags are findings about the footage, not failures: `"ok": true`.
+- `outputs` is empty; `summary` is the sun summary dict (`file`, `points`,
+  `sun_computed`, `utc_start`/`utc_end`, elevation/azimuth stats, `flags`).
+- `--format json` cannot be combined with `--progress jsonl`.
 
 ## Relation to `--log-json`
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -226,7 +226,8 @@ def _jsonl_terminal(
         raise
 
 
-# Shared by photomap/flightmap/embed/check. Contract: docs/PROGRESS_JSONL.md.
+# Shared by every progress-wired command (photomap/flightmap/embed/check/
+# doctor/convert/validate/verify-sun). Contract: docs/PROGRESS_JSONL.md.
 _progress_option = click.option(
     "--progress",
     "progress_mode",
@@ -447,6 +448,7 @@ def check(
     help="Opt-in: extract the HOME/launch point (operator location) into "
     "gpx/csv/geojson output. Subject to --redact.",
 )
+@_progress_option
 @click.option("-v", "--verbose", is_flag=True)
 @click.option("-q", "--quiet", is_flag=True)
 def convert(
@@ -462,6 +464,7 @@ def convert(
     footprint_interval: float,
     model: str | None,
     extract_home: bool,
+    progress_mode: str | None,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -470,66 +473,91 @@ def convert(
     The html format embeds the flight data but loads Leaflet and the map tiles
     from the internet, so the produced file needs a connection to render.
     """
+    progress = make_progress(progress_mode)
+    if progress.active:
+        quiet = True  # stdout belongs to the JSONL events
     setup_logging(verbose, quiet)
-
-    try:
-        offset = parse_utc_offset(tz_offset)
-    except ValueError as e:
-        raise click.BadParameter(str(e), param_hint="--tz-offset")
-
     src = Path(input)
-    if batch and not src.is_dir():
-        raise click.ClickException("--batch requires a directory input")
-
-    # -o pointing at an existing directory means "write <stem>.<ext> in there",
-    # matching embed -o semantics (#257).
-    if output is not None and Path(output).is_dir():
-        suffix = ".cot.xml" if command == "cot" else f".{command}"
-        output = str(Path(output) / (src.stem + suffix))
-
-    def run_one(srt: Path, out: str | None) -> None:
-        if command == "gpx":
-            extract_telemetry_to_gpx(srt, out, tz_offset=offset,
-                                     extract_home=extract_home, redact=redact)
-        elif command == "csv":
-            extract_telemetry_to_csv(srt, out, tz_offset=offset,
-                                     extract_home=extract_home, redact=redact)
-        elif command == "geojson":
-            convert_to_geojson(
-                srt, out, redact=redact,
-                footprint=footprint, footprint_interval=footprint_interval, model=model,
-                extract_home=extract_home,
-            )
-        elif command == "kml":
-            convert_to_kml(
-                srt, out, redact=redact,
-                footprint=footprint, footprint_interval=footprint_interval, model=model,
-            )
-        elif command == "cot":
-            convert_to_cot(
-                srt, out, redact=redact, tz_offset=offset,
-                interval=interval, cot_type=cot_type,
-            )
-        else:  # html
-            convert_to_html(srt, out, redact=redact)
-
-    if batch:
-        patterns = ("*.SRT", "*.srt", "*.MP4", "*.mp4", "*.MOV", "*.mov")
-        seen: set[Path] = set()
-        for pattern in patterns:
-            for path in src.glob(pattern):
-                if path in seen:
-                    continue
-                seen.add(path)
-                try:
-                    run_one(path, None)
-                except Mp4TelemetryError as e:
-                    click.echo(f"Skipping {path.name}: {e}", err=True)
-    else:
+    # Batch file count is unknown until the directory is scanned inside.
+    with _jsonl_terminal(progress, "convert", total=None if batch else 1):
         try:
-            run_one(src, output)
-        except Mp4TelemetryError as e:
-            raise click.ClickException(str(e))
+            offset = parse_utc_offset(tz_offset)
+        except ValueError as e:
+            raise click.BadParameter(str(e), param_hint="--tz-offset")
+
+        if batch and not src.is_dir():
+            raise click.ClickException("--batch requires a directory input")
+
+        # -o pointing at an existing directory means "write <stem>.<ext> in
+        # there", matching embed -o semantics (#257).
+        if output is not None and Path(output).is_dir():
+            suffix = ".cot.xml" if command == "cot" else f".{command}"
+            output = str(Path(output) / (src.stem + suffix))
+
+        def run_one(srt: Path, out: str | None) -> Path:
+            if command == "gpx":
+                return extract_telemetry_to_gpx(
+                    srt, out, tz_offset=offset,
+                    extract_home=extract_home, redact=redact)
+            elif command == "csv":
+                return extract_telemetry_to_csv(
+                    srt, out, tz_offset=offset,
+                    extract_home=extract_home, redact=redact)
+            elif command == "geojson":
+                return convert_to_geojson(
+                    srt, out, redact=redact,
+                    footprint=footprint, footprint_interval=footprint_interval,
+                    model=model, extract_home=extract_home,
+                )
+            elif command == "kml":
+                return convert_to_kml(
+                    srt, out, redact=redact,
+                    footprint=footprint, footprint_interval=footprint_interval,
+                    model=model,
+                )
+            elif command == "cot":
+                return convert_to_cot(
+                    srt, out, redact=redact, tz_offset=offset,
+                    interval=interval, cot_type=cot_type,
+                )
+            else:  # html
+                return convert_to_html(srt, out, redact=redact)
+
+        outputs: list[Path] = []
+        skipped = 0
+        if batch:
+            patterns = ("*.SRT", "*.srt", "*.MP4", "*.mp4", "*.MOV", "*.mov")
+            seen: set[Path] = set()
+            targets: list[Path] = []
+            for pattern in patterns:
+                for path in src.glob(pattern):
+                    if path not in seen:
+                        seen.add(path)
+                        targets.append(path)
+            for index, path in enumerate(targets, start=1):
+                progress.advance(index, len(targets), item=path.name)
+                try:
+                    outputs.append(run_one(path, None))
+                except Mp4TelemetryError as e:
+                    skipped += 1
+                    progress.warning(str(e), item=path.name)
+                    if not progress.active:
+                        click.echo(f"Skipping {path.name}: {e}", err=True)
+        else:
+            progress.advance(1, 1, item=src.name)
+            try:
+                outputs.append(run_one(src, output))
+            except Mp4TelemetryError as e:
+                raise click.ClickException(str(e))
+        progress.result(
+            ok=True,
+            outputs=[str(p.resolve()) for p in outputs],
+            summary={
+                "converted": len(outputs),
+                "skipped": skipped,
+                "format": command,
+            },
+        )
 
 
 @main.command()
@@ -1115,6 +1143,7 @@ def doctor(
     default="text",
     help="Output format for drift report",
 )
+@_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
 @click.pass_context
@@ -1123,21 +1152,45 @@ def validate(
     directory: str,
     drift_threshold: float,
     format: str,
+    progress_mode: str | None,
     verbose: bool,
     quiet: bool,
 ) -> None:
     """Validate SRT/MP4 pairs and generate drift analysis report."""
+    if progress_mode and format.lower() == "json":
+        raise click.UsageError(
+            "--format json cannot be combined with --progress jsonl (the "
+            "result event's summary already carries the full report)"
+        )
+    progress = make_progress(progress_mode)
+    if progress.active:
+        quiet = True  # stdout belongs to the JSONL events
     log_json = ctx.obj.get('log_json', False)
     setup_logging(verbose, quiet, log_json)
-    
+
+    if progress.active:
+        with _jsonl_terminal(progress, "validate"):
+            from .core.validator import validate_directory
+
+            validation_result = validate_directory(
+                Path(directory), drift_threshold=drift_threshold
+            )
+            # Findings are a report, not a command failure: one warning per
+            # issue, full report in the summary, exit 0 (text mode keeps
+            # ExitCode.VALIDATION_ERROR for scripts).
+            for issue in validation_result.get("issues", []):
+                progress.warning(issue)
+            progress.result(ok=True, outputs=[], summary=validation_result)
+        return
+
     try:
         from .core.validator import validate_directory
-        
+
         validation_result = validate_directory(
             Path(directory),
             drift_threshold=drift_threshold
         )
-        
+
         if format == "json" or log_json:
             click.echo(json.dumps(validation_result))
         else:
@@ -1183,6 +1236,7 @@ def validate(
     show_default=True,
     help="Output format",
 )
+@_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
 @click.pass_context
@@ -1191,6 +1245,7 @@ def verify_sun(
     srt: str,
     tz_offset: str,
     fmt: str,
+    progress_mode: str | None,
     verbose: bool,
     quiet: bool,
 ) -> None:
@@ -1199,8 +1254,30 @@ def verify_sun(
     Computes solar azimuth/elevation for each GPS point so analysts can compare
     shadow direction/length in the footage against the astronomical sun.
     """
+    if progress_mode and fmt.lower() == "json":
+        raise click.UsageError(
+            "--format json cannot be combined with --progress jsonl (the "
+            "result event's summary already carries the full report)"
+        )
+    progress = make_progress(progress_mode)
+    if progress.active:
+        quiet = True  # stdout belongs to the JSONL events
     log_json = ctx.obj.get("log_json", False)
     setup_logging(verbose, quiet, log_json)
+
+    if progress.active:
+        with _jsonl_terminal(progress, "verify-sun"):
+            try:
+                offset = parse_utc_offset(tz_offset)
+            except ValueError as e:
+                raise click.BadParameter(str(e), param_hint="--tz-offset")
+            sun_summary = summarize_sun(Path(srt), tz_offset=offset)
+            # Flags (night, very_low_sun, sun_not_computable) are findings
+            # about the footage, not command failures: warn and stay ok.
+            for flag in sun_summary["flags"]:
+                progress.warning(flag)
+            progress.result(ok=True, outputs=[], summary=sun_summary)
+        return
 
     try:
         offset = parse_utc_offset(tz_offset)

--- a/tests/test_progress_jsonl.py
+++ b/tests/test_progress_jsonl.py
@@ -439,6 +439,197 @@ def test_doctor_jsonl_missing_tool_warns_but_exits_zero(monkeypatch):
     assert result["summary"]["tools"]["ffmpeg"]["present"] is False
 
 
+# --- convert / validate / verify-sun (GUI 2.0 M4 prerequisite) ------------
+
+FLIGHT_TIMED = (
+    "1\n00:00:00,000 --> 00:00:01,000\n"
+    '<font size="28">FrameCnt: 1, DiffTime: 1000ms\n'
+    "2026-06-15 16:00:00.000\n"
+    "[latitude: 34.0] [longitude: -84.0] "
+    "[rel_alt: 1.000 abs_alt: 100.0]</font>\n\n"
+    "2\n00:00:01,000 --> 00:00:02,000\n"
+    '<font size="28">FrameCnt: 2, DiffTime: 1000ms\n'
+    "2026-06-15 16:00:01.000\n"
+    "[latitude: 34.001] [longitude: -84.001] "
+    "[rel_alt: 1.000 abs_alt: 101.0]</font>\n"
+)
+
+
+def test_convert_jsonl_happy_single_file(tmp_path):
+    src = tmp_path / "DJI_0001.SRT"
+    src.write_text(FLIGHT_A, encoding="utf-8")
+    res = CliRunner().invoke(
+        main, ["convert", "gpx", str(src), "--progress", "jsonl"]
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert events[0]["command"] == "convert" and events[0]["total"] == 1
+    progress = [e for e in events if e["event"] == "progress"]
+    assert len(progress) == 1 and progress[0]["item"] == "DJI_0001.SRT"
+    assert progress[0]["current"] == progress[0]["total"] == 1
+    last = events[-1]
+    assert last["ok"] is True
+    assert last["outputs"] == [str((tmp_path / "DJI_0001.gpx").resolve())]
+    assert last["summary"] == {"converted": 1, "skipped": 0, "format": "gpx"}
+
+
+def test_convert_jsonl_batch_warns_per_skipped_file(monkeypatch, tmp_path):
+    from dji_metadata_embedder import cli as cli_mod
+    from dji_metadata_embedder.mp4_telemetry import Mp4TelemetryError
+
+    def fake_gpx(srt_file, output_file=None, **kwargs):
+        path = Path(srt_file)
+        if path.suffix.upper() == ".MP4":
+            raise Mp4TelemetryError("no djmd stream")
+        out = path.with_suffix(".gpx")
+        out.write_text("<gpx/>", encoding="utf-8")
+        return out
+
+    monkeypatch.setattr(cli_mod, "extract_telemetry_to_gpx", fake_gpx)
+    (tmp_path / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
+    (tmp_path / "DJI_0002.MP4").write_bytes(b"fake")
+    res = CliRunner().invoke(
+        main, ["convert", "gpx", str(tmp_path), "-b", "--progress", "jsonl"]
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert "total" not in events[0]  # batch: count unknown until scanned
+    progress = [e for e in events if e["event"] == "progress"]
+    assert {p["item"] for p in progress} == {"DJI_0001.SRT", "DJI_0002.MP4"}
+    assert progress[-1]["total"] == 2
+    warnings = [e for e in events if e["event"] == "warning"]
+    assert len(warnings) == 1 and warnings[0]["item"] == "DJI_0002.MP4"
+    last = events[-1]
+    assert last["ok"] is True
+    assert last["outputs"] == [str((tmp_path / "DJI_0001.gpx").resolve())]
+    assert last["summary"] == {"converted": 1, "skipped": 1, "format": "gpx"}
+
+
+def test_convert_jsonl_fatal_error_event(tmp_path):
+    src = tmp_path / "DJI_0001.SRT"
+    src.write_text(FLIGHT_A, encoding="utf-8")
+    res = CliRunner().invoke(
+        main,
+        ["convert", "gpx", str(src), "--tz-offset", "banana",
+         "--progress", "jsonl"],
+    )
+    assert res.exit_code != 0
+    events = _events(res.stdout)
+    assert events[-1]["event"] == "error"
+    assert "tz-offset" in events[-1]["message"]
+
+
+def _mock_validate_directory(monkeypatch, canned):
+    from dji_metadata_embedder.core import validator
+
+    monkeypatch.setattr(
+        validator, "validate_directory", lambda directory, drift_threshold: canned
+    )
+
+
+def test_validate_jsonl_happy_directory(monkeypatch, tmp_path):
+    canned = {
+        "total_files": 2,
+        "valid_pairs": 2,
+        "issues": [],
+        "warnings": [],
+        "file_analyses": [],
+    }
+    _mock_validate_directory(monkeypatch, canned)
+    res = CliRunner().invoke(
+        main, ["validate", str(tmp_path), "--progress", "jsonl"]
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert events[0]["command"] == "validate"
+    assert "total" not in events[0]
+    assert not any(e["event"] == "warning" for e in events)
+    last = events[-1]
+    assert last["ok"] is True and last["outputs"] == []
+    assert last["summary"] == canned
+
+
+def test_validate_jsonl_issues_become_warnings_and_exit_zero(
+    monkeypatch, tmp_path
+):
+    canned = {
+        "total_files": 2,
+        "valid_pairs": 1,
+        "issues": ["No SRT file found for DJI_0002.mp4"],
+        "warnings": ["Drift above threshold in DJI_0001.mp4"],
+        "file_analyses": [],
+    }
+    _mock_validate_directory(monkeypatch, canned)
+    res = CliRunner().invoke(
+        main, ["validate", str(tmp_path), "--progress", "jsonl"]
+    )
+    # Findings are a report, not a command failure: exit 0 in progress mode
+    # (text mode keeps ExitCode.VALIDATION_ERROR for scripts).
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    warnings = [e for e in events if e["event"] == "warning"]
+    assert [w["message"] for w in warnings] == canned["issues"]
+    last = events[-1]
+    assert last["ok"] is True
+    assert last["summary"] == canned
+
+
+def test_validate_jsonl_rejects_format_json(tmp_path):
+    res = CliRunner().invoke(
+        main,
+        ["validate", str(tmp_path), "--format", "json", "--progress", "jsonl"],
+    )
+    assert res.exit_code != 0
+    assert "--format" in res.output and "--progress" in res.output
+
+
+def test_verify_sun_jsonl_happy_path(tmp_path):
+    src = tmp_path / "DJI_0001.SRT"
+    src.write_text(FLIGHT_TIMED, encoding="utf-8")
+    res = CliRunner().invoke(
+        main,
+        ["verify-sun", str(src), "--tz-offset", "+0", "--progress", "jsonl"],
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert events[0]["command"] == "verify-sun"
+    assert not any(e["event"] == "warning" for e in events)
+    last = events[-1]
+    assert last["ok"] is True and last["outputs"] == []
+    assert last["summary"]["file"] == "DJI_0001.SRT"
+    assert last["summary"]["points"] == 2
+    assert last["summary"]["sun_computed"] == 2
+    assert last["summary"]["flags"] == []
+
+
+def test_verify_sun_jsonl_flags_become_warnings(tmp_path):
+    src = tmp_path / "DJI_0001.SRT"
+    src.write_text(FLIGHT_A, encoding="utf-8")  # no absolute datetimes
+    res = CliRunner().invoke(
+        main,
+        ["verify-sun", str(src), "--tz-offset", "+0", "--progress", "jsonl"],
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    warnings = [e for e in events if e["event"] == "warning"]
+    assert len(warnings) == 1
+    assert "sun_not_computable" in warnings[0]["message"]
+    last = events[-1]
+    assert last["ok"] is True
+    assert last["summary"]["flags"] == ["sun_not_computable"]
+
+
+def test_verify_sun_jsonl_rejects_format_json(tmp_path):
+    src = tmp_path / "DJI_0001.SRT"
+    src.write_text(FLIGHT_A, encoding="utf-8")
+    res = CliRunner().invoke(
+        main,
+        ["verify-sun", str(src), "--format", "json", "--progress", "jsonl"],
+    )
+    assert res.exit_code != 0
+    assert "--format" in res.output and "--progress" in res.output
+
+
 def test_doctor_jsonl_never_runs_the_online_update_check(monkeypatch):
     # Consent for going online is interactive-only; a machine consumer of
     # the event stream must never trigger the network path.


### PR DESCRIPTION
## Summary

The GUI 2.0 M4 prerequisite ("Ships before M4" in the workspace spec): `convert`, `validate`, and `verify-sun` now speak the JSONL progress contract, so the upcoming Convert and Verify GUI modes can drive them the same way as embed/photomap/flightmap/check.

- **convert** — `start` carries `total: 1` in single-file mode; batch scans inside the run (progress events carry the total). A batch file whose telemetry can't be read (`Mp4TelemetryError`) is skipped with a `warning`; single-file it stays fatal. `outputs` lists every written file (absolute); summary `{converted, skipped, format}`.
- **validate** — findings are a report, not a command failure: one `warning` per issue, the full validation report as the `result` summary, **exit 0** in progress mode. Text mode keeps `VALIDATION_ERROR` for scripts.
- **verify-sun** — analysis flags (`night`, `very_low_sun`, `sun_not_computable`) become `warning` events; summary is the sun dict; `ok` stays true.
- Both report commands reject `--format json` + `--progress jsonl` (same shape as photomap rejecting `--serve`).
- `--tz-offset` parsing moved inside `_jsonl_terminal` so a bad value surfaces as an `error` event.

docs/PROGRESS_JSONL.md gains per-command sections for all three.

## Test plan

- 9 new golden tests in `tests/test_progress_jsonl.py` (TDD, watched red): happy paths, batch skip warning, fatal tz-offset, validate issues→warnings+exit 0, sun flag→warning, both `--format json` rejections. Every line schema-validated as before.
- Full suite: 687 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XuoE5YY4z8jFGhSQXPrNZ