### PR TITLE
GUI 2.0 M4a: single-file sources + Convert mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,9 @@ task-flow pages. The mode strip tops out at six modes (Embed, Flight map,
 Photo map, Convert, Verify, Setup); M1 wires up four (Flight map, Photo map,
 Embed, Setup), with Convert and Verify joining in M4. Options stay curated,
 not exhaustive: they arrive in M3+, one *Advanced* expander per mode for the
-long tail, exotic flags remain CLI-only. A WebView is now allowed, but
+long tail, exotic flags remain CLI-only. As of M4a, the SOURCE door also
+accepts a single telemetry file (`.SRT`/`.MP4`/`.MOV`), not just a folder,
+and Convert turns it (or a folder) into GPX/CSV/GeoJSON/KML/an HTML map/CoT. A WebView is now allowed, but
 solely for the preview pane (arrives M2) — no other embedded browser
 surface. There is still no settings dialog; the only state the app persists
 is MRU folders and window bounds. The thin-frontend architecture is

--- a/HELP.md
+++ b/HELP.md
@@ -34,9 +34,12 @@ Free, open-source (MIT) tool for DJI drone footage. Everything runs locally.
 Two ways to use it — same engine:
 
 1. **Windows app** ("DJI Metadata Embedder"): install, open, drop a folder,
-   pick a mode (*Flight map*, *Photo map*, *Embed telemetry*, *Setup*), and
-   press the action button; finished maps render right in the app's preview
-   pane, with an *Open in browser* pop-out. No terminal.
+   pick a mode (*Flight map*, *Photo map*, *Embed telemetry*,
+   *Convert telemetry*, *Setup*), and press the action button; finished maps
+   render right in the app's preview pane, with an *Open in browser* pop-out.
+   No terminal. The workspace also accepts a single telemetry file
+   (`.SRT`/`.MP4`/`.MOV`) as the source, and *Convert telemetry* turns it
+   (or a folder) into GPX, CSV, GeoJSON, KML, an HTML map, or CoT.
 2. **`dji-embed` command line**: every feature, all platforms. The Windows
    app's installer puts `dji-embed` on your PATH automatically.
 

--- a/docs/superpowers/specs/2026-07-21-gui-m4a-source-file-and-convert-mode-design.md
+++ b/docs/superpowers/specs/2026-07-21-gui-m4a-source-file-and-convert-mode-design.md
@@ -1,0 +1,106 @@
+# GUI M4a — single-file sources + Convert mode
+
+*Design round 2026-07-21 (Marcus + Claude). Amends nothing; implements the
+Convert row of the mode-curation table in the GUI 2.0 workspace spec
+(2026-07-18), plus the source-area lift that row requires. Verify (M4b) is a
+separate spec.*
+
+## Decisions taken in the round
+
+- **Source lift = one slot, file OR folder.** The SOURCE area keeps exactly
+  one selected item; it may now be a single telemetry file where the mode
+  allows it. The spec's "removable chips" plural is deliberately not built:
+  only Check-metadata could ever use N items, and folder expansion covers
+  that in M4b. Rejected: a multi-chip model (states multiply for no user
+  win) and a per-mode file picker inside the options panel (splits source
+  selection across two places, breaks drag-drop consistency).
+- **M4 ships as two PRs.** M4a = this spec. M4b = Verify mode.
+
+## Source model
+
+- `WorkspaceMode` replaces `NeedsFolder` with `SourceKinds` (a `[Flags]`
+  enum: `None`, `Folder`, `File`). Existing modes are `Folder`; Setup is
+  `None`; Convert is `Folder | File`.
+- `WorkspaceViewModel` gains `SelectedFile` (`string?`) beside
+  `SelectedFolder`, **mutually exclusive** — setting either non-null clears
+  the other. One source chip shows whichever is set (file chip shows the
+  file name, folder chip unchanged); its ✕ runs `ClearSource` (the renamed
+  `ClearFolder`), which clears both plus the folder-derived state it already
+  clears today.
+- `SetFile(string path)`: IsBusy-gated like `SetFolderAsync`; no
+  FolderInspector scan, no existing-maps probe (both stay folder-only);
+  clears `ExistingMaps`, outputs/warnings, output overrides, preview;
+  `Step = Pick`; sets `SuggestedMode` = Convert and selects it (Convert is
+  the only file-accepting mode in M4a). Synchronous — there is no scan to
+  race, so no overtake re-check is needed.
+- **Drag-drop**: `FolderPicking.EnableDrop` currently keeps only dropped
+  directories. It grows a file branch: a dropped `.srt`/`.mp4`/`.mov` file
+  routes to an `onFile` callback; anything else is still ignored. Folder
+  drops keep priority when a drop contains both.
+- **Browse**: the source card gets a second button — "Choose folder…"
+  (today's) and "Choose file…" (`OpenFilePickerAsync`, filter
+  `*.srt;*.SRT;*.mp4;*.MP4;*.mov;*.MOV`, single select), exposed through a
+  `FilePicker` seam on `WorkspaceView` in the `SavePicker` mould so
+  headless tests can drive it.
+
+## Mode/source mismatch guards (#346 pattern)
+
+`CanRun` becomes "the mode needs no source, or a source of *any* kind is
+selected" — the button stays lit and the run blocks with guidance, matching
+the recursion-mismatch design:
+
+- Folder-only mode + file selected → `Fail` with a pinned string, e.g.
+  Flight map: "Flight map works on a folder of footage — pick the folder
+  that holds your flights, not a single file." (analogous wording per mode;
+  exact strings pinned by tests, GUI language, never CLI flags).
+- Convert + folder guard: `convert -b` globs **top-level** `*.SRT/MP4/MOV`
+  only, so the guard requires `HasTopLevelFlightLogs || HasTopLevelVideos`;
+  subfolder-only media gets "…are in subfolders — Convert reads only the
+  folder you pick; pick the subfolder that holds the files." (the #333
+  lesson; Convert has no recursive flag at all).
+
+## Convert mode
+
+- `WorkspaceModeKind.Convert`, card title "Convert telemetry", verb
+  "Convert", failure message "Something went wrong while converting the
+  telemetry.", strip position between Embed and Setup. Never auto-suggested
+  for folder drops (flightmap > photomap > embed order unchanged); always
+  suggested for file drops.
+- **Options** (record `ConvertTelemetryOptions` + `ConvertOptionsViewModel`,
+  VM property `ConvertOptions` — the M3d naming convention):
+  - Curated: **Format** (GPX default; CSV, GeoJSON, KML, HTML map, CoT) and
+    **Privacy** (Keep / Fuzz ~100 m / Drop) — reusing M3d's three-value
+    enum, promoted from `EmbedPrivacy` to a shared `TelemetryPrivacy` in
+    its own file (the minimal M4 revisit of the "shared shapes" note; no
+    base-class extraction).
+  - Advanced: **Timezone** (M3b-style text, `--tz-offset`); **Footprints**
+    toggle + interval slider + **Model** field, *visible only for
+    GeoJSON/KML* (`--footprint`, `--footprint-interval`, `--model`); **CoT
+    interval + type**, *visible only for CoT* (`--interval`, `--cot-type`);
+    **Save as** override via the existing `SavePicker` seam, *single-file
+    sources only* — the CLI's batch loop has no `-o` (each output lands
+    next to its source), so the control is hidden for folder sources.
+  - `--extract-home` stays CLI-only (privacy-sensitive opt-in, same call
+    as M3d's `--overwrite`).
+- **`CommandBuilder.Convert(source, isFolder, options)`** feeds run + strip.
+  Defaults invariant: untouched = `convert gpx <folder> -b` /
+  `convert gpx <file>`. Flags emit only off-default (house style). The idle
+  strip placeholder shows the folder form (`convert gpx <folder> -b`) —
+  folders are the primary flow; picking a file flips the strip to the file
+  form.
+- **Run/done**: runner unchanged — PR #349 gave `convert` the JSONL
+  contract (batch progress events drive `ProgressDetail`; per-file
+  `Mp4TelemetryError` skips arrive as `warning` events into the existing
+  expander; `outputs` = absolute written paths). Running message
+  "Converting…". Done state: `PrimePreviewAsync` already previews the first
+  `.html` output, so **HTML format gets the inline map preview for free**;
+  every other format shows the done card (outputs + summary).
+
+## Testing
+
+House pattern throughout: TDD; CommandBuilder golden tests (option state in,
+argv out, defaults invariant); guard tests with pinned strings; named
+controls + `Assert.Same(vm.X, control.Command)` binding-identity checks for
+the new panel; mismatch guards driven through real gated runs via the
+`folderInspector` seam; drop-handler file/folder routing unit-tested against
+`FolderPicking`. Suite baseline 340.

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -446,4 +446,79 @@ public class CommandBuilderTests
              "--output", "/out/copies"],
             CommandBuilder.Embed("/x", opts));
     }
+
+    [Fact]
+    public void Convert_defaults_folder_is_bare_batch_gpx()
+        => Assert.Equal(["convert", "gpx", "F", "-b"],
+            CommandBuilder.Convert("F", batch: true, ConvertTelemetryOptions.Defaults));
+
+    [Fact]
+    public void Convert_defaults_file_is_bare_gpx()
+        => Assert.Equal(["convert", "gpx", "clip.SRT"],
+            CommandBuilder.Convert("clip.SRT", batch: false,
+                ConvertTelemetryOptions.Defaults));
+
+    [Fact]
+    public void Convert_full_options_emit_in_fixed_order()
+    {
+        var opts = ConvertTelemetryOptions.Defaults with
+        {
+            Format = "kml", Privacy = TelemetryPrivacy.Fuzz, TzOffset = "+02:00",
+            Footprints = true, FootprintInterval = 5, Model = "air3",
+        };
+        Assert.Equal(
+            ["convert", "kml", "clip.SRT", "--redact", "fuzz",
+             "--tz-offset", "+02:00", "--footprint",
+             "--footprint-interval", "5", "--model", "air3"],
+            CommandBuilder.Convert("clip.SRT", batch: false, opts));
+    }
+
+    [Fact]
+    public void Convert_footprint_flags_only_reach_formats_that_take_them()
+    {
+        // --footprint is a geojson/kml flag; on gpx the CLI would reject it.
+        var opts = ConvertTelemetryOptions.Defaults with { Footprints = true };
+        Assert.DoesNotContain("--footprint",
+            CommandBuilder.Convert("F", batch: true, opts));
+    }
+
+    [Fact]
+    public void Convert_cot_settings_only_reach_cot()
+    {
+        var cot = ConvertTelemetryOptions.Defaults with
+        { Format = "cot", CotInterval = 2.5, CotType = "a-f-A" };
+        Assert.Equal(
+            ["convert", "cot", "F", "-b", "--interval", "2.5",
+             "--cot-type", "a-f-A"],
+            CommandBuilder.Convert("F", batch: true, cot));
+        var gpx = cot with { Format = "gpx" };
+        Assert.DoesNotContain("--interval",
+            CommandBuilder.Convert("F", batch: true, gpx));
+    }
+
+    [Fact]
+    public void Convert_output_applies_to_single_files_only()
+    {
+        // The CLI's batch loop has no -o: every output lands beside its source.
+        var opts = ConvertTelemetryOptions.Defaults with { Output = "out.gpx" };
+        Assert.Equal(["convert", "gpx", "clip.SRT", "--output", "out.gpx"],
+            CommandBuilder.Convert("clip.SRT", batch: false, opts));
+        Assert.DoesNotContain("--output",
+            CommandBuilder.Convert("F", batch: true, opts));
+    }
+
+    [Fact]
+    public void Convert_auto_and_blank_tz_are_omitted()
+    {
+        foreach (var tz in new[] { "", "  ", "auto", "AUTO" })
+        {
+            Assert.DoesNotContain("--tz-offset", CommandBuilder.Convert(
+                "F", true, ConvertTelemetryOptions.Defaults with { TzOffset = tz }));
+        }
+    }
+
+    [Fact]
+    public void Build_convert_arm_uses_defaults_batch()
+        => Assert.Equal(["convert", "gpx", "F", "-b"],
+            CommandBuilder.Build(WorkspaceModeKind.Convert, "F"));
 }

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -335,7 +335,7 @@ public class CommandBuilderTests
 
     // Every option switched on; shared by the two CLI-only guards below.
     private static readonly EmbedTelemetryOptions EverythingOn = new(
-        Privacy: EmbedPrivacy.Drop, Container: "mkv", ExtractHome: true,
+        Privacy: TelemetryPrivacy.Drop, Container: "mkv", ExtractHome: true,
         UseExifTool: true, AudioSidecar: true, DatAuto: true,
         Output: "/out/copies");
 
@@ -356,10 +356,10 @@ public class CommandBuilderTests
     }
 
     [Theory]
-    [InlineData(EmbedPrivacy.Fuzz, "fuzz")]
-    [InlineData(EmbedPrivacy.Drop, "drop")]
+    [InlineData(TelemetryPrivacy.Fuzz, "fuzz")]
+    [InlineData(TelemetryPrivacy.Drop, "drop")]
     public void Embed_passes_a_non_default_privacy_stance(
-        EmbedPrivacy privacy, string value)
+        TelemetryPrivacy privacy, string value)
     {
         var argv = CommandBuilder.Embed("/x",
             EmbedTelemetryOptions.Defaults with { Privacy = privacy });
@@ -439,7 +439,7 @@ public class CommandBuilderTests
     [Fact]
     public void Embed_all_options_compose_in_a_stable_order()
     {
-        var opts = EverythingOn with { Privacy = EmbedPrivacy.Fuzz };
+        var opts = EverythingOn with { Privacy = TelemetryPrivacy.Fuzz };
         Assert.Equal(
             ["embed", "/x", "--redact", "fuzz", "--container", "mkv",
              "--extract-home", "--exiftool", "--audio-sidecar", "--dat-auto",

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -476,7 +476,8 @@ public class CommandBuilderTests
     [Fact]
     public void Convert_footprint_flags_only_reach_formats_that_take_them()
     {
-        // --footprint is a geojson/kml flag; on gpx the CLI would reject it.
+        // --footprint is meaningless on gpx: Click declares it on the shared
+        // convert command, but run_one silently never forwards it there.
         var opts = ConvertTelemetryOptions.Defaults with { Footprints = true };
         Assert.DoesNotContain("--footprint",
             CommandBuilder.Convert("F", batch: true, opts));
@@ -516,6 +517,48 @@ public class CommandBuilderTests
                 "F", true, ConvertTelemetryOptions.Defaults with { TzOffset = tz }));
         }
     }
+
+    [Fact]
+    public void Convert_drop_privacy_emits_redact_drop()
+        => Assert.Equal(["convert", "gpx", "F", "-b", "--redact", "drop"],
+            CommandBuilder.Convert("F", batch: true,
+                ConvertTelemetryOptions.Defaults with { Privacy = TelemetryPrivacy.Drop }));
+
+    [Fact]
+    public void Convert_footprints_at_default_interval_and_empty_model_emit_footprint_alone()
+    {
+        var opts = ConvertTelemetryOptions.Defaults with
+        { Format = "geojson", Footprints = true };
+        Assert.Equal(["convert", "geojson", "F", "-b", "--footprint"],
+            CommandBuilder.Convert("F", batch: true, opts));
+    }
+
+    [Fact]
+    public void Convert_cot_at_all_defaults_emits_no_cot_flags()
+        => Assert.Equal(["convert", "cot", "F", "-b"],
+            CommandBuilder.Convert("F", batch: true,
+                ConvertTelemetryOptions.Defaults with { Format = "cot" }));
+
+    [Fact]
+    public void Convert_trims_model()
+    {
+        var opts = ConvertTelemetryOptions.Defaults with
+        { Format = "kml", Footprints = true, Model = " air3 " };
+        Assert.Equal(["convert", "kml", "F", "-b", "--footprint", "--model", "air3"],
+            CommandBuilder.Convert("F", batch: true, opts));
+    }
+
+    [Fact]
+    public void Convert_cot_type_trimmed_to_the_default_is_omitted()
+        => Assert.Equal(["convert", "cot", "F", "-b"],
+            CommandBuilder.Convert("F", batch: true, ConvertTelemetryOptions.Defaults with
+            { Format = "cot", CotType = " a-n-A " }));
+
+    [Fact]
+    public void Convert_blank_output_on_a_single_file_is_omitted()
+        => Assert.Equal(["convert", "gpx", "clip.SRT"],
+            CommandBuilder.Convert("clip.SRT", batch: false,
+                ConvertTelemetryOptions.Defaults with { Output = "  " }));
 
     [Fact]
     public void Build_convert_arm_uses_defaults_batch()

--- a/gui/DjiEmbed.Gui.Tests/EmbedTelemetryOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/EmbedTelemetryOptionsViewModelTests.cs
@@ -16,7 +16,7 @@ public class EmbedTelemetryOptionsViewModelTests
     {
         var vm = new EmbedTelemetryOptionsViewModel();
         Assert.Equal("mp4", vm.SelectedContainer.Key);
-        Assert.Equal(EmbedPrivacy.Keep, vm.SelectedPrivacy.Value);
+        Assert.Equal(TelemetryPrivacy.Keep, vm.SelectedPrivacy.Value);
         Assert.False(vm.ExtractHome);
         Assert.False(vm.UseExifTool);
         Assert.False(vm.AudioSidecar);
@@ -29,7 +29,7 @@ public class EmbedTelemetryOptionsViewModelTests
     {
         var vm = new EmbedTelemetryOptionsViewModel();
         Assert.Equal(
-            [EmbedPrivacy.Keep, EmbedPrivacy.Fuzz, EmbedPrivacy.Drop],
+            [TelemetryPrivacy.Keep, TelemetryPrivacy.Fuzz, TelemetryPrivacy.Drop],
             vm.PrivacyOptions.Select(p => p.Value));
     }
 
@@ -53,10 +53,10 @@ public class EmbedTelemetryOptionsViewModelTests
         };
         vm.SelectedContainer = vm.Containers.Single(c => c.Key == "mkv");
         vm.SelectedPrivacy =
-            vm.PrivacyOptions.Single(p => p.Value == EmbedPrivacy.Drop);
+            vm.PrivacyOptions.Single(p => p.Value == TelemetryPrivacy.Drop);
 
         Assert.Equal(new EmbedTelemetryOptions(
-            Privacy: EmbedPrivacy.Drop,
+            Privacy: TelemetryPrivacy.Drop,
             Container: "mkv",
             ExtractHome: true,
             UseExifTool: true,
@@ -79,11 +79,11 @@ public class EmbedTelemetryOptionsViewModelTests
         Assert.False(vm.ShowsHomeEmptiedNote);          // Keep + extracting
 
         vm.SelectedPrivacy =
-            vm.PrivacyOptions.Single(p => p.Value == EmbedPrivacy.Fuzz);
+            vm.PrivacyOptions.Single(p => p.Value == TelemetryPrivacy.Fuzz);
         Assert.False(vm.ShowsHomeEmptiedNote);          // Fuzz still records one
 
         vm.SelectedPrivacy =
-            vm.PrivacyOptions.Single(p => p.Value == EmbedPrivacy.Drop);
+            vm.PrivacyOptions.Single(p => p.Value == TelemetryPrivacy.Drop);
         Assert.True(vm.ShowsHomeEmptiedNote);           // Drop + extracting
 
         vm.ExtractHome = false;
@@ -98,7 +98,7 @@ public class EmbedTelemetryOptionsViewModelTests
         vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
 
         vm.SelectedPrivacy =
-            vm.PrivacyOptions.Single(p => p.Value == EmbedPrivacy.Drop);
+            vm.PrivacyOptions.Single(p => p.Value == TelemetryPrivacy.Drop);
         vm.ExtractHome = true;
 
         Assert.Equal(2, notified.Count(

--- a/gui/DjiEmbed.Gui.Tests/FolderPickingTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FolderPickingTests.cs
@@ -1,0 +1,77 @@
+using DjiEmbed.Gui.Views;
+
+namespace DjiEmbed.Gui.Tests;
+
+// M4a: ResolveDrop is FolderPicking's pure drop-payload resolution — no
+// Avalonia types involved, so it is exercised directly against real temp
+// files/dirs rather than through the headless view harness.
+public class FolderPickingTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-folderpicking-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string Touch(string name)
+    {
+        var path = Path.Combine(_dir, name);
+        File.WriteAllText(path, "");
+        return path;
+    }
+
+    private string MakeDir(string name)
+    {
+        var path = Path.Combine(_dir, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    [Theory]
+    [InlineData("clip.SRT", false, "file")]   // telemetry file accepted
+    [InlineData("movie.mkv", false, "none")]  // wrong extension ignored
+    [InlineData("clip.srt", true, "folder")]  // folder in payload wins
+    public void Drop_resolution_prefers_folders_then_telemetry_files(
+        string fileName, bool includeDir, string expected)
+    {
+        var file = Touch(fileName);
+        var paths = new List<string> { file };
+        string? dir = null;
+        if (includeDir)
+        {
+            dir = MakeDir("footage");
+            paths.Add(dir);   // file first, dir second — order must not
+                               // matter for folder priority
+        }
+
+        FolderPicking.ResolveDrop(paths, out var folder, out var resolvedFile);
+
+        switch (expected)
+        {
+            case "folder":
+                Assert.Equal(dir, folder);
+                break;
+            case "file":
+                Assert.Null(folder);
+                Assert.Equal(file, resolvedFile);
+                break;
+            case "none":
+                Assert.Null(folder);
+                Assert.Null(resolvedFile);
+                break;
+        }
+    }
+
+    [Theory]
+    [InlineData("clip.mp4")]
+    [InlineData("clip.MOV")]
+    public void Drop_resolution_accepts_video_extensions_case_insensitively(
+        string fileName)
+    {
+        var file = Touch(fileName);
+
+        FolderPicking.ResolveDrop([file], out var folder, out var resolvedFile);
+
+        Assert.Null(folder);
+        Assert.Equal(file, resolvedFile);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -307,6 +307,49 @@ public class ScreenshotCaptureTests
         Capture(window, Path.Combine(dir!, "workspace-embed-options-advanced.png"));
     }
 
+    /// <summary>
+    /// The Convert curated options (M4a): a single telemetry file selected
+    /// (so the save-as row applies, unlike the folder-source captures
+    /// above) with KML chosen so the footprint section renders, and
+    /// Advanced open — the state that shows the panel's full shape: the
+    /// format/privacy combos, the footprint controls, and the tz/save-as
+    /// Advanced rows together.
+    /// </summary>
+    [AvaloniaFact]
+    public void Captures_convert_options_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture the Convert options.");
+        Directory.CreateDirectory(dir!);
+
+        var vm = new WorkspaceViewModel(
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
+        vm.SetFile(@"C:\Users\demo\Videos\flight\DJI_0001.SRT");
+        vm.ConvertOptions.SelectedFormat = vm.ConvertOptions.Formats
+            .Single(f => f.Key == "kml");
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        view.DataContext = vm;
+        // Taller than the app's 720: the point of this capture is to review
+        // the whole panel at once, which the real window scrolls to reach.
+        var window = new Window { Width = 1140, Height = 1400, Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        view.FindControl<Expander>("ConvertAdvanced")!.IsExpanded = true;
+        // The expander reveals its content with an animation; without
+        // advancing the headless render clock the capture catches it
+        // half-open and the Advanced rows are clipped away. Interleaved
+        // ticks are required — one big tick count does NOT settle it.
+        for (var i = 0; i < 80; i++)
+        {
+            AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+        Capture(window, Path.Combine(dir!, "workspace-convert-options-advanced.png"));
+    }
+
     private static void CaptureView(
         Control view, string outPath, double width = 1140, double height = 720) =>
         Capture(new Window { Width = width, Height = height, Content = view },

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -284,7 +284,7 @@ public class ScreenshotCaptureTests
             height: 1100);
 
         vm.EmbedOptions.SelectedPrivacy = vm.EmbedOptions.PrivacyOptions
-            .Single(p => p.Value == EmbedPrivacy.Drop);
+            .Single(p => p.Value == TelemetryPrivacy.Drop);
         vm.EmbedOptions.ExtractHome = true;
         vm.EmbedOptions.DatAuto = true;
         vm.EmbedOptions.Output = @"C:\Users\demo\Desktop\embedded";

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
@@ -14,10 +14,11 @@ public class WorkspaceModeTests
     }
 
     [Fact]
-    public void Only_setup_runs_without_a_folder()
+    public void Folder_modes_take_folders_setup_takes_nothing()
     {
-        Assert.All(WorkspaceMode.All, m =>
-            Assert.Equal(m.Kind != WorkspaceModeKind.Setup, m.NeedsFolder));
+        Assert.All(WorkspaceMode.All, m => Assert.Equal(
+            m.Kind == WorkspaceModeKind.Setup ? SourceKinds.None : SourceKinds.Folder,
+            m.Sources));
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
@@ -5,20 +5,33 @@ namespace DjiEmbed.Gui.Tests;
 public class WorkspaceModeTests
 {
     [Fact]
-    public void Catalogue_has_the_four_m1_modes_in_strip_order()
+    public void Catalogue_has_the_five_m1_plus_m4a_modes_in_strip_order()
     {
         Assert.Equal(
             [WorkspaceModeKind.FlightMap, WorkspaceModeKind.PhotoMap,
-             WorkspaceModeKind.Embed, WorkspaceModeKind.Setup],
+             WorkspaceModeKind.Embed, WorkspaceModeKind.Convert,
+             WorkspaceModeKind.Setup],
             WorkspaceMode.All.Select(m => m.Kind).ToArray());
     }
 
     [Fact]
-    public void Folder_modes_take_folders_setup_takes_nothing()
+    public void Sources_match_each_modes_reach()
     {
-        Assert.All(WorkspaceMode.All, m => Assert.Equal(
-            m.Kind == WorkspaceModeKind.Setup ? SourceKinds.None : SourceKinds.Folder,
-            m.Sources));
+        Assert.All(WorkspaceMode.All, m => Assert.Equal(m.Kind switch
+        {
+            WorkspaceModeKind.Setup => SourceKinds.None,
+            WorkspaceModeKind.Convert => SourceKinds.Folder | SourceKinds.File,
+            _ => SourceKinds.Folder,
+        }, m.Sources));
+    }
+
+    [Fact]
+    public void Convert_sits_between_embed_and_setup_in_the_strip()
+    {
+        var kinds = WorkspaceMode.All.Select(m => m.Kind).ToArray();
+        Assert.Equal([WorkspaceModeKind.FlightMap, WorkspaceModeKind.PhotoMap,
+            WorkspaceModeKind.Embed, WorkspaceModeKind.Convert,
+            WorkspaceModeKind.Setup], kinds);
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
@@ -26,15 +26,6 @@ public class WorkspaceModeTests
     }
 
     [Fact]
-    public void Convert_sits_between_embed_and_setup_in_the_strip()
-    {
-        var kinds = WorkspaceMode.All.Select(m => m.Kind).ToArray();
-        Assert.Equal([WorkspaceModeKind.FlightMap, WorkspaceModeKind.PhotoMap,
-            WorkspaceModeKind.Embed, WorkspaceModeKind.Convert,
-            WorkspaceModeKind.Setup], kinds);
-    }
-
-    [Fact]
     public void Of_finds_each_mode()
     {
         Assert.Equal("Flight map",

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -34,12 +34,12 @@ public class WorkspaceScreenTests
             previewAvailable: static () => false);
 
     [AvaloniaFact]
-    public void Mode_strip_shows_exactly_the_four_m1_modes()
+    public void Mode_strip_shows_exactly_the_five_m1_plus_m4a_modes()
     {
         var window = ShowWorkspace();
         var strip = window.GetVisualDescendants().OfType<ListBox>()
             .Single(l => l.Name == "ModeStrip");
-        Assert.Equal(4, strip.ItemCount);
+        Assert.Equal(5, strip.ItemCount);
     }
 
     [AvaloniaFact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -1011,4 +1011,234 @@ public class WorkspaceScreenTests
         Dispatcher.UIThread.RunJobs();
         Assert.Equal("C:/x/DJI_1.SRT", vm.SelectedFile);
     }
+
+    // M4a: the Convert options panel renders only for Convert, and — like
+    // the other three options panels — freezes for the whole lifetime of a
+    // run (#340), not just while Step == Running.
+    [AvaloniaFact]
+    public async Task Convert_panel_shows_only_in_convert_mode_and_freezes_when_busy()
+    {
+        var dir = Directory.CreateTempSubdirectory("djiembed-screen-convert-busy").FullName;
+        try
+        {
+            var cli = FakeCli.WriteEventStream(dir,
+            [
+                """{"v": 1, "event": "start", "command": "convert", "total": 1}""",
+                """{"v": 1, "event": "result", "ok": true, "outputs": ["DJI_0001.gpx"], "summary": {}}""",
+            ]);
+            var gate = new TaskCompletionSource();
+            Func<string, FolderContents> inspect = _ => new FolderContents(
+                true, false, false, true, false, false, null, null);
+            var vm = new WorkspaceViewModel(cli, new DjiEmbedRunner(),
+                new FakeMapServer(null), () => { },
+                previewAvailable: static () => false,
+                folderInspector: d => inspect(d));
+            var window = ShowWorkspace(vm);
+
+            var panel = window.GetVisualDescendants().OfType<Border>()
+                .Single(b => b.Name == "ConvertOptionsPanel");
+            Assert.False(panel.IsEffectivelyVisible);   // default mode: Flight map
+
+            vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Assert.True(panel.IsEffectivelyVisible);
+
+            await vm.SetFolderAsync(dir);
+            inspect = _ =>
+            {
+                gate.Task.Wait();
+                return new FolderContents(
+                    true, false, false, true, false, false, null, null);
+            };
+
+            var run = vm.RunCommand.ExecuteAsync(null);
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(panel.IsEnabled);
+
+            gate.SetResult();
+            await run;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(panel.IsEnabled);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Non_convert_mode_hides_the_convert_options_panel()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "ConvertOptionsPanel");
+        Assert.False(panel.IsEffectivelyVisible);
+    }
+
+    // #336-style: flip every control from the CONTROL side and assert its
+    // own options VM moved, catching a wrong-OBJECT binding that a
+    // compiled-binding build would let through.
+    [AvaloniaFact]
+    public void Convert_panel_controls_bind_the_convert_options()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var format = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "ConvertFormatCombo");
+        Assert.Same(vm.ConvertOptions.Formats, format.ItemsSource);
+        format.SelectedItem = vm.ConvertOptions.Formats.Single(f => f.Key == "kml");
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("kml", vm.ConvertOptions.SelectedFormat.Key);
+
+        var privacy = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "ConvertPrivacyCombo");
+        Assert.Same(vm.ConvertOptions.PrivacyOptions, privacy.ItemsSource);
+        privacy.SelectedItem = vm.ConvertOptions.PrivacyOptions
+            .Single(p => p.Value == TelemetryPrivacy.Fuzz);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(TelemetryPrivacy.Fuzz, vm.ConvertOptions.SelectedPrivacy.Value);
+
+        var tz = window.GetVisualDescendants().OfType<TextBox>()
+            .Single(t => t.Name == "ConvertTzBox");
+        tz.Text = "+02:00";
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("+02:00", vm.ConvertOptions.TzOffset);
+
+        var footprints = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "FootprintsCheck");
+        Assert.False(footprints.IsChecked);
+        footprints.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.ConvertOptions.Footprints);
+
+        var interval = window.GetVisualDescendants().OfType<Slider>()
+            .Single(s => s.Name == "FootprintIntervalSlider");
+        interval.Value = 5;
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(5, vm.ConvertOptions.FootprintInterval);
+
+        var model = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "ConvertModelCombo");
+        Assert.Same(vm.ConvertOptions.Models, model.ItemsSource);
+        model.SelectedItem = vm.ConvertOptions.Models.Single(m => m.Key == "air3");
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("air3", vm.ConvertOptions.SelectedModel.Key);
+
+        // Switch to cot to reach the CoT-only controls.
+        format.SelectedItem = vm.ConvertOptions.Formats.Single(f => f.Key == "cot");
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var cotInterval = window.GetVisualDescendants().OfType<TextBox>()
+            .Single(t => t.Name == "CotIntervalBox");
+        cotInterval.Text = "3";
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(3, vm.ConvertOptions.CotInterval);
+
+        var cotType = window.GetVisualDescendants().OfType<TextBox>()
+            .Single(t => t.Name == "CotTypeBox");
+        cotType.Text = "a-h-A";
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("a-h-A", vm.ConvertOptions.CotType);
+
+        var clear = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ClearConvertOutputButton");
+        // A Button with a NULL Command still reports IsEffectivelyEnabled ==
+        // true, so identity is the only assertion that proves the binding.
+        Assert.Same(vm.ConvertOptions.ClearOutputCommand, clear.Command);
+    }
+
+    [AvaloniaFact]
+    public async Task Convert_conditional_sections_follow_the_format()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var footprintSection = window.GetVisualDescendants().OfType<StackPanel>()
+            .Single(s => s.Name == "FootprintSection");
+        var cotSection = window.GetVisualDescendants().OfType<StackPanel>()
+            .Single(s => s.Name == "CotSection");
+        var saveSection = window.GetVisualDescendants().OfType<StackPanel>()
+            .Single(s => s.Name == "ConvertSaveSection");
+
+        // Default format is gpx: neither conditional section, no file source.
+        Assert.False(footprintSection.IsEffectivelyVisible);
+        Assert.False(cotSection.IsEffectivelyVisible);
+        Assert.False(saveSection.IsEffectivelyVisible);
+
+        vm.ConvertOptions.SelectedFormat =
+            vm.ConvertOptions.Formats.Single(f => f.Key == "kml");
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(footprintSection.IsEffectivelyVisible);
+        Assert.False(cotSection.IsEffectivelyVisible);
+
+        vm.ConvertOptions.SelectedFormat =
+            vm.ConvertOptions.Formats.Single(f => f.Key == "cot");
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.False(footprintSection.IsEffectivelyVisible);
+        Assert.True(cotSection.IsEffectivelyVisible);
+
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(saveSection.IsEffectivelyVisible);
+
+        var dir = Directory.CreateTempSubdirectory("djiembed-screen-convert-savesection").FullName;
+        try
+        {
+            await vm.SetFolderAsync(dir);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Assert.False(saveSection.IsEffectivelyVisible);   // a folder source has no save-as
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // #335-style: the seam is pinned so no native dialog opens headless, and
+    // the suggested name proves the picker is wired with the SOURCE file's
+    // stem and the currently-selected format's own suffix.
+    [AvaloniaFact]
+    public void Choose_convert_output_routes_through_the_typed_save_picker()
+    {
+        var window = ShowWorkspace();
+        var view = (WorkspaceView)window.Content!;
+        var vm = (WorkspaceViewModel)view.DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        vm.ConvertOptions.SelectedFormat =
+            vm.ConvertOptions.Formats.Single(f => f.Key == "kml");
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        string? suggestedName = null;
+        string? pattern = null;
+        view.ConvertSavePicker = (_, _, name, _, ext) =>
+        {
+            suggestedName = name;
+            pattern = ext;
+            return Task.FromResult<string?>("C:/x/DJI_0001.kml");
+        };
+
+        window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "ChooseConvertOutputButton")
+            .RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("DJI_0001.kml", suggestedName);
+        Assert.Equal("*.kml", pattern);
+        Assert.Equal("C:/x/DJI_0001.kml", vm.ConvertOptions.Output);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -1107,9 +1107,9 @@ public class WorkspaceScreenTests
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();
 
-        var cotInterval = window.GetVisualDescendants().OfType<TextBox>()
-            .Single(t => t.Name == "CotIntervalBox");
-        cotInterval.Text = "3";
+        var cotInterval = window.GetVisualDescendants().OfType<Slider>()
+            .Single(s => s.Name == "CotIntervalSlider");
+        cotInterval.Value = 3;
         Dispatcher.UIThread.RunJobs();
         Assert.Equal(3, vm.ConvertOptions.CotInterval);
         Assert.Contains("--interval 3", vm.CommandPreview);

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -981,6 +981,7 @@ public class WorkspaceScreenTests
             Assert.False(byName("FlightOptionsPanel").IsEnabled);
             Assert.False(byName("PhotoOptionsPanel").IsEnabled);
             Assert.False(byName("EmbedOptionsPanel").IsEnabled);
+            Assert.False(byName("ConvertOptionsPanel").IsEnabled);
             Assert.True(byName("CopyCommandButton").IsEffectivelyEnabled);
 
             gate.SetResult();
@@ -1012,59 +1013,25 @@ public class WorkspaceScreenTests
         Assert.Equal("C:/x/DJI_1.SRT", vm.SelectedFile);
     }
 
-    // M4a: the Convert options panel renders only for Convert, and — like
-    // the other three options panels — freezes for the whole lifetime of a
-    // run (#340), not just while Step == Running.
+    // M4a: the Convert options panel renders only for Convert, with the
+    // Advanced expander closed by default. The panel's freeze-while-busy
+    // behaviour is covered alongside the other three panels' by
+    // Left_column_freezes_while_a_run_is_in_flight (#340).
     [AvaloniaFact]
-    public async Task Convert_panel_shows_only_in_convert_mode_and_freezes_when_busy()
+    public void Convert_mode_shows_the_options_panel_with_advanced_collapsed()
     {
-        var dir = Directory.CreateTempSubdirectory("djiembed-screen-convert-busy").FullName;
-        try
-        {
-            var cli = FakeCli.WriteEventStream(dir,
-            [
-                """{"v": 1, "event": "start", "command": "convert", "total": 1}""",
-                """{"v": 1, "event": "result", "ok": true, "outputs": ["DJI_0001.gpx"], "summary": {}}""",
-            ]);
-            var gate = new TaskCompletionSource();
-            Func<string, FolderContents> inspect = _ => new FolderContents(
-                true, false, false, true, false, false, null, null);
-            var vm = new WorkspaceViewModel(cli, new DjiEmbedRunner(),
-                new FakeMapServer(null), () => { },
-                previewAvailable: static () => false,
-                folderInspector: d => inspect(d));
-            var window = ShowWorkspace(vm);
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
 
-            var panel = window.GetVisualDescendants().OfType<Border>()
-                .Single(b => b.Name == "ConvertOptionsPanel");
-            Assert.False(panel.IsEffectivelyVisible);   // default mode: Flight map
-
-            vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
-            Dispatcher.UIThread.RunJobs();
-            window.UpdateLayout();
-            Assert.True(panel.IsEffectivelyVisible);
-
-            await vm.SetFolderAsync(dir);
-            inspect = _ =>
-            {
-                gate.Task.Wait();
-                return new FolderContents(
-                    true, false, false, true, false, false, null, null);
-            };
-
-            var run = vm.RunCommand.ExecuteAsync(null);
-            Dispatcher.UIThread.RunJobs();
-            Assert.False(panel.IsEnabled);
-
-            gate.SetResult();
-            await run;
-            Dispatcher.UIThread.RunJobs();
-            Assert.True(panel.IsEnabled);
-        }
-        finally
-        {
-            Directory.Delete(dir, recursive: true);
-        }
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "ConvertOptionsPanel");
+        Assert.True(panel.IsEffectivelyVisible);
+        var advanced = window.GetVisualDescendants().OfType<Expander>()
+            .Single(e => e.Name == "ConvertAdvanced");
+        Assert.False(advanced.IsExpanded);
     }
 
     [AvaloniaFact]
@@ -1094,6 +1061,7 @@ public class WorkspaceScreenTests
         format.SelectedItem = vm.ConvertOptions.Formats.Single(f => f.Key == "kml");
         Dispatcher.UIThread.RunJobs();
         Assert.Equal("kml", vm.ConvertOptions.SelectedFormat.Key);
+        Assert.Contains("convert kml", vm.CommandPreview);
 
         var privacy = window.GetVisualDescendants().OfType<ComboBox>()
             .Single(c => c.Name == "ConvertPrivacyCombo");
@@ -1102,12 +1070,14 @@ public class WorkspaceScreenTests
             .Single(p => p.Value == TelemetryPrivacy.Fuzz);
         Dispatcher.UIThread.RunJobs();
         Assert.Equal(TelemetryPrivacy.Fuzz, vm.ConvertOptions.SelectedPrivacy.Value);
+        Assert.Contains("--redact fuzz", vm.CommandPreview);
 
         var tz = window.GetVisualDescendants().OfType<TextBox>()
             .Single(t => t.Name == "ConvertTzBox");
         tz.Text = "+02:00";
         Dispatcher.UIThread.RunJobs();
         Assert.Equal("+02:00", vm.ConvertOptions.TzOffset);
+        Assert.Contains("--tz-offset +02:00", vm.CommandPreview);
 
         var footprints = window.GetVisualDescendants().OfType<CheckBox>()
             .Single(c => c.Name == "FootprintsCheck");
@@ -1115,12 +1085,14 @@ public class WorkspaceScreenTests
         footprints.IsChecked = true;
         Dispatcher.UIThread.RunJobs();
         Assert.True(vm.ConvertOptions.Footprints);
+        Assert.Contains("--footprint", vm.CommandPreview);
 
         var interval = window.GetVisualDescendants().OfType<Slider>()
             .Single(s => s.Name == "FootprintIntervalSlider");
         interval.Value = 5;
         Dispatcher.UIThread.RunJobs();
         Assert.Equal(5, vm.ConvertOptions.FootprintInterval);
+        Assert.Contains("--footprint-interval 5", vm.CommandPreview);
 
         var model = window.GetVisualDescendants().OfType<ComboBox>()
             .Single(c => c.Name == "ConvertModelCombo");
@@ -1128,6 +1100,7 @@ public class WorkspaceScreenTests
         model.SelectedItem = vm.ConvertOptions.Models.Single(m => m.Key == "air3");
         Dispatcher.UIThread.RunJobs();
         Assert.Equal("air3", vm.ConvertOptions.SelectedModel.Key);
+        Assert.Contains("--model air3", vm.CommandPreview);
 
         // Switch to cot to reach the CoT-only controls.
         format.SelectedItem = vm.ConvertOptions.Formats.Single(f => f.Key == "cot");
@@ -1139,12 +1112,14 @@ public class WorkspaceScreenTests
         cotInterval.Text = "3";
         Dispatcher.UIThread.RunJobs();
         Assert.Equal(3, vm.ConvertOptions.CotInterval);
+        Assert.Contains("--interval 3", vm.CommandPreview);
 
         var cotType = window.GetVisualDescendants().OfType<TextBox>()
             .Single(t => t.Name == "CotTypeBox");
         cotType.Text = "a-h-A";
         Dispatcher.UIThread.RunJobs();
         Assert.Equal("a-h-A", vm.ConvertOptions.CotType);
+        Assert.Contains("--cot-type a-h-A", vm.CommandPreview);
 
         var clear = window.GetVisualDescendants().OfType<Button>()
             .Single(b => b.Name == "ClearConvertOutputButton");

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -924,7 +924,7 @@ public class WorkspaceScreenTests
         window.UpdateLayout();
 
         var privacy = window.GetVisualDescendants().OfType<ComboBox>()
-            .Single(c => c.Name == "TelemetryPrivacyCombo");
+            .Single(c => c.Name == "EmbedPrivacyCombo");
         Assert.Same(vm.EmbedOptions.PrivacyOptions, privacy.ItemsSource);
         privacy.SelectedItem = vm.EmbedOptions.PrivacyOptions
             .Single(p => p.Value == TelemetryPrivacy.Drop);

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -994,4 +994,21 @@ public class WorkspaceScreenTests
             Directory.Delete(dir, recursive: true);
         }
     }
+
+    // M4a: the SOURCE card's second button ("Choose a file…") routes
+    // through the same test-seam mould as SavePicker/OutputFolderPicker —
+    // pinned here so the picked path lands on SelectedFile without ever
+    // touching a real file dialog headless.
+    [AvaloniaFact]
+    public void Choose_file_button_routes_through_the_file_picker_seam()
+    {
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        var vm = NewWorkspaceViewModel();
+        view.FilePicker = static (_) => Task.FromResult<string?>("C:/x/DJI_1.SRT");
+        view.DataContext = vm;
+        var button = view.FindControl<Button>("ChooseFileButton")!;
+        button.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("C:/x/DJI_1.SRT", vm.SelectedFile);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -870,7 +870,7 @@ public class WorkspaceScreenTests
 
         vm.EmbedOptions.ExtractHome = true;
         vm.EmbedOptions.SelectedPrivacy = vm.EmbedOptions.PrivacyOptions
-            .Single(p => p.Value == EmbedPrivacy.Drop);
+            .Single(p => p.Value == TelemetryPrivacy.Drop);
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();
         Assert.True(note.IsEffectivelyVisible);
@@ -924,10 +924,10 @@ public class WorkspaceScreenTests
         window.UpdateLayout();
 
         var privacy = window.GetVisualDescendants().OfType<ComboBox>()
-            .Single(c => c.Name == "EmbedPrivacyCombo");
+            .Single(c => c.Name == "TelemetryPrivacyCombo");
         Assert.Same(vm.EmbedOptions.PrivacyOptions, privacy.ItemsSource);
         privacy.SelectedItem = vm.EmbedOptions.PrivacyOptions
-            .Single(p => p.Value == EmbedPrivacy.Drop);
+            .Single(p => p.Value == TelemetryPrivacy.Drop);
 
         var container = window.GetVisualDescendants().OfType<ComboBox>()
             .Single(c => c.Name == "ContainerCombo");

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -1289,7 +1289,7 @@ public class WorkspaceViewModelTests : IDisposable
         ]);
         var vm = Vm(cli);
         vm.EmbedOptions.SelectedPrivacy = vm.EmbedOptions.PrivacyOptions
-            .Single(p => p.Value == EmbedPrivacy.Drop);
+            .Single(p => p.Value == TelemetryPrivacy.Drop);
         vm.EmbedOptions.SelectedContainer =
             vm.EmbedOptions.Containers.Single(c => c.Key == "mkv");
         vm.EmbedOptions.DatAuto = true;
@@ -1452,7 +1452,7 @@ public class WorkspaceViewModelTests : IDisposable
         await vm.SetFolderAsync(MakeFolder(videos: true));
         Assert.Equal(WorkspaceModeKind.Embed, vm.SelectedMode.Kind);
         vm.EmbedOptions.SelectedPrivacy = vm.EmbedOptions.PrivacyOptions
-            .Single(p => p.Value == EmbedPrivacy.Fuzz);
+            .Single(p => p.Value == TelemetryPrivacy.Fuzz);
         vm.EmbedOptions.SelectedContainer =
             vm.EmbedOptions.Containers.Single(c => c.Key == "mkv");
         vm.EmbedOptions.ExtractHome = true;

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -126,10 +126,91 @@ public class WorkspaceViewModelTests : IDisposable
     {
         var vm = Vm("unused");
         await vm.SetFolderAsync(MakeFolder(srt: true));
-        vm.ClearFolderCommand.Execute(null);
+        vm.ClearSourceCommand.Execute(null);
         Assert.Null(vm.SelectedFolder);
         Assert.Null(vm.SuggestedMode);
         Assert.False(vm.CanRun);
+    }
+
+    // M4a Task 2: SOURCE learns to hold a single file instead of a folder,
+    // mutually exclusive with it.
+    [Fact]
+    public async Task Picking_a_file_clears_the_folder_and_vice_versa()
+    {
+        var vm = Vm("unused",
+            folderInspector: _ => Contents(logs: true, topLogs: true));
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.Equal("C:/clips/DJI_0001.SRT", vm.SelectedFile);
+        Assert.Null(vm.SelectedFolder);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        Assert.Null(vm.SelectedFile);
+        Assert.NotNull(vm.SelectedFolder);
+    }
+
+    [Fact]
+    public void File_pick_suggests_nothing_yet()
+    {
+        // Becomes "suggests Convert" when the Convert mode lands (M4a Task 6).
+        var vm = Vm("unused");
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.Null(vm.SuggestedMode);
+    }
+
+    [Fact]
+    public void Clear_source_removes_a_file_too()
+    {
+        var vm = Vm("unused");
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        vm.ClearSourceCommand.Execute(null);
+        Assert.Null(vm.SelectedFile);
+        Assert.Equal(FlowStep.Pick, vm.Step);
+    }
+
+    [Fact]
+    public void Source_display_shows_folder_path_but_file_name_only()
+    {
+        var vm = Vm("unused");
+        Assert.Null(vm.SourceDisplay);
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.Equal("DJI_0001.SRT", vm.SourceDisplay);
+    }
+
+    [Fact]
+    public void File_pick_enables_the_run_button()
+    {
+        var vm = Vm("unused");
+        Assert.False(vm.CanRun);
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.True(vm.CanRun);
+    }
+
+    [Fact]
+    public async Task File_pick_is_inert_while_busy()
+    {
+        // Same discipline as SetFolderAsync: a run owns its inputs (#340).
+        // Copies the gated-scan idiom from The_whole_run_is_busy_from_its_first_line.
+        var cli = FakeCli.WriteEventStream(_dir, FlightmapStream);
+        Func<string, FolderContents> inspect =
+            _ => Contents(logs: true, topLogs: true);
+        var vm = Vm(cli, folderInspector: dir => inspect(dir));
+        var folder = MakeFolder(srt: true);
+        await vm.SetFolderAsync(folder);
+
+        var gate = new TaskCompletionSource();
+        inspect = _ =>
+        {
+            gate.Task.Wait();
+            return Contents(logs: true, topLogs: true);
+        };
+        var run = vm.RunCommand.ExecuteAsync(null);
+
+        Assert.True(vm.IsBusy);
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.Null(vm.SelectedFile);      // inert while busy
+
+        gate.SetResult();
+        await run;
+        Assert.False(vm.IsBusy);
     }
 
     [Fact]
@@ -350,7 +431,7 @@ public class WorkspaceViewModelTests : IDisposable
         var run = vm.RunCommand.ExecuteAsync(null);
 
         Assert.True(vm.IsBusy);
-        vm.ClearFolderCommand.Execute(null);
+        vm.ClearSourceCommand.Execute(null);
         Assert.Equal(folder, vm.SelectedFolder);      // inert while busy
         await vm.SetFolderAsync("Z:/other");
         Assert.Equal(folder, vm.SelectedFolder);      // inert while busy
@@ -965,7 +1046,7 @@ public class WorkspaceViewModelTests : IDisposable
     {
         var vm = Vm("unused");
         await vm.SetFolderAsync(MakeFolder(srt: true, flightMap: true));
-        vm.ClearFolderCommand.Execute(null);
+        vm.ClearSourceCommand.Execute(null);
 
         Assert.Empty(vm.ExistingMaps);
     }
@@ -1008,7 +1089,7 @@ public class WorkspaceViewModelTests : IDisposable
         await vm.OpenExistingMapCommand.ExecuteAsync(vm.ExistingMaps[0]);
         Assert.True(vm.ShowPreview);
 
-        vm.ClearFolderCommand.Execute(null);
+        vm.ClearSourceCommand.Execute(null);
 
         Assert.Null(vm.PreviewUrl);
         Assert.False(vm.ShowPreview);
@@ -1517,7 +1598,7 @@ public class WorkspaceViewModelTests : IDisposable
         vm.PhotoOptions.Output = Path.Combine(_dir, "photomap.html");
         vm.EmbedOptions.Output = Path.Combine(_dir, "copies");
 
-        vm.ClearFolderCommand.Execute(null);
+        vm.ClearSourceCommand.Execute(null);
 
         Assert.Equal("", vm.FlightOptions.Output);
         Assert.Equal("", vm.PhotoOptions.Output);
@@ -1535,7 +1616,7 @@ public class WorkspaceViewModelTests : IDisposable
         var notified = new List<string>();
         vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
 
-        vm.ClearFolderCommand.Execute(null);
+        vm.ClearSourceCommand.Execute(null);
 
         Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
         Assert.Equal("dji-embed flightmap <folder> -r", vm.CommandPreview);
@@ -1556,7 +1637,7 @@ public class WorkspaceViewModelTests : IDisposable
         vm.Warnings.Add("something from the run just finished");
         vm.Step = FlowStep.Done;
 
-        vm.ClearFolderCommand.Execute(null);
+        vm.ClearSourceCommand.Execute(null);
 
         Assert.True(vm.ShowIdle);
         Assert.False(vm.ShowDoneCard);
@@ -1586,7 +1667,7 @@ public class WorkspaceViewModelTests : IDisposable
         };
         var run = vm.RunCommand.ExecuteAsync(null);
 
-        vm.ClearFolderCommand.Execute(null);
+        vm.ClearSourceCommand.Execute(null);
 
         Assert.Equal(folder, vm.SelectedFolder);
         Assert.Equal(Path.Combine(_dir, "flightmap.html"), vm.FlightOptions.Output);

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -170,12 +170,15 @@ public class WorkspaceViewModelTests : IDisposable
     }
 
     [Fact]
-    public void Source_display_shows_folder_path_but_file_name_only()
+    public async Task Source_display_shows_folder_path_but_file_name_only()
     {
         var vm = Vm("unused");
         Assert.Null(vm.SourceDisplay);
         vm.SetFile("C:/clips/DJI_0001.SRT");
         Assert.Equal("DJI_0001.SRT", vm.SourceDisplay);
+        var folder = MakeFolder(srt: true);
+        await vm.SetFolderAsync(folder);
+        Assert.Equal(folder, vm.SourceDisplay);
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -151,12 +151,43 @@ public class WorkspaceViewModelTests : IDisposable
     }
 
     [Fact]
-    public void File_pick_suggests_nothing_yet()
+    public void File_pick_suggests_and_selects_convert_mode()
     {
-        // Becomes "suggests Convert" when the Convert mode lands (M4a Task 6).
         var vm = Vm("unused");
         vm.SetFile("C:/clips/DJI_0001.SRT");
-        Assert.Null(vm.SuggestedMode);
+        Assert.Equal(WorkspaceModeKind.Convert, vm.SelectedMode.Kind);
+        Assert.Equal(WorkspaceModeKind.Convert, vm.SuggestedMode!.Kind);
+    }
+
+    [Fact]
+    public void Convert_strip_previews_batch_for_folders_and_bare_for_files()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        Assert.Equal("dji-embed convert gpx <folder> -b", vm.CommandPreview);
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.Equal("dji-embed convert gpx C:/clips/DJI_0001.SRT",
+            vm.CommandPreview);
+    }
+
+    [Fact]
+    public void Convert_options_repaint_the_strip()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        vm.ConvertOptions.SelectedFormat = vm.ConvertOptions.Formats
+            .First(f => f.Key == "kml");
+        Assert.Contains("convert kml", vm.CommandPreview);
+    }
+
+    [Fact]
+    public void Source_changes_clear_the_convert_output_override_too()
+    {
+        var vm = Vm("unused",
+            folderInspector: _ => Contents(logs: true, topLogs: true));
+        vm.ConvertOptions.Output = "C:/elsewhere/track.gpx";
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.Equal("", vm.ConvertOptions.Output);
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -1373,6 +1373,32 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Contains(nameof(WorkspaceViewModel.IsEmbedMode), notified);
     }
 
+    [Fact]
+    public void Changing_a_convert_option_notifies_command_preview()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.ConvertOptions.TzOffset = "2";
+        Assert.Contains(nameof(WorkspaceViewModel.CommandPreview), notified);
+    }
+
+    [Fact]
+    public void Only_convert_mode_reports_the_convert_options_panel_visible()
+    {
+        var vm = Vm("unused");   // default mode Flight map
+        Assert.False(vm.IsConvertMode);
+        var notified = new List<string>();
+        vm.PropertyChanged += (_, e) => notified.Add(e.PropertyName!);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        Assert.True(vm.IsConvertMode);
+        Assert.False(vm.IsFlightMapMode);
+        Assert.False(vm.IsPhotoMapMode);
+        Assert.False(vm.IsEmbedMode);
+        Assert.Contains(nameof(WorkspaceViewModel.IsConvertMode), notified);
+    }
+
     // #334: the CLI transparency strip's whole promise is that the command it
     // shows IS the command the runner executes — the runner may append only
     // the machine-only `--progress jsonl`. Argv-fragment tests and preview

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -145,6 +145,9 @@ public class WorkspaceViewModelTests : IDisposable
         await vm.SetFolderAsync(MakeFolder(srt: true));
         Assert.Null(vm.SelectedFile);
         Assert.NotNull(vm.SelectedFolder);
+        vm.SetFile("C:/clips/DJI_0002.SRT");
+        Assert.Equal("C:/clips/DJI_0002.SRT", vm.SelectedFile);
+        Assert.Null(vm.SelectedFolder);
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -297,6 +297,13 @@ public class WorkspaceViewModelTests : IDisposable
         """{"v": 1, "event": "result", "ok": true, "outputs": ["photomap.html"], "summary": {}}""",
     ];
 
+    private static readonly string[] ConvertStream =
+    [
+        """{"v": 1, "event": "start", "command": "convert", "total": 1}""",
+        """{"v": 1, "event": "progress", "current": 1, "total": 1, "item": "DJI_0001.SRT"}""",
+        """{"v": 1, "event": "result", "ok": true, "outputs": ["DJI_0001.gpx"], "summary": {"converted": 1, "skipped": 0, "format": "gpx"}}""",
+    ];
+
     private static readonly string[] DoctorStream =
     [
         """{"v": 1, "event": "start", "command": "doctor"}""",
@@ -532,6 +539,106 @@ public class WorkspaceViewModelTests : IDisposable
         await vm.RunCommand.ExecuteAsync(null);
         Assert.Equal(FlowStep.Failed, vm.Step);
         Assert.Contains("photos", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // M4a Task 7: Convert runs bare on a single file, batch on a folder,
+    // and guards a folder whose media is out of -b's one-level reach the
+    // same way embed does (#333/#338).
+    [Fact]
+    public async Task Convert_runs_bare_on_a_single_file()
+    {
+        var argsFile = Path.Combine(_dir, "args-convert-file.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, ConvertStream);
+        var vm = Vm(cli);
+        var srt = Path.Combine(MakeFolder(srt: true), "DJI_0001.SRT");
+        vm.SetFile(srt);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        var argv = File.ReadAllLines(argsFile);
+        Assert.Equal(["convert", "gpx", srt], argv[..3]);
+        Assert.DoesNotContain("-b", argv);
+    }
+
+    [Fact]
+    public async Task Convert_runs_batch_on_a_folder()
+    {
+        var argsFile = Path.Combine(_dir, "args-convert-folder.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, ConvertStream);
+        var vm = Vm(cli);
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Contains("-b", File.ReadAllLines(argsFile));
+    }
+
+    [Fact]
+    public async Task Convert_blocks_a_folder_whose_media_is_nested_with_guidance()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.SetFolderAsync(MakeFolder(nestedSrt: true));
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(
+            "Those files are in subfolders — Convert reads only the folder "
+            + "you pick. Pick the subfolder that holds the flight logs or "
+            + "videos.",
+            vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Convert_blocks_an_empty_folder_with_guidance()
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(
+            "No flight logs (.SRT) or drone videos were found in that "
+            + "folder. Pick the folder that holds the footage to convert.",
+            vm.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData(WorkspaceModeKind.FlightMap,
+        "Flight map works on a folder of footage — pick the folder that "
+        + "holds your flights, not a single file.")]
+    [InlineData(WorkspaceModeKind.PhotoMap,
+        "Photo map works on a folder of pictures — pick the folder that "
+        + "holds your photos, not a single file.")]
+    [InlineData(WorkspaceModeKind.Embed,
+        "Embed telemetry works on a folder of videos with their .SRT "
+        + "flight logs — pick that folder, not a single file.")]
+    public async Task Folder_modes_block_a_file_source_with_guidance(
+        WorkspaceModeKind kind, string message)
+    {
+        var vm = Vm(Path.Combine(_dir, "does-not-exist"));
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        vm.SelectedMode = WorkspaceMode.Of(kind);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(message, vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Convert_html_file_run_primes_the_inline_preview()
+    {
+        var cli = FakeCli.WriteEventStream(_dir,
+        [
+            """{"v": 1, "event": "start", "command": "convert", "total": 1}""",
+            """{"v": 1, "event": "result", "ok": true, "outputs": ["DJI_0001.html"], "summary": {"converted": 1, "skipped": 0, "format": "html"}}""",
+        ]);
+        var server = new FakeMapServer("http://127.0.0.1:8/DJI_0001.html");
+        var vm = Vm(cli, mapServer: server, previewAvailable: static () => true);
+        var srt = Path.Combine(MakeFolder(srt: true), "DJI_0001.SRT");
+        vm.SetFile(srt);
+        vm.ConvertOptions.SelectedFormat = vm.ConvertOptions.Formats
+            .First(f => f.Key == "html");
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.NotNull(vm.PreviewUrl);
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -152,9 +152,9 @@ public static class CommandBuilder
         var args = new List<string> { "embed", folder };
         var redact = opts.Privacy switch
         {
-            EmbedPrivacy.Keep => null,
-            EmbedPrivacy.Fuzz => "fuzz",
-            EmbedPrivacy.Drop => "drop",
+            TelemetryPrivacy.Keep => null,
+            TelemetryPrivacy.Fuzz => "fuzz",
+            TelemetryPrivacy.Drop => "drop",
             _ => throw new ArgumentOutOfRangeException(
                 nameof(opts), opts.Privacy, null),
         };

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -201,8 +201,11 @@ public static class CommandBuilder
     /// <c>convert gpx &lt;source&gt; [-b]</c>. Order is fixed for golden
     /// tests. No <c>--progress</c>: the runner appends that.
     /// <c>--footprint</c>/<c>--footprint-interval</c>/<c>--model</c> reach
-    /// only <c>geojson</c>/<c>kml</c> — the CLI rejects them on other
-    /// formats. <c>--interval</c>/<c>--cot-type</c> reach only <c>cot</c>.
+    /// only <c>geojson</c>/<c>kml</c> — Click declares them on the shared
+    /// <c>convert</c> command, but <c>run_one</c> silently never forwards
+    /// them for other formats, so they'd be meaningless noise in the strip.
+    /// <c>--interval</c>/<c>--cot-type</c> reach only <c>cot</c> for the
+    /// same reason.
     /// <c>--output</c> reaches only single-file (non-batch) sources: the
     /// CLI's batch loop has no <c>-o</c>, every output lands beside its
     /// source.

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -24,6 +24,8 @@ public static class CommandBuilder
         WorkspaceModeKind.FlightMap => FlightMap(folder!, FlightMapOptions.Defaults),
         WorkspaceModeKind.PhotoMap => PhotoMap(folder!, PhotoMapOptions.Defaults),
         WorkspaceModeKind.Embed => Embed(folder!, EmbedTelemetryOptions.Defaults),
+        WorkspaceModeKind.Convert =>
+            Convert(folder!, batch: true, ConvertTelemetryOptions.Defaults),
         WorkspaceModeKind.Setup => ["doctor"],
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
     };
@@ -186,6 +188,86 @@ public static class CommandBuilder
         }
         var output = opts.Output.Trim();
         if (output.Length > 0)
+        {
+            args.Add("--output");
+            args.Add(output);
+        }
+        return args.ToArray();
+    }
+
+    /// <summary>
+    /// The Convert argv from typed <paramref name="opts"/> (GUI 2.0 spec,
+    /// M4a). Flags are omitted at their defaults so an untouched run reads
+    /// <c>convert gpx &lt;source&gt; [-b]</c>. Order is fixed for golden
+    /// tests. No <c>--progress</c>: the runner appends that.
+    /// <c>--footprint</c>/<c>--footprint-interval</c>/<c>--model</c> reach
+    /// only <c>geojson</c>/<c>kml</c> — the CLI rejects them on other
+    /// formats. <c>--interval</c>/<c>--cot-type</c> reach only <c>cot</c>.
+    /// <c>--output</c> reaches only single-file (non-batch) sources: the
+    /// CLI's batch loop has no <c>-o</c>, every output lands beside its
+    /// source.
+    /// </summary>
+    public static string[] Convert(
+        string source, bool batch, ConvertTelemetryOptions opts)
+    {
+        var args = new List<string> { "convert", opts.Format, source };
+        if (batch)
+        {
+            args.Add("-b");
+        }
+        var redact = opts.Privacy switch
+        {
+            TelemetryPrivacy.Keep => null,
+            TelemetryPrivacy.Fuzz => "fuzz",
+            TelemetryPrivacy.Drop => "drop",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(opts), opts.Privacy, null),
+        };
+        if (redact is not null)
+        {
+            args.Add("--redact");
+            args.Add(redact);
+        }
+        var tz = opts.TzOffset.Trim();
+        if (tz.Length > 0 && !tz.Equals("auto", StringComparison.OrdinalIgnoreCase))
+        {
+            args.Add("--tz-offset");
+            args.Add(tz);
+        }
+        if (opts.Footprints && opts.Format is "geojson" or "kml")
+        {
+            args.Add("--footprint");
+            if (opts.FootprintInterval
+                != ConvertTelemetryOptions.Defaults.FootprintInterval)
+            {
+                args.Add("--footprint-interval");
+                args.Add(opts.FootprintInterval.ToString(
+                    CultureInfo.InvariantCulture));
+            }
+            var model = opts.Model.Trim();
+            if (model.Length > 0)
+            {
+                args.Add("--model");
+                args.Add(model);
+            }
+        }
+        if (opts.Format == "cot")
+        {
+            if (opts.CotInterval != ConvertTelemetryOptions.Defaults.CotInterval)
+            {
+                args.Add("--interval");
+                args.Add(opts.CotInterval.ToString(CultureInfo.InvariantCulture));
+            }
+            var cotType = opts.CotType.Trim();
+            if (cotType.Length > 0
+                && cotType != ConvertTelemetryOptions.Defaults.CotType)
+            {
+                args.Add("--cot-type");
+                args.Add(cotType);
+            }
+        }
+        var output = opts.Output.Trim();
+        if (!batch && output.Length > 0)
         {
             args.Add("--output");
             args.Add(output);

--- a/gui/DjiEmbed.Gui/ViewModels/ConvertOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/ConvertOptionsViewModel.cs
@@ -1,0 +1,130 @@
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>A selectable output format: a label over a CLI format key,
+/// plus the filename suffix the save dialog suggests.</summary>
+public sealed record FormatChoice(string Label, string Key, string Suffix);
+
+/// <summary>A selectable footprint lens: a label over a CLI --model key
+/// (empty = the CLI's generic wide default).</summary>
+public sealed record ModelChoice(string Label, string Key);
+
+/// <summary>
+/// Observable control state for the Convert options panel (GUI 2.0 spec,
+/// M4a). Bound directly to the panel; <see cref="ToOptions"/> snapshots it
+/// into the immutable <see cref="ConvertTelemetryOptions"/> the builder
+/// consumes. Lives on <see cref="WorkspaceViewModel"/>; in-memory only.
+/// </summary>
+public partial class ConvertOptionsViewModel : ViewModelBase
+{
+    public IReadOnlyList<FormatChoice> Formats { get; } =
+    [
+        new("GPX track", "gpx", "gpx"),
+        new("CSV spreadsheet", "csv", "csv"),
+        new("GeoJSON", "geojson", "geojson"),
+        new("KML (Google Earth)", "kml", "kml"),
+        new("Web map (HTML)", "html", "html"),
+        new("CoT (ATAK/WinTAK)", "cot", "cot.xml"),
+    ];
+
+    public IReadOnlyList<TelemetryPrivacyChoice> PrivacyOptions { get; } =
+    [
+        new("Keep exact locations", TelemetryPrivacy.Keep),
+        new("Fuzz to ~100 m", TelemetryPrivacy.Fuzz),
+        new("Remove GPS entirely", TelemetryPrivacy.Drop),
+    ];
+
+    public IReadOnlyList<ModelChoice> Models { get; } =
+    [
+        new("Generic wide lens (default)", ""),
+        new("DJI Air 3", "air3"),
+        new("DJI Avata 2", "avata2"),
+        new("DJI Mini 4 Pro", "mini4pro"),
+        new("DJI Avata 360", "avata360"),
+    ];
+
+    [ObservableProperty]
+    public partial FormatChoice SelectedFormat { get; set; }
+
+    [ObservableProperty]
+    public partial TelemetryPrivacyChoice SelectedPrivacy { get; set; }
+
+    [ObservableProperty]
+    public partial string TzOffset { get; set; } = "";
+
+    [ObservableProperty]
+    public partial bool Footprints { get; set; }
+
+    [ObservableProperty]
+    public partial double FootprintInterval { get; set; } = 2;
+
+    [ObservableProperty]
+    public partial ModelChoice SelectedModel { get; set; }
+
+    [ObservableProperty]
+    public partial double CotInterval { get; set; } = 1;
+
+    [ObservableProperty]
+    public partial string CotType { get; set; } = "a-n-A";
+
+    [ObservableProperty]
+    public partial string Output { get; set; } = "";
+
+    public ConvertOptionsViewModel()
+    {
+        SelectedFormat = Formats[0];
+        SelectedPrivacy = PrivacyOptions[0];
+        SelectedModel = Models[0];
+    }
+
+    /// <summary>Footprint controls apply to GeoJSON/KML only — the other
+    /// formats have no polygon to carry.</summary>
+    public bool ShowsFootprintOptions =>
+        SelectedFormat.Key is "geojson" or "kml";
+
+    /// <summary>CoT sampling controls apply to CoT only.</summary>
+    public bool ShowsCotOptions => SelectedFormat.Key == "cot";
+
+    /// <summary>
+    /// True when footprints are requested but the privacy stance silently
+    /// suppresses them: the CLI drops footprints under any redaction — a
+    /// precise polygon would re-sharpen a fuzzed centre — and says nothing.
+    /// A real property (not a XAML multi-binding) so it is assertable
+    /// headless.
+    /// </summary>
+    public bool ShowsFootprintsSuppressedNote =>
+        Footprints && ShowsFootprintOptions
+        && SelectedPrivacy.Value != TelemetryPrivacy.Keep;
+
+    partial void OnSelectedFormatChanged(FormatChoice value)
+    {
+        OnPropertyChanged(nameof(ShowsFootprintOptions));
+        OnPropertyChanged(nameof(ShowsCotOptions));
+        OnPropertyChanged(nameof(ShowsFootprintsSuppressedNote));
+    }
+
+    partial void OnFootprintsChanged(bool value) =>
+        OnPropertyChanged(nameof(ShowsFootprintsSuppressedNote));
+
+    partial void OnSelectedPrivacyChanged(TelemetryPrivacyChoice value) =>
+        OnPropertyChanged(nameof(ShowsFootprintsSuppressedNote));
+
+    public ConvertTelemetryOptions ToOptions() => new(
+        Format: SelectedFormat.Key,
+        Privacy: SelectedPrivacy.Value,
+        TzOffset: TzOffset,
+        Footprints: Footprints,
+        FootprintInterval: FootprintInterval,
+        Model: SelectedModel.Key,
+        CotInterval: CotInterval,
+        CotType: CotType,
+        Output: Output);
+
+    /// <summary>Reset the output override back to the default (beside the
+    /// source file).</summary>
+    [RelayCommand]
+    private void ClearOutput() => Output = "";
+}

--- a/gui/DjiEmbed.Gui/ViewModels/ConvertOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/ConvertOptionsViewModel.cs
@@ -27,7 +27,7 @@ public partial class ConvertOptionsViewModel : ViewModelBase
         new("GeoJSON", "geojson", "geojson"),
         new("KML (Google Earth)", "kml", "kml"),
         new("Web map (HTML)", "html", "html"),
-        new("CoT (ATAK/WinTAK)", "cot", "cot.xml"),
+        new("Tactical markers (ATAK/WinTAK)", "cot", "cot.xml"),
     ];
 
     public IReadOnlyList<TelemetryPrivacyChoice> PrivacyOptions { get; } =

--- a/gui/DjiEmbed.Gui/ViewModels/ConvertTelemetryOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/ConvertTelemetryOptions.cs
@@ -1,0 +1,43 @@
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>
+/// Immutable, typed state for a Convert run (GUI 2.0 spec, M4a). Single
+/// input to <see cref="Services.CommandBuilder.Convert"/>; the defaults
+/// reproduce the bare argv (<c>convert gpx &lt;source&gt; [-b]</c>).
+/// <c>--extract-home</c> stays CLI-only per the M4a spec.
+/// </summary>
+/// <param name="Format">A CLI format key: gpx (default), csv, geojson,
+/// kml, html, cot.</param>
+/// <param name="FootprintInterval">Seconds between footprint samples
+/// (CLI default 2).</param>
+/// <param name="Model">FOV-table key for footprints; empty = the CLI's
+/// generic wide lens.</param>
+/// <param name="CotInterval">cot only: seconds between sampled points
+/// (CLI default 1).</param>
+/// <param name="CotType">cot only: CoT event/affiliation code (CLI
+/// default a-n-A, neutral air).</param>
+/// <param name="Output">Single-file sources only: the output path; empty
+/// means beside the source. Batch runs always write beside each source —
+/// the CLI has no batch -o.</param>
+public sealed record ConvertTelemetryOptions(
+    string Format,
+    TelemetryPrivacy Privacy,
+    string TzOffset,
+    bool Footprints,
+    double FootprintInterval,
+    string Model,
+    double CotInterval,
+    string CotType,
+    string Output)
+{
+    public static readonly ConvertTelemetryOptions Defaults = new(
+        Format: "gpx",
+        Privacy: TelemetryPrivacy.Keep,
+        TzOffset: "",
+        Footprints: false,
+        FootprintInterval: 2,
+        Model: "",
+        CotInterval: 1,
+        CotType: "a-n-A",
+        Output: "");
+}

--- a/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptions.cs
@@ -1,25 +1,6 @@
 namespace DjiEmbed.Gui.ViewModels;
 
 /// <summary>
-/// What happens to GPS coordinates on the way into the copies. Deliberately
-/// NOT <see cref="MapPrivacy"/>: <c>embed --redact</c> accepts
-/// <c>none|drop|fuzz</c>, while <c>flightmap</c>/<c>photomap</c> accept only
-/// <c>none|fuzz</c> and would reject <c>drop</c>. One enum per command keeps
-/// each mode total over what its own CLI accepts.
-/// </summary>
-public enum EmbedPrivacy
-{
-    /// <summary>Coordinates pass through untouched (flag omitted).</summary>
-    Keep,
-
-    /// <summary>Coarsened to ~100 m (<c>--redact fuzz</c>).</summary>
-    Fuzz,
-
-    /// <summary>Removed entirely (<c>--redact drop</c>).</summary>
-    Drop,
-}
-
-/// <summary>
 /// Immutable, typed state for an Embed telemetry run (GUI 2.0 spec, M3d). It
 /// is the single input to <see cref="Services.CommandBuilder.Embed"/>, so the
 /// argv is a pure function of this record — golden-testable. Every field maps
@@ -32,7 +13,7 @@ public enum EmbedPrivacy
 /// drops.</param>
 /// <param name="ExtractHome">Write the launch point into the JSON sidecar
 /// (<c>--extract-home</c>). Never written into the video, and redacted along
-/// with everything else — <see cref="EmbedPrivacy.Drop"/> empties it.</param>
+/// with everything else — <see cref="TelemetryPrivacy.Drop"/> empties it.</param>
 /// <param name="UseExifTool">Also write GPS metadata with ExifTool
 /// (the flag is <c>--exiftool</c>, not <c>--use-exiftool</c>).</param>
 /// <param name="DatAuto">Scan for a DAT flight log sitting beside each video
@@ -42,7 +23,7 @@ public enum EmbedPrivacy
 /// <param name="Output">Destination directory for the copies; empty means the
 /// CLI default, a <c>processed</c> folder inside the source folder.</param>
 public sealed record EmbedTelemetryOptions(
-    EmbedPrivacy Privacy,
+    TelemetryPrivacy Privacy,
     string Container,
     bool ExtractHome,
     bool UseExifTool,
@@ -51,7 +32,7 @@ public sealed record EmbedTelemetryOptions(
     string Output)
 {
     public static readonly EmbedTelemetryOptions Defaults = new(
-        Privacy: EmbedPrivacy.Keep,
+        Privacy: TelemetryPrivacy.Keep,
         Container: "mp4",
         ExtractHome: false,
         UseExifTool: false,

--- a/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/EmbedTelemetryOptionsViewModel.cs
@@ -7,11 +7,6 @@ namespace DjiEmbed.Gui.ViewModels;
 /// <summary>A selectable output container: a label over a CLI key.</summary>
 public sealed record ContainerChoice(string Label, string Key);
 
-/// <summary>A selectable privacy stance: a label over an <see cref="EmbedPrivacy"/>.
-/// Separate from <see cref="PrivacyChoice"/>, which wraps <see cref="MapPrivacy"/>
-/// and so cannot express the third stance <c>embed --redact</c> accepts.</summary>
-public sealed record EmbedPrivacyChoice(string Label, EmbedPrivacy Value);
-
 /// <summary>
 /// Observable control state for the Embed telemetry options panel (GUI 2.0
 /// spec, M3d). Bound directly to the SukiUI-themed controls;
@@ -27,18 +22,18 @@ public partial class EmbedTelemetryOptionsViewModel : ViewModelBase
         new("MKV (keeps DJI data streams)", "mkv"),
     ];
 
-    public IReadOnlyList<EmbedPrivacyChoice> PrivacyOptions { get; } =
+    public IReadOnlyList<TelemetryPrivacyChoice> PrivacyOptions { get; } =
     [
-        new("Keep exact locations", EmbedPrivacy.Keep),
-        new("Fuzz to ~100 m", EmbedPrivacy.Fuzz),
-        new("Remove GPS entirely", EmbedPrivacy.Drop),
+        new("Keep exact locations", TelemetryPrivacy.Keep),
+        new("Fuzz to ~100 m", TelemetryPrivacy.Fuzz),
+        new("Remove GPS entirely", TelemetryPrivacy.Drop),
     ];
 
     [ObservableProperty]
     public partial ContainerChoice SelectedContainer { get; set; }
 
     [ObservableProperty]
-    public partial EmbedPrivacyChoice SelectedPrivacy { get; set; }
+    public partial TelemetryPrivacyChoice SelectedPrivacy { get; set; }
 
     [ObservableProperty]
     public partial bool ExtractHome { get; set; }
@@ -69,9 +64,9 @@ public partial class EmbedTelemetryOptionsViewModel : ViewModelBase
     /// XAML multi-binding) so it is assertable headless.
     /// </summary>
     public bool ShowsHomeEmptiedNote =>
-        SelectedPrivacy.Value == EmbedPrivacy.Drop && ExtractHome;
+        SelectedPrivacy.Value == TelemetryPrivacy.Drop && ExtractHome;
 
-    partial void OnSelectedPrivacyChanged(EmbedPrivacyChoice value) =>
+    partial void OnSelectedPrivacyChanged(TelemetryPrivacyChoice value) =>
         OnPropertyChanged(nameof(ShowsHomeEmptiedNote));
 
     partial void OnExtractHomeChanged(bool value) =>

--- a/gui/DjiEmbed.Gui/ViewModels/TelemetryPrivacy.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/TelemetryPrivacy.cs
@@ -1,0 +1,26 @@
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>
+/// What happens to GPS coordinates on the way into the copies. Covers every
+/// command whose <c>--redact</c> accepts <c>none|drop|fuzz</c> (embed,
+/// convert). Deliberately NOT <see cref="MapPrivacy"/>: <c>flightmap</c>/
+/// <c>photomap</c> accept only <c>none|fuzz</c> and would reject <c>drop</c>.
+/// One enum per redaction domain keeps each mode total over what its own CLI
+/// accepts.
+/// </summary>
+public enum TelemetryPrivacy
+{
+    /// <summary>Coordinates pass through untouched (flag omitted).</summary>
+    Keep,
+
+    /// <summary>Coarsened to ~100 m (<c>--redact fuzz</c>).</summary>
+    Fuzz,
+
+    /// <summary>Removed entirely (<c>--redact drop</c>).</summary>
+    Drop,
+}
+
+/// <summary>A selectable privacy stance: a label over a <see cref="TelemetryPrivacy"/>.
+/// Separate from <see cref="PrivacyChoice"/>, which wraps <see cref="MapPrivacy"/>
+/// and so cannot express the third stance <c>--redact</c> accepts.</summary>
+public sealed record TelemetryPrivacyChoice(string Label, TelemetryPrivacy Value);

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
@@ -9,6 +9,7 @@ public enum WorkspaceModeKind
     FlightMap,
     PhotoMap,
     Embed,
+    Convert,
     Setup,
 }
 

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -11,6 +12,16 @@ public enum WorkspaceModeKind
     Setup,
 }
 
+/// <summary>What the SOURCE area may hold for a mode (GUI 2.0 spec, M4a):
+/// a folder, a single telemetry file, or nothing (Setup).</summary>
+[Flags]
+public enum SourceKinds
+{
+    None = 0,
+    Folder = 1,
+    File = 2,
+}
+
 /// <summary>
 /// One entry in the workspace mode strip (GUI 2.0 spec). M1 ships four;
 /// Convert and Verify join in M4.
@@ -19,22 +30,22 @@ public sealed record WorkspaceMode(
     WorkspaceModeKind Kind,
     string Title,
     string Verb,
-    bool NeedsFolder,
+    SourceKinds Sources,
     string FailureMessage)
 {
     public static readonly IReadOnlyList<WorkspaceMode> All =
     [
         new(WorkspaceModeKind.FlightMap, "Flight map", "Generate flight map",
-            NeedsFolder: true,
+            Sources: SourceKinds.Folder,
             "Something went wrong while mapping your flights."),
         new(WorkspaceModeKind.PhotoMap, "Photo map", "Generate photo map",
-            NeedsFolder: true,
+            Sources: SourceKinds.Folder,
             "Something went wrong while mapping your photos."),
         new(WorkspaceModeKind.Embed, "Embed telemetry", "Embed telemetry",
-            NeedsFolder: true,
+            Sources: SourceKinds.Folder,
             "Something went wrong while embedding the flight data."),
         new(WorkspaceModeKind.Setup, "Setup", "Check my setup",
-            NeedsFolder: false,
+            Sources: SourceKinds.None,
             "The setup check could not be completed."),
     ];
 

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
@@ -25,7 +25,7 @@ public enum SourceKinds
 
 /// <summary>
 /// One entry in the workspace mode strip (GUI 2.0 spec). M1 ships four;
-/// Convert and Verify join in M4.
+/// Convert joins in M4a, Verify pending M4b.
 /// </summary>
 public sealed record WorkspaceMode(
     WorkspaceModeKind Kind,
@@ -45,6 +45,9 @@ public sealed record WorkspaceMode(
         new(WorkspaceModeKind.Embed, "Embed telemetry", "Embed telemetry",
             Sources: SourceKinds.Folder,
             "Something went wrong while embedding the flight data."),
+        new(WorkspaceModeKind.Convert, "Convert telemetry", "Convert",
+            Sources: SourceKinds.Folder | SourceKinds.File,
+            "Something went wrong while converting the telemetry."),
         new(WorkspaceModeKind.Setup, "Setup", "Check my setup",
             Sources: SourceKinds.None,
             "The setup check could not be completed."),

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -146,7 +146,7 @@ public partial class WorkspaceViewModel : FlowViewModel
     partial void OnPreviewUrlChanged(string? value) => RaiseGateChanged();
 
     /// <summary>The action button lights up as soon as a run could work.</summary>
-    public bool CanRun => !SelectedMode.NeedsFolder || SelectedFolder is not null;
+    public bool CanRun => SelectedMode.Sources == SourceKinds.None || SelectedFolder is not null;
 
     /// <summary>Whether the Flight map options panel applies to the current mode.</summary>
     public bool IsFlightMapMode => SelectedMode.Kind == WorkspaceModeKind.FlightMap;
@@ -213,9 +213,9 @@ public partial class WorkspaceViewModel : FlowViewModel
         get
         {
             var folder = SelectedFolder
-                ?? (SelectedMode.NeedsFolder ? "<folder>" : null);
+                ?? (SelectedMode.Sources.HasFlag(SourceKinds.Folder) ? "<folder>" : null);
             // folder! is safe in the three explicit arms below: each of those
-            // modes has NeedsFolder true, so the line above yields the
+            // modes has Sources including Folder, so the line above yields the
             // "<folder>" placeholder (never null) when no folder is picked.
             var argv = SelectedMode.Kind switch
             {

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -567,6 +567,36 @@ public partial class WorkspaceViewModel : FlowViewModel
             await RunSetupAsync();
             return;
         }
+        // A file in the slot with a folder-only mode selected: say which folder
+        // the mode wants instead of failing into the CLI's usage error (#346
+        // discipline — reach-aware guidance in the panel's own language).
+        if (SelectedFile is { } file && !mode.Sources.HasFlag(SourceKinds.File))
+        {
+            Fail(mode.Kind switch
+            {
+                WorkspaceModeKind.FlightMap =>
+                    "Flight map works on a folder of footage — pick the folder "
+                    + "that holds your flights, not a single file.",
+                WorkspaceModeKind.PhotoMap =>
+                    "Photo map works on a folder of pictures — pick the folder "
+                    + "that holds your photos, not a single file.",
+                _ =>
+                    "Embed telemetry works on a folder of videos with their .SRT "
+                    + "flight logs — pick that folder, not a single file.",
+            });
+            return;
+        }
+        if (mode.Kind == WorkspaceModeKind.Convert && SelectedFile is { } source)
+        {
+            // No folder, no scan, no overtake window: snapshot and go.
+            var single = ConvertOptions.ToOptions();
+            ResetPreview();
+            await ExecuteFlowAsync(async () =>
+                await RunStepAsync("Converting…",
+                    CommandBuilder.Convert(source, batch: false, single))
+                && await PrimePreviewAsync());
+            return;
+        }
         if (SelectedFolder is not { } folder)
         {
             return;
@@ -577,6 +607,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         var flight = FlightOptions.ToOptions();
         var photo = PhotoOptions.ToOptions();
         var embed = EmbedOptions.ToOptions();
+        var convert = ConvertOptions.ToOptions();
         var contents = await Task.Run(() => _inspectFolder(folder));
         // The scan runs before ExecuteFlowAsync sets Step = Running, so the
         // folder can be cleared or replaced underneath us while it is in
@@ -652,6 +683,23 @@ public partial class WorkspaceViewModel : FlowViewModel
                 await ExecuteFlowAsync(() => RunStepAsync(
                     "Embedding flight data into new copies…",
                     CommandBuilder.Embed(folder, embed)));
+                return;
+            case WorkspaceModeKind.Convert
+                when !(contents.HasTopLevelFlightLogs || contents.HasTopLevelVideos):
+                // convert -b globs one directory level (SRT/MP4/MOV) and has no
+                // recursive flag at all — same reach rule as embed (#333/#338).
+                Fail(contents.HasFlightLogs || contents.HasVideos
+                    ? "Those files are in subfolders — Convert reads only the folder "
+                      + "you pick. Pick the subfolder that holds the flight logs or "
+                      + "videos."
+                    : "No flight logs (.SRT) or drone videos were found in that "
+                      + "folder. Pick the folder that holds the footage to convert.");
+                return;
+            case WorkspaceModeKind.Convert:
+                await ExecuteFlowAsync(async () =>
+                    await RunStepAsync("Converting…",
+                        CommandBuilder.Convert(folder, batch: true, convert))
+                    && await PrimePreviewAsync());
                 return;
         }
     }

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -78,6 +78,15 @@ public partial class WorkspaceViewModel : FlowViewModel
     public partial string? SelectedFolder { get; set; }
 
     [ObservableProperty]
+    public partial string? SelectedFile { get; set; }
+
+    /// <summary>The one source chip's text: a folder shows its full path, a
+    /// file just its name (the path is long and the name is what identifies
+    /// the clip).</summary>
+    public string? SourceDisplay =>
+        SelectedFolder ?? (SelectedFile is { } f ? Path.GetFileName(f) : null);
+
+    [ObservableProperty]
     public partial WorkspaceMode SelectedMode { get; set; } = WorkspaceMode.All[0];
 
     [ObservableProperty]
@@ -146,7 +155,9 @@ public partial class WorkspaceViewModel : FlowViewModel
     partial void OnPreviewUrlChanged(string? value) => RaiseGateChanged();
 
     /// <summary>The action button lights up as soon as a run could work.</summary>
-    public bool CanRun => SelectedMode.Sources == SourceKinds.None || SelectedFolder is not null;
+    public bool CanRun =>
+        SelectedMode.Sources == SourceKinds.None
+        || SelectedFolder is not null || SelectedFile is not null;
 
     /// <summary>Whether the Flight map options panel applies to the current mode.</summary>
     public bool IsFlightMapMode => SelectedMode.Kind == WorkspaceModeKind.FlightMap;
@@ -233,9 +244,26 @@ public partial class WorkspaceViewModel : FlowViewModel
 
     partial void OnSelectedFolderChanged(string? value)
     {
+        if (value is not null)
+        {
+            SelectedFile = null;
+        }
         OnPropertyChanged(nameof(CanRun));
         OnPropertyChanged(nameof(CommandPreview));
         OnPropertyChanged(nameof(PhotoLinksCannotReachOriginals));
+        OnPropertyChanged(nameof(SourceDisplay));
+        RunCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedFileChanged(string? value)
+    {
+        if (value is not null)
+        {
+            SelectedFolder = null;
+        }
+        OnPropertyChanged(nameof(CanRun));
+        OnPropertyChanged(nameof(CommandPreview));
+        OnPropertyChanged(nameof(SourceDisplay));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -308,10 +336,34 @@ public partial class WorkspaceViewModel : FlowViewModel
         Step = FlowStep.Pick;
     }
 
-    [RelayCommand]
-    private void ClearFolder()
+    /// <summary>
+    /// Single-file pick (M4a): the mirror of <see cref="SetFolderAsync"/> for
+    /// modes that take one telemetry file. No inspector scan and no
+    /// existing-map probe — both are folder concepts — so this is synchronous
+    /// and has no overtake race to re-check.
+    /// </summary>
+    public void SetFile(string path)
     {
-        // Inert while a run is in flight: pulling the folder out from under
+        if (IsBusy)
+        {
+            return;
+        }
+        SelectedFile = path;
+        ExistingMaps.Clear();
+        Outputs.Clear();
+        Warnings.Clear();
+        FlightOptions.Output = "";
+        PhotoOptions.Output = "";
+        EmbedOptions.Output = "";
+        ResetPreview();
+        Step = FlowStep.Pick;
+        SuggestedMode = null;   // becomes Convert in Task 6
+    }
+
+    [RelayCommand]
+    private void ClearSource()
+    {
+        // Inert while a run is in flight: pulling the source out from under
         // a running job would also discard the output overrides. IsBusy
         // spans the run's folder scan too, and RunAsync's ownership
         // re-check after the scan stays as defence in depth.
@@ -320,25 +372,26 @@ public partial class WorkspaceViewModel : FlowViewModel
             return;
         }
         SelectedFolder = null;
+        SelectedFile = null;
         SuggestedMode = null;
         ExistingMaps.Clear();
         // The same ownership rule SetFolderAsync explains: an output override
-        // belongs to the folder it was chosen for, and removing the folder
+        // belongs to the source it was chosen for, and removing the source
         // leaves it with no owner at all. The strip is where that shows —
         // it would go on advertising `--output <path>` beside the `<folder>`
         // placeholder. (Each Output setter raises through the ctor's options
         // subscription, so the strip repaints with the cleared value. The
-        // SelectedFolder raise above fires before these lines and still sees
-        // the old path.)
+        // SelectedFolder/SelectedFile raises above fire before these lines
+        // and still see the old path.)
         FlightOptions.Output = "";
         PhotoOptions.Output = "";
         EmbedOptions.Output = "";
         // A map browsed out of that folder can't outlive it: without this the
-        // pane keeps rendering it with no folder and no drop hero behind it.
+        // pane keeps rendering it with no source and no drop hero behind it.
         ResetPreview();
         // Nor can a finished run's results: without these, ✕ after a run left
         // Step == Done with the preview nulled, which is precisely the
-        // done-card state — outputs and warnings listed over no folder.
+        // done-card state — outputs and warnings listed over no source.
         Outputs.Clear();
         Warnings.Clear();
         Step = FlowStep.Pick;

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -570,7 +570,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         // A file in the slot with a folder-only mode selected: say which folder
         // the mode wants instead of failing into the CLI's usage error (#346
         // discipline — reach-aware guidance in the panel's own language).
-        if (SelectedFile is { } file && !mode.Sources.HasFlag(SourceKinds.File))
+        if (SelectedFile is not null && !mode.Sources.HasFlag(SourceKinds.File))
         {
             Fail(mode.Kind switch
             {
@@ -580,9 +580,10 @@ public partial class WorkspaceViewModel : FlowViewModel
                 WorkspaceModeKind.PhotoMap =>
                     "Photo map works on a folder of pictures — pick the folder "
                     + "that holds your photos, not a single file.",
-                _ =>
+                WorkspaceModeKind.Embed =>
                     "Embed telemetry works on a folder of videos with their .SRT "
                     + "flight logs — pick that folder, not a single file.",
+                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode.Kind, null),
             });
             return;
         }
@@ -689,11 +690,12 @@ public partial class WorkspaceViewModel : FlowViewModel
                 // convert -b globs one directory level (SRT/MP4/MOV) and has no
                 // recursive flag at all — same reach rule as embed (#333/#338).
                 Fail(contents.HasFlightLogs || contents.HasVideos
-                    ? "Those files are in subfolders — Convert reads only the folder "
-                      + "you pick. Pick the subfolder that holds the flight logs or "
-                      + "videos."
-                    : "No flight logs (.SRT) or drone videos were found in that "
-                      + "folder. Pick the folder that holds the footage to convert.");
+                    ? "Those files are in subfolders — Convert reads only the "
+                      + "folder you pick. Pick the subfolder that holds the "
+                      + "flight logs or videos."
+                    : "No flight logs (.SRT) or drone videos were found in "
+                      + "that folder. Pick the folder that holds the footage "
+                      + "to convert.");
                 return;
             case WorkspaceModeKind.Convert:
                 await ExecuteFlowAsync(async () =>

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -49,6 +49,8 @@ public partial class WorkspaceViewModel : FlowViewModel
         };
         EmbedOptions.PropertyChanged += (_, _) =>
             OnPropertyChanged(nameof(CommandPreview));
+        ConvertOptions.PropertyChanged += (_, _) =>
+            OnPropertyChanged(nameof(CommandPreview));
     }
 
     /// <summary>
@@ -71,6 +73,10 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Curated option state for the Embed telemetry mode (M3d). Feeds
     /// both the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
     public EmbedTelemetryOptionsViewModel EmbedOptions { get; } = new();
+
+    /// <summary>Curated option state for the Convert telemetry mode (M4a). Feeds
+    /// both the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
+    public ConvertOptionsViewModel ConvertOptions { get; } = new();
 
     public IReadOnlyList<WorkspaceMode> Modes => WorkspaceMode.All;
 
@@ -168,6 +174,9 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Whether the Embed telemetry options panel applies to the current mode.</summary>
     public bool IsEmbedMode => SelectedMode.Kind == WorkspaceModeKind.Embed;
 
+    /// <summary>Whether the Convert telemetry options panel applies to the current mode.</summary>
+    public bool IsConvertMode => SelectedMode.Kind == WorkspaceModeKind.Convert;
+
     /// <summary>
     /// True when a Photo map's "Save map to" override would leave the pins
     /// unable to find the original photos. <c>photomap --link-originals</c>
@@ -236,6 +245,12 @@ public partial class WorkspaceViewModel : FlowViewModel
                     CommandBuilder.PhotoMap(folder!, PhotoOptions.ToOptions()),
                 WorkspaceModeKind.Embed =>
                     CommandBuilder.Embed(folder!, EmbedOptions.ToOptions()),
+                WorkspaceModeKind.Convert =>
+                    SelectedFile is { } file
+                        ? CommandBuilder.Convert(file, batch: false,
+                            ConvertOptions.ToOptions())
+                        : CommandBuilder.Convert(folder!, batch: true,
+                            ConvertOptions.ToOptions()),
                 _ => CommandBuilder.Build(SelectedMode.Kind, folder),
             };
             return CommandLine.Format("dji-embed", argv);
@@ -274,6 +289,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(IsFlightMapMode));
         OnPropertyChanged(nameof(IsPhotoMapMode));
         OnPropertyChanged(nameof(IsEmbedMode));
+        OnPropertyChanged(nameof(IsConvertMode));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -301,6 +317,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         FlightOptions.Output = "";
         PhotoOptions.Output = "";
         EmbedOptions.Output = "";
+        ConvertOptions.Output = "";
         ResetPreview();
     }
 
@@ -361,7 +378,8 @@ public partial class WorkspaceViewModel : FlowViewModel
             return;
         }
         SelectedFile = path;
-        SuggestedMode = null;   // becomes Convert in Task 6
+        SuggestedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        SelectedMode = SuggestedMode;
         ResetDerivedSourceState();
         Step = FlowStep.Pick;
     }

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -177,6 +177,10 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Whether the Convert telemetry options panel applies to the current mode.</summary>
     public bool IsConvertMode => SelectedMode.Kind == WorkspaceModeKind.Convert;
 
+    /// <summary>The Save-as override only exists for single-file sources:
+    /// the CLI's batch loop writes every output beside its source.</summary>
+    public bool ConvertSaveApplies => SelectedFile is not null;
+
     /// <summary>
     /// True when a Photo map's "Save map to" override would leave the pins
     /// unable to find the original photos. <c>photomap --link-originals</c>
@@ -267,6 +271,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(CommandPreview));
         OnPropertyChanged(nameof(PhotoLinksCannotReachOriginals));
         OnPropertyChanged(nameof(SourceDisplay));
+        OnPropertyChanged(nameof(ConvertSaveApplies));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -279,6 +284,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(CanRun));
         OnPropertyChanged(nameof(CommandPreview));
         OnPropertyChanged(nameof(SourceDisplay));
+        OnPropertyChanged(nameof(ConvertSaveApplies));
         RunCommand.NotifyCanExecuteChanged();
     }
 

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -281,6 +281,30 @@ public partial class WorkspaceViewModel : FlowViewModel
         SelectedMode.FailureMessage;
 
     /// <summary>
+    /// An absolute output override ("Save map to", "Save copies to")
+    /// belongs to the source it was chosen for — carried to a new source it
+    /// either overwrites that source's outputs or writes nowhere the new
+    /// source shows. Every other option (tile style, privacy, container,
+    /// popup fields, title, timezone, ...) is deliberately app-session
+    /// state that survives a source change (GUI 2.0 spec).
+    ///
+    /// A new source (or none) disowns everything derived from the
+    /// old one: the previous run's outputs/warnings, per-source output
+    /// overrides, the browsed/primed preview. Shared by SetFolderAsync,
+    /// SetFile and ClearSource so the three doors stay in step.
+    /// </summary>
+    private void ResetDerivedSourceState()
+    {
+        ExistingMaps.Clear();
+        Outputs.Clear();
+        Warnings.Clear();
+        FlightOptions.Output = "";
+        PhotoOptions.Output = "";
+        EmbedOptions.Output = "";
+        ResetPreview();
+    }
+
+    /// <summary>
     /// Folder drop/pick: remember it, suggest the likely mode. A new folder
     /// is a fresh start — Done/Failed flip back to the idle pane. Ignored
     /// while a run is in flight.
@@ -314,25 +338,13 @@ public partial class WorkspaceViewModel : FlowViewModel
         {
             SelectedMode = SuggestedMode;
         }
-        ExistingMaps.Clear();
+        // A new folder is a fresh start: the previous run's outputs and
+        // warnings must not frame a map that was already sitting here.
+        ResetDerivedSourceState();
         foreach (var map in scan.maps)
         {
             ExistingMaps.Add(map);
         }
-        // A new folder is a fresh start: the previous run's outputs and
-        // warnings must not frame a map that was already sitting here.
-        Outputs.Clear();
-        Warnings.Clear();
-        // An absolute output override ("Save map to", "Save copies to")
-        // belongs to the folder it was chosen for — carried to a new folder it
-        // either overwrites that folder's outputs or writes nowhere the new
-        // folder shows. Every other option (tile style, privacy, container,
-        // popup fields, title, timezone, ...) is deliberately app-session
-        // state that survives a folder change (GUI 2.0 spec).
-        FlightOptions.Output = "";
-        PhotoOptions.Output = "";
-        EmbedOptions.Output = "";
-        ResetPreview();
         Step = FlowStep.Pick;
     }
 
@@ -349,15 +361,9 @@ public partial class WorkspaceViewModel : FlowViewModel
             return;
         }
         SelectedFile = path;
-        ExistingMaps.Clear();
-        Outputs.Clear();
-        Warnings.Clear();
-        FlightOptions.Output = "";
-        PhotoOptions.Output = "";
-        EmbedOptions.Output = "";
-        ResetPreview();
-        Step = FlowStep.Pick;
         SuggestedMode = null;   // becomes Convert in Task 6
+        ResetDerivedSourceState();
+        Step = FlowStep.Pick;
     }
 
     [RelayCommand]
@@ -374,26 +380,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         SelectedFolder = null;
         SelectedFile = null;
         SuggestedMode = null;
-        ExistingMaps.Clear();
-        // The same ownership rule SetFolderAsync explains: an output override
-        // belongs to the source it was chosen for, and removing the source
-        // leaves it with no owner at all. The strip is where that shows —
-        // it would go on advertising `--output <path>` beside the `<folder>`
-        // placeholder. (Each Output setter raises through the ctor's options
-        // subscription, so the strip repaints with the cleared value. The
-        // SelectedFolder/SelectedFile raises above fire before these lines
-        // and still see the old path.)
-        FlightOptions.Output = "";
-        PhotoOptions.Output = "";
-        EmbedOptions.Output = "";
-        // A map browsed out of that folder can't outlive it: without this the
-        // pane keeps rendering it with no source and no drop hero behind it.
-        ResetPreview();
-        // Nor can a finished run's results: without these, ✕ after a run left
-        // Step == Done with the preview nulled, which is precisely the
-        // done-card state — outputs and warnings listed over no source.
-        Outputs.Clear();
-        Warnings.Clear();
+        ResetDerivedSourceState();
         Step = FlowStep.Pick;
     }
 

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -118,8 +118,18 @@ internal static class FolderPicking
 
     /// <summary>Pick where to save a map's HTML, or <c>null</c> when the
     /// dialog was dismissed.</summary>
+    internal static Task<string?> PickSaveAsync(
+        Control anchor, string title, string suggestedName) =>
+        PickSaveAsync(anchor, title, suggestedName, "Web map", "*.html");
+
+    /// <summary>Pick where to save a file of the given kind, or <c>null</c>
+    /// when the dialog was dismissed — the typed form behind
+    /// <see cref="PickSaveAsync(Control, string, string)"/>, used directly
+    /// by Convert (M4a) so each format gets its own extension and filter
+    /// label instead of "Web map"/"*.html".</summary>
     internal static async Task<string?> PickSaveAsync(
-        Control anchor, string title, string suggestedName)
+        Control anchor, string title, string suggestedName,
+        string filterLabel, string pattern)
     {
         if (TopLevel.GetTopLevel(anchor) is not { } top)
         {
@@ -130,10 +140,10 @@ internal static class FolderPicking
             {
                 Title = title,
                 SuggestedFileName = suggestedName,
-                DefaultExtension = "html",
+                DefaultExtension = pattern[(pattern.LastIndexOf('.') + 1)..],
                 FileTypeChoices =
                 [
-                    new FilePickerFileType("Web map") { Patterns = ["*.html"] },
+                    new FilePickerFileType(filterLabel) { Patterns = [pattern] },
                 ],
             });
         return file?.TryGetLocalPath();

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -44,8 +45,38 @@ internal static class FolderPicking
         }
     }
 
+    /// <summary>Extensions the SOURCE area accepts as a single file (M4a):
+    /// the telemetry sources <c>convert</c> reads.</summary>
+    private static readonly string[] SourceFileExtensions =
+        [".srt", ".mp4", ".mov"];
+
+    /// <summary>Pure drop-payload resolution: the first directory wins,
+    /// otherwise the first telemetry file; anything else yields nothing.</summary>
+    internal static void ResolveDrop(
+        IEnumerable<string> paths, out string? folder, out string? file)
+    {
+        folder = null;
+        file = null;
+        foreach (var path in paths)
+        {
+            if (System.IO.Directory.Exists(path))
+            {
+                folder = path;
+                return;
+            }
+            if (file is null
+                && System.IO.File.Exists(path)
+                && Array.Exists(SourceFileExtensions, e => path.EndsWith(
+                    e, StringComparison.OrdinalIgnoreCase)))
+            {
+                file = path;
+            }
+        }
+    }
+
     internal static void EnableDrop(
-        Control target, Func<string, Task> onFolder, Control? dropZone = null)
+        Control target, Func<string, Task> onFolder, Control? dropZone = null,
+        Func<string, Task>? onFile = null)
     {
         target.AddHandler(DragDrop.DragOverEvent, (_, e) =>
             e.DragEffects = e.DataTransfer.Contains(DataFormat.File)
@@ -65,13 +96,18 @@ internal static class FolderPicking
             {
                 SetDragOver(dropZone, false);
             }
-            var folder = e.DataTransfer.TryGetFiles()
+            var paths = e.DataTransfer.TryGetFiles()
                 ?.Select(f => f.TryGetLocalPath())
-                .FirstOrDefault(p =>
-                    p is not null && System.IO.Directory.Exists(p));
+                .Where(p => p is not null)
+                .Select(p => p!) ?? [];
+            ResolveDrop(paths, out var folder, out var file);
             if (folder is not null)
             {
                 await onFolder(folder);
+            }
+            else if (file is not null && onFile is not null)
+            {
+                await onFile(file);
             }
         });
     }
@@ -101,5 +137,29 @@ internal static class FolderPicking
                 ],
             });
         return file?.TryGetLocalPath();
+    }
+
+    /// <summary>Pick a single telemetry file, or <c>null</c> when dismissed.</summary>
+    internal static async Task<string?> PickSourceFileAsync(Control anchor)
+    {
+        if (TopLevel.GetTopLevel(anchor) is not { } top)
+        {
+            return null;
+        }
+        var files = await top.StorageProvider.OpenFilePickerAsync(
+            new FilePickerOpenOptions
+            {
+                AllowMultiple = false,
+                Title = "Choose a flight log or drone video",
+                FileTypeFilter =
+                [
+                    new FilePickerFileType("Telemetry sources")
+                    {
+                        Patterns = ["*.srt", "*.SRT", "*.mp4", "*.MP4",
+                                    "*.mov", "*.MOV"],
+                    },
+                ],
+            });
+        return files.FirstOrDefault()?.TryGetLocalPath();
     }
 }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -459,7 +459,7 @@
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Privacy" Opacity="0.7"
                                                    FontSize="12" />
-                                        <ComboBox Name="TelemetryPrivacyCombo"
+                                        <ComboBox Name="EmbedPrivacyCombo"
                                                   HorizontalAlignment="Stretch"
                                                   ItemsSource="{Binding EmbedOptions.PrivacyOptions}"
                                                   SelectedItem="{Binding EmbedOptions.SelectedPrivacy}">

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -555,6 +555,136 @@
                         </StackPanel>
                     </Border>
 
+                    <Border Name="ConvertOptionsPanel"
+                            IsVisible="{Binding IsConvertMode}"
+                            IsEnabled="{Binding !IsBusy}">
+                        <StackPanel>
+                            <TextBlock Classes="zone" Text="OPTIONS" />
+                            <suki:GlassCard Padding="14">
+                                <StackPanel Spacing="12">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Convert to" Opacity="0.7" FontSize="12" />
+                                        <ComboBox Name="ConvertFormatCombo"
+                                                  HorizontalAlignment="Stretch"
+                                                  ItemsSource="{Binding ConvertOptions.Formats}"
+                                                  SelectedItem="{Binding ConvertOptions.SelectedFormat}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:FormatChoice">
+                                                    <TextBlock Text="{Binding Label}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Privacy" Opacity="0.7" FontSize="12" />
+                                        <ComboBox Name="ConvertPrivacyCombo"
+                                                  HorizontalAlignment="Stretch"
+                                                  ItemsSource="{Binding ConvertOptions.PrivacyOptions}"
+                                                  SelectedItem="{Binding ConvertOptions.SelectedPrivacy}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:TelemetryPrivacyChoice">
+                                                    <TextBlock Text="{Binding Label}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Name="FootprintSection" Spacing="4"
+                                                IsVisible="{Binding ConvertOptions.ShowsFootprintOptions}">
+                                        <CheckBox Name="FootprintsCheck"
+                                                  IsChecked="{Binding ConvertOptions.Footprints}"
+                                                  Content="Camera footprint polygons" />
+                                        <StackPanel Spacing="4" Margin="24,0,0,0"
+                                                    IsVisible="{Binding ConvertOptions.Footprints}">
+                                            <DockPanel>
+                                                <TextBlock DockPanel.Dock="Right"
+                                                           Text="{Binding ConvertOptions.FootprintInterval, StringFormat='{}{0} s'}"
+                                                           Opacity="0.7" FontSize="12" />
+                                                <TextBlock Text="Sample every" Opacity="0.7" FontSize="12" />
+                                            </DockPanel>
+                                            <Slider Name="FootprintIntervalSlider"
+                                                    Minimum="1" Maximum="10"
+                                                    TickFrequency="1" IsSnapToTickEnabled="True"
+                                                    Value="{Binding ConvertOptions.FootprintInterval}" />
+                                            <ComboBox Name="ConvertModelCombo"
+                                                      HorizontalAlignment="Stretch"
+                                                      ItemsSource="{Binding ConvertOptions.Models}"
+                                                      SelectedItem="{Binding ConvertOptions.SelectedModel}">
+                                                <ComboBox.ItemTemplate>
+                                                    <DataTemplate x:DataType="vm:ModelChoice">
+                                                        <TextBlock Text="{Binding Label}" />
+                                                    </DataTemplate>
+                                                </ComboBox.ItemTemplate>
+                                            </ComboBox>
+                                        </StackPanel>
+                                        <TextBlock Name="FootprintsSuppressedNote"
+                                                   Text="Privacy is on, so footprints are left out — a precise polygon would re-sharpen a fuzzed location."
+                                                   IsVisible="{Binding ConvertOptions.ShowsFootprintsSuppressedNote}"
+                                                   TextWrapping="Wrap" Opacity="0.5" FontSize="11" />
+                                    </StackPanel>
+
+                                    <Expander Name="ConvertAdvanced" Header="Advanced"
+                                              IsExpanded="False">
+                                        <StackPanel Spacing="12" Margin="0,8,0,0">
+                                            <StackPanel Spacing="4">
+                                                <TextBlock Text="Time zone of the clips"
+                                                           Opacity="0.7" FontSize="12" />
+                                                <TextBox Name="ConvertTzBox"
+                                                         Text="{Binding ConvertOptions.TzOffset}"
+                                                         PlaceholderText="auto" />
+                                            </StackPanel>
+
+                                            <StackPanel Name="CotSection" Spacing="4"
+                                                        IsVisible="{Binding ConvertOptions.ShowsCotOptions}">
+                                                <TextBlock Text="CoT sampling interval (seconds)"
+                                                           Opacity="0.7" FontSize="12" />
+                                                <TextBox Name="CotIntervalBox"
+                                                         Text="{Binding ConvertOptions.CotInterval}" />
+                                                <TextBlock Text="CoT event type" Opacity="0.7"
+                                                           FontSize="12" />
+                                                <TextBox Name="CotTypeBox"
+                                                         Text="{Binding ConvertOptions.CotType}"
+                                                         PlaceholderText="a-n-A" />
+                                            </StackPanel>
+
+                                            <StackPanel Name="ConvertSaveSection" Spacing="4"
+                                                        IsVisible="{Binding ConvertSaveApplies}">
+                                                <TextBlock Text="Save as" Opacity="0.7" FontSize="12" />
+                                                <DockPanel>
+                                                    <Button DockPanel.Dock="Right" Margin="8,0,0,0"
+                                                            Name="ChooseConvertOutputButton"
+                                                            Click="OnChooseConvertOutputClick">
+                                                        <TextBlock Text="Choose…" FontSize="12" />
+                                                    </Button>
+                                                    <Button DockPanel.Dock="Right" Margin="8,0,0,0"
+                                                            Name="ClearConvertOutputButton"
+                                                            Command="{Binding ConvertOptions.ClearOutputCommand}"
+                                                            IsVisible="{Binding ConvertOptions.Output,
+                                                                Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                            ToolTip.Tip="Reset to beside the source file">
+                                                        <TextBlock Text="Use default" FontSize="12" />
+                                                    </Button>
+                                                    <Panel VerticalAlignment="Center">
+                                                        <TextBlock Text="(beside the source file)"
+                                                                   IsVisible="{Binding ConvertOptions.Output,
+                                                                       Converter={x:Static StringConverters.IsNullOrEmpty}}"
+                                                                   Opacity="0.5" FontSize="12" />
+                                                        <TextBlock Text="{Binding ConvertOptions.Output}"
+                                                                   IsVisible="{Binding ConvertOptions.Output,
+                                                                       Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                                   TextTrimming="CharacterEllipsis"
+                                                                   Opacity="0.8" FontSize="12" />
+                                                    </Panel>
+                                                </DockPanel>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Expander>
+                                </StackPanel>
+                            </suki:GlassCard>
+                        </StackPanel>
+                    </Border>
+
                     <TextBlock Classes="zone" Text="ACTION" />
                     <Button Name="RunButton" Classes="Flat"
                             HorizontalAlignment="Stretch"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -459,12 +459,12 @@
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Privacy" Opacity="0.7"
                                                    FontSize="12" />
-                                        <ComboBox Name="EmbedPrivacyCombo"
+                                        <ComboBox Name="TelemetryPrivacyCombo"
                                                   HorizontalAlignment="Stretch"
                                                   ItemsSource="{Binding EmbedOptions.PrivacyOptions}"
                                                   SelectedItem="{Binding EmbedOptions.SelectedPrivacy}">
                                             <ComboBox.ItemTemplate>
-                                                <DataTemplate x:DataType="vm:EmbedPrivacyChoice">
+                                                <DataTemplate x:DataType="vm:TelemetryPrivacyChoice">
                                                     <TextBlock Text="{Binding Label}" />
                                                 </DataTemplate>
                                             </ComboBox.ItemTemplate>

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -76,15 +76,15 @@
                                     </StackPanel>
                                 </Panel>
                             </Border>
-                            <DockPanel IsVisible="{Binding SelectedFolder,
+                            <DockPanel IsVisible="{Binding SourceDisplay,
                                            Converter={x:Static ObjectConverters.IsNotNull}}">
                                 <Button DockPanel.Dock="Right"
-                                        Command="{Binding ClearFolderCommand}"
-                                        AutomationProperties.Name="Remove folder"
-                                        ToolTip.Tip="Remove folder">
+                                        Command="{Binding ClearSourceCommand}"
+                                        AutomationProperties.Name="Remove source"
+                                        ToolTip.Tip="Remove">
                                     <TextBlock Text="✕" FontSize="12" />
                                 </Button>
-                                <TextBlock Text="{Binding SelectedFolder}"
+                                <TextBlock Text="{Binding SourceDisplay}"
                                            VerticalAlignment="Center"
                                            TextTrimming="CharacterEllipsis"
                                            Opacity="0.8" FontSize="12" />

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -68,7 +68,7 @@
                                         <TextBlock Text="Drop a folder of footage here"
                                                    FontSize="15"
                                                    HorizontalAlignment="Center" />
-                                        <TextBlock Text="photos, drone videos with their .SRT flight logs, or both"
+                                        <TextBlock Text="photos, drone videos with their .SRT flight logs, or both — or a single .SRT/.MP4 to convert"
                                                    Opacity="0.6" FontSize="12"
                                                    HorizontalAlignment="Center"
                                                    TextWrapping="Wrap"
@@ -89,11 +89,17 @@
                                            TextTrimming="CharacterEllipsis"
                                            Opacity="0.8" FontSize="12" />
                             </DockPanel>
-                            <Button Name="ChooseFolderButton"
-                                    HorizontalAlignment="Center"
-                                    Click="OnChooseFolderClick">
-                                <TextBlock Text="Choose a folder…" />
-                            </Button>
+                            <StackPanel Orientation="Horizontal" Spacing="8"
+                                        HorizontalAlignment="Center">
+                                <Button Name="ChooseFolderButton"
+                                        Click="OnChooseFolderClick">
+                                    <TextBlock Text="Choose a folder…" />
+                                </Button>
+                                <Button Name="ChooseFileButton"
+                                        Click="OnChooseFileClick">
+                                    <TextBlock Text="Choose a file…" />
+                                </Button>
+                            </StackPanel>
                         </StackPanel>
                     </suki:GlassCard>
 

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -637,10 +637,16 @@
 
                                             <StackPanel Name="CotSection" Spacing="4"
                                                         IsVisible="{Binding ConvertOptions.ShowsCotOptions}">
-                                                <TextBlock Text="CoT sampling interval (seconds)"
-                                                           Opacity="0.7" FontSize="12" />
-                                                <TextBox Name="CotIntervalBox"
-                                                         Text="{Binding ConvertOptions.CotInterval}" />
+                                                <DockPanel>
+                                                    <TextBlock DockPanel.Dock="Right"
+                                                               Text="{Binding ConvertOptions.CotInterval, StringFormat='{}{0} s'}"
+                                                               Opacity="0.7" FontSize="12" />
+                                                    <TextBlock Text="CoT sampling interval" Opacity="0.7" FontSize="12" />
+                                                </DockPanel>
+                                                <Slider Name="CotIntervalSlider"
+                                                        Minimum="1" Maximum="10"
+                                                        TickFrequency="1" IsSnapToTickEnabled="True"
+                                                        Value="{Binding ConvertOptions.CotInterval}" />
                                                 <TextBlock Text="CoT event type" Opacity="0.7"
                                                            FontSize="12" />
                                                 <TextBox Name="CotTypeBox"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.IO;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -50,6 +51,12 @@ public partial class WorkspaceView : UserControl
     /// </summary>
     internal Func<Control, Task<string?>> FilePicker
     { get; set; } = FolderPicking.PickSourceFileAsync;
+
+    /// <summary>Save-file picking for Convert's Choose… button — the
+    /// <see cref="SavePicker"/> seam with the format's own extension:
+    /// (anchor, title, suggestedName, filterLabel, pattern) → path or null.</summary>
+    internal Func<Control, string, string, string, string, Task<string?>>
+        ConvertSavePicker { get; set; } = FolderPicking.PickSaveAsync;
 
     public WorkspaceView()
     {
@@ -177,6 +184,22 @@ public partial class WorkspaceView : UserControl
                 this, "Choose where to save the embedded copies") is { } path)
         {
             vm.EmbedOptions.Output = path;
+        }
+    }
+
+    private async void OnChooseConvertOutputClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not WorkspaceViewModel vm
+            || vm.SelectedFile is not { } file)
+        {
+            return;
+        }
+        var fmt = vm.ConvertOptions.SelectedFormat;
+        var name = Path.GetFileNameWithoutExtension(file) + "." + fmt.Suffix;
+        if (await ConvertSavePicker(this, "Save the converted file as", name,
+                fmt.Label, "*." + fmt.Suffix) is { } path)
+        {
+            vm.ConvertOptions.Output = path;
         }
     }
 

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -43,10 +43,18 @@ public partial class WorkspaceView : UserControl
     internal Func<Control, string, Task<string?>> OutputFolderPicker
     { get; set; } = FolderPicking.PickFolderAsync;
 
+    /// <summary>
+    /// Single-file picking for the source card's "Choose a file…"
+    /// button — a test seam in the <see cref="SavePicker"/> mould:
+    /// (anchor) → the chosen path, or null when dismissed.
+    /// </summary>
+    internal Func<Control, Task<string?>> FilePicker
+    { get; set; } = FolderPicking.PickSourceFileAsync;
+
     public WorkspaceView()
     {
         InitializeComponent();
-        FolderPicking.EnableDrop(this, SetFolderAsync, DropZone);
+        FolderPicking.EnableDrop(this, SetFolderAsync, DropZone, SetFileAsync);
         DataContextChanged += (_, _) =>
         {
             if (_vm is not null)
@@ -133,6 +141,15 @@ public partial class WorkspaceView : UserControl
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>
         await FolderPicking.ChooseAsync(this, SetFolderAsync);
 
+    private async void OnChooseFileClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is WorkspaceViewModel vm
+            && await FilePicker(this) is { } path)
+        {
+            vm.SetFile(path);
+        }
+    }
+
     private async void OnChooseOutputClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is WorkspaceViewModel vm
@@ -183,4 +200,10 @@ public partial class WorkspaceView : UserControl
         DataContext is WorkspaceViewModel vm
             ? vm.SetFolderAsync(folder)
             : System.Threading.Tasks.Task.CompletedTask;
+
+    private Task SetFileAsync(string file)
+    {
+        (DataContext as WorkspaceViewModel)?.SetFile(file);
+        return Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
## What this adds

**The SOURCE door now takes a single telemetry file** (`.SRT`/`.MP4`/`.MOV`) as well as a folder — drop it or use the new "Choose a file…" button. File and folder are one slot, mutually exclusive; picking one clears the other and all derived state (shared `ResetDerivedSourceState`).

**A new Convert mode** sits between Embed and Setup in the strip and turns either source into GPX / CSV / GeoJSON / KML / web map (HTML) / CoT via the CLI's `convert` subcommand (JSONL contract from #349):

- Curated options: format, privacy (shared `TelemetryPrivacy`, promoted from the Embed panel), footprint polygons with interval + drone-model pickers (KML/GeoJSON only), CoT interval/type (CoT only), time zone and save-as under Advanced.
- Single-file runs go straight to the CLI (no folder scan) and an HTML conversion primes the inline preview for free via the existing `PrimePreviewAsync` mechanism.
- Folder runs batch with `-b`, guarded by the same top-level-reach rule as Embed (`convert -b` globs one level, no recursion) — nested/empty folders block with plain-language guidance instead of a CLI usage error.
- Folder-only modes (Flight map / Photo map / Embed) block a file source at run time with mode-specific guidance, per the recursion-mismatch design.
- The footprint-suppression interaction (CLI silently drops footprints under any redaction) surfaces as an explanatory note in the panel.

## Discipline

- Spec committed on-branch: `docs/superpowers/specs/2026-07-21-gui-m4a-source-file-and-convert-mode-design.md`.
- TDD throughout; every task spec-reviewed + quality-reviewed, plus a whole-branch fresh-eyes review (verdict: ship). Suite 340 → 385 (371 passed / 14 skipped), 0 warnings, Debug + Release both green.
- CoT interval ships as a snap-to-tick slider: a double-bound TextBox parses with UI culture and misbehaves on comma-decimal locales.

## Noted fast-follows (deliberately out of scope)

- Telemetry extension list now exists in 3 places (FolderPicking, its picker patterns, FolderInspector) — consolidate.
- `ResolveDrop`'s out-params → tuple to match house style.
- A pre-run assertion covering CanRun/strip state for file-source + folder-only-mode.

M4b (Verify mode) follows in its own PR per the two-PR delivery decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XuoE5YY4z8jFGhSQXPrNZ