### PR TITLE
GUI M5a: persisted state — recent folders + window bounds

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -52,7 +52,7 @@ Two ways to use it — same engine:
 
 | Situation | Do this |
 | --- | --- |
-| **Windows, simplest** | Download `dji-metadata-embedder-setup-<version>.exe` from the GitHub Releases page. One installer = app + CLI + FFmpeg + ExifTool, nothing else needed. Installers from v1.23.0 onwards are code-signed (publisher: "Open Source Developer, Marcus Westermark"); SmartScreen may still warn while the certificate builds reputation — click **More info → Run anyway**. Older releases are unsigned. |
+| **Windows, simplest** | Download `dji-metadata-embedder-setup-<version>.exe` from the GitHub Releases page. One installer = app + CLI + FFmpeg + ExifTool, nothing else needed. Installers from v1.23.0 onwards are code-signed (publisher: "Open Source Developer, Marcus Westermark"); SmartScreen may still warn while the certificate builds reputation — click **More info → Run anyway**. Older releases are unsigned. The app remembers your window size and recent folders (stored locally in %APPDATA%\DjiEmbed\state.json — delete that file to reset). |
 | Windows, CLI only | `winget install CallMarcus.DJIMetadataEmbedder` (portable exe), or `pip install dji-drone-metadata-embedder` with Python 3.10–3.12. |
 | macOS | `brew install pipx ffmpeg exiftool` then `pipx install dji-drone-metadata-embedder` (plain `pip3` is blocked on Homebrew Python). |
 | Linux | `pip install dji-drone-metadata-embedder` (or pipx) + `ffmpeg`/`exiftool` from your package manager. |

--- a/docs/superpowers/specs/2026-07-22-gui-m5a-state-persistence-design.md
+++ b/docs/superpowers/specs/2026-07-22-gui-m5a-state-persistence-design.md
@@ -1,0 +1,126 @@
+# GUI M5a — persisted state (MRU + window bounds)
+
+*Design round 2026-07-22 (Marcus + Claude). Amends nothing; implements the
+"GUI state on disk" decision and the MRU/window-bounds items of the M5 row
+in the GUI 2.0 workspace spec (2026-07-18). First of the two M5 PRs — M5b
+(visual polish: animations, empty-state hero styling, accessibility pass,
+docs/screenshots) follows separately.*
+
+## Decisions taken in the round
+
+- **M5 splits in two.** M5a is the persistence machinery (this spec); M5b
+  is the visual/finish pass. Persistence is crisply testable on its own,
+  and the visual pass wants Marcus's eyes on a real Windows build without
+  persistence risk mixed in.
+- **MRU surfaces in the hero and the Browse dialog.** The empty source
+  hero shows a short "Recent" list (click to re-select), and the folder
+  picker starts in the most recent folder. Rejected: picker-start-only
+  (drag-and-drop users never see a benefit) and a flyout next to Browse
+  (an extra control for the same value).
+- **A folder is remembered when a run starts on it** — including the
+  existing-map open (#328), which is real work with the folder. Rejected:
+  on-selection (mis-drops pollute the list) and successful-runs-only (a
+  failed run is often exactly the folder you retry).
+- **Folders only.** The workspace spec says "MRU folders"; single files
+  (Convert/Verify sources) are never remembered.
+
+## Hard boundary (from the workspace spec, restated)
+
+The only persisted GUI state is MRU folders and window bounds, in one
+small JSON in the user config dir. Nothing else, ever, without a spec
+amendment. No telemetry; the file holds local paths only and never leaves
+the machine.
+
+## GuiState service
+
+`Services/GuiState.cs`, house style — immutable record + pure static
+methods, unit-testable with a temp path, no UI types:
+
+- `record WindowBounds(int X, int Y, int Width, int Height, bool Maximized)`.
+- `record GuiState(WindowBounds? Window, IReadOnlyList<string> RecentFolders)`
+  with an `Empty` **singleton** (record equality over `IReadOnlyList`
+  needs reference identity — the `VerifyReport.Empty` lesson).
+- `GuiState.Load(path)`: missing, corrupt, or unreadable file → `Empty`;
+  unknown JSON fields ignored (forward compatibility); never throws and
+  never blocks startup — the DoctorReport degradation rule applied to
+  config.
+- `GuiState.Save(state, path)`: creates the directory, writes a temp file
+  in the same directory, then moves over the target (atomic); swallows
+  I/O and permission failures — losing recents must never crash the app.
+- `state.WithRecent(folder)`: returns a new state with the folder pushed
+  to the front — de-duplicated case-insensitively (`OrdinalIgnoreCase`,
+  Windows paths), capped at **5**, order most-recent-first.
+- Default path: `%APPDATA%/DjiEmbed/state.json` via
+  `Environment.SpecialFolder.ApplicationData`; every method takes the
+  path as a parameter so tests never touch the real config dir.
+- Wire format: System.Text.Json, camelCase —
+  `{ "window": { "x", "y", "width", "height", "maximized" }, "recentFolders": [ ... ] }`.
+  Numbers are integers (device-independent pixels as Avalonia reports
+  them, truncated); no culture-sensitive formatting anywhere.
+
+One small **store** object (`Services/GuiStateStore.cs`) owns the file at
+runtime: it loads once at startup, holds the current state, and exposes
+`PushRecent(folder)` (apply `WithRecent` + save immediately — a crash
+must not lose the list) and `SaveWindow(bounds)` (called on close). The
+store is created in `App.OnFrameworkInitializationCompleted` and handed
+down; view models never see file paths.
+
+## Window bounds
+
+- Saved when the main window closes: position, size, and whether it was
+  maximized (with the normal bounds saved behind the maximized flag, so
+  un-maximizing later lands somewhere sane).
+- Restored at startup **only when the saved rectangle intersects a
+  visible screen's working area** (the undocked-laptop case); otherwise
+  the 1140×720 defaults stand. Maximized restores as maximized after the
+  normal bounds are applied.
+- All of this lives in `MainWindow` code-behind (it is windowing, not
+  view-model logic); the intersection check is a pure static helper on
+  `GuiState` (`RestorableOn(bounds, screens)` over plain rectangles) so
+  it is unit-tested without a window.
+
+## MRU behaviour
+
+- **Push point:** `RunAsync`, before the work starts, when the captured
+  source is a folder **and the mode uses it** — Setup runs ignore the
+  source and push nothing, and `SelectedFile` runs push nothing; plus
+  `OpenExistingMapAsync`, same rule. Guard-blocked runs still count — the
+  user chose to work with that folder.
+- **Display prune:** entries whose folder no longer exists are hidden
+  from the hero list and dropped on the next save. The stored file may
+  briefly hold dead paths; the UI never shows them.
+- **Browse start:** the folder picker's `SuggestedStartLocation` is the
+  most recent folder that still exists; none → picker default behaviour.
+- **State never affects argv.** The transparency strip and
+  `CommandBuilder` are untouched by everything in this spec — one
+  explicit test pins it.
+
+## Hero "Recent" list
+
+- Shown inside the SOURCE card beneath the drop zone, only when no
+  source is selected and at least one recent folder survives the prune.
+  Selecting a source (or a run in flight) hides it; clearing the source
+  brings it back.
+- Pinned copy: header **"Recent folders"** (quiet zone-label styling).
+  Each entry is a link-style button showing the folder's leaf name, full
+  path as tooltip and `AutomationProperties.Name`.
+- Clicking an entry calls the normal `SetFolderAsync` flow — identical to
+  dropping the folder: mode suggestion, existing-map probe, fresh-start
+  reset all included.
+- `WorkspaceViewModel` exposes `RecentFolders` (observable) and receives
+  the store's push/read functions via constructor injection in the
+  established `_inspectFolder`-style seam, so VM tests run with an
+  in-memory store and no disk.
+
+## Testing
+
+House pattern: TDD throughout. GuiState unit tests — round-trip,
+missing/corrupt/unreadable file, unknown-field tolerance, atomic write
+(temp file gone after save), `WithRecent` dedupe/cap/order/case rules,
+`RestorableOn` intersection cases. VM tests — push on run start (folder
+yes, file no, existing-map open yes), hero list prune, click-recent flows
+through `SetFolderAsync`, `CommandPreview` unaffected by state. Screen
+tests — recent list visible/hidden per source state, click selects, the
+shared freeze test grows the recents region. Screenshot capture of the
+hero with recents (interleaved-tick idiom). GUI suite baseline 407
+passed / 15 skipped; Python side untouched.

--- a/gui/DjiEmbed.Gui.Tests/GuiStateStoreTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/GuiStateStoreTests.cs
@@ -1,0 +1,85 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class GuiStateStoreTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-statestore-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string StatePath => Path.Combine(_dir, "state.json");
+
+    private string MakeFolder(string name)
+    {
+        var folder = Path.Combine(_dir, name);
+        Directory.CreateDirectory(folder);
+        return folder;
+    }
+
+    [Fact]
+    public void Loads_existing_state_at_construction()
+    {
+        GuiState.Save(GuiState.Empty.WithRecent("a"), StatePath);
+        Assert.Equal(["a"], new GuiStateStore(StatePath).State.RecentFolders);
+    }
+
+    [Fact]
+    public void PushRecent_saves_immediately()
+    {
+        var folder = MakeFolder("flight");
+        new GuiStateStore(StatePath).PushRecent(folder);
+        // A crash after the push must not lose the list — the file
+        // already holds it.
+        Assert.Equal([folder], GuiState.Load(StatePath).RecentFolders);
+    }
+
+    [Fact]
+    public void SaveWindow_saves_immediately()
+    {
+        new GuiStateStore(StatePath)
+            .SaveWindow(new WindowBounds(1, 2, 900, 700, false));
+        Assert.Equal(new WindowBounds(1, 2, 900, 700, false),
+            GuiState.Load(StatePath).Window);
+    }
+
+    [Fact]
+    public void Saving_drops_recents_whose_folder_is_gone()
+    {
+        var kept = MakeFolder("kept");
+        var doomed = MakeFolder("doomed");
+        var store = new GuiStateStore(StatePath);
+        store.PushRecent(doomed);
+        store.PushRecent(kept);
+        Directory.Delete(doomed);
+
+        store.SaveWindow(new WindowBounds(0, 0, 900, 700, false));
+
+        Assert.Equal([kept], GuiState.Load(StatePath).RecentFolders);
+    }
+
+    [Fact]
+    public void ExistingRecents_hides_dead_paths_without_saving()
+    {
+        var kept = MakeFolder("kept");
+        var doomed = MakeFolder("doomed");
+        var store = new GuiStateStore(StatePath);
+        store.PushRecent(doomed);
+        store.PushRecent(kept);
+        Directory.Delete(doomed);
+
+        Assert.Equal([kept], store.ExistingRecents());
+    }
+
+    [Fact]
+    public void Ephemeral_store_never_touches_disk()
+    {
+        var store = GuiStateStore.Ephemeral();
+        store.PushRecent(MakeFolder("flight"));
+        store.SaveWindow(new WindowBounds(0, 0, 900, 700, false));
+        // Only the folder this test created — no state file anywhere.
+        Assert.Equal(["flight"],
+            Directory.GetFileSystemEntries(_dir).Select(Path.GetFileName));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/GuiStateTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/GuiStateTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class GuiStateTests : IDisposable
+{
+    private readonly string _dir =
+        Directory.CreateTempSubdirectory("djiembed-guistate-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_dir, recursive: true);
+
+    private string StatePath => Path.Combine(_dir, "state.json");
+
+    [Fact]
+    public void Missing_file_loads_as_the_Empty_singleton()
+    {
+        Assert.Same(GuiState.Empty, GuiState.Load(StatePath));
+    }
+
+    [Fact]
+    public void Corrupt_json_loads_as_the_Empty_singleton()
+    {
+        File.WriteAllText(StatePath, "{ not json at all");
+        Assert.Same(GuiState.Empty, GuiState.Load(StatePath));
+    }
+
+    [Fact]
+    public void Wrongly_typed_json_loads_as_the_Empty_singleton()
+    {
+        File.WriteAllText(StatePath, """{"recentFolders": 42}""");
+        Assert.Same(GuiState.Empty, GuiState.Load(StatePath));
+    }
+
+    [Fact]
+    public void State_round_trips_through_the_file()
+    {
+        var state = new GuiState(
+            new WindowBounds(10, 20, 1200, 800, Maximized: true),
+            ["C:\\Drone\\latest", "D:\\Trips\\alps"]);
+
+        GuiState.Save(state, StatePath);
+        var loaded = GuiState.Load(StatePath);
+
+        Assert.Equal(new WindowBounds(10, 20, 1200, 800, true), loaded.Window);
+        Assert.Equal(["C:\\Drone\\latest", "D:\\Trips\\alps"],
+            loaded.RecentFolders);
+    }
+
+    [Fact]
+    public void Wire_format_is_camel_case()
+    {
+        GuiState.Save(new GuiState(
+            new WindowBounds(1, 2, 3, 4, false), ["x"]), StatePath);
+        using var doc = JsonDocument.Parse(File.ReadAllText(StatePath));
+        Assert.True(doc.RootElement.TryGetProperty("window", out var w));
+        Assert.Equal(1, w.GetProperty("x").GetInt32());
+        Assert.False(w.GetProperty("maximized").GetBoolean());
+        Assert.Equal("x",
+            doc.RootElement.GetProperty("recentFolders")[0].GetString());
+    }
+
+    [Fact]
+    public void Unknown_fields_are_ignored_on_load()
+    {
+        File.WriteAllText(StatePath,
+            """{"recentFolders": ["a"], "futureThing": {"nested": 1}}""");
+        Assert.Equal(["a"], GuiState.Load(StatePath).RecentFolders);
+    }
+
+    [Fact]
+    public void Save_leaves_no_temp_file_behind()
+    {
+        GuiState.Save(GuiState.Empty.WithRecent("a"), StatePath);
+        Assert.Equal([StatePath],
+            Directory.GetFiles(_dir).Select(Path.GetFullPath));
+    }
+
+    [Fact]
+    public void Save_creates_the_directory()
+    {
+        var nested = Path.Combine(_dir, "DjiEmbed", "state.json");
+        GuiState.Save(GuiState.Empty.WithRecent("a"), nested);
+        Assert.Equal(["a"], GuiState.Load(nested).RecentFolders);
+    }
+
+    [Fact]
+    public void Save_failure_is_swallowed()
+    {
+        // The target IS a directory — the final move cannot succeed.
+        // (Inside _dir, so the orphaned temp file is cleaned up too.)
+        var target = Path.Combine(_dir, "sub");
+        Directory.CreateDirectory(target);
+        GuiState.Save(GuiState.Empty.WithRecent("a"), target);
+    }
+
+    [Fact]
+    public void WithRecent_pushes_to_the_front()
+    {
+        var state = GuiState.Empty.WithRecent("a").WithRecent("b");
+        Assert.Equal(["b", "a"], state.RecentFolders);
+    }
+
+    [Fact]
+    public void WithRecent_dedupes_case_insensitively()
+    {
+        var state = GuiState.Empty
+            .WithRecent("C:\\Drone").WithRecent("b").WithRecent("c:\\drone");
+        Assert.Equal(["c:\\drone", "b"], state.RecentFolders);
+    }
+
+    [Fact]
+    public void WithRecent_caps_at_five()
+    {
+        var state = GuiState.Empty;
+        foreach (var f in new[] { "a", "b", "c", "d", "e", "f" })
+        {
+            state = state.WithRecent(f);
+        }
+        Assert.Equal(["f", "e", "d", "c", "b"], state.RecentFolders);
+    }
+
+    [Fact]
+    public void Load_caps_an_oversized_stored_list()
+    {
+        File.WriteAllText(StatePath,
+            """{"recentFolders": ["a","b","c","d","e","f","g"]}""");
+        Assert.Equal(5, GuiState.Load(StatePath).RecentFolders.Count);
+    }
+
+    public static readonly TheoryData<WindowBounds, bool> RestoreCases = new()
+    {
+        // Fully inside the single 1920×1080 screen.
+        { new WindowBounds(100, 100, 800, 600, false), true },
+        // Overlapping the right edge still counts.
+        { new WindowBounds(1800, 100, 800, 600, false), true },
+        // Entirely off to the right (undocked-monitor case).
+        { new WindowBounds(2000, 100, 800, 600, false), false },
+        // Entirely above.
+        { new WindowBounds(100, -700, 800, 600, false), false },
+        // Degenerate size never restores.
+        { new WindowBounds(100, 100, 0, 600, false), false },
+    };
+
+    [Theory]
+    [MemberData(nameof(RestoreCases))]
+    public void RestorableOn_requires_intersection_with_a_screen(
+        WindowBounds bounds, bool expected)
+    {
+        Assert.Equal(expected,
+            GuiState.RestorableOn(bounds, [(0, 0, 1920, 1080)]));
+    }
+
+    [Fact]
+    public void RestorableOn_second_screen_counts()
+    {
+        Assert.True(GuiState.RestorableOn(
+            new WindowBounds(2000, 100, 800, 600, false),
+            [(0, 0, 1920, 1080), (1920, 0, 1920, 1080)]));
+    }
+
+    [Fact]
+    public void RestorableOn_no_screens_means_restorable()
+    {
+        // Headless platforms report no screens; restoring is harmless there.
+        Assert.True(GuiState.RestorableOn(
+            new WindowBounds(100, 100, 800, 600, false), []));
+    }
+
+    [Fact]
+    public void Default_path_is_the_DjiEmbed_config_file()
+    {
+        Assert.EndsWith(Path.Combine("DjiEmbed", "state.json"),
+            GuiState.DefaultPath);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/MainWindowStateTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/MainWindowStateTests.cs
@@ -1,0 +1,106 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using DjiEmbed.Gui.Services;
+using DjiEmbed.Gui.ViewModels;
+using DjiEmbed.Gui.Views;
+
+namespace DjiEmbed.Gui.Tests;
+
+// M5a window-bounds persistence. The restore *decision* (screen
+// intersection) is pure and covered in GuiStateTests; these tests cover
+// the window plumbing on the headless platform, where no screens are
+// reported and RestorableOn therefore always allows the restore.
+public class MainWindowStateTests
+{
+    private static GuiStateStore StoreWith(WindowBounds bounds)
+    {
+        var store = GuiStateStore.Ephemeral();
+        store.SaveWindow(bounds);
+        return store;
+    }
+
+    [AvaloniaFact]
+    public void Restores_saved_size_on_startup()
+    {
+        var window = new MainWindow(
+            StoreWith(new WindowBounds(50, 60, 1200, 800, Maximized: false)))
+        { DataContext = new MainViewModel() };
+        window.Show();
+
+        Assert.Equal(1200, window.Width);
+        Assert.Equal(800, window.Height);
+        Assert.Equal(WindowStartupLocation.Manual,
+            window.WindowStartupLocation);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void Restores_maximized_with_normal_bounds_behind_it()
+    {
+        var window = new MainWindow(
+            StoreWith(new WindowBounds(50, 60, 1200, 800, Maximized: true)))
+        { DataContext = new MainViewModel() };
+        window.Show();
+
+        Assert.Equal(WindowState.Maximized, window.WindowState);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void No_store_keeps_the_default_shape()
+    {
+        var window = new MainWindow { DataContext = new MainViewModel() };
+        window.Show();
+
+        Assert.Equal(1140, window.Width);
+        Assert.Equal(720, window.Height);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void Degenerate_saved_bounds_keep_the_default_shape()
+    {
+        var window = new MainWindow(
+            StoreWith(new WindowBounds(0, 0, 0, 0, Maximized: false)))
+        { DataContext = new MainViewModel() };
+        window.Show();
+
+        Assert.Equal(1140, window.Width);
+        Assert.Equal(720, window.Height);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void Closing_saves_the_current_bounds()
+    {
+        var store = GuiStateStore.Ephemeral();
+        var window = new MainWindow(store)
+        { DataContext = new MainViewModel() };
+        window.Show();
+        window.Width = 1000;
+        window.Height = 690;
+        window.UpdateLayout();
+
+        window.Close();
+
+        var saved = store.State.Window;
+        Assert.NotNull(saved);
+        Assert.Equal(1000, saved!.Width);
+        Assert.Equal(690, saved.Height);
+        Assert.False(saved.Maximized);
+    }
+
+    [AvaloniaFact]
+    public void Closing_while_maximized_saves_the_flag()
+    {
+        var store = GuiStateStore.Ephemeral();
+        var window = new MainWindow(store)
+        { DataContext = new MainViewModel() };
+        window.Show();
+        window.WindowState = WindowState.Maximized;
+
+        window.Close();
+
+        Assert.True(store.State.Window!.Maximized);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -151,6 +151,36 @@ public class ScreenshotCaptureTests
         CaptureView(view, Path.Combine(dir!, "workspace-preview.png"));
     }
 
+    [AvaloniaFact]
+    public void Captures_hero_recents_to_dir_when_requested()
+    {
+        var dir = Environment.GetEnvironmentVariable("DJIEMBED_CAPTURE_DIR");
+        Assert.SkipWhen(string.IsNullOrEmpty(dir),
+            "Set DJIEMBED_CAPTURE_DIR=<dir> to capture the hero recents.");
+        Directory.CreateDirectory(dir!);
+
+        var temp = Directory.CreateTempSubdirectory("djiembed-recents-capture");
+        try
+        {
+            var store = GuiStateStore.Ephemeral();
+            foreach (var name in new[] { "alps-trip", "harbor-flight" })
+            {
+                store.PushRecent(Directory.CreateDirectory(
+                    Path.Combine(temp.FullName, name)).FullName);
+            }
+            var vm = new WorkspaceViewModel(
+                null, new DjiEmbedRunner(), new FakeMapServer(null), () => { },
+                previewAvailable: static () => false, stateStore: store);
+            var view = new WorkspaceView { WebViewGate = static () => false };
+            view.DataContext = vm;
+            CaptureView(view, Path.Combine(dir!, "workspace-hero-recents.png"));
+        }
+        finally
+        {
+            Directory.Delete(temp.FullName, recursive: true);
+        }
+    }
+
     /// <summary>
     /// Done step on a machine without a usable WebView2: the done card
     /// with the WebView2-unavailable note visible instead of the inline

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -33,6 +33,72 @@ public class WorkspaceScreenTests
         new("unused", new DjiEmbedRunner(), new FakeMapServer(null), () => { },
             previewAvailable: static () => false);
 
+    private static (WorkspaceViewModel Vm, string Folder, IDisposable Cleanup)
+        RecentsVm()
+    {
+        var dir = Directory.CreateTempSubdirectory("djiembed-recents-screen");
+        var folder = Directory.CreateDirectory(
+            Path.Combine(dir.FullName, "flights")).FullName;
+        File.WriteAllText(Path.Combine(folder, "DJI_0001.SRT"), "");
+        var store = GuiStateStore.Ephemeral();
+        store.PushRecent(folder);
+        var vm = new WorkspaceViewModel(
+            "unused", new DjiEmbedRunner(), new FakeMapServer(null),
+            () => { }, previewAvailable: static () => false,
+            stateStore: store);
+        return (vm, folder, new TempDir(dir.FullName));
+    }
+
+    private sealed class TempDir(string path) : IDisposable
+    {
+        public void Dispose() => Directory.Delete(path, recursive: true);
+    }
+
+    [AvaloniaFact]
+    public void Hero_lists_recent_folders_with_the_pinned_header()
+    {
+        var (vm, folder, cleanup) = RecentsVm();
+        using var _ = cleanup;
+        var window = ShowWorkspace(vm);
+
+        var section = window.GetVisualDescendants().OfType<StackPanel>()
+            .Single(p => p.Name == "RecentFoldersSection");
+        Assert.True(section.IsVisible);
+        var texts = section.GetVisualDescendants()
+            .OfType<TextBlock>().Select(t => t.Text).ToList();
+        Assert.Contains("Recent folders", texts);
+        Assert.Contains("flights", texts);   // leaf name, not the full path
+        Assert.DoesNotContain(folder, texts);
+    }
+
+    [AvaloniaFact]
+    public void Clicking_a_recent_selects_the_folder_and_hides_the_list()
+    {
+        var (vm, folder, cleanup) = RecentsVm();
+        using var _ = cleanup;
+        var window = ShowWorkspace(vm);
+
+        var list = window.GetVisualDescendants().OfType<ItemsControl>()
+            .Single(c => c.Name == "RecentFoldersList");
+        var button = list.GetVisualDescendants().OfType<Button>().Single();
+        Assert.Same(vm.ChooseRecentCommand, button.Command);
+        button.Command!.Execute(button.CommandParameter);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        Assert.Equal(folder, vm.SelectedFolder);
+        Assert.False(window.GetVisualDescendants().OfType<StackPanel>()
+            .Single(p => p.Name == "RecentFoldersSection").IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void No_recents_means_no_hero_section_visible()
+    {
+        var window = ShowWorkspace();
+        Assert.False(window.GetVisualDescendants().OfType<StackPanel>()
+            .Single(p => p.Name == "RecentFoldersSection").IsVisible);
+    }
+
     [AvaloniaFact]
     public void Mode_strip_shows_exactly_the_six_modes()
     {
@@ -1232,6 +1298,10 @@ public class WorkspaceScreenTests
             Assert.False(byName("ConvertOptionsPanel").IsEnabled);
             Assert.False(byName("VerifyOptionsPanel").IsEnabled);
             Assert.True(byName("CopyCommandButton").IsEffectivelyEnabled);
+            // Recents disappear while a run is in flight: ShowRecentFolders
+            // gates on !IsBusy, so a mid-run click can never swap the source.
+            Assert.False(window.GetVisualDescendants().OfType<StackPanel>()
+                .Single(p => p.Name == "RecentFoldersSection").IsVisible);
 
             gate.SetResult();
             await run;

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -2164,6 +2164,22 @@ public class WorkspaceViewModelTests : IDisposable
     }
 
     [Fact]
+    public async Task Clicking_a_recent_whose_folder_vanished_drops_it_instead_of_crashing()
+    {
+        var doomed = MakeFolder(srt: true);
+        var store = GuiStateStore.Ephemeral();
+        store.PushRecent(doomed);
+        var vm = Vm(cli: null, stateStore: store);
+        Assert.Equal([doomed], vm.RecentFolders);
+        Directory.Delete(doomed, recursive: true);
+
+        await vm.ChooseRecentCommand.ExecuteAsync(doomed);
+
+        Assert.Null(vm.SelectedFolder);      // nothing was selected
+        Assert.Empty(vm.RecentFolders);      // the dead entry is gone
+    }
+
+    [Fact]
     public async Task Hero_recents_show_only_when_nothing_is_selected()
     {
         var kept = MakeFolder(srt: true);

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -41,11 +41,12 @@ public class WorkspaceViewModelTests : IDisposable
     private static WorkspaceViewModel Vm(
         string? cli, Func<string?>? cliResolver = null,
         IMapServer? mapServer = null, Func<bool>? previewAvailable = null,
-        Func<string, FolderContents>? folderInspector = null) =>
+        Func<string, FolderContents>? folderInspector = null,
+        GuiStateStore? stateStore = null) =>
         new(cli, new DjiEmbedRunner(), mapServer ?? new FakeMapServer(null),
             () => { }, cliResolver,
             previewAvailable ?? (static () => false),
-            folderInspector);
+            folderInspector, stateStore);
 
     private static FolderContents Contents(
         bool logs = false, bool photos = false, bool videos = false,
@@ -2066,5 +2067,146 @@ public class WorkspaceViewModelTests : IDisposable
         public Task<string?> GetUrlAsync(
             string cliPath, string htmlPath, CancellationToken cancellationToken) =>
             throw new OperationCanceledException();
+    }
+
+    // ---- M5a: MRU + hero recents ----------------------------------------
+
+    [Fact]
+    public async Task Starting_a_run_on_a_folder_remembers_it()
+    {
+        var store = GuiStateStore.Ephemeral();
+        var vm = Vm(cli: null, stateStore: store,
+            folderInspector: _ => Contents(logs: true, topLogs: true));
+        var folder = MakeFolder(srt: true);
+        await vm.SetFolderAsync(folder);
+
+        // No CLI on purpose: the push happens as the run starts, before
+        // anything can fail — a guard-blocked run still counts.
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Equal([folder], store.State.RecentFolders);
+        Assert.Equal([folder], vm.RecentFolders);
+    }
+
+    [Fact]
+    public async Task File_runs_remember_nothing()
+    {
+        var store = GuiStateStore.Ephemeral();
+        var vm = Vm(cli: null, stateStore: store);
+        vm.SetFile(Path.Combine(_dir, "DJI_0001.SRT"));
+
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Empty(store.State.RecentFolders);
+    }
+
+    [Fact]
+    public async Task Setup_runs_remember_nothing()
+    {
+        var store = GuiStateStore.Ephemeral();
+        var vm = Vm(cli: null, stateStore: store,
+            folderInspector: _ => Contents(logs: true, topLogs: true));
+        await vm.SetFolderAsync(MakeFolder(srt: true));
+        vm.SelectedMode = WorkspaceMode.All[^1];   // Setup ignores the source
+
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Empty(store.State.RecentFolders);
+    }
+
+    [Fact]
+    public async Task Opening_an_existing_map_remembers_the_folder()
+    {
+        var store = GuiStateStore.Ephemeral();
+        var server = new FakeMapServer(FakeUrl);
+        var vm = Vm("cli", mapServer: server,
+            previewAvailable: static () => false, stateStore: store);
+        vm.UrlLauncher = _ => { };
+        var folder = MakeFolder(srt: true, flightMap: true);
+        await vm.SetFolderAsync(folder);
+        var map = Assert.Single(vm.ExistingMaps);
+
+        await vm.OpenExistingMapCommand.ExecuteAsync(map);
+
+        Assert.Equal([folder], store.State.RecentFolders);
+    }
+
+    [Fact]
+    public void Recents_seed_from_the_store_pruned_to_existing_folders()
+    {
+        var kept = MakeFolder(srt: true);
+        var store = GuiStateStore.Ephemeral();
+        store.PushRecent(Path.Combine(_dir, "gone"));
+        store.PushRecent(kept);
+
+        var vm = Vm(cli: null, stateStore: store);
+
+        Assert.Equal([kept], vm.RecentFolders);
+    }
+
+    [Fact]
+    public async Task Choosing_a_recent_is_identical_to_dropping_it()
+    {
+        var kept = MakeFolder(srt: true);
+        var store = GuiStateStore.Ephemeral();
+        store.PushRecent(kept);
+        var inspected = new List<string>();
+        var vm = Vm(cli: null, stateStore: store, folderInspector: dir =>
+        {
+            inspected.Add(dir);
+            return Contents(logs: true, topLogs: true);
+        });
+
+        await vm.ChooseRecentCommand.ExecuteAsync(kept);
+
+        Assert.Equal(kept, vm.SelectedFolder);
+        Assert.Equal([kept], inspected);   // the normal SetFolderAsync flow ran
+    }
+
+    [Fact]
+    public async Task Hero_recents_show_only_when_nothing_is_selected()
+    {
+        var kept = MakeFolder(srt: true);
+        var store = GuiStateStore.Ephemeral();
+        store.PushRecent(kept);
+        var vm = Vm(cli: null, stateStore: store,
+            folderInspector: _ => Contents(logs: true, topLogs: true));
+        Assert.True(vm.ShowRecentFolders);
+
+        await vm.SetFolderAsync(kept);
+        Assert.False(vm.ShowRecentFolders);
+
+        vm.ClearSourceCommand.Execute(null);
+        Assert.True(vm.ShowRecentFolders);
+    }
+
+    [Fact]
+    public void No_recents_means_no_hero_section()
+    {
+        Assert.False(Vm(cli: null).ShowRecentFolders);
+    }
+
+    [Fact]
+    public void Most_recent_existing_folder_feeds_the_picker_start()
+    {
+        var older = MakeFolder(srt: true);
+        var newer = MakeFolder(srt: true);
+        var store = GuiStateStore.Ephemeral();
+        store.PushRecent(older);
+        store.PushRecent(newer);
+
+        Assert.Equal(newer, Vm(cli: null, stateStore: store)
+            .MostRecentExistingFolder);
+        Assert.Null(Vm(cli: null).MostRecentExistingFolder);
+    }
+
+    [Fact]
+    public void Recents_never_touch_the_command_preview()
+    {
+        var store = GuiStateStore.Ephemeral();
+        store.PushRecent(MakeFolder(srt: true));
+        // State never affects argv: same strip with and without recents.
+        Assert.Equal(Vm(cli: null).CommandPreview,
+            Vm(cli: null, stateStore: store).CommandPreview);
     }
 }

--- a/gui/DjiEmbed.Gui/App.axaml.cs
+++ b/gui/DjiEmbed.Gui/App.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using DjiEmbed.Gui.Services;
 using DjiEmbed.Gui.ViewModels;
 using DjiEmbed.Gui.Views;
 
@@ -17,9 +18,12 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = new MainWindow
+            // The one persisted GUI state (workspace spec): MRU folders +
+            // window bounds in %APPDATA%/DjiEmbed/state.json.
+            var store = new GuiStateStore(GuiState.DefaultPath);
+            desktop.MainWindow = new MainWindow(store)
             {
-                DataContext = new MainViewModel(),
+                DataContext = new MainViewModel(store),
             };
         }
 

--- a/gui/DjiEmbed.Gui/Services/GuiState.cs
+++ b/gui/DjiEmbed.Gui/Services/GuiState.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>A window's last normal position and size, in the units the
+/// window itself reported, plus whether it was maximized at the time.</summary>
+public sealed record WindowBounds(
+    int X, int Y, int Width, int Height, bool Maximized);
+
+/// <summary>
+/// The one persisted GUI state (workspace spec 2026-07-18): MRU folders and
+/// window bounds, nothing else, ever, without a spec amendment. Pure data
+/// plus static I/O helpers; the runtime lifecycle lives in
+/// <see cref="GuiStateStore"/>.
+/// </summary>
+public sealed record GuiState(
+    WindowBounds? Window, IReadOnlyList<string> RecentFolders)
+{
+    /// <summary>Shared no-saved-state instance: record equality over
+    /// IReadOnlyList is reference equality, so "no state" must be one
+    /// object (the VerifyReport.Empty lesson).</summary>
+    public static GuiState Empty { get; } = new(null, []);
+
+    public const int MaxRecent = 5;
+
+    public static string DefaultPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "DjiEmbed", "state.json");
+
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    // Mutable DTOs rather than the records themselves: a file with a
+    // missing or null list must still load, and positional-record
+    // deserialization would happily hand back a null RecentFolders.
+    private sealed class WindowDto
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public bool Maximized { get; set; }
+    }
+
+    private sealed class StateDto
+    {
+        public WindowDto? Window { get; set; }
+        public List<string>? RecentFolders { get; set; }
+    }
+
+    /// <summary>Missing, corrupt, or unreadable → <see cref="Empty"/>.
+    /// Never throws: config must never block startup (the DoctorReport
+    /// degradation rule applied to config).</summary>
+    public static GuiState Load(string path)
+    {
+        try
+        {
+            var dto = JsonSerializer.Deserialize<StateDto>(
+                File.ReadAllText(path), Json);
+            if (dto is null)
+            {
+                return Empty;
+            }
+            var window = dto.Window is { } w
+                ? new WindowBounds(w.X, w.Y, w.Width, w.Height, w.Maximized)
+                : null;
+            var recents = (dto.RecentFolders ?? [])
+                .Where(static f => !string.IsNullOrWhiteSpace(f))
+                .Take(MaxRecent)
+                .ToList();
+            return window is null && recents.Count == 0
+                ? Empty
+                : new GuiState(window, recents);
+        }
+        catch (Exception)
+        {
+            return Empty;
+        }
+    }
+
+    /// <summary>Best-effort atomic write: temp file in the target
+    /// directory, then move over the target. Failure is swallowed —
+    /// losing recents must never crash the app.</summary>
+    public static void Save(GuiState state, string path)
+    {
+        try
+        {
+            if (Path.GetDirectoryName(path) is { Length: > 0 } dir)
+            {
+                Directory.CreateDirectory(dir);
+            }
+            var dto = new StateDto
+            {
+                Window = state.Window is { } w
+                    ? new WindowDto
+                    {
+                        X = w.X, Y = w.Y,
+                        Width = w.Width, Height = w.Height,
+                        Maximized = w.Maximized,
+                    }
+                    : null,
+                RecentFolders = state.RecentFolders.ToList(),
+            };
+            var temp = path + ".tmp";
+            File.WriteAllText(temp, JsonSerializer.Serialize(dto, Json));
+            File.Move(temp, path, overwrite: true);
+        }
+        catch (Exception e) when (e is IOException
+            or UnauthorizedAccessException or NotSupportedException)
+        {
+        }
+    }
+
+    /// <summary>The folder pushed to the front: de-duplicated
+    /// case-insensitively (Windows paths), capped at
+    /// <see cref="MaxRecent"/>, most-recent-first.</summary>
+    public GuiState WithRecent(string folder) => this with
+    {
+        RecentFolders = new[] { folder }
+            .Concat(RecentFolders.Where(f => !string.Equals(
+                f, folder, StringComparison.OrdinalIgnoreCase)))
+            .Take(MaxRecent)
+            .ToList(),
+    };
+
+    /// <summary>
+    /// True when the saved rectangle intersects any screen rectangle — the
+    /// undocked-laptop gate. An empty screen list (headless platforms)
+    /// counts as restorable: restoring is harmless when nobody can see it.
+    /// </summary>
+    public static bool RestorableOn(
+        WindowBounds bounds,
+        IReadOnlyList<(int X, int Y, int Width, int Height)> screens)
+    {
+        if (bounds.Width <= 0 || bounds.Height <= 0)
+        {
+            return false;
+        }
+        return screens.Count == 0 || screens.Any(s =>
+            bounds.X < s.X + s.Width && s.X < bounds.X + bounds.Width
+            && bounds.Y < s.Y + s.Height && s.Y < bounds.Y + bounds.Height);
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/GuiStateStore.cs
+++ b/gui/DjiEmbed.Gui/Services/GuiStateStore.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// Owns state.json at runtime: loads once at construction, holds the
+/// current state, saves immediately on every change (a crash must not
+/// lose the recents). View models see this store, never file paths.
+/// </summary>
+public sealed class GuiStateStore
+{
+    private readonly string? _path;
+
+    public GuiState State { get; private set; }
+
+    public GuiStateStore(string? path)
+    {
+        _path = path;
+        State = path is null ? GuiState.Empty : GuiState.Load(path);
+    }
+
+    /// <summary>In-memory store for tests and parameterless view-model
+    /// construction: never touches disk.</summary>
+    public static GuiStateStore Ephemeral() => new(null);
+
+    /// <summary>A run started on this folder — remember it.</summary>
+    public void PushRecent(string folder)
+    {
+        State = State.WithRecent(folder);
+        SaveNow();
+    }
+
+    public void SaveWindow(WindowBounds bounds)
+    {
+        State = State with { Window = bounds };
+        SaveNow();
+    }
+
+    /// <summary>Recents that still exist on disk — the only list the UI
+    /// shows. The stored file may briefly hold dead paths; they are
+    /// dropped on the next save.</summary>
+    public IReadOnlyList<string> ExistingRecents() =>
+        State.RecentFolders.Where(Directory.Exists).ToList();
+
+    private void SaveNow()
+    {
+        if (_path is null)
+        {
+            return;
+        }
+        State = State with
+        {
+            RecentFolders = State.RecentFolders
+                .Where(Directory.Exists).ToList(),
+        };
+        GuiState.Save(State, _path);
+    }
+}

--- a/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
@@ -19,11 +19,11 @@ public partial class MainViewModel : ViewModelBase
 
     private readonly WorkspaceViewModel _workspace;
 
-    public MainViewModel()
+    public MainViewModel(GuiStateStore? store = null)
     {
         _workspace = new WorkspaceViewModel(
             CliLocator.Find(), new DjiEmbedRunner(), _mapServer,
-            OpenCliDiscovery, CliLocator.Find);
+            OpenCliDiscovery, CliLocator.Find, stateStore: store);
         CurrentPage = _workspace;
     }
 

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -23,12 +24,14 @@ public partial class WorkspaceViewModel : FlowViewModel
     private readonly Func<string?>? _cliResolver;
     private readonly Func<bool> _previewAvailable;
     private readonly Func<string, FolderContents> _inspectFolder;
+    private readonly GuiStateStore _stateStore;
 
     public WorkspaceViewModel(string? cli, DjiEmbedRunner runner,
         IMapServer mapServer, Action openCliDiscovery,
         Func<string?>? cliResolver = null,
         Func<bool>? previewAvailable = null,
-        Func<string, FolderContents>? folderInspector = null)
+        Func<string, FolderContents>? folderInspector = null,
+        GuiStateStore? stateStore = null)
         : base(cli, runner, static () => { })
     {
         _mapServer = mapServer;
@@ -60,6 +63,14 @@ public partial class WorkspaceViewModel : FlowViewModel
             OnPropertyChanged(nameof(ShowDoneWarnings));
         VerifyCards.CollectionChanged += (_, _) =>
             OnPropertyChanged(nameof(ShowDoneWarnings));
+
+        _stateStore = stateStore ?? GuiStateStore.Ephemeral();
+        foreach (var f in _stateStore.ExistingRecents())
+        {
+            RecentFolders.Add(f);
+        }
+        RecentFolders.CollectionChanged += (_, _) =>
+            OnPropertyChanged(nameof(ShowRecentFolders));
     }
 
     /// <summary>
@@ -106,6 +117,20 @@ public partial class WorkspaceViewModel : FlowViewModel
     public string? SourceDisplay =>
         SelectedFolder ?? (SelectedFile is { } f ? Path.GetFileName(f) : null);
 
+    /// <summary>Recent folders that still exist — the hero's quick
+    /// re-entry list (M5a), most-recent-first, rebuilt on every push.</summary>
+    public ObservableCollection<string> RecentFolders { get; } = [];
+
+    /// <summary>The hero shows recents only while there is nothing else
+    /// to look at: no source selected, no run in flight.</summary>
+    public bool ShowRecentFolders =>
+        RecentFolders.Count > 0 && SourceDisplay is null && !IsBusy;
+
+    /// <summary>Where the folder picker starts: the most recent folder
+    /// still on disk, or null for the picker's own default.</summary>
+    public string? MostRecentExistingFolder =>
+        _stateStore.ExistingRecents().FirstOrDefault();
+
     [ObservableProperty]
     public partial WorkspaceMode SelectedMode { get; set; } = WorkspaceMode.All[0];
 
@@ -125,8 +150,11 @@ public partial class WorkspaceViewModel : FlowViewModel
     [ObservableProperty]
     public partial bool IsBusy { get; private set; }
 
-    partial void OnIsBusyChanged(bool value) =>
+    partial void OnIsBusyChanged(bool value)
+    {
         OpenExistingMapCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(ShowRecentFolders));
+    }
 
     public ObservableCollection<SetupItem> SetupItems { get; } = [];
 
@@ -349,6 +377,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(VerifyValidateEnabled));
         OnPropertyChanged(nameof(VerifySunEnabled));
         OnPropertyChanged(nameof(VerifySubActionNote));
+        OnPropertyChanged(nameof(ShowRecentFolders));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -372,6 +401,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(VerifyValidateEnabled));
         OnPropertyChanged(nameof(VerifySunEnabled));
         OnPropertyChanged(nameof(VerifySubActionNote));
+        OnPropertyChanged(nameof(ShowRecentFolders));
         RunCommand.NotifyCanExecuteChanged();
     }
 
@@ -511,6 +541,23 @@ public partial class WorkspaceViewModel : FlowViewModel
         }
     }
 
+    /// <summary>A run started on this folder (M5a MRU signal): push it,
+    /// rebuild the pruned display list.</summary>
+    private void RememberFolder(string folder)
+    {
+        _stateStore.PushRecent(folder);
+        RecentFolders.Clear();
+        foreach (var f in _stateStore.ExistingRecents())
+        {
+            RecentFolders.Add(f);
+        }
+        OnPropertyChanged(nameof(MostRecentExistingFolder));
+    }
+
+    /// <summary>Hero recents click: identical to dropping the folder.</summary>
+    [RelayCommand]
+    private Task ChooseRecentAsync(string folder) => SetFolderAsync(folder);
+
     /// <summary>A run owns the preview pane while it is in flight. Private:
     /// it raises no PropertyChanged, so nothing may bind it — a button gets
     /// this gate from the command's own CanExecute.</summary>
@@ -526,6 +573,11 @@ public partial class WorkspaceViewModel : FlowViewModel
     [RelayCommand(CanExecute = nameof(CanOpenExistingMap))]
     private async Task OpenExistingMapAsync(ExistingMap map)
     {
+        // Browsing an existing map is real work with the folder (M5a).
+        if (SelectedFolder is { } mapFolder)
+        {
+            RememberFolder(mapFolder);
+        }
         if (!_previewAvailable() || CliPath is null)
         {
             // OpenOutputCoreAsync still routes through the map server, so the
@@ -633,6 +685,15 @@ public partial class WorkspaceViewModel : FlowViewModel
     [RelayCommand(CanExecute = nameof(CanRun))]
     private async Task RunAsync()
     {
+        // A run starting on a folder is the MRU signal (M5a) — before
+        // anything can fail, so guard-blocked runs still count: the user
+        // chose to work with this folder. Setup ignores the source and
+        // file runs have no folder; neither pushes.
+        if (SelectedFile is null && SelectedFolder is { } mruFolder
+            && SelectedMode.Kind != WorkspaceModeKind.Setup)
+        {
+            RememberFolder(mruFolder);
+        }
         // Busy for the run's entire lifetime, from before the folder scan:
         // AsyncRelayCommand only covers the button, and Step only turns
         // Running later, inside ExecuteFlowAsync (#340).

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -546,6 +546,15 @@ public partial class WorkspaceViewModel : FlowViewModel
     private void RememberFolder(string folder)
     {
         _stateStore.PushRecent(folder);
+        RefreshRecents();
+    }
+
+    /// <summary>Rebuilds the displayed recents list from the store, pruned to
+    /// folders that still exist. Shared by <see cref="RememberFolder"/> (a
+    /// fresh push) and <see cref="ChooseRecentAsync"/> (a stale entry found
+    /// dead at click time).</summary>
+    private void RefreshRecents()
+    {
         RecentFolders.Clear();
         foreach (var f in _stateStore.ExistingRecents())
         {
@@ -554,9 +563,20 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(MostRecentExistingFolder));
     }
 
-    /// <summary>Hero recents click: identical to dropping the folder.</summary>
+    /// <summary>Hero recents click: identical to dropping the folder.
+    /// The list prunes at seed and on push, not on filesystem change —
+    /// an SD card ejected mid-session leaves a dead entry, and clicking
+    /// it must drop it, not crash in the folder scan.</summary>
     [RelayCommand]
-    private Task ChooseRecentAsync(string folder) => SetFolderAsync(folder);
+    private async Task ChooseRecentAsync(string folder)
+    {
+        if (!Directory.Exists(folder))
+        {
+            RefreshRecents();
+            return;
+        }
+        await SetFolderAsync(folder);
+    }
 
     /// <summary>A run owns the preview pane while it is in flight. Private:
     /// it raises no PropertyChanged, so nothing may bind it — a button gets

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -20,25 +20,34 @@ internal static class FolderPicking
     /// <c>-o</c> is a directory, not a file, so its Choose… button routes
     /// here rather than to <see cref="PickSaveAsync"/>'s save dialog.
     /// </summary>
-    internal static async Task<string?> PickFolderAsync(Control anchor, string title)
+    internal static async Task<string?> PickFolderAsync(
+        Control anchor, string title, string? startFolder = null)
     {
         if (TopLevel.GetTopLevel(anchor) is not { } top)
         {
             return null;
         }
+        // Best-effort: an unreachable start folder means the picker's
+        // own default, nothing more.
+        var start = startFolder is null
+            ? null
+            : await top.StorageProvider.TryGetFolderFromPathAsync(startFolder);
         var folders = await top.StorageProvider.OpenFolderPickerAsync(
             new FolderPickerOpenOptions
             {
                 AllowMultiple = false,
                 Title = title,
+                SuggestedStartLocation = start,
             });
         return folders.FirstOrDefault()?.TryGetLocalPath();
     }
 
     internal static async Task ChooseAsync(
-        Control anchor, Func<string, Task> onFolder)
+        Control anchor, Func<string, Task> onFolder,
+        string? startFolder = null)
     {
-        if (await PickFolderAsync(anchor, "Choose the folder with your footage")
+        if (await PickFolderAsync(
+                anchor, "Choose the folder with your footage", startFolder)
             is { } path)
         {
             await onFolder(path);

--- a/gui/DjiEmbed.Gui/Views/MainWindow.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/MainWindow.axaml.cs
@@ -1,11 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
+using DjiEmbed.Gui.Services;
 
 namespace DjiEmbed.Gui.Views;
 
 public partial class MainWindow : Window
 {
-    public MainWindow()
+    private readonly GuiStateStore? _store;
+
+    // Last bounds seen in the Normal state: Avalonia has no RestoreBounds,
+    // so closing while maximized saves these instead — un-maximizing after
+    // the next launch then lands somewhere sane.
+    private PixelPoint _normalPosition;
+    private Size _normalSize;
+
+    public MainWindow() : this(null)
+    {
+    }
+
+    public MainWindow(GuiStateStore? store)
     {
         InitializeComponent();
+        _store = store;
+        if (store?.State.Window is { } b
+            && GuiState.RestorableOn(b, ScreenRects()))
+        {
+            // CenterScreen (the XAML default) would override a manual
+            // Position on open; switching to Manual makes ours stick.
+            WindowStartupLocation = WindowStartupLocation.Manual;
+            Position = new PixelPoint(b.X, b.Y);
+            Width = b.Width;
+            Height = b.Height;
+            if (b.Maximized)
+            {
+                WindowState = WindowState.Maximized;
+            }
+        }
+        _normalPosition = Position;
+        _normalSize = new Size(Width, Height);
+        PositionChanged += (_, e) =>
+        {
+            if (WindowState == WindowState.Normal)
+            {
+                _normalPosition = e.Point;
+            }
+        };
+        SizeChanged += (_, e) =>
+        {
+            if (WindowState == WindowState.Normal)
+            {
+                _normalSize = e.NewSize;
+            }
+        };
+        Closing += (_, _) => SaveBounds();
+    }
+
+    // Position is physical pixels while Width/Height are DIPs, so under a
+    // non-100% scale this intersection is approximate — good enough for
+    // "is any part of the window still reachable", which is all the gate
+    // asks (spec 2026-07-22).
+    private IReadOnlyList<(int X, int Y, int Width, int Height)> ScreenRects() =>
+        Screens.All
+            .Select(s => (s.WorkingArea.X, s.WorkingArea.Y,
+                s.WorkingArea.Width, s.WorkingArea.Height))
+            .ToList();
+
+    private void SaveBounds()
+    {
+        if (_store is null)
+        {
+            return;
+        }
+        // Live values while Normal (robust even where the platform never
+        // fired SizeChanged); the tracked normals only stand in while the
+        // window is maximized and the live ones describe the wrong state.
+        var maximized = WindowState == WindowState.Maximized;
+        var pos = maximized ? _normalPosition : Position;
+        var size = maximized ? _normalSize : new Size(Width, Height);
+        _store.SaveWindow(new WindowBounds(
+            pos.X, pos.Y, (int)size.Width, (int)size.Height, maximized));
     }
 }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceConverters.cs
@@ -27,6 +27,21 @@ public static class WorkspaceConverters
     public static readonly FuncValueConverter<string?, string?> FileNameOnly =
         new(static p => p is null ? null : Path.GetFileName(p));
 
+    /// <summary>A recent folder's leaf name. Manual separator split: on
+    /// Linux <c>Path.GetFileName</c> does not split '\', and stored paths
+    /// are wire-format text (the VerifyReport.FileName lesson).</summary>
+    public static readonly FuncValueConverter<string?, string?> FolderLeafName =
+        new(static p =>
+        {
+            if (p is null)
+            {
+                return null;
+            }
+            var trimmed = p.TrimEnd('/', '\\');
+            var cut = trimmed.LastIndexOfAny(['/', '\\']);
+            return cut < 0 ? trimmed : trimmed[(cut + 1)..];
+        });
+
     /// <summary>
     /// An existing map's age in words ("2 days ago"). The clock is read here
     /// so <see cref="RelativeTime"/> itself stays pure. It is read once per

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -76,6 +76,34 @@
                                     </StackPanel>
                                 </Panel>
                             </Border>
+                            <StackPanel Name="RecentFoldersSection" Spacing="4"
+                                        IsVisible="{Binding ShowRecentFolders}">
+                                <TextBlock Text="Recent folders"
+                                           Opacity="0.6" FontSize="12" />
+                                <ItemsControl Name="RecentFoldersList"
+                                              ItemsSource="{Binding RecentFolders}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Spacing="2" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="x:String">
+                                            <Button Command="{Binding $parent[ItemsControl].((vm:WorkspaceViewModel)DataContext).ChooseRecentCommand}"
+                                                    CommandParameter="{Binding}"
+                                                    ToolTip.Tip="{Binding}"
+                                                    AutomationProperties.Name="{Binding}"
+                                                    HorizontalAlignment="Stretch"
+                                                    Background="Transparent"
+                                                    Padding="6,3">
+                                                <TextBlock Text="{Binding Converter={x:Static views:WorkspaceConverters.FolderLeafName}}"
+                                                           FontSize="12"
+                                                           TextTrimming="CharacterEllipsis" />
+                                            </Button>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
                             <DockPanel IsVisible="{Binding SourceDisplay,
                                            Converter={x:Static ObjectConverters.IsNotNull}}">
                                 <Button DockPanel.Dock="Right"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -42,7 +42,7 @@ public partial class WorkspaceView : UserControl
     /// null when dismissed.
     /// </summary>
     internal Func<Control, string, Task<string?>> OutputFolderPicker
-    { get; set; } = FolderPicking.PickFolderAsync;
+    { get; set; } = (anchor, title) => FolderPicking.PickFolderAsync(anchor, title);
 
     /// <summary>
     /// Single-file picking for the source card's "Choose a file…"
@@ -146,7 +146,8 @@ public partial class WorkspaceView : UserControl
     };
 
     private async void OnChooseFolderClick(object? sender, RoutedEventArgs e) =>
-        await FolderPicking.ChooseAsync(this, SetFolderAsync);
+        await FolderPicking.ChooseAsync(this, SetFolderAsync,
+            (DataContext as WorkspaceViewModel)?.MostRecentExistingFolder);
 
     private async void OnChooseFileClick(object? sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
## Summary

First half of the M5 polish milestone (spec: `docs/superpowers/specs/2026-07-22-gui-m5a-state-persistence-design.md`): the desktop app now remembers the little that's worth remembering — and nothing else.

- **One `state.json`** in `%APPDATA%/DjiEmbed/` holding MRU folders + window bounds. Pure `GuiState` record (atomic save, degrade-to-defaults load, never blocks startup) + a `GuiStateStore` runtime owner (load once, save immediately on change, prune dead folders on save).
- **Hero "Recent folders" list**: up to 5 folders you actually worked with (pushed when a run starts on them, incl. existing-map opens; Setup and single-file runs don't count). Click = identical to dropping the folder. Clicking an entry whose SD card was ejected mid-session drops the entry gracefully instead of crashing (whole-branch review catch, regression-tested).
- **Folder picker** starts in the most recent folder.
- **Window bounds** restore on startup — only when the saved rectangle still intersects a visible screen (undocked-laptop gate) — and save on close, maximized state included.
- **State never affects argv**: CommandBuilder/CommandPreview untouched, pinned by test.

## Test plan

- GUI suite: 454 passed / 16 skipped, 0 build warnings (new: GuiStateTests 21, GuiStateStoreTests 6, MainWindowStateTests 6, 11 VM tests, 3 screen tests + freeze-test growth, hero-recents screenshot capture).
- Python untouched; gates still green: 691 passed, ruff clean, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZUDWn8fX49nqMp7gos2iT