### PR TITLE
GUI M4b: Verify mode — check/validate/verify-sun behind one sub-action switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,11 @@ Embed, Setup), with Convert and Verify joining in M4. Options stay curated,
 not exhaustive: they arrive in M3+, one *Advanced* expander per mode for the
 long tail, exotic flags remain CLI-only. As of M4a, the SOURCE door also
 accepts a single telemetry file (`.SRT`/`.MP4`/`.MOV`), not just a folder,
-and Convert turns it (or a folder) into GPX/CSV/GeoJSON/KML/an HTML map/CoT. A WebView is now allowed, but
+and Convert turns it (or a folder) into GPX/CSV/GeoJSON/KML/an HTML map/CoT.
+As of M4b the sixth mode, Verify footage, merges `check` / `validate` /
+`verify-sun` behind a sub-action switch and renders their result
+summaries as report cards in the done pane; `check` now expands a
+directory argument to its top-level media files. A WebView is now allowed, but
 solely for the preview pane (arrives M2) — no other embedded browser
 surface. There is still no settings dialog; the only state the app persists
 is MRU folders and window bounds. The thin-frontend architecture is

--- a/HELP.md
+++ b/HELP.md
@@ -35,11 +35,16 @@ Two ways to use it — same engine:
 
 1. **Windows app** ("DJI Metadata Embedder"): install, open, drop a folder,
    pick a mode (*Flight map*, *Photo map*, *Embed telemetry*,
-   *Convert telemetry*, *Setup*), and press the action button; finished maps
-   render right in the app's preview pane, with an *Open in browser* pop-out.
-   No terminal. The workspace also accepts a single telemetry file
-   (`.SRT`/`.MP4`/`.MOV`) as the source, and *Convert telemetry* turns it
-   (or a folder) into GPX, CSV, GeoJSON, KML, an HTML map, or CoT.
+   *Convert telemetry*, *Verify footage*, *Setup*), and press the action
+   button; finished maps render right in the app's preview pane, with an
+   *Open in browser* pop-out. No terminal. The workspace also accepts a
+   single telemetry file (`.SRT`/`.MP4`/`.MOV`) as the source, and
+   *Convert telemetry* turns it (or a folder) into GPX, CSV, GeoJSON, KML,
+   an HTML map, or CoT. *Verify footage* answers three questions about what
+   you already have: does a video or photo carry embedded GPS/altitude/time
+   metadata, do a folder's videos pair up cleanly with their .SRT flight
+   logs, and does the sun's computed position over a clip match the shadows
+   you see.
 2. **`dji-embed` command line**: every feature, all platforms. The Windows
    app's installer puts `dji-embed` on your PATH automatically.
 

--- a/docs/PROGRESS_JSONL.md
+++ b/docs/PROGRESS_JSONL.md
@@ -93,7 +93,7 @@ field, never by arrival order.
   `warning` event (`"Not found or unreadable"`) — the run still ends in
   `result` with `"ok": true`.
 - A directory argument stands for its **top-level** media files
-  (`*.mp4`/`*.mov`/`*.jpg`, case-insensitive, no recursion):
+  (`*.mp4`/`*.mov`/`*.jpg`/`*.jpeg`/`*.dng`, case-insensitive, no recursion):
   `start.total`, the `progress` events and `summary.files` all name the
   expanded files, never the directory itself. A directory with no media
   files contributes nothing and yields one `warning` event

--- a/docs/PROGRESS_JSONL.md
+++ b/docs/PROGRESS_JSONL.md
@@ -98,7 +98,10 @@ field, never by arrival order.
   expanded files, never the directory itself. A directory with no media
   files contributes nothing and yields one `warning` event
   (`"No media files found"`, `item` = the directory) — the run still
-  ends in `result` with `"ok": true`.
+  ends in `result` with `"ok": true`. A directory that cannot be listed
+  (e.g. a permissions error) is handled the same way: it contributes
+  nothing and yields one `warning` event (`"Not found or unreadable"`,
+  `item` = the directory) rather than aborting the run.
 
 ### `doctor`
 - No `progress` events. One `warning` per missing tool (`item` = tool

--- a/docs/PROGRESS_JSONL.md
+++ b/docs/PROGRESS_JSONL.md
@@ -92,6 +92,13 @@ field, never by arrival order.
   bool}`. A path that does not exist or cannot be read yields `{}` and a
   `warning` event (`"Not found or unreadable"`) — the run still ends in
   `result` with `"ok": true`.
+- A directory argument stands for its **top-level** media files
+  (`*.mp4`/`*.mov`/`*.jpg`, case-insensitive, no recursion):
+  `start.total`, the `progress` events and `summary.files` all name the
+  expanded files, never the directory itself. A directory with no media
+  files contributes nothing and yields one `warning` event
+  (`"No media files found"`, `item` = the directory) — the run still
+  ends in `result` with `"ok": true`.
 
 ### `doctor`
 - No `progress` events. One `warning` per missing tool (`item` = tool

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -58,7 +58,7 @@ This guide helps you choose the right command and approach for your specific use
 | **Purpose** | **Command** | **Use Case** |
 |-------------|-------------|--------------|
 | Check existing metadata | `dji-embed check /path/to/files` | See what's already embedded |
-| Validate SRT/MP4 sync | `dji-embed validate /path/to/videos` | Check for timing drift issues |
+| Validate SRT/video sync | `dji-embed validate /path/to/videos` | Check for timing drift issues |
 | System diagnostics | `dji-embed doctor` | Troubleshoot installation problems |
 | Version information | `dji-embed --version` | Check tool and dependency versions |
 

--- a/docs/superpowers/specs/2026-07-22-gui-m4b-verify-mode-design.md
+++ b/docs/superpowers/specs/2026-07-22-gui-m4b-verify-mode-design.md
@@ -1,0 +1,150 @@
+# GUI M4b — Verify mode
+
+*Design round 2026-07-22 (Marcus + Claude). Amends nothing; implements the
+Verify row of the mode-curation table in the GUI 2.0 workspace spec
+(2026-07-18) on top of the M4a source lift. Completes the M4 milestone —
+the second of the two PRs decided in the M4a round.*
+
+## Decisions taken in the round
+
+- **Mismatched sub-actions grey out.** The sub-action switch disables
+  segments the current source shape cannot feed, instead of the
+  block-with-guidance run guard used for mode/source mismatches. The
+  geometry makes this safe: a file disables only Validate pairing, a
+  folder disables only Sun check, no source disables nothing — so at most
+  one segment is ever grey, and it gets an inline note explaining itself.
+- **`check` learns directories in the CLI**, not in the GUI. The
+  subcommand today ffprobes a directory argument itself (the media glob
+  lives only in the standalone `metadata_check` entry point); expanding it
+  in the CLI keeps the frontend thin, keeps the transparency strip short
+  and honest (`check <folder>`), and fixes the quirk for terminal users
+  too. Rejected: GUI-side enumeration (strip becomes a file dump) and
+  file-only Check (a folder of embedded MP4s is the natural post-Embed
+  spot-check).
+- **Validate's report card is verdict + issue rows.** The per-file drift
+  table (`file_analyses`) stays CLI-only (`validate --format json`) —
+  analyst-grade detail per the curated-options philosophy. The issue and
+  warning strings already name the offending files.
+
+## Sub-action model
+
+- `VerifySubAction { Check, Validate, Sun }`. The options panel leads with
+  a three-segment switch: **Check metadata / Validate pairing / Sun
+  check**. Default: Check — the only sub-action valid for both source
+  shapes, and the defaults invariant (untouched Verify runs bare
+  `check <source>`).
+- Verify's `SourceKinds` = `Folder | File`; the M4a source slot works
+  unchanged. File drops keep suggesting Convert (M4a rule untouched);
+  Verify is never auto-suggested.
+- Enablement from the source shape:
+
+  | Source | Check | Validate | Sun |
+  |---|---|---|---|
+  | none | ✓ | ✓ | ✓ |
+  | file | ✓ | greyed | ✓ |
+  | folder | ✓ | ✓ | greyed |
+
+  The one greyed segment gets a quiet inline note beneath the switch
+  (pinned strings, GUI language): Validate greyed → "Validate pairing
+  compares a whole folder of videos with their flight logs — choose a
+  folder." Sun greyed → "Sun check reads one flight log or video — drop a
+  single file." No source → no note.
+- **Snap-back:** when a source change disables the selected sub-action,
+  selection moves to Check metadata. The switch never rests on a disabled
+  segment, so the action button and strip never describe a run that can't
+  happen. (`verify-sun` accepts SRT *and* MP4/MOV — `load_gps_points`
+  routes videos through the ExifTool extractor — so every file the source
+  slot accepts keeps Sun check enabled.)
+- The action verb adapts to the sub-action: "Check metadata" / "Validate
+  pairing" / "Check the sun". Running message: "Checking…" /
+  "Validating…" / "Checking the sun…". Failure message: "Something went
+  wrong while verifying the footage."
+
+## CLI work item: `check` directory expansion (first commit, additive)
+
+- The `check` subcommand expands a directory argument to its top-level
+  media files, sharing one helper with the standalone entry's glob
+  (`*.mp4/MP4/mov/MOV/jpg/JPG`); top level only, consistent with the
+  non-recursive-command guards. File arguments unchanged.
+- JSONL stays contract-shaped: `start.total` and the `progress` events
+  count the *expanded* file list; `summary.files` keys are file paths. An
+  empty directory yields `{"checked": 0, "files": {}}` with a warning —
+  the GUI's #346-style pre-run guard should normally prevent that run.
+- One added paragraph in `docs/PROGRESS_JSONL.md` under `### check`.
+  Python-side TDD; suite baseline 687.
+
+## Options and argv
+
+- Curated controls: the sub-action switch **is** the curated control. No
+  output/save section — Verify writes nothing.
+- One **Advanced** expander, contextual sections in the Convert-CoT mould:
+  - **DriftSection** (visible only for Validate): drift-threshold slider,
+    snap-to-tick, 0.5–5.0 s in 0.5 steps, default 1.0 s (the CLI
+    default; omitted from argv when untouched). Sliders, never
+    double-bound TextBoxes — the CotInterval culture lesson.
+  - **TzSection** (visible only for Sun): timezone offset text box in the
+    Convert `--tz-offset` mould — string passthrough, empty = the CLI's
+    `auto` default, culture-safe because it is never parsed as a number.
+- Record `VerifyTelemetryOptions` (SubAction, DriftThreshold, TzOffset) +
+  `VerifyOptionsViewModel`, VM property `VerifyOptions` — the M3d naming
+  convention. Choice records co-located with the single-consumer VM.
+- **`CommandBuilder.Verify(source, options)`** feeds run + strip, with the
+  exhaustive-switch idiom:
+  - Check → `check <source>`
+  - Validate → `validate <folder>` (+ `--drift-threshold X` off-default;
+    invariant-culture serialization)
+  - Sun → `verify-sun <file>` (+ `--tz-offset X` when set)
+- Idle strip placeholder before a source is picked: `check <source>`.
+
+## Mode/source guards
+
+`CanRun` semantics unchanged from M4a. The sub-action greying removes the
+shape-mismatch class before the run, but the folder-content guard remains:
+Check or Validate on a folder with no top-level media/flight logs blocks
+with #346-style pinned guidance (Check needs top-level videos or photos;
+Validate needs top-level videos or flight logs). Sun check needs no guard
+beyond the file itself — the CLI's failure is the answer and surfaces
+through the normal error card.
+
+## Report cards
+
+The done pane renders **report cards, never raw text** (spec grace note),
+via the proven `DoctorReport.Parse` pattern: pure static parsers over the
+result event's `Summary` JsonElement, one per sub-action, all producing one
+shared display shape — a **headline** string plus rows of
+`VerifyCard(Status, Title, Detail)` (status glyph ✓/⚠/✗). One display
+record → one ItemsControl in the done pane; three parsers in
+`Services/VerifyReport.cs`:
+
+- **CheckReport**: headline "Checked 12 files"; one row per file — title =
+  file name, detail = "GPS ✓ · Altitude ✓ · Recording time ✗", status =
+  worst-of: ✓ when all three flags are present, ⚠ when some are missing.
+  An unreadable entry (`{}`) → ✗ "Couldn't read this file."
+- **ValidateReport**: headline verdict — "Everything pairs up — 12 of 12"
+  when clean, "11 of 12 pairs check out" otherwise; one row per issue (⚠)
+  and per report warning, in the report's own words.
+- **SunReport**: stat rows (GPS points, UTC span, sun elevation range,
+  azimuth start → end) plus flags translated to novice language: `night` →
+  "Shot at night — the sun was below the horizon the whole time";
+  `very_low_sun` → "The sun was very low — long shadows, near sunrise or
+  sunset"; `sun_not_computable` → "Couldn't work out the sun's position —
+  the file has no usable timestamps."
+- Malformed or missing summaries parse to an empty card list, never throw
+  (the DoctorReport degradation rule).
+- **No double display:** validate's issues and sun's flags are *also*
+  emitted as JSONL `warning` events, so a successful Verify run shows the
+  report instead of the generic warnings expander. Failure paths keep the
+  standard error card + stderr details.
+
+## Testing
+
+House pattern throughout: TDD; CommandBuilder golden tests (option state
+in, argv out, defaults invariant `check <source>`); parser unit tests fed
+real JSONL summary shapes including empty/malformed; named controls +
+`Assert.Same(vm.X, control.Command)` binding-identity checks; every panel
+mutation paired with a `CommandPreview` assertion; enablement + snap-back
+tests for the switch; pinned-string tests for the inline notes and guards;
+the shared freeze test grows the Verify panel; screenshot capture
+`workspace-verify-options.png` (interleaved-tick idiom). Python side:
+check-expansion tests + the PROGRESS_JSONL.md paragraph. GUI suite
+baseline 385.

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -564,4 +564,46 @@ public class CommandBuilderTests
     public void Build_convert_arm_uses_defaults_batch()
         => Assert.Equal(["convert", "gpx", "F", "-b"],
             CommandBuilder.Build(WorkspaceModeKind.Convert, "F"));
+
+    [Fact]
+    public void Verify_defaults_run_bare_check() =>
+        Assert.Equal(["check", "/f"],
+            CommandBuilder.Verify("/f", VerifyTelemetryOptions.Defaults));
+
+    [Fact]
+    public void Verify_validate_omits_the_default_drift_threshold()
+    {
+        var opts = VerifyTelemetryOptions.Defaults with
+        { SubAction = VerifySubAction.Validate };
+        Assert.Equal(["validate", "/f"], CommandBuilder.Verify("/f", opts));
+    }
+
+    [Fact]
+    public void Verify_validate_emits_drift_threshold_invariantly()
+    {
+        var opts = VerifyTelemetryOptions.Defaults with
+        { SubAction = VerifySubAction.Validate, DriftThreshold = 2.5 };
+        Assert.Equal(["validate", "/f", "--drift-threshold", "2.5"],
+            CommandBuilder.Verify("/f", opts));
+    }
+
+    [Fact]
+    public void Verify_sun_emits_tz_offset_when_set()
+    {
+        var opts = VerifyTelemetryOptions.Defaults with
+        { SubAction = VerifySubAction.Sun, TzOffset = "+02:00" };
+        Assert.Equal(["verify-sun", "/clip.SRT", "--tz-offset", "+02:00"],
+            CommandBuilder.Verify("/clip.SRT", opts));
+    }
+
+    [Fact]
+    public void Verify_sun_treats_empty_and_auto_tz_as_default()
+    {
+        var sun = VerifyTelemetryOptions.Defaults with
+        { SubAction = VerifySubAction.Sun };
+        Assert.Equal(["verify-sun", "/c.SRT"],
+            CommandBuilder.Verify("/c.SRT", sun));
+        Assert.Equal(["verify-sun", "/c.SRT"],
+            CommandBuilder.Verify("/c.SRT", sun with { TzOffset = " auto " }));
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -350,6 +350,51 @@ public class ScreenshotCaptureTests
         Capture(window, Path.Combine(dir!, "workspace-convert-options-advanced.png"));
     }
 
+    /// <summary>
+    /// The Verify curated options (M4b): a folder selected (so the
+    /// Validate segment is live and the Sun note explains why Sun check
+    /// is greyed) with Validate pairing chosen and Advanced open — the
+    /// state that shows the panel's full shape: the sub-action switch,
+    /// the note, and the drift-threshold Advanced row together.
+    /// </summary>
+    [AvaloniaFact]
+    public async Task Captures_verify_options_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture the Verify options.");
+        Directory.CreateDirectory(dir!);
+
+        var folder = Path.Combine(Path.GetTempPath(),
+            "djiembed-capture-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "DJI_0001.MP4"), "");
+
+        var vm = new WorkspaceViewModel(
+            null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+            previewAvailable: static () => false);
+        await vm.SetFolderAsync(folder);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        var view = new WorkspaceView { WebViewGate = static () => false };
+        view.DataContext = vm;
+        var window = new Window { Width = 1140, Height = 1200, Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        view.FindControl<RadioButton>("ValidateSubActionRadio")!.IsChecked = true;
+        view.FindControl<Expander>("VerifyAdvanced")!.IsExpanded = true;
+        // The expander reveals its content with an animation; without
+        // advancing the headless render clock the capture catches it
+        // half-open and the Advanced rows are clipped away. Interleaved
+        // ticks are required — one big tick count does NOT settle it.
+        for (var i = 0; i < 80; i++)
+        {
+            AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+        }
+        Capture(window, Path.Combine(dir!, "workspace-verify-options.png"));
+    }
+
     private static void CaptureView(
         Control view, string outPath, double width = 1140, double height = 720) =>
         Capture(new Window { Width = width, Height = height, Content = view },

--- a/gui/DjiEmbed.Gui.Tests/VerifyOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/VerifyOptionsViewModelTests.cs
@@ -1,0 +1,62 @@
+using DjiEmbed.Gui.ViewModels;
+using Xunit;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class VerifyOptionsViewModelTests
+{
+    [Fact]
+    public void Defaults_are_check_with_cli_default_drift_and_auto_tz()
+    {
+        var vm = new VerifyOptionsViewModel();
+        Assert.Equal(VerifyTelemetryOptions.Defaults, vm.ToOptions());
+        Assert.True(vm.IsCheck);
+        Assert.False(vm.IsValidate);
+        Assert.False(vm.IsSun);
+    }
+
+    [Fact]
+    public void Radio_bools_drive_and_reflect_the_sub_action()
+    {
+        var vm = new VerifyOptionsViewModel();
+        vm.IsValidate = true;
+        Assert.Equal(VerifySubAction.Validate, vm.SubAction);
+        Assert.False(vm.IsCheck);
+        // The OLD radio turning off must not steal the selection back.
+        vm.IsCheck = false;
+        Assert.Equal(VerifySubAction.Validate, vm.SubAction);
+        vm.IsSun = true;
+        Assert.Equal(VerifySubAction.Sun, vm.SubAction);
+    }
+
+    [Fact]
+    public void Contextual_gates_follow_the_sub_action()
+    {
+        var vm = new VerifyOptionsViewModel();
+        Assert.False(vm.ShowsDriftOptions);
+        Assert.False(vm.ShowsTzOptions);
+        Assert.False(vm.ShowsAdvancedOptions);
+        vm.SubAction = VerifySubAction.Validate;
+        Assert.True(vm.ShowsDriftOptions);
+        Assert.False(vm.ShowsTzOptions);
+        Assert.True(vm.ShowsAdvancedOptions);
+        vm.SubAction = VerifySubAction.Sun;
+        Assert.False(vm.ShowsDriftOptions);
+        Assert.True(vm.ShowsTzOptions);
+        Assert.True(vm.ShowsAdvancedOptions);
+    }
+
+    [Fact]
+    public void ToOptions_snapshots_the_control_state()
+    {
+        var vm = new VerifyOptionsViewModel
+        {
+            SubAction = VerifySubAction.Validate,
+            DriftThreshold = 2.5,
+            TzOffset = "+02:00",
+        };
+        Assert.Equal(
+            new VerifyTelemetryOptions(VerifySubAction.Validate, 2.5, "+02:00"),
+            vm.ToOptions());
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/VerifyReportTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/VerifyReportTests.cs
@@ -1,0 +1,132 @@
+using System.Linq;
+using System.Text.Json;
+using DjiEmbed.Gui.Services;
+using Xunit;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class VerifyReportTests
+{
+    private static JsonElement Json(string json) =>
+        JsonDocument.Parse(json).RootElement.Clone();
+
+    [Fact]
+    public void Check_reports_one_row_per_file_with_flag_glyphs()
+    {
+        var report = VerifyReport.FromCheck(Json(
+            """
+            {"checked": 2, "files": {
+                "C:\\clips\\DJI_0001.MP4":
+                    {"gps": true, "altitude": true, "creation_time": true},
+                "C:\\clips\\DJI_0002.MP4":
+                    {"gps": false, "altitude": true, "creation_time": true}}}
+            """));
+        Assert.Equal("Checked 2 files", report.Headline);
+        Assert.Equal(2, report.Cards.Count);
+        Assert.Equal(VerifyStatus.Ok, report.Cards[0].Status);
+        Assert.Equal("DJI_0001.MP4", report.Cards[0].Title);
+        Assert.Equal("GPS ✓ · Altitude ✓ · Recording time ✓",
+            report.Cards[0].Detail);
+        Assert.Equal(VerifyStatus.Attention, report.Cards[1].Status);
+        Assert.Equal("GPS ✗ · Altitude ✓ · Recording time ✓",
+            report.Cards[1].Detail);
+    }
+
+    [Fact]
+    public void Check_marks_an_unreadable_file_failed()
+    {
+        var report = VerifyReport.FromCheck(Json(
+            """{"checked": 1, "files": {"gone.mp4": {}}}"""));
+        Assert.Equal("Checked 1 file", report.Headline);
+        var card = Assert.Single(report.Cards);
+        Assert.Equal(VerifyStatus.Failed, card.Status);
+        Assert.Equal("Couldn't read this file.", card.Detail);
+    }
+
+    [Fact]
+    public void Validate_clean_run_headline_has_no_cards()
+    {
+        var report = VerifyReport.FromValidate(Json(
+            """
+            {"total_files": 2, "valid_pairs": 2, "issues": [],
+             "warnings": [], "file_analyses": []}
+            """));
+        Assert.Equal("Everything pairs up — 2 of 2", report.Headline);
+        Assert.Empty(report.Cards);
+    }
+
+    [Fact]
+    public void Validate_issues_and_warnings_become_attention_rows()
+    {
+        var report = VerifyReport.FromValidate(Json(
+            """
+            {"total_files": 2, "valid_pairs": 1,
+             "issues": ["No SRT file found for: DJI_0002.MP4"],
+             "warnings": ["DJI_0001: drift 1.4s exceeds threshold"],
+             "file_analyses": []}
+            """));
+        Assert.Equal("1 of 2 pairs check out", report.Headline);
+        Assert.Equal(2, report.Cards.Count);
+        Assert.All(report.Cards,
+            c => Assert.Equal(VerifyStatus.Attention, c.Status));
+        Assert.Equal("No SRT file found for: DJI_0002.MP4",
+            report.Cards[0].Title);
+    }
+
+    [Fact]
+    public void Sun_reports_stats_and_translates_the_night_flag()
+    {
+        var report = VerifyReport.FromSun(Json(
+            """
+            {"file": "DJI_0001.SRT", "points": 120, "sun_computed": 120,
+             "utc_start": "2026-07-01T20:00:00Z",
+             "utc_end": "2026-07-01T20:02:00Z",
+             "elevation_min": -8.1, "elevation_max": -5.2,
+             "azimuth_start": 310.5, "azimuth_end": 312.9,
+             "flags": ["night"]}
+            """));
+        Assert.Equal("Sun position over DJI_0001.SRT", report.Headline);
+        Assert.Equal(5, report.Cards.Count);
+        Assert.Equal("120 in the clip · 120 with a computed sun position",
+            report.Cards[0].Detail);
+        Assert.Equal("2026-07-01T20:00:00Z → 2026-07-01T20:02:00Z",
+            report.Cards[1].Detail);
+        Assert.Equal("-8.1° to -5.2°", report.Cards[2].Detail);
+        Assert.Equal("310.5° → 312.9°", report.Cards[3].Detail);
+        var flag = report.Cards[4];
+        Assert.Equal(VerifyStatus.Attention, flag.Status);
+        Assert.Equal(
+            "Shot at night — the sun was below the horizon the whole time.",
+            flag.Title);
+        Assert.Equal("", flag.Detail);
+    }
+
+    [Fact]
+    public void Sun_not_computable_skips_stats_and_fails_the_flag_row()
+    {
+        var report = VerifyReport.FromSun(Json(
+            """
+            {"file": "DJI_0001.SRT", "points": 3, "sun_computed": 0,
+             "utc_start": null, "utc_end": null, "elevation_min": null,
+             "elevation_max": null, "azimuth_start": null,
+             "azimuth_end": null, "flags": ["sun_not_computable"]}
+            """));
+        Assert.Equal(2, report.Cards.Count);
+        Assert.Equal(VerifyStatus.Failed, report.Cards[1].Status);
+        Assert.Equal(
+            "Couldn't work out the sun's position — the file has no usable timestamps.",
+            report.Cards[1].Title);
+    }
+
+    [Fact]
+    public void Malformed_summaries_parse_to_the_empty_report()
+    {
+        Assert.Equal(VerifyReport.Empty, VerifyReport.FromCheck(null));
+        Assert.Equal(VerifyReport.Empty, VerifyReport.FromValidate(null));
+        Assert.Equal(VerifyReport.Empty, VerifyReport.FromSun(null));
+        Assert.Equal(VerifyReport.Empty,
+            VerifyReport.FromCheck(Json("""["not", "an", "object"]""")));
+        Assert.Equal(VerifyReport.Empty,
+            VerifyReport.FromCheck(Json("""{"files": 7}""")));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
@@ -5,14 +5,19 @@ namespace DjiEmbed.Gui.Tests;
 public class WorkspaceModeTests
 {
     [Fact]
-    public void Catalogue_has_the_five_m1_plus_m4a_modes_in_strip_order()
-    {
+    public void Catalogue_has_the_six_modes_in_strip_order() =>
         Assert.Equal(
-            [WorkspaceModeKind.FlightMap, WorkspaceModeKind.PhotoMap,
-             WorkspaceModeKind.Embed, WorkspaceModeKind.Convert,
-             WorkspaceModeKind.Setup],
-            WorkspaceMode.All.Select(m => m.Kind).ToArray());
-    }
+            [
+                WorkspaceModeKind.FlightMap, WorkspaceModeKind.PhotoMap,
+                WorkspaceModeKind.Embed, WorkspaceModeKind.Convert,
+                WorkspaceModeKind.Verify, WorkspaceModeKind.Setup,
+            ],
+            WorkspaceMode.All.Select(m => m.Kind));
+
+    [Fact]
+    public void Verify_accepts_both_source_kinds() =>
+        Assert.Equal(SourceKinds.Folder | SourceKinds.File,
+            WorkspaceMode.Of(WorkspaceModeKind.Verify).Sources);
 
     [Fact]
     public void Sources_match_each_modes_reach()
@@ -20,7 +25,8 @@ public class WorkspaceModeTests
         Assert.All(WorkspaceMode.All, m => Assert.Equal(m.Kind switch
         {
             WorkspaceModeKind.Setup => SourceKinds.None,
-            WorkspaceModeKind.Convert => SourceKinds.Folder | SourceKinds.File,
+            WorkspaceModeKind.Convert or WorkspaceModeKind.Verify =>
+                SourceKinds.Folder | SourceKinds.File,
             _ => SourceKinds.Folder,
         }, m.Sources));
     }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -34,12 +34,12 @@ public class WorkspaceScreenTests
             previewAvailable: static () => false);
 
     [AvaloniaFact]
-    public void Mode_strip_shows_exactly_the_five_m1_plus_m4a_modes()
+    public void Mode_strip_shows_exactly_the_six_modes()
     {
         var window = ShowWorkspace();
         var strip = window.GetVisualDescendants().OfType<ListBox>()
             .Single(l => l.Name == "ModeStrip");
-        Assert.Equal(5, strip.ItemCount);
+        Assert.Equal(6, strip.ItemCount);
     }
 
     [AvaloniaFact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -182,6 +182,254 @@ public class WorkspaceScreenTests
     // Manual plan §2.6 "Copy is exact": the strip's Copy button must put the
     // preview on the clipboard byte-identically — a transformation on the way
     // out would break the paste-into-a-terminal promise.
+    // M4b: the Verify options panel renders only for Verify, with the
+    // advanced expander hidden entirely for the default sub-action (Check
+    // has no advanced options at all).
+    [AvaloniaFact]
+    public void Verify_mode_shows_the_options_panel_with_advanced_hidden_for_check()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "VerifyOptionsPanel");
+        Assert.True(panel.IsEffectivelyVisible);
+        Assert.False(window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "FlightOptionsPanel").IsEffectivelyVisible);
+        Assert.False(window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "PhotoOptionsPanel").IsEffectivelyVisible);
+        Assert.False(window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "EmbedOptionsPanel").IsEffectivelyVisible);
+        Assert.False(window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "ConvertOptionsPanel").IsEffectivelyVisible);
+
+        var check = window.GetVisualDescendants().OfType<RadioButton>()
+            .Single(r => r.Name == "CheckSubActionRadio");
+        Assert.True(check.IsChecked);
+
+        var advanced = window.GetVisualDescendants().OfType<Expander>()
+            .Single(e => e.Name == "VerifyAdvanced");
+        Assert.False(advanced.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Non_verify_mode_hides_the_verify_options_panel()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "VerifyOptionsPanel");
+        Assert.False(panel.IsEffectivelyVisible);
+    }
+
+    // #336-style: flip every control from the CONTROL side and assert the
+    // strip moved, catching a wrong-OBJECT binding that a compiled-binding
+    // build would let through.
+    [AvaloniaFact]
+    public void Verify_controls_flow_into_the_command_strip()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var validate = window.GetVisualDescendants().OfType<RadioButton>()
+            .Single(r => r.Name == "ValidateSubActionRadio");
+        validate.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(VerifySubAction.Validate, vm.VerifyOptions.SubAction);
+        Assert.Contains("validate", vm.CommandPreview);
+
+        var advanced = window.GetVisualDescendants().OfType<Expander>()
+            .Single(e => e.Name == "VerifyAdvanced");
+        advanced.IsExpanded = true;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var drift = window.GetVisualDescendants().OfType<Slider>()
+            .Single(s => s.Name == "DriftThresholdSlider");
+        drift.Value = 2.5;
+        Dispatcher.UIThread.RunJobs();
+        Assert.Contains("--drift-threshold 2.5", vm.CommandPreview);
+
+        vm.SetFile("/clips/DJI_0001.SRT");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var sun = window.GetVisualDescendants().OfType<RadioButton>()
+            .Single(r => r.Name == "SunSubActionRadio");
+        sun.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.Contains("verify-sun", vm.CommandPreview);
+        window.UpdateLayout();
+        var tz = window.GetVisualDescendants().OfType<TextBox>()
+            .Single(t => t.Name == "VerifyTzBox");
+        tz.Text = "+02:00";
+        Dispatcher.UIThread.RunJobs();
+        Assert.Contains("--tz-offset +02:00", vm.CommandPreview);
+    }
+
+    // At most one sub-action segment is ever disabled: a file disables only
+    // Validate, a folder only Sun, and the inline note explains whichever
+    // one it is.
+    [AvaloniaFact]
+    public async Task Verify_sub_action_radios_grey_out_by_source_shape()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var validate = window.GetVisualDescendants().OfType<RadioButton>()
+            .Single(r => r.Name == "ValidateSubActionRadio");
+        var sun = window.GetVisualDescendants().OfType<RadioButton>()
+            .Single(r => r.Name == "SunSubActionRadio");
+        var note = window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "VerifySubActionNoteText");
+
+        // No source: both enabled, note invisible.
+        Assert.True(validate.IsEnabled);
+        Assert.True(sun.IsEnabled);
+        Assert.False(note.IsEffectivelyVisible);
+
+        vm.SetFile("/clips/DJI_0001.SRT");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.False(validate.IsEnabled);
+        Assert.True(sun.IsEnabled);
+        Assert.True(note.IsEffectivelyVisible);
+        Assert.Equal("Validate pairing compares a whole folder of videos with "
+            + "their flight logs — choose a folder.", note.Text);
+
+        var dir = Directory.CreateTempSubdirectory("djiembed-screen-verify-source").FullName;
+        try
+        {
+            await vm.SetFolderAsync(dir);
+            vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+            Assert.True(validate.IsEnabled);
+            Assert.False(sun.IsEnabled);
+            Assert.True(note.IsEffectivelyVisible);
+            Assert.Equal("Sun check reads one flight log or video — drop a "
+                + "single file.", note.Text);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [AvaloniaFact]
+    public void Verify_contextual_sections_follow_the_sub_action()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        vm.VerifyOptions.SubAction = VerifySubAction.Validate;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var advanced = window.GetVisualDescendants().OfType<Expander>()
+            .Single(e => e.Name == "VerifyAdvanced");
+        Assert.True(advanced.IsEffectivelyVisible);
+        advanced.IsExpanded = true;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var driftSection = window.GetVisualDescendants().OfType<StackPanel>()
+            .Single(s => s.Name == "DriftSection");
+        var tzSection = window.GetVisualDescendants().OfType<StackPanel>()
+            .Single(s => s.Name == "VerifyTzSection");
+        Assert.True(driftSection.IsEffectivelyVisible);
+        Assert.False(tzSection.IsEffectivelyVisible);
+
+        vm.VerifyOptions.SubAction = VerifySubAction.Sun;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.False(driftSection.IsEffectivelyVisible);
+        Assert.True(tzSection.IsEffectivelyVisible);
+        Assert.True(advanced.IsEffectivelyVisible);
+    }
+
+    [AvaloniaFact]
+    public void Run_button_verb_follows_the_verify_sub_action()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var runButton = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "RunButton");
+        var label = runButton.GetVisualDescendants().OfType<TextBlock>().Single();
+        Assert.Equal("Check metadata", label.Text);
+
+        var validate = window.GetVisualDescendants().OfType<RadioButton>()
+            .Single(r => r.Name == "ValidateSubActionRadio");
+        validate.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("Validate pairing", label.Text);
+
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.FlightMap);
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal("Generate flight map", label.Text);
+    }
+
+    // Same fixture as WorkspaceViewModelTests's ValidateStream — duplicated
+    // here rather than hoisted, since nothing in this file shares fixtures
+    // with that one today.
+    private static readonly string[] ValidateStream =
+    [
+        """{"v": 1, "event": "start", "command": "validate"}""",
+        """{"v": 1, "event": "warning", "message": "No SRT file found for: DJI_0002.MP4"}""",
+        """{"v": 1, "event": "result", "ok": true, "outputs": [], "summary": {"total_files": 2, "valid_pairs": 1, "issues": ["No SRT file found for: DJI_0002.MP4"], "warnings": [], "file_analyses": []}}""",
+    ];
+
+    [AvaloniaFact]
+    public async Task Verify_done_pane_renders_the_report_and_hides_raw_warnings()
+    {
+        var dir = Directory.CreateTempSubdirectory("djiembed-screen-verify-done").FullName;
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "DJI_0001.MP4"), "");
+            File.WriteAllText(Path.Combine(dir, "DJI_0002.MP4"), "");
+            var cli = FakeCli.WriteEventStream(dir, ValidateStream);
+            var vm = new WorkspaceViewModel(cli, new DjiEmbedRunner(),
+                new FakeMapServer(null), () => { },
+                previewAvailable: static () => false);
+            var window = ShowWorkspace(vm);
+            await vm.SetFolderAsync(dir);
+            vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+            vm.VerifyOptions.SubAction = VerifySubAction.Validate;
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            await vm.RunCommand.ExecuteAsync(null);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var report = window.GetVisualDescendants().OfType<StackPanel>()
+                .Single(s => s.Name == "VerifyReportSection");
+            Assert.True(report.IsEffectivelyVisible);
+            var headline = window.GetVisualDescendants().OfType<TextBlock>()
+                .Single(t => t.Name == "VerifyHeadlineText");
+            Assert.Equal("1 of 2 pairs check out", headline.Text);
+            var warnings = window.GetVisualDescendants().OfType<ItemsControl>()
+                .Single(i => i.Name == "DoneWarningsList");
+            Assert.False(warnings.IsEffectivelyVisible);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     [AvaloniaFact]
     public async Task Copy_command_puts_the_exact_preview_on_the_clipboard()
     {
@@ -982,6 +1230,7 @@ public class WorkspaceScreenTests
             Assert.False(byName("PhotoOptionsPanel").IsEnabled);
             Assert.False(byName("EmbedOptionsPanel").IsEnabled);
             Assert.False(byName("ConvertOptionsPanel").IsEnabled);
+            Assert.False(byName("VerifyOptionsPanel").IsEnabled);
             Assert.True(byName("CopyCommandButton").IsEffectivelyEnabled);
 
             gate.SetResult();

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -304,6 +304,27 @@ public class WorkspaceViewModelTests : IDisposable
         """{"v": 1, "event": "result", "ok": true, "outputs": ["DJI_0001.gpx"], "summary": {"converted": 1, "skipped": 0, "format": "gpx"}}""",
     ];
 
+    private static readonly string[] CheckStream =
+    [
+        """{"v": 1, "event": "start", "command": "check", "total": 1}""",
+        """{"v": 1, "event": "progress", "current": 1, "total": 1, "item": "DJI_0001.MP4"}""",
+        """{"v": 1, "event": "result", "ok": true, "outputs": [], "summary": {"checked": 1, "files": {"DJI_0001.MP4": {"gps": true, "altitude": true, "creation_time": true}}}}""",
+    ];
+
+    private static readonly string[] ValidateStream =
+    [
+        """{"v": 1, "event": "start", "command": "validate"}""",
+        """{"v": 1, "event": "warning", "message": "No SRT file found for: DJI_0002.MP4"}""",
+        """{"v": 1, "event": "result", "ok": true, "outputs": [], "summary": {"total_files": 2, "valid_pairs": 1, "issues": ["No SRT file found for: DJI_0002.MP4"], "warnings": [], "file_analyses": []}}""",
+    ];
+
+    private static readonly string[] SunStream =
+    [
+        """{"v": 1, "event": "start", "command": "verify-sun"}""",
+        """{"v": 1, "event": "warning", "message": "night"}""",
+        """{"v": 1, "event": "result", "ok": true, "outputs": [], "summary": {"file": "DJI_0001.SRT", "points": 120, "sun_computed": 120, "utc_start": "2026-07-01T20:00:00Z", "utc_end": "2026-07-01T20:02:00Z", "elevation_min": -8.1, "elevation_max": -5.2, "azimuth_start": 310.5, "azimuth_end": 312.9, "flags": ["night"]}}""",
+    ];
+
     private static readonly string[] DoctorStream =
     [
         """{"v": 1, "event": "start", "command": "doctor"}""",
@@ -1844,6 +1865,193 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Equal(Path.Combine(_dir, "copies"), vm.EmbedOptions.Output);
         gate.SetResult();
         await run;
+    }
+
+    [Fact]
+    public void Verify_strip_teaches_bare_check_before_a_source_is_picked()
+    {
+        var vm = Vm("cli");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        Assert.Equal("dji-embed check <source>", vm.CommandPreview);
+    }
+
+    [Fact]
+    public void Verify_sub_action_enablement_follows_the_source_shape()
+    {
+        var vm = Vm("cli");
+        Assert.True(vm.VerifyValidateEnabled);
+        Assert.True(vm.VerifySunEnabled);
+        Assert.Null(vm.VerifySubActionNote);
+        vm.SetFile("/clips/DJI_0001.SRT");
+        Assert.False(vm.VerifyValidateEnabled);
+        Assert.True(vm.VerifySunEnabled);
+        Assert.Equal(
+            "Validate pairing compares a whole folder of videos with "
+            + "their flight logs — choose a folder.",
+            vm.VerifySubActionNote);
+    }
+
+    [Fact]
+    public async Task Verify_sub_action_enablement_for_a_folder_source()
+    {
+        var vm = Vm("cli");
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        Assert.True(vm.VerifyValidateEnabled);
+        Assert.False(vm.VerifySunEnabled);
+        Assert.Equal(
+            "Sun check reads one flight log or video — drop a single file.",
+            vm.VerifySubActionNote);
+    }
+
+    [Fact]
+    public async Task Verify_sub_action_snaps_back_to_check_when_disabled()
+    {
+        var vm = Vm("cli");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        vm.VerifyOptions.SubAction = VerifySubAction.Validate;
+        vm.SetFile("/clips/DJI_0001.SRT");
+        Assert.Equal(VerifySubAction.Check, vm.VerifyOptions.SubAction);
+        vm.VerifyOptions.SubAction = VerifySubAction.Sun;
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        Assert.Equal(VerifySubAction.Check, vm.VerifyOptions.SubAction);
+    }
+
+    [Fact]
+    public void Action_verb_follows_the_verify_sub_action()
+    {
+        var vm = Vm("cli");
+        Assert.Equal("Generate flight map", vm.ActionVerb);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        Assert.Equal("Check metadata", vm.ActionVerb);
+        vm.VerifyOptions.SubAction = VerifySubAction.Validate;
+        Assert.Equal("Validate pairing", vm.ActionVerb);
+        vm.VerifyOptions.SubAction = VerifySubAction.Sun;
+        Assert.Equal("Check the sun", vm.ActionVerb);
+    }
+
+    [Fact]
+    public async Task Verify_check_runs_bare_on_a_single_file()
+    {
+        var argsFile = Path.Combine(_dir, "argv.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, CheckStream);
+        var vm = Vm(cli);
+        var mp4 = Path.Combine(_dir, "DJI_0001.MP4");
+        File.WriteAllText(mp4, "fake");
+        vm.SetFile(mp4);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        var argv = File.ReadAllLines(argsFile);
+        Assert.Equal(["check", mp4], argv.Take(2).ToArray());
+        Assert.DoesNotContain("--drift-threshold", argv);
+        Assert.Equal("Checked 1 file", vm.VerifyHeadline);
+        var card = Assert.Single(vm.VerifyCards);
+        Assert.Equal(VerifyStatus.Ok, card.Status);
+    }
+
+    [Fact]
+    public async Task Verify_validate_runs_on_a_folder_and_hides_raw_warnings()
+    {
+        var argsFile = Path.Combine(_dir, "argv.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, ValidateStream);
+        var vm = Vm(cli);
+        var folder = MakeFolder(videos: true);
+        await vm.SetFolderAsync(folder);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        vm.VerifyOptions.SubAction = VerifySubAction.Validate;
+        vm.VerifyOptions.DriftThreshold = 2.5;
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        var argv = File.ReadAllLines(argsFile);
+        Assert.Equal(["validate", folder, "--drift-threshold", "2.5"],
+            argv.Take(4).ToArray());
+        Assert.Equal("1 of 2 pairs check out", vm.VerifyHeadline);
+        Assert.Single(vm.VerifyCards);
+        // The report IS the curated rendering of the same warning event:
+        Assert.Single(vm.Warnings);
+        Assert.False(vm.ShowDoneWarnings);
+    }
+
+    [Fact]
+    public async Task Verify_sun_runs_on_a_single_file_with_tz()
+    {
+        var argsFile = Path.Combine(_dir, "argv.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, SunStream);
+        var vm = Vm(cli);
+        var srt = Path.Combine(_dir, "DJI_0001.SRT");
+        File.WriteAllText(srt, "fake");
+        vm.SetFile(srt);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        vm.VerifyOptions.SubAction = VerifySubAction.Sun;
+        vm.VerifyOptions.TzOffset = "+02:00";
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Done, vm.Step);
+        Assert.Equal(["verify-sun", srt, "--tz-offset", "+02:00"],
+            File.ReadAllLines(argsFile).Take(4).ToArray());
+        Assert.Equal("Sun position over DJI_0001.SRT", vm.VerifyHeadline);
+        Assert.Equal(5, vm.VerifyCards.Count);
+    }
+
+    [Fact]
+    public async Task Verify_check_blocks_an_srt_file_with_guidance()
+    {
+        var vm = Vm("cli");
+        vm.SetFile("/clips/DJI_0001.SRT");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(
+            "Check metadata reads the video or photo itself — a .SRT "
+            + "flight log has no embedded metadata to check. Use Sun "
+            + "check for flight logs.",
+            vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Verify_check_blocks_a_folder_without_media_with_guidance()
+    {
+        var vm = Vm("cli");
+        await vm.SetFolderAsync(MakeFolder(srt: true));   // logs, no media
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(
+            "No videos or photos were found in that folder. Pick the "
+            + "folder that holds the drone footage to check.",
+            vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Verify_validate_blocks_a_folder_without_videos_with_guidance()
+    {
+        var vm = Vm("cli");
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        vm.VerifyOptions.SubAction = VerifySubAction.Validate;
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Equal(
+            "No videos (.MP4) were found in that folder. Validate "
+            + "pairing needs the folder that holds the videos together "
+            + "with their .SRT flight logs.",
+            vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task New_source_clears_the_verify_report()
+    {
+        var argsFile = Path.Combine(_dir, "argv.txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile, CheckStream);
+        var vm = Vm(cli);
+        var mp4 = Path.Combine(_dir, "DJI_0001.MP4");
+        File.WriteAllText(mp4, "fake");
+        vm.SetFile(mp4);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.NotEmpty(vm.VerifyCards);
+        vm.SetFile(mp4);   // fresh start through the same door
+        Assert.Empty(vm.VerifyCards);
+        Assert.Null(vm.VerifyHeadline);
     }
 
     private sealed class ThrowingMapServer : IMapServer

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -279,6 +279,48 @@ public static class CommandBuilder
     }
 
     /// <summary>
+    /// The Verify argv from typed <paramref name="opts"/> (GUI 2.0 spec,
+    /// M4b): one of three sub-commands behind the panel's sub-action
+    /// switch. Flags are omitted at their defaults so an untouched run
+    /// reads <c>check &lt;source&gt;</c>. Order is fixed for golden
+    /// tests. No <c>--progress</c>: the runner appends that. No
+    /// <c>--format</c>: the CLI rejects <c>--format json</c> alongside
+    /// <c>--progress jsonl</c>, and the result summary already carries
+    /// the full report.
+    /// </summary>
+    public static string[] Verify(string source, VerifyTelemetryOptions opts)
+    {
+        switch (opts.SubAction)
+        {
+            case VerifySubAction.Check:
+                return ["check", source];
+            case VerifySubAction.Validate:
+                var validate = new List<string> { "validate", source };
+                if (opts.DriftThreshold
+                    != VerifyTelemetryOptions.Defaults.DriftThreshold)
+                {
+                    validate.Add("--drift-threshold");
+                    validate.Add(opts.DriftThreshold.ToString(
+                        CultureInfo.InvariantCulture));
+                }
+                return validate.ToArray();
+            case VerifySubAction.Sun:
+                var sun = new List<string> { "verify-sun", source };
+                var tz = opts.TzOffset.Trim();
+                if (tz.Length > 0
+                    && !tz.Equals("auto", StringComparison.OrdinalIgnoreCase))
+                {
+                    sun.Add("--tz-offset");
+                    sun.Add(tz);
+                }
+                return sun.ToArray();
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(opts), opts.SubAction, null);
+        }
+    }
+
+    /// <summary>
     /// The <c>--popup-fields</c> value, or <c>null</c> to omit the flag.
     /// Names follow the CLI's own <c>POPUP_FIELDS</c> order. "Nothing ticked"
     /// MUST encode as <c>none</c>: <c>parse_popup_fields</c> raises on an

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -26,6 +26,8 @@ public static class CommandBuilder
         WorkspaceModeKind.Embed => Embed(folder!, EmbedTelemetryOptions.Defaults),
         WorkspaceModeKind.Convert =>
             Convert(folder!, batch: true, ConvertTelemetryOptions.Defaults),
+        WorkspaceModeKind.Verify =>
+            Verify(folder!, VerifyTelemetryOptions.Defaults),
         WorkspaceModeKind.Setup => ["doctor"],
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
     };

--- a/gui/DjiEmbed.Gui/Services/VerifyReport.cs
+++ b/gui/DjiEmbed.Gui/Services/VerifyReport.cs
@@ -1,0 +1,210 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>How one Verify report row reads at a glance.</summary>
+public enum VerifyStatus
+{
+    Ok,
+    Attention,
+    Failed,
+}
+
+/// <summary>One row of a Verify report. <paramref name="Detail"/> may be
+/// empty — flag rows carry their whole sentence in the title.</summary>
+public sealed record VerifyCard(
+    VerifyStatus Status, string Title, string Detail);
+
+/// <summary>
+/// Turns a verify-family result summary into the novice-worded report the
+/// done pane renders (GUI 2.0 spec, M4b: "reports as cards, never raw
+/// text") — the <see cref="DoctorReport"/> pattern, one factory per
+/// sub-action. A missing or malformed summary parses to
+/// <see cref="Empty"/>, never a throw: report rendering must not be able
+/// to fail a run that the CLI called successful.
+/// </summary>
+public sealed record VerifyReport(
+    string Headline, IReadOnlyList<VerifyCard> Cards)
+{
+    public static readonly VerifyReport Empty = new("", []);
+
+    /// <summary>`check`: {"checked": N, "files": {path: {gps, altitude,
+    /// creation_time}}}. An empty per-file object is the CLI's
+    /// couldn't-read marker (docs/PROGRESS_JSONL.md).</summary>
+    public static VerifyReport FromCheck(JsonElement? summary)
+    {
+        if (summary is not { ValueKind: JsonValueKind.Object } s
+            || !s.TryGetProperty("files", out var files)
+            || files.ValueKind != JsonValueKind.Object)
+        {
+            return Empty;
+        }
+        var cards = new List<VerifyCard>();
+        foreach (var file in files.EnumerateObject())
+        {
+            if (file.Value.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+            var name = FileName(file.Name);
+            var seen = false;
+            foreach (var _ in file.Value.EnumerateObject())
+            {
+                seen = true;
+                break;
+            }
+            if (!seen)
+            {
+                cards.Add(new VerifyCard(VerifyStatus.Failed, name,
+                    "Couldn't read this file."));
+                continue;
+            }
+            var gps = Flag(file.Value, "gps");
+            var altitude = Flag(file.Value, "altitude");
+            var time = Flag(file.Value, "creation_time");
+            cards.Add(new VerifyCard(
+                gps && altitude && time
+                    ? VerifyStatus.Ok : VerifyStatus.Attention,
+                name,
+                $"GPS {Glyph(gps)} · Altitude {Glyph(altitude)} · "
+                + $"Recording time {Glyph(time)}"));
+        }
+        var checkedCount = Int(s, "checked") ?? cards.Count;
+        return new VerifyReport(
+            checkedCount == 1
+                ? "Checked 1 file" : $"Checked {checkedCount} files",
+            cards);
+    }
+
+    /// <summary>`validate`: the full drift report. Issues and warnings
+    /// become rows; the per-file analyses deliberately stay CLI-only
+    /// (`validate --format json`).</summary>
+    public static VerifyReport FromValidate(JsonElement? summary)
+    {
+        if (summary is not { ValueKind: JsonValueKind.Object } s)
+        {
+            return Empty;
+        }
+        var cards = new List<VerifyCard>();
+        foreach (var issue in Strings(s, "issues"))
+        {
+            cards.Add(new VerifyCard(VerifyStatus.Attention, issue, ""));
+        }
+        foreach (var warning in Strings(s, "warnings"))
+        {
+            cards.Add(new VerifyCard(VerifyStatus.Attention, warning, ""));
+        }
+        var total = Int(s, "total_files") ?? 0;
+        var valid = Int(s, "valid_pairs") ?? 0;
+        var headline =
+            total == 0 ? "No videos to validate"
+            : cards.Count == 0 ? $"Everything pairs up — {valid} of {total}"
+            : $"{valid} of {total} pairs check out";
+        return new VerifyReport(headline, cards);
+    }
+
+    /// <summary>`verify-sun`: the sun summary dict. Stats become rows;
+    /// the angular stats are null when nothing was computable, and the
+    /// flags are translated out of their CLI names.</summary>
+    public static VerifyReport FromSun(JsonElement? summary)
+    {
+        if (summary is not { ValueKind: JsonValueKind.Object } s)
+        {
+            return Empty;
+        }
+        var cards = new List<VerifyCard>();
+        var points = Int(s, "points") ?? 0;
+        var computed = Int(s, "sun_computed") ?? 0;
+        cards.Add(new VerifyCard(VerifyStatus.Ok, "GPS points",
+            $"{points} in the clip · {computed} with a computed sun position"));
+        if (Str(s, "utc_start") is { } start && Str(s, "utc_end") is { } end)
+        {
+            cards.Add(new VerifyCard(VerifyStatus.Ok, "Time span (UTC)",
+                $"{start} → {end}"));
+        }
+        if (Num(s, "elevation_min") is { } elMin
+            && Num(s, "elevation_max") is { } elMax)
+        {
+            cards.Add(new VerifyCard(VerifyStatus.Ok, "Sun elevation",
+                $"{elMin}° to {elMax}°"));
+        }
+        if (Num(s, "azimuth_start") is { } azStart
+            && Num(s, "azimuth_end") is { } azEnd)
+        {
+            cards.Add(new VerifyCard(VerifyStatus.Ok,
+                "Sun direction (azimuth)", $"{azStart}° → {azEnd}°"));
+        }
+        foreach (var flag in Strings(s, "flags"))
+        {
+            cards.Add(flag switch
+            {
+                "night" => new VerifyCard(VerifyStatus.Attention,
+                    "Shot at night — the sun was below the horizon the "
+                    + "whole time.", ""),
+                "very_low_sun" => new VerifyCard(VerifyStatus.Attention,
+                    "The sun was very low — long shadows, near sunrise "
+                    + "or sunset.", ""),
+                "sun_not_computable" => new VerifyCard(VerifyStatus.Failed,
+                    "Couldn't work out the sun's position — the file has "
+                    + "no usable timestamps.", ""),
+                _ => new VerifyCard(VerifyStatus.Attention, flag, ""),
+            });
+        }
+        var file = Str(s, "file");
+        return new VerifyReport(
+            file is null ? "Sun position" : $"Sun position over {file}",
+            cards);
+    }
+
+    /// <summary>Last path segment after '/' or '\'. The CLI's summary
+    /// paths are Windows paths regardless of the host OS running this
+    /// code (dev/CI can be Linux), so this can't defer to
+    /// <c>Path.GetFileName</c>, which only splits on the runtime
+    /// platform's own separator.</summary>
+    private static string FileName(string path)
+    {
+        var index = path.LastIndexOfAny(['/', '\\']);
+        return index < 0 ? path : path[(index + 1)..];
+    }
+
+    private static bool Flag(JsonElement obj, string name) =>
+        obj.TryGetProperty(name, out var p)
+        && p.ValueKind == JsonValueKind.True;
+
+    private static string Glyph(bool present) => present ? "✓" : "✗";
+
+    private static int? Int(JsonElement obj, string name) =>
+        obj.TryGetProperty(name, out var p)
+        && p.ValueKind == JsonValueKind.Number
+            ? p.GetInt32() : null;
+
+    private static string? Str(JsonElement obj, string name) =>
+        obj.TryGetProperty(name, out var p)
+        && p.ValueKind == JsonValueKind.String
+            ? p.GetString() : null;
+
+    /// <summary>Raw JSON number text — the wire format is already
+    /// invariant ("-8.1"), so the display never round-trips a double
+    /// through a culture.</summary>
+    private static string? Num(JsonElement obj, string name) =>
+        obj.TryGetProperty(name, out var p)
+        && p.ValueKind == JsonValueKind.Number
+            ? p.GetRawText() : null;
+
+    private static IEnumerable<string> Strings(JsonElement obj, string name)
+    {
+        if (!obj.TryGetProperty(name, out var arr)
+            || arr.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+        foreach (var element in arr.EnumerateArray())
+        {
+            if (element.ValueKind == JsonValueKind.String)
+            {
+                yield return element.GetString()!;
+            }
+        }
+    }
+}

--- a/gui/DjiEmbed.Gui/ViewModels/VerifyOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/VerifyOptionsViewModel.cs
@@ -1,0 +1,69 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>
+/// Observable control state for the Verify options panel (GUI 2.0 spec,
+/// M4b). Bound directly to the panel; <see cref="ToOptions"/> snapshots
+/// it into the immutable <see cref="VerifyTelemetryOptions"/> the builder
+/// consumes. Lives on <see cref="WorkspaceViewModel"/>; in-memory only.
+/// The three radio-shaped booleans exist because a RadioButton binds a
+/// bool, not an enum member; their setters ignore <c>false</c> (the old
+/// radio switching off) so only the newly picked segment writes
+/// <see cref="SubAction"/>.
+/// </summary>
+public partial class VerifyOptionsViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    public partial VerifySubAction SubAction { get; set; }
+        = VerifySubAction.Check;
+
+    [ObservableProperty]
+    public partial double DriftThreshold { get; set; } = 1.0;
+
+    [ObservableProperty]
+    public partial string TzOffset { get; set; } = "";
+
+    public bool IsCheck
+    {
+        get => SubAction == VerifySubAction.Check;
+        set { if (value) { SubAction = VerifySubAction.Check; } }
+    }
+
+    public bool IsValidate
+    {
+        get => SubAction == VerifySubAction.Validate;
+        set { if (value) { SubAction = VerifySubAction.Validate; } }
+    }
+
+    public bool IsSun
+    {
+        get => SubAction == VerifySubAction.Sun;
+        set { if (value) { SubAction = VerifySubAction.Sun; } }
+    }
+
+    /// <summary>The drift slider applies to Validate pairing only.</summary>
+    public bool ShowsDriftOptions => SubAction == VerifySubAction.Validate;
+
+    /// <summary>The timezone box applies to Sun check only.</summary>
+    public bool ShowsTzOptions => SubAction == VerifySubAction.Sun;
+
+    /// <summary>Check metadata has no advanced options at all — showing
+    /// an empty expander would promise settings that aren't there.</summary>
+    public bool ShowsAdvancedOptions => SubAction != VerifySubAction.Check;
+
+    partial void OnSubActionChanged(VerifySubAction value)
+    {
+        OnPropertyChanged(nameof(IsCheck));
+        OnPropertyChanged(nameof(IsValidate));
+        OnPropertyChanged(nameof(IsSun));
+        OnPropertyChanged(nameof(ShowsDriftOptions));
+        OnPropertyChanged(nameof(ShowsTzOptions));
+        OnPropertyChanged(nameof(ShowsAdvancedOptions));
+    }
+
+    public VerifyTelemetryOptions ToOptions() => new(
+        SubAction: SubAction,
+        DriftThreshold: DriftThreshold,
+        TzOffset: TzOffset);
+}

--- a/gui/DjiEmbed.Gui/ViewModels/VerifyTelemetryOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/VerifyTelemetryOptions.cs
@@ -1,0 +1,31 @@
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>Which verification command a Verify run means (GUI 2.0 spec,
+/// M4b): the mode merges check, validate and verify-sun behind one
+/// sub-action switch.</summary>
+public enum VerifySubAction
+{
+    Check,
+    Validate,
+    Sun,
+}
+
+/// <summary>
+/// Immutable, typed state for a Verify run (GUI 2.0 spec, M4b). Single
+/// input to <see cref="Services.CommandBuilder.Verify"/>; the defaults
+/// reproduce the bare argv (<c>check &lt;source&gt;</c>).
+/// </summary>
+/// <param name="DriftThreshold">Validate only: seconds of SRT/MP4 drift
+/// before the report flags a pair (CLI default 1.0).</param>
+/// <param name="TzOffset">Sun check only: UTC offset of the clip's
+/// timestamps; empty means the CLI's mtime auto-detect.</param>
+public sealed record VerifyTelemetryOptions(
+    VerifySubAction SubAction,
+    double DriftThreshold,
+    string TzOffset)
+{
+    public static readonly VerifyTelemetryOptions Defaults = new(
+        SubAction: VerifySubAction.Check,
+        DriftThreshold: 1.0,
+        TzOffset: "");
+}

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
@@ -10,6 +10,7 @@ public enum WorkspaceModeKind
     PhotoMap,
     Embed,
     Convert,
+    Verify,
     Setup,
 }
 
@@ -25,7 +26,7 @@ public enum SourceKinds
 
 /// <summary>
 /// One entry in the workspace mode strip (GUI 2.0 spec). M1 ships four;
-/// Convert joins in M4a, Verify pending M4b.
+/// Convert joins in M4a, Verify in M4b.
 /// </summary>
 public sealed record WorkspaceMode(
     WorkspaceModeKind Kind,
@@ -48,6 +49,9 @@ public sealed record WorkspaceMode(
         new(WorkspaceModeKind.Convert, "Convert telemetry", "Convert",
             Sources: SourceKinds.Folder | SourceKinds.File,
             "Something went wrong while converting the telemetry."),
+        new(WorkspaceModeKind.Verify, "Verify footage", "Check metadata",
+            Sources: SourceKinds.Folder | SourceKinds.File,
+            "Something went wrong while verifying the footage."),
         new(WorkspaceModeKind.Setup, "Setup", "Check my setup",
             Sources: SourceKinds.None,
             "The setup check could not be completed."),

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -51,6 +51,15 @@ public partial class WorkspaceViewModel : FlowViewModel
             OnPropertyChanged(nameof(CommandPreview));
         ConvertOptions.PropertyChanged += (_, _) =>
             OnPropertyChanged(nameof(CommandPreview));
+        VerifyOptions.PropertyChanged += (_, _) =>
+        {
+            OnPropertyChanged(nameof(CommandPreview));
+            OnPropertyChanged(nameof(ActionVerb));
+        };
+        Warnings.CollectionChanged += (_, _) =>
+            OnPropertyChanged(nameof(ShowDoneWarnings));
+        VerifyCards.CollectionChanged += (_, _) =>
+            OnPropertyChanged(nameof(ShowDoneWarnings));
     }
 
     /// <summary>
@@ -77,6 +86,11 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Curated option state for the Convert telemetry mode (M4a). Feeds
     /// both the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>.</summary>
     public ConvertOptionsViewModel ConvertOptions { get; } = new();
+
+    /// <summary>Curated option state for the Verify mode (M4b). Feeds both
+    /// the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>
+    /// and the sub-action-shaped <see cref="ActionVerb"/>.</summary>
+    public VerifyOptionsViewModel VerifyOptions { get; } = new();
 
     public IReadOnlyList<WorkspaceMode> Modes => WorkspaceMode.All;
 
@@ -115,6 +129,13 @@ public partial class WorkspaceViewModel : FlowViewModel
         OpenExistingMapCommand.NotifyCanExecuteChanged();
 
     public ObservableCollection<SetupItem> SetupItems { get; } = [];
+
+    /// <summary>The last Verify run's report rows (M4b), rendered as
+    /// cards in the done pane.</summary>
+    public ObservableCollection<VerifyCard> VerifyCards { get; } = [];
+
+    [ObservableProperty]
+    public partial string? VerifyHeadline { get; set; }
 
     /// <summary>Maps this folder already had when it was picked (#328) —
     /// what is on disk, independent of the selected mode.</summary>
@@ -176,6 +197,51 @@ public partial class WorkspaceViewModel : FlowViewModel
 
     /// <summary>Whether the Convert telemetry options panel applies to the current mode.</summary>
     public bool IsConvertMode => SelectedMode.Kind == WorkspaceModeKind.Convert;
+
+    /// <summary>Whether the Verify options panel applies to the current mode.</summary>
+    public bool IsVerifyMode => SelectedMode.Kind == WorkspaceModeKind.Verify;
+
+    /// <summary>Validate pairing needs a folder — a single file greys its
+    /// segment out (the M4b enablement table).</summary>
+    public bool VerifyValidateEnabled => SelectedFile is null;
+
+    /// <summary>Sun check needs a single file — a folder greys its
+    /// segment out.</summary>
+    public bool VerifySunEnabled => SelectedFolder is null;
+
+    /// <summary>The one inline sentence that explains the one greyed
+    /// sub-action segment (at most one is ever disabled: a file disables
+    /// only Validate, a folder only Sun). Null when nothing is greyed.</summary>
+    public string? VerifySubActionNote =>
+        SelectedFile is not null
+            ? "Validate pairing compares a whole folder of videos with "
+              + "their flight logs — choose a folder."
+            : SelectedFolder is not null
+                ? "Sun check reads one flight log or video — drop a "
+                  + "single file."
+                : null;
+
+    /// <summary>The action button's verb. Verify is the one mode whose
+    /// verb follows a sub-action switch; everywhere else it is the mode's
+    /// own.</summary>
+    public string ActionVerb =>
+        SelectedMode.Kind == WorkspaceModeKind.Verify
+            ? VerifyOptions.SubAction switch
+            {
+                VerifySubAction.Check => "Check metadata",
+                VerifySubAction.Validate => "Validate pairing",
+                VerifySubAction.Sun => "Check the sun",
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(VerifyOptions), VerifyOptions.SubAction, null),
+            }
+            : SelectedMode.Verb;
+
+    /// <summary>The done card's raw warning list hides while a Verify
+    /// report is showing: validate and verify-sun emit their findings
+    /// BOTH as warning events and in the summary, and the report is the
+    /// curated rendering of the same facts.</summary>
+    public bool ShowDoneWarnings =>
+        Warnings.Count > 0 && VerifyCards.Count == 0;
 
     /// <summary>The Save-as override only exists for single-file sources:
     /// the CLI's batch loop writes every output beside its source.</summary>
@@ -255,6 +321,10 @@ public partial class WorkspaceViewModel : FlowViewModel
                             ConvertOptions.ToOptions())
                         : CommandBuilder.Convert(folder!, batch: true,
                             ConvertOptions.ToOptions()),
+                WorkspaceModeKind.Verify =>
+                    CommandBuilder.Verify(
+                        SelectedFile ?? SelectedFolder ?? "<source>",
+                        VerifyOptions.ToOptions()),
                 _ => CommandBuilder.Build(SelectedMode.Kind, folder),
             };
             return CommandLine.Format("dji-embed", argv);
@@ -266,12 +336,19 @@ public partial class WorkspaceViewModel : FlowViewModel
         if (value is not null)
         {
             SelectedFile = null;
+            if (VerifyOptions.SubAction == VerifySubAction.Sun)
+            {
+                VerifyOptions.SubAction = VerifySubAction.Check;
+            }
         }
         OnPropertyChanged(nameof(CanRun));
         OnPropertyChanged(nameof(CommandPreview));
         OnPropertyChanged(nameof(PhotoLinksCannotReachOriginals));
         OnPropertyChanged(nameof(SourceDisplay));
         OnPropertyChanged(nameof(ConvertSaveApplies));
+        OnPropertyChanged(nameof(VerifyValidateEnabled));
+        OnPropertyChanged(nameof(VerifySunEnabled));
+        OnPropertyChanged(nameof(VerifySubActionNote));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -280,11 +357,21 @@ public partial class WorkspaceViewModel : FlowViewModel
         if (value is not null)
         {
             SelectedFolder = null;
+            if (VerifyOptions.SubAction == VerifySubAction.Validate)
+            {
+                // A disabled segment must not stay selected: the strip and
+                // the action button would describe a run this source can't
+                // feed.
+                VerifyOptions.SubAction = VerifySubAction.Check;
+            }
         }
         OnPropertyChanged(nameof(CanRun));
         OnPropertyChanged(nameof(CommandPreview));
         OnPropertyChanged(nameof(SourceDisplay));
         OnPropertyChanged(nameof(ConvertSaveApplies));
+        OnPropertyChanged(nameof(VerifyValidateEnabled));
+        OnPropertyChanged(nameof(VerifySunEnabled));
+        OnPropertyChanged(nameof(VerifySubActionNote));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -296,6 +383,8 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(IsPhotoMapMode));
         OnPropertyChanged(nameof(IsEmbedMode));
         OnPropertyChanged(nameof(IsConvertMode));
+        OnPropertyChanged(nameof(IsVerifyMode));
+        OnPropertyChanged(nameof(ActionVerb));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -320,6 +409,8 @@ public partial class WorkspaceViewModel : FlowViewModel
         ExistingMaps.Clear();
         Outputs.Clear();
         Warnings.Clear();
+        VerifyCards.Clear();
+        VerifyHeadline = null;
         FlightOptions.Output = "";
         PhotoOptions.Output = "";
         EmbedOptions.Output = "";
@@ -479,6 +570,8 @@ public partial class WorkspaceViewModel : FlowViewModel
         // render: the finished run's outputs and warnings must not follow it.
         Outputs.Clear();
         Warnings.Clear();
+        VerifyCards.Clear();
+        VerifyHeadline = null;
         Step = FlowStep.Pick;
     }
 
@@ -562,6 +655,8 @@ public partial class WorkspaceViewModel : FlowViewModel
             return;
         }
         SetupItems.Clear();
+        VerifyCards.Clear();
+        VerifyHeadline = null;
         AllGood = false;
         // Captured with the folder and options below: SelectedMode is a
         // bare bindable property, so only captures guarantee a mid-scan
@@ -604,6 +699,25 @@ public partial class WorkspaceViewModel : FlowViewModel
                 && await PrimePreviewAsync());
             return;
         }
+        if (mode.Kind == WorkspaceModeKind.Verify && SelectedFile is { } vfile)
+        {
+            var vopts = VerifyOptions.ToOptions();
+            // The greyed switch removes shape mismatches, but not this
+            // content one: check reads embedded metadata and a .SRT
+            // sidecar has none — say so instead of showing three ✗ (#346
+            // discipline).
+            if (vopts.SubAction == VerifySubAction.Check
+                && vfile.EndsWith(".srt", StringComparison.OrdinalIgnoreCase))
+            {
+                Fail("Check metadata reads the video or photo itself — a "
+                     + ".SRT flight log has no embedded metadata to check. "
+                     + "Use Sun check for flight logs.");
+                return;
+            }
+            ResetPreview();
+            await RunVerifyAsync(vfile, vopts);
+            return;
+        }
         if (SelectedFolder is not { } folder)
         {
             return;
@@ -615,6 +729,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         var photo = PhotoOptions.ToOptions();
         var embed = EmbedOptions.ToOptions();
         var convert = ConvertOptions.ToOptions();
+        var verify = VerifyOptions.ToOptions();
         var contents = await Task.Run(() => _inspectFolder(folder));
         // The scan runs before ExecuteFlowAsync sets Step = Running, so the
         // folder can be cleared or replaced underneath us while it is in
@@ -709,8 +824,82 @@ public partial class WorkspaceViewModel : FlowViewModel
                         CommandBuilder.Convert(folder, batch: true, convert))
                     && await PrimePreviewAsync());
                 return;
+            case WorkspaceModeKind.Verify
+                when verify.SubAction == VerifySubAction.Check
+                     && !(contents.HasTopLevelVideos || contents.HasTopLevelPhotos):
+                // check expands one directory level (Task 1) — same reach
+                // rule as embed/convert (#333, #338).
+                Fail(contents.HasVideos || contents.HasPhotos
+                    ? "Those files are in subfolders — Check reads only "
+                      + "the folder you pick. Pick the subfolder that "
+                      + "holds the videos or photos."
+                    : "No videos or photos were found in that folder. "
+                      + "Pick the folder that holds the drone footage to "
+                      + "check.");
+                return;
+            case WorkspaceModeKind.Verify
+                when verify.SubAction == VerifySubAction.Validate
+                     && !contents.HasTopLevelVideos:
+                // validate pairs each top-level .MP4 with its .SRT — no
+                // top-level videos means a hollow "0 pairs" report.
+                Fail(contents.HasVideos
+                    ? "Those videos are in subfolders — Validate reads "
+                      + "only the folder you pick. Pick the subfolder "
+                      + "that holds the videos and their flight logs."
+                    : "No videos (.MP4) were found in that folder. "
+                      + "Validate pairing needs the folder that holds the "
+                      + "videos together with their .SRT flight logs.");
+                return;
+            case WorkspaceModeKind.Verify:
+                // Sun + folder is unreachable: the segment greys out and
+                // the selection snaps back to Check on a folder pick.
+                await RunVerifyAsync(folder, verify);
+                return;
         }
     }
+
+    /// <summary>
+    /// One Verify run (M4b): all three sub-commands produce no outputs —
+    /// their result summary IS the deliverable, parsed into the report
+    /// cards the done pane renders. The RunSetupAsync idiom, not
+    /// RunStepAsync: the summary must be read, not just the outputs.
+    /// </summary>
+    private Task RunVerifyAsync(string source, VerifyTelemetryOptions opts) =>
+        ExecuteFlowAsync(async () =>
+        {
+            var status = opts.SubAction switch
+            {
+                VerifySubAction.Check => "Checking metadata…",
+                VerifySubAction.Validate => "Validating pairs…",
+                VerifySubAction.Sun => "Checking the sun…",
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(opts), opts.SubAction, null),
+            };
+            var result = await RunCliAsync(
+                status, CommandBuilder.Verify(source, opts));
+            if (result.ExitCode != 0
+                || result.Terminal is not { Kind: ProgressEventKind.Result } t)
+            {
+                Fail(result.Terminal?.Message ?? GenericFailureMessage,
+                    string.IsNullOrWhiteSpace(result.StderrText)
+                        ? null : result.StderrText);
+                return false;
+            }
+            var report = opts.SubAction switch
+            {
+                VerifySubAction.Check => VerifyReport.FromCheck(t.Summary),
+                VerifySubAction.Validate => VerifyReport.FromValidate(t.Summary),
+                VerifySubAction.Sun => VerifyReport.FromSun(t.Summary),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(opts), opts.SubAction, null),
+            };
+            VerifyHeadline = report.Headline;
+            foreach (var card in report.Cards)
+            {
+                VerifyCards.Add(card);
+            }
+            return true;
+        });
 
     private Task RunSetupAsync() => ExecuteFlowAsync(async () =>
     {

--- a/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
@@ -42,4 +42,13 @@ public static class WorkspaceConverters
     /// been processed when the map on screen was already in the folder.</summary>
     public static readonly FuncValueConverter<FlowStep, string> PreviewGoHomeLabel =
         new(static step => step == FlowStep.Done ? "Process another" : "Close map");
+
+    /// <summary>A Verify report row's at-a-glance glyph.</summary>
+    public static readonly IValueConverter VerifyGlyph =
+        new FuncValueConverter<VerifyStatus, string>(status => status switch
+        {
+            VerifyStatus.Ok => "✅",
+            VerifyStatus.Attention => "⚠️",
+            _ => "❌",
+        });
 }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -691,13 +691,78 @@
                         </StackPanel>
                     </Border>
 
+                    <Border Name="VerifyOptionsPanel"
+                            IsVisible="{Binding IsVerifyMode}"
+                            IsEnabled="{Binding !IsBusy}">
+                        <StackPanel>
+                            <TextBlock Classes="zone" Text="OPTIONS" />
+                            <suki:GlassCard Padding="14">
+                                <StackPanel Spacing="12">
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Text="What to verify"
+                                                   Opacity="0.7" FontSize="12" />
+                                        <RadioButton Name="CheckSubActionRadio"
+                                                     GroupName="VerifySubAction"
+                                                     IsChecked="{Binding VerifyOptions.IsCheck}"
+                                                     Content="Check metadata" />
+                                        <RadioButton Name="ValidateSubActionRadio"
+                                                     GroupName="VerifySubAction"
+                                                     IsChecked="{Binding VerifyOptions.IsValidate}"
+                                                     IsEnabled="{Binding VerifyValidateEnabled}"
+                                                     Content="Validate pairing" />
+                                        <RadioButton Name="SunSubActionRadio"
+                                                     GroupName="VerifySubAction"
+                                                     IsChecked="{Binding VerifyOptions.IsSun}"
+                                                     IsEnabled="{Binding VerifySunEnabled}"
+                                                     Content="Sun check" />
+                                        <TextBlock Name="VerifySubActionNoteText"
+                                                   Text="{Binding VerifySubActionNote}"
+                                                   IsVisible="{Binding VerifySubActionNote,
+                                                       Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                                   TextWrapping="Wrap" Opacity="0.5"
+                                                   FontSize="11" />
+                                    </StackPanel>
+
+                                    <Expander Name="VerifyAdvanced" Header="Advanced"
+                                              IsExpanded="False"
+                                              IsVisible="{Binding VerifyOptions.ShowsAdvancedOptions}">
+                                        <StackPanel Spacing="12" Margin="0,8,0,0">
+                                            <StackPanel Name="DriftSection" Spacing="4"
+                                                        IsVisible="{Binding VerifyOptions.ShowsDriftOptions}">
+                                                <DockPanel>
+                                                    <TextBlock DockPanel.Dock="Right"
+                                                               Text="{Binding VerifyOptions.DriftThreshold, StringFormat='{}{0} s'}"
+                                                               Opacity="0.7" FontSize="12" />
+                                                    <TextBlock Text="Flag pairs drifting more than"
+                                                               Opacity="0.7" FontSize="12" />
+                                                </DockPanel>
+                                                <Slider Name="DriftThresholdSlider"
+                                                        Minimum="0.5" Maximum="5"
+                                                        TickFrequency="0.5" IsSnapToTickEnabled="True"
+                                                        Value="{Binding VerifyOptions.DriftThreshold}" />
+                                            </StackPanel>
+                                            <StackPanel Name="VerifyTzSection" Spacing="4"
+                                                        IsVisible="{Binding VerifyOptions.ShowsTzOptions}">
+                                                <TextBlock Text="Time zone of the clip"
+                                                           Opacity="0.7" FontSize="12" />
+                                                <TextBox Name="VerifyTzBox"
+                                                         Text="{Binding VerifyOptions.TzOffset}"
+                                                         PlaceholderText="auto" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Expander>
+                                </StackPanel>
+                            </suki:GlassCard>
+                        </StackPanel>
+                    </Border>
+
                     <TextBlock Classes="zone" Text="ACTION" />
                     <Button Name="RunButton" Classes="Flat"
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="Center"
                             Padding="0,12"
                             Command="{Binding RunCommand}">
-                        <TextBlock Text="{Binding SelectedMode.Verb}"
+                        <TextBlock Text="{Binding ActionVerb}"
                                    FontSize="15" FontWeight="SemiBold" />
                     </Button>
                     <!-- CLI transparency strip (GUI 2.0 spec, M3a): the exact
@@ -824,8 +889,37 @@
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
                     </StackPanel>
-                    <ItemsControl ItemsSource="{Binding Warnings}"
-                                  IsVisible="{Binding !!Warnings.Count}">
+                    <StackPanel Name="VerifyReportSection" Spacing="10"
+                                IsVisible="{Binding VerifyHeadline,
+                                    Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <TextBlock Name="VerifyHeadlineText" FontSize="16"
+                                   TextWrapping="Wrap"
+                                   Text="{Binding VerifyHeadline}" />
+                        <ItemsControl ItemsSource="{Binding VerifyCards}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="svc:VerifyCard">
+                                    <DockPanel Margin="0,3">
+                                        <TextBlock DockPanel.Dock="Left" Width="28"
+                                                   Opacity="0.8" FontSize="12"
+                                                   Text="{Binding Status,
+                                                       Converter={x:Static views:WorkspaceConverters.VerifyGlyph}}" />
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Title}"
+                                                       TextWrapping="Wrap" />
+                                            <TextBlock Text="{Binding Detail}"
+                                                       Opacity="0.6" FontSize="12"
+                                                       TextWrapping="Wrap"
+                                                       IsVisible="{Binding Detail,
+                                                           Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                        </StackPanel>
+                                    </DockPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                    <ItemsControl Name="DoneWarningsList"
+                                  ItemsSource="{Binding Warnings}"
+                                  IsVisible="{Binding ShowDoneWarnings}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="x:String">
                                 <TextBlock Text="{Binding StringFormat='⚠️ {0}'}"

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -14,7 +14,7 @@ from typing import Any
 from . import __version__
 from .embedder import DJIMetadataEmbedder, run_doctor
 from .utils.provision import EXIFTOOL_VERSION, provision_exiftool
-from .metadata_check import check_metadata
+from .metadata_check import check_metadata, media_files_in
 from .telemetry_converter import (
     extract_telemetry_to_gpx,
     extract_telemetry_to_csv,
@@ -371,12 +371,31 @@ def check(
     if progress.active:
         quiet = True  # stdout belongs to the JSONL events
     setup_logging(verbose, quiet)
-    with _jsonl_terminal(progress, "check", total=len(paths)):
+    # A directory argument stands for its top-level media files (GUI
+    # M4b). Expanded before the start event so its total counts real
+    # targets, not directory names.
+    targets: list[str] = []
+    empty_dirs: list[str] = []
+    for raw in paths:
+        p = Path(raw)
+        if p.is_dir():
+            found = media_files_in(p)
+            if found:
+                targets.extend(str(f) for f in found)
+            else:
+                empty_dirs.append(raw)
+        else:
+            targets.append(raw)
+    with _jsonl_terminal(progress, "check", total=len(targets)):
         if not paths:
             raise click.ClickException("No file or directory specified")
+        for directory in empty_dirs:
+            progress.warning("No media files found", item=directory)
+            if not progress.active:
+                click.echo(f"{directory}: no media files found")
         files: dict[str, dict] = {}
-        for index, target in enumerate(paths, start=1):
-            progress.advance(index, len(paths), item=target)
+        for index, target in enumerate(targets, start=1):
+            progress.advance(index, len(targets), item=target)
             result = check_metadata(target)
             files[target] = result
             if not result:
@@ -386,7 +405,7 @@ def check(
         progress.result(
             ok=True,
             outputs=[],
-            summary={"checked": len(paths), "files": files},
+            summary={"checked": len(targets), "files": files},
         )
 
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -192,7 +192,7 @@ def main(ctx: click.Context, log_json: bool) -> None:
 
     Available commands:
       embed     Embed telemetry from SRT files into MP4 videos
-      validate  Validate SRT/MP4 pairs and report drift
+      validate  Validate SRT/MP4/MOV pairs and report drift
       convert   Convert SRT telemetry to GPX or CSV formats
       flightmap Map every flight in a folder of SRT logs on one combined map (experimental)
       photomap  Map GPS-tagged still photos to an HTML/KML/GeoJSON map
@@ -1184,7 +1184,7 @@ def validate(
     verbose: bool,
     quiet: bool,
 ) -> None:
-    """Validate SRT/MP4 pairs and generate drift analysis report."""
+    """Validate SRT/MP4/MOV pairs and generate drift analysis report."""
     if progress_mode and format.lower() == "json":
         raise click.UsageError(
             "--format json cannot be combined with --progress jsonl (the "

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -376,10 +376,15 @@ def check(
     # targets, not directory names.
     targets: list[str] = []
     empty_dirs: list[str] = []
+    unreadable_dirs: list[str] = []
     for raw in paths:
         p = Path(raw)
         if p.is_dir():
-            found = media_files_in(p)
+            try:
+                found = media_files_in(p)
+            except OSError:
+                unreadable_dirs.append(raw)
+                continue
             if found:
                 targets.extend(str(f) for f in found)
             else:
@@ -393,6 +398,10 @@ def check(
             progress.warning("No media files found", item=directory)
             if not progress.active:
                 click.echo(f"{directory}: no media files found")
+        for directory in unreadable_dirs:
+            progress.warning("Not found or unreadable", item=directory)
+            if not progress.active:
+                click.echo(f"{directory}: not found or unreadable")
         files: dict[str, dict] = {}
         for index, target in enumerate(targets, start=1):
             progress.advance(index, len(targets), item=target)

--- a/src/dji_metadata_embedder/core/validator.py
+++ b/src/dji_metadata_embedder/core/validator.py
@@ -1,4 +1,4 @@
-"""Validation module for SRT/MP4 pairs and drift analysis."""
+"""Validation module for SRT/MP4/MOV pairs and drift analysis."""
 
 import logging
 from pathlib import Path
@@ -174,7 +174,7 @@ def analyze_drift(srt_path: Path, mp4_path: Path, threshold: float = 1.0) -> Dic
 
 
 def validate_directory(directory: Path, drift_threshold: float = 1.0) -> Dict[str, Any]:
-    """Validate all SRT/MP4 pairs in a directory."""
+    """Validate all SRT/MP4/MOV pairs in a directory."""
     result: Dict[str, Any] = {
         "directory": str(directory),
         "timestamp": datetime.now().isoformat(),
@@ -186,11 +186,16 @@ def validate_directory(directory: Path, drift_threshold: float = 1.0) -> Dict[st
     }
     
     try:
-        # Find MP4 files
-        mp4_files = list(directory.glob("*.mp4")) + list(directory.glob("*.MP4"))
-        result["total_files"] = len(mp4_files)
-        
-        for mp4_file in mp4_files:
+        # Find video files. Deduplicated via a set — a case-insensitive
+        # filesystem (Windows, macOS) matches "*.mp4" and "*.MP4" with the
+        # same file — and sorted for a deterministic report order.
+        video_globs = ("*.mp4", "*.MP4", "*.mov", "*.MOV")
+        video_files = sorted(
+            {f for pattern in video_globs for f in directory.glob(pattern)}
+        )
+        result["total_files"] = len(video_files)
+
+        for mp4_file in video_files:
             # Look for corresponding SRT
             srt_candidates = [
                 mp4_file.with_suffix(".SRT"),

--- a/src/dji_metadata_embedder/metadata_check.py
+++ b/src/dji_metadata_embedder/metadata_check.py
@@ -82,7 +82,18 @@ def check_metadata(path: str | Path) -> Dict[str, bool]:
     return check_file(file_path)
 
 
-_MEDIA_GLOBS = ("*.mp4", "*.MP4", "*.mov", "*.MOV", "*.jpg", "*.JPG")
+_MEDIA_GLOBS = (
+    "*.mp4",
+    "*.MP4",
+    "*.mov",
+    "*.MOV",
+    "*.jpg",
+    "*.JPG",
+    "*.jpeg",
+    "*.JPEG",
+    "*.dng",
+    "*.DNG",
+)
 
 
 def media_files_in(directory: Path) -> list[Path]:

--- a/src/dji_metadata_embedder/metadata_check.py
+++ b/src/dji_metadata_embedder/metadata_check.py
@@ -82,6 +82,21 @@ def check_metadata(path: str | Path) -> Dict[str, bool]:
     return check_file(file_path)
 
 
+_MEDIA_GLOBS = ("*.mp4", "*.MP4", "*.mov", "*.MOV", "*.jpg", "*.JPG")
+
+
+def media_files_in(directory: Path) -> list[Path]:
+    """Top-level media files a directory-shaped ``check`` argument means.
+
+    Deduplicated via a set — a case-insensitive filesystem (Windows,
+    macOS) matches ``*.mp4`` and ``*.MP4`` with the same file — and
+    sorted for a deterministic report order.
+    """
+    return sorted(
+        {f for pattern in _MEDIA_GLOBS for f in directory.glob(pattern)}
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Check DJI media files for embedded flight metadata"
@@ -99,12 +114,7 @@ def main() -> None:
     for p in args.paths:
         path = Path(p)
         if path.is_dir():
-            files.extend(path.glob("*.mp4"))
-            files.extend(path.glob("*.MP4"))
-            files.extend(path.glob("*.mov"))
-            files.extend(path.glob("*.MOV"))
-            files.extend(path.glob("*.jpg"))
-            files.extend(path.glob("*.JPG"))
+            files.extend(media_files_in(path))
         else:
             files.append(path)
 

--- a/tests/test_golden_fixtures.py
+++ b/tests/test_golden_fixtures.py
@@ -12,6 +12,7 @@ from dji_metadata_embedder.utilities import parse_telemetry_points
 from dji_metadata_embedder.core.validator import (
     validate_srt_format,
     normalize_telemetry_units,
+    validate_directory,
 )
 from tests.fixtures.golden_srt_samples import (
     GOLDEN_SAMPLES, 
@@ -379,6 +380,26 @@ class TestComprehensiveValidation:
                 case_dir = edge_cases_dir / case_name
                 assert case_dir.exists()
                 assert (case_dir / "clip.SRT").exists()
+
+
+class TestValidateDirectoryVideoGlobs:
+    """validate_directory must reach .MOV clips, not just .mp4/.MP4 (M4b)."""
+
+    def test_mov_srt_pair_is_counted(self):
+        """A folder holding only a .MOV + matching .SRT is not reported empty."""
+        srt_content = GOLDEN_SAMPLES["mini_3_4_pro"]["srt_content"]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            directory = Path(temp_dir)
+            (directory / "DJI_0001.MOV").write_bytes(b"fake video bytes")
+            (directory / "DJI_0001.SRT").write_text(srt_content, encoding="utf-8")
+
+            result = validate_directory(directory)
+
+            assert result["total_files"] == 1
+            assert result["valid_pairs"] == 1
+            assert not any(
+                "No SRT file found" in issue for issue in result["issues"]
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_progress_jsonl.py
+++ b/tests/test_progress_jsonl.py
@@ -383,6 +383,8 @@ def test_check_jsonl_expands_directories(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_mod, "check_metadata", lambda target: dict(canned))
     (tmp_path / "DJI_0001.MP4").write_bytes(b"fake")
     (tmp_path / "IMG_0002.JPG").write_bytes(b"fake")
+    (tmp_path / "IMG_0003.JPEG").write_bytes(b"fake")
+    (tmp_path / "IMG_0004.DNG").write_bytes(b"fake")
     (tmp_path / "notes.txt").write_text("not media", encoding="utf-8")
     sub = tmp_path / "sub"
     sub.mkdir()
@@ -392,12 +394,17 @@ def test_check_jsonl_expands_directories(monkeypatch, tmp_path):
     )
     assert res.exit_code == 0, res.output
     events = _events(res.stdout)
-    assert events[0]["total"] == 2
-    expected = [str(tmp_path / "DJI_0001.MP4"), str(tmp_path / "IMG_0002.JPG")]
+    assert events[0]["total"] == 4
+    expected = [
+        str(tmp_path / "DJI_0001.MP4"),
+        str(tmp_path / "IMG_0002.JPG"),
+        str(tmp_path / "IMG_0003.JPEG"),
+        str(tmp_path / "IMG_0004.DNG"),
+    ]
     progress = [e for e in events if e["event"] == "progress"]
     assert [p["item"] for p in progress] == expected
-    assert events[-1]["summary"]["checked"] == 2
-    assert sorted(events[-1]["summary"]["files"]) == expected
+    assert events[-1]["summary"]["checked"] == 4
+    assert sorted(events[-1]["summary"]["files"]) == sorted(expected)
 
 
 def test_check_jsonl_warns_on_empty_directory(tmp_path):

--- a/tests/test_progress_jsonl.py
+++ b/tests/test_progress_jsonl.py
@@ -376,6 +376,48 @@ def test_check_jsonl_warns_on_missing_path(monkeypatch, tmp_path):
     assert warnings[0]["item"] == str(tmp_path / "nope.mp4")
 
 
+def test_check_jsonl_expands_directories(monkeypatch, tmp_path):
+    from dji_metadata_embedder import cli as cli_mod
+
+    canned = {"gps": True, "altitude": True, "creation_time": True}
+    monkeypatch.setattr(cli_mod, "check_metadata", lambda target: dict(canned))
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"fake")
+    (tmp_path / "IMG_0002.JPG").write_bytes(b"fake")
+    (tmp_path / "notes.txt").write_text("not media", encoding="utf-8")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "DJI_0003.MP4").write_bytes(b"fake")  # below top level: excluded
+    res = CliRunner().invoke(
+        main, ["check", str(tmp_path), "--progress", "jsonl"]
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert events[0]["total"] == 2
+    expected = [str(tmp_path / "DJI_0001.MP4"), str(tmp_path / "IMG_0002.JPG")]
+    progress = [e for e in events if e["event"] == "progress"]
+    assert [p["item"] for p in progress] == expected
+    assert events[-1]["summary"]["checked"] == 2
+    assert sorted(events[-1]["summary"]["files"]) == expected
+
+
+def test_check_jsonl_warns_on_empty_directory(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    res = CliRunner().invoke(
+        main, ["check", str(empty), "--progress", "jsonl"]
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert events[0]["total"] == 0
+    warnings = [e for e in events if e["event"] == "warning"]
+    assert len(warnings) == 1
+    assert warnings[0]["item"] == str(empty)
+    assert warnings[0]["message"] == "No media files found"
+    last = events[-1]
+    assert last["ok"] is True
+    assert last["summary"] == {"checked": 0, "files": {}}
+
+
 def test_flightmap_jsonl_all_formats_lists_every_output(tmp_path):
     (tmp_path / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
     res = CliRunner().invoke(

--- a/tests/test_progress_jsonl.py
+++ b/tests/test_progress_jsonl.py
@@ -418,6 +418,31 @@ def test_check_jsonl_warns_on_empty_directory(tmp_path):
     assert last["summary"] == {"checked": 0, "files": {}}
 
 
+def test_check_jsonl_warns_on_unreadable_directory(monkeypatch, tmp_path):
+    from dji_metadata_embedder import cli as cli_mod
+
+    unreadable = tmp_path / "unreadable"
+    unreadable.mkdir()
+    monkeypatch.setattr(
+        cli_mod,
+        "media_files_in",
+        lambda p: (_ for _ in ()).throw(PermissionError("denied")),
+    )
+    res = CliRunner().invoke(
+        main, ["check", str(unreadable), "--progress", "jsonl"]
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert events[0]["total"] == 0
+    warnings = [e for e in events if e["event"] == "warning"]
+    assert len(warnings) == 1
+    assert warnings[0]["item"] == str(unreadable)
+    assert warnings[0]["message"] == "Not found or unreadable"
+    last = events[-1]
+    assert last["ok"] is True
+    assert last["summary"] == {"checked": 0, "files": {}}
+
+
 def test_flightmap_jsonl_all_formats_lists_every_output(tmp_path):
     (tmp_path / "DJI_0001.SRT").write_text(FLIGHT_A, encoding="utf-8")
     res = CliRunner().invoke(


### PR DESCRIPTION
Completes the M4 milestone of the GUI 2.0 workspace (spec: docs/superpowers/specs/2026-07-22-gui-m4b-verify-mode-design.md, second of the two PRs decided in the M4a round).

## What's new

**Verify footage** joins the mode strip (sixth mode) — merging the CLI's `check`, `validate` and `verify-sun` behind a three-segment sub-action switch:

- **Source-shape-aware switch**: a file greys out *Validate pairing*, a folder greys out *Sun check* — at most one segment is ever disabled, explained by a quiet inline note; the selection snaps back to *Check metadata* when a source change would strand it on a disabled segment, so the strip and action button never describe a run the source can't feed.
- **Curated options**: the switch is the curated control. Advanced holds a drift-threshold slider (Validate, 0.5–5 s snap-to-tick) and a timezone box (Sun check). Untouched Verify runs bare `check <source>`.
- **Report cards, never raw text**: the done pane renders each result summary as a headline + status-glyph card rows (per-file metadata flags for Check; verdict + issue rows for Validate; sun stats + plain-language flags for Sun check). Since validate/verify-sun emit their findings both as warning events and in the summary, the report supersedes the raw warnings list — no double display.
- **Adaptive action verb**: "Check metadata" / "Validate pairing" / "Check the sun".
- **CLI: `check` learns directories** — a directory argument now expands to its top-level media files (mp4/mov/jpg/jpeg/dng), shared glob with the standalone checker, unreadable/empty directories degrade to a warning with the JSONL stream staying contract-shaped. `validate` now pairs `.MOV` videos with their `.SRT` logs too.
- Reach-aware pre-run guards in the M4a/#346 mould, with the guard's media reach and the CLI's globs now provably matching.

## Process

TDD throughout, subagent-driven: 6 tasks, each with two-stage review (spec compliance + code quality), then a whole-branch fresh-eyes review (verdict SHIP after one cross-layer fix: the GUI guard's extension sets vs the CLI globs). Suites: Python 687→691 (+ruff+mypy clean), GUI 385→422 (407 passed / 15 skipped), 0 warnings, Debug+Release green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZUDWn8fX49nqMp7gos2iT