### PR TITLE
docs: post-2.0 sweep (hover toggle, roadmap refresh, index links)

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -75,6 +75,7 @@ dji-embed flightmap <folder>    HTML map of all flights from the .SRT logs
 dji-embed convert <fmt> <file>  SRT → gpx | csv | geojson | kml | cot | html
 dji-embed check <folder>        What metadata do these files already carry?
 dji-embed validate <folder>     Are SRT and MP4 in sync? (drift report)
+dji-embed serve <folder>        Serve an existing map locally (enables the 360° viewer)
 dji-embed doctor                Diagnostics: versions, FFmpeg/ExifTool present?
 dji-embed verify-sun <file>     Sun position over a clip (shadow plausibility)
 ```
@@ -121,8 +122,11 @@ Every command accepts `--help` for its options.
   for **any** GPS-tagged photos, not just DJI's.
 - The Windows app is a front end over the same CLI: anything the app does,
   the `dji-embed` command can do with more options.
-- On mobile browsers the map skips hover previews and enlarges pin tap
-  targets; tap a pin to open its popup, tap the popup photo to open a 360°.
+- Photo-map pins open their popup on click/tap; thumbnail previews on hover
+  are **off by default** — a "Hover previews" toggle in the map's top-right
+  corner (mouse devices only; the browser remembers the choice) turns them
+  on. Mobile browsers enlarge pin tap targets; tap the popup photo to open
+  a 360°.
 
 ## When something fails
 
@@ -134,4 +138,4 @@ Every command accepts `--help` for its options.
    <https://github.com/CallMarcus/dji-drone-metadata-embedder/issues>
 
 *This document ships with the project and is updated alongside it; it
-describes v1.21+ behavior.*
+describes v2.0+ behavior.*

--- a/README.md
+++ b/README.md
@@ -539,8 +539,10 @@ Notes:
   distinct on the map.
 - Popup previews use the small EXIF thumbnail, falling back to a size-capped
   embedded preview for DNGs that carry no thumbnail.
-- Hovering a marker shows the thumbnail and filename in a tooltip, so a map
-  can be skimmed without clicking every pin (HTML output, desktop browsers).
+- A **Hover previews** toggle in the map's top-right corner (off by default,
+  mouse devices only, remembered by the browser) shows each pin's thumbnail
+  and filename in a tooltip, so a map can be skimmed without clicking every
+  pin (HTML output).
 - Photos with no EXIF altitude are clamped to the ground in KML (Google Earth)
   instead of being buried at 0 m below terrain.
 - `--link-originals` makes each popup's thumbnail and filename a click-through

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -1,6 +1,6 @@
 # Development Roadmap
 
-_Last updated: 2026-06-21 · Current version: **v2.0.0** · Status: **Production Ready**_
+_Last updated: 2026-07-23 · Current version: **v2.0.0** · Status: **Production Ready**_
 
 This roadmap tracks the evolution of **DJI Drone Metadata Embedder**. The
 original Phase 1–6 plan (standalone Windows GUI, dependency bootstrap,
@@ -16,18 +16,22 @@ from pre-existing environmental gaps.
 ### Packaging & distribution
 - Single-source versioning driven by `src/dji_metadata_embedder/__init__.py`
   and `tools/sync_version.py`.
-- Tag-driven releases for PyPI, the Windows EXE, and winget (the winget
-  workflow is currently parked and fires only on manual dispatch).
+- Tag-driven releases for PyPI and the signed Windows installer/EXE
+  (Authenticode from v1.23.0, Sigstore build attestations); the winget
+  catalog update is a manual per-release dispatch.
 - PyInstaller spec (`dji-embed.spec`) and build script (`tools/build_exe.py`).
 - PowerShell bootstrap installer (`tools/bootstrap.ps1`) for Windows users.
 - `uv`-managed dependency set with a hash-verified `uv.lock`.
 
 ### CLI & processing
-- Professional subcommand CLI (`dji-embed embed|validate|convert|check|doctor|ui`).
+- Professional subcommand CLI (`dji-embed
+  embed|check|convert|photomap|flightmap|serve|doctor|validate|verify-sun`).
 - Core embedding pipeline (`core/processor.py`) and SRT/MP4 drift validator
   (`core/validator.py`).
-- Parsers for Mini 3/4 Pro, Air 3, Avata 2, and Mavic 3 Enterprise SRT
-  formats, with golden fixtures in `samples/` and `tests/fixtures/`.
+- Parsers for Mini 3/4/5 Pro, Air 3/3S, Avata 2/360, Neo 2, Mavic 3
+  Enterprise, Matrice 300, and Phantom 4 RTK SRT formats, with golden
+  fixtures in `samples/` and `tests/fixtures/` (full list:
+  `SRT_FORMATS.md`).
 - Lenient parser mode with structured warnings, unit normalisation, and
   sanity checks for altitude/speed.
 - CLI options for time offsets, resample strategy, GPS redaction (drop /
@@ -35,15 +39,23 @@ from pre-existing environmental gaps.
 - Telemetry export to JSON, GPX, and CSV.
 - DAT flight-log parsing and per-frame embedding helpers.
 
-### UI
+### Desktop app
 - The Avalonia desktop app (`gui/`, Windows installer) is the supported
-  interactive surface. The Flask-based `dji-embed ui` local web UI was
-  removed in v2.0.0 after a deprecation cycle; a legacy Tk skeleton was
-  removed earlier, in the 2026-06 cleanup pass.
+  interactive surface: a single-window workspace with six modes (Embed,
+  Flight map, Photo map, Convert, Verify, Setup), curated per-mode options
+  with a CLI-transparency strip, an inline map preview pane, and persisted
+  recents/window state. It is a thin frontend that shells out to the
+  bundled CLI over the `--progress jsonl` contract (see
+  `desktop-app.md` and the GUI 2.0 spec under `superpowers/specs/`).
+- The Flask-based `dji-embed ui` local web UI was removed in v2.0.0 after
+  a deprecation cycle; a legacy Tk skeleton was removed earlier, in the
+  2026-06 cleanup pass.
 
 ### Testing & CI
-- Unit test suite (`tests/`, 264 tests) covering parsing, embedding, DAT,
-  redaction, sync, UI server, and CLI smoke.
+- Unit test suite (`tests/`) covering parsing, embedding, DAT, redaction,
+  sync, mapping/exports, and CLI smoke, plus a headless xunit.v3 suite for
+  the desktop app (`gui/DjiEmbed.Gui.Tests/`) and a durable browser suite
+  for generated maps.
 - End-to-end validation suite (`validation_tests/`) for release verification
   when FFmpeg/ExifTool and real media are available.
 - GitHub Actions CI matrix for Windows + Linux on Python 3.10–3.12
@@ -64,7 +76,7 @@ from pre-existing environmental gaps.
 ## In progress / near-term
 
 - **Keep the baseline honest.** When you touch parsing, FFmpeg command
-  assembly, or the UI, re-run `uv run pytest -q` and — if you have the
+  assembly, or the GUI, re-run `uv run pytest -q` and — if you have the
   binaries — `validation_tests/run_all_tests.py`, then update
   `docs/ci_baseline.md` if expectations change.
 - **Housekeeping follow-ups.** See `HOUSEKEEPING.md` for the current
@@ -97,9 +109,13 @@ from pre-existing environmental gaps.
   pause, speed, scrubbing; per-point `times_s` in the flight GeoJSON); and
   [#268](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/268)
   a 3D terrain view (MapLibre `--3d` template, deliberately parked).
-- **Richer web UI.** Incremental improvements to the Flask UI
-  (`src/dji_metadata_embedder/ui/`) – nicer job progress, downloadable
-  per-job artefacts, and richer previews – instead of new GUI frameworks.
+- **Linux desktop build.** Community-requested (
+  [#360](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/360),
+  .AppImage): Avalonia makes it feasible; needs a WebView alternative to
+  WebView2, Linux tool provisioning, and AppImage CI. Interim answer on
+  Linux is the CLI via pipx. Related:
+  [#361](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/361)
+  publish an AUR package for Arch-family distros.
 - **Performance work on large batches.** Candidates include parallel
   per-clip embedding and streaming SRT parsing for long flights.
 - **Winget catalog publish — live.** `CallMarcus.DJIMetadataEmbedder` is
@@ -115,11 +131,10 @@ from pre-existing environmental gaps.
 
 ## Explicitly out of scope
 
-- **Standalone Tk/Win32 GUI.** The `gui/` experiment was superseded by the
-  packaged Flask UI and removed in the 2026-06 cleanup pass; no further Tk
-  work is planned.
-- **Winget-first install story.** Winget is demoted in the README until the
-  manifests ship on a cadence that matches PyPI and the EXE release.
+- **Standalone Tk/Win32 GUI and the Flask web UI.** Both are gone (Tk in
+  the 2026-06 cleanup, Flask `dji-embed ui` in v2.0.0); the Avalonia
+  desktop app is the only interactive surface, and no in-browser UI is
+  planned.
 - **Re-encoding pipelines.** The project's contract is "no re-encode"; any
   feature that forces transcoding needs an RFC first.
 
@@ -135,3 +150,9 @@ from pre-existing environmental gaps.
   recipes, troubleshooting expansion, auto-changelog.
 - **v1.2 – UI & release polish** (2026) – Flask-based `dji-embed ui`, winget
   workflow parked, README install order reshuffled, Dependabot enabled.
+- **v1.x – Maps, privacy & supply chain** (2026-06/07) – photomap, flightmap,
+  360° pano viewer, `--redact` / `--popup-fields`, winget catalog live,
+  Authenticode signing + Sigstore attestations.
+- **v2.0 – Desktop workspace app** (2026-07) – Avalonia single-window app
+  (GUI 2.0 milestones M1–M5): six modes, curated options with CLI
+  transparency, inline preview, persisted state; Flask web UI removed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,11 @@
 # DJI Drone Metadata Embedder
 
-Welcome to the documentation for **DJI Drone Metadata Embedder**. This project provides tools to embed telemetry from DJI drone SRT files into videos and to convert telemetry to other formats.
+Welcome to the documentation for **DJI Drone Metadata Embedder**. This project embeds telemetry from DJI drone SRT files into videos, maps flights and GPS-tagged photos as interactive HTML maps, and converts telemetry to other formats — all locally on your machine, via a Windows desktop app or the `dji-embed` command line.
 
-Use the guides in this site to embed GPS data in your footage, redact sensitive information and generate GPX tracks.
+Use the guides in this site to embed GPS data in your footage, map where you've flown, redact sensitive information and generate GPX tracks.
 
 - [Installation](installation.md)
+- [Desktop App](desktop-app.md) — the Windows workspace, no terminal needed
 - [User Guide](user_guide.md)
 - [Maps & Panoramas](geospatial.md) — photo maps, flight maps, the 360° viewer
 - [Decision Table](decision-table.md)


### PR DESCRIPTION
Docs sweep after the v2.0.0 release, catching text that still described pre-2.0 behavior.

- **README + HELP.md**: the photo-map hover previews became an opt-in toggle in #345 (merged, unreleased) — both docs still described always-on hover tooltips. HELP also gets `dji-embed serve` in its command list and its footer bumped from "v1.21+" to "v2.0+".
- **docs/development_roadmap.md**: still listed the removed `dji-embed ui` command, planned a "richer Flask web UI", claimed the winget workflow was "parked", and stopped its model list at four drones. Refreshed: shipped Avalonia workspace summary, current CLI roster, current parser/test-suite descriptions, Linux desktop (#360) + AUR (#361) in future direction, v1.x/v2.0 milestone history entries.
- **docs/index.md**: now mentions the desktop app and links the Desktop App guide (the MkDocs nav already had it; the landing page didn't).

`mkdocs build` passes. AGENTS.md, user_guide, desktop-app, decision-table, troubleshooting and installation were checked and are already current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)