### PR TITLE
feat(flightmap): 3D terrain view via MapLibre (--3d) (#268)

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -104,6 +104,10 @@ Every command accepts `--help` for its options.
 - **"Export a flight for Google Earth / an editor":**
   `dji-embed convert kml DJI_0001.SRT` (or `gpx`, `csv`, …); add `-b` on a
   folder for batch.
+- **"See my flights over real terrain in 3D":**
+  `dji-embed flightmap D:\Footage --3d` → writes `flightmap-3d.html` (the
+  flat `flightmap.html` is untouched); tracks follow the terrain surface,
+  altitudes are in the popups; needs internet for the terrain tiles.
 
 ## Facts that answer most confusion
 

--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ Notes:
   flight data itself is embedded, so the HTML file is portable but needs a
   connection to render. A flight map publishes where you fly — share it
   deliberately, or use `--redact fuzz`.
+- `--3d` renders the flights over real 3D terrain (MapLibre + Mapterhorn/
+  Copernicus, keyless) as a separate `flightmap-3d.html`, instead of the
+  flat basemap.
 
 ### `dji-embed photomap` - Map Still Photos
 

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -47,6 +47,7 @@ This guide helps you choose the right command and approach for your specific use
 | Directory of SRT files | Multiple CSV files | `dji-embed convert csv /path/to/srt/dir --batch` |
 | Directory of SRT files | Multiple HTML maps | `dji-embed convert html /path/to/srt/dir --batch` |
 | Directory of SRT files | ONE combined HTML/KML/GeoJSON map | `dji-embed flightmap /path/to/srt/dir` |
+| Directory of SRT files | 3D terrain map (draped tracks, no playback; the 2D map above keeps basemap styles + playback) | `dji-embed flightmap /path/to/srt/dir --3d` |
 | Custom output filename | Specific output file | `dji-embed convert gpx input.SRT -o custom.gpx` |
 | MP4 with no sidecar SRT (Air 3S, Mini 5 Pro) | GPX/CSV/GeoJSON/KML track | `dji-embed convert <fmt> FILE.MP4` (ExifTool-backed; needs recent ExifTool — see [MP4 Timed Metadata](MP4_TIMED_METADATA.md)) |
 | MP4 with no sidecar SRT (Air 3S, Mini 5 Pro) | Sun/shadow verification | `dji-embed verify-sun FILE.MP4` (ExifTool-backed; needs recent ExifTool — see [MP4 Timed Metadata](MP4_TIMED_METADATA.md)) |

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -246,6 +246,28 @@ and `cyclosm` (cycling-oriented, detailed paths). Each style carries its
 provider's attribution automatically. KML and GeoJSON outputs have no
 basemap and are unchanged.
 
+### 3D terrain view
+
+```bash
+dji-embed flightmap ./footage --3d               # -> footage/flightmap-3d.html
+```
+
+`--3d` writes a separate `flightmap-3d.html` next to (never instead of) the
+regular `flightmap.html` — `-o` overrides the output path as usual, and
+combining `--3d` with `--format kml|geojson|all` errors, since the 3D map is
+HTML-only. Both maps read the same flight data and honor `--redact fuzz`
+(~100 m coarsened tracks) before either file is written.
+
+Rendered with MapLibre GL instead of Leaflet, tracks are draped on the
+terrain surface — they follow the ground under a tilted camera rather than
+floating at altitude; altitude numbers are still available in the track
+popups. Terrain comes from Mapterhorn (Copernicus elevation data), loaded
+keylessly over the network — like the 2D map it needs a connection to
+render, and if the terrain tiles can't load, it falls back to a flat view
+with an on-map notice. Browsers without WebGL get a plain HTML message
+instead. `--tile-style` has no effect in 3D (ignored, with a warning), and
+there's no playback in the 3D view.
+
 ## Photo map (`photomap`)
 
 ```bash

--- a/docs/superpowers/specs/2026-07-23-flightmap-3d-design.md
+++ b/docs/superpowers/specs/2026-07-23-flightmap-3d-design.md
@@ -42,9 +42,11 @@ A sibling of `flightmap_html.py` with the same contract and structure:
   changes to `flightmap.py` or the GeoJSON shape. Data is embedded in the
   same `<script type="application/json">` block with the same
   backslash-u003c escaping of `<` (no `</script>` breakout).
-- MapLibre GL JS (v6.x, exact version resolved at implementation time)
-  loaded from unpkg with pinned version **and SRI hashes**, matching the
-  Leaflet pins in the 2D writers.
+- MapLibre GL JS **5.24.0** loaded from unpkg with pinned version **and
+  SRI hashes**, matching the Leaflet pins in the 2D writers. (v6 was
+  evaluated 2026-07-23 and rejected: it is ESM-only — no UMD bundle —
+  and its multi-file module graph defeats the single-script-tag + SRI
+  pattern every template here uses. v5 is the maintained UMD line.)
 - Module docstring documents AWS Terrarium
   (`s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png`,
   `encoding: "terrarium"`) as the drop-in replacement terrain source if
@@ -61,9 +63,10 @@ A sibling of `flightmap_html.py` with the same contract and structure:
 - **Camera:** starts pitched (~60°) and fitted to the union of track
   bounds.
 - **Tracks:** one line layer per flight in the same color rotation as the
-  2D map, rendered at per-point altitude (third GeoJSON coordinate).
-  Single-fix `Point` features (degenerate flights) render as a marker,
-  not a line — the data walk must not assume LineString.
+  2D map, **draped on the terrain surface** (MapLibre line layers are
+  strictly 2D — see "Altitude representation" below). Single-fix `Point`
+  features (degenerate flights) render as a circle layer, not a line —
+  the data walk must not assume LineString.
 - **Popups:** click a track → popup with the same summary fields the 2D
   map shows (name, start, duration, altitude summary).
 - **Flight toggle:** a plain HTML overlay panel with one checkbox per
@@ -71,21 +74,24 @@ A sibling of `flightmap_html.py` with the same contract and structure:
 - **Attribution:** OSM contributors + Mapterhorn/Copernicus, always
   visible per both providers' terms.
 
-## Altitude anchoring (the datum problem)
+## Altitude representation (amended 2026-07-23)
 
-DJI "absolute" altitude and the Copernicus DEM do not share a vertical
-datum exactly; rendered naively, tracks sit visibly under or above the
-ground. Fix — exploit the physical fact that every flight starts on the
-ground: after terrain loads, query `map.queryTerrainElevation()` at each
-flight's first point and vertically offset that entire flight so its
-start touches the terrain surface.
+The original design called for tracks rendered *at* recorded altitude
+with a takeoff-anchoring correction. Verification against the MapLibre
+style spec killed that: **MapLibre has no way to render line layers at
+an elevation** — no `line-z-offset` (that is Mapbox-proprietary), and
+elevated flight paths are an open upstream request
+([maplibre-gl-js#644](https://github.com/maplibre/maplibre-gl-js/issues/644),
+duplicate [#6755](https://github.com/maplibre/maplibre-gl-js/issues/6755)
+filed for exactly this drone use case).
 
-- Per-flight offset, so mixed-site archives stay correct.
-- `--redact fuzz` shifts the lookup point ≤ ~100 m; the resulting ground
-  error is marginal and accepted.
-- A small corner note — "altitudes anchored to terrain at takeoff" —
-  keeps the adjustment honest.
-- If terrain is unavailable (see below) no offset is applied.
+Decision (Marcus, 2026-07-23): **draped tracks.** Lines follow the
+terrain surface like a GPS ground trace; the 3D value is the terrain
+relief itself under a tilted camera. Altitude numbers stay in the
+popups (height-above-takeoff preferred, as in 2D). The whole anchoring
+scheme is dropped — there is nothing for it to act on. At-altitude
+rendering (fill-extrusion "curtains" or a deck.gl overlay, or native
+support if #644 lands) is explicitly a follow-up, not this slice.
 
 ## Degradation
 
@@ -107,8 +113,8 @@ Python (pytest, mirroring `test_flightmap_html` structure):
   non-HTML formats, `--tile-style` warning, JSONL `result.outputs`.
 - Generated HTML: embedded GeoJSON present and parseable, pinned MapLibre
   URL + SRI attributes, Mapterhorn TileJSON URL, both attribution
-  strings, anchoring JS present, `<` escaping (no literal
-  `</script>` in data), single-fix flight handled.
+  strings, `<` escaping (no literal `</script>` in data), single-fix
+  flight handled.
 
 Browser (durable browser suite, Track B pattern): one test that loads a
 generated `flightmap-3d.html` and asserts the map initializes and the
@@ -129,6 +135,8 @@ not rendered pixels.
 
 - Playback in 3D (file only if the viewer earns it; `times_s` is already
   in the data).
+- Tracks rendered at altitude — blocked upstream (MapLibre #644);
+  curtain-extrusion and deck.gl approaches were considered and deferred.
 - Basemap style choice in 3D.
 - GUI exposure: follow-up issue — Flight map options checkbox +
   `CommandBuilder` + `ExistingMapFinder` probing `flightmap-3d.html`

--- a/docs/superpowers/specs/2026-07-23-flightmap-3d-design.md
+++ b/docs/superpowers/specs/2026-07-23-flightmap-3d-design.md
@@ -1,0 +1,136 @@
+# Flightmap 3D terrain view (`--3d`) — design
+
+*2026-07-23 · issue [#268](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/268) · status: approved*
+
+## Summary
+
+A second, separate HTML template for `dji-embed flightmap`: MapLibre GL JS
+rendering flight tracks as colored 3D lines at recorded altitude, draped
+over real terrain. The 2D Leaflet map stays the default and is untouched —
+`--3d` writes a sibling file. Keyless end to end: OSM raster basemap,
+Mapterhorn terrain tiles, MapLibre from a pinned CDN URL. No build step,
+no API keys, no new Python dependencies.
+
+Scope decisions (Marcus, 2026-07-23): **lean viewer** (no playback, one
+basemap style), **`--3d` flag writing `flightmap-3d.html`** (2D map never
+clobbered), **CLI-first** (GUI checkbox is a follow-up issue).
+
+## CLI surface
+
+- New `--3d` boolean option on `flightmap` (Click parameter name
+  `three_d`; `3d` is not a valid Python identifier).
+- Valid only with the HTML format: combining `--3d` with `--format
+  kml|geojson|all` raises `click.UsageError` — those formats have no 3D
+  variant.
+- Default output: `<folder>/flightmap-3d.html`. `--output` overrides as
+  usual. The 2D default (`flightmap.html`) is unaffected; both maps
+  coexist in a folder.
+- `--tile-style` is accepted but **ignored with a warning** under `--3d`
+  (single basemap in this version) — warning, not error, because the GUI
+  and shell history may pass it habitually.
+- All other options behave identically: `-r`, `--redact`, `--join-gap`,
+  `--tz-offset`, `--title`, `--progress jsonl` (the `result` event lists
+  the 3D file in `outputs` exactly like any other target).
+
+## New module: `geo/flightmap3d_html.py`
+
+A sibling of `flightmap_html.py` with the same contract and structure:
+
+- `flights_to_3d_html(tracks: list[Track], title: str) -> str`
+- `write_flights_3d_html(tracks, output_path, title) -> Path`
+- Consumes the **same** `flights_to_geojson()` output as the 2D map — no
+  changes to `flightmap.py` or the GeoJSON shape. Data is embedded in the
+  same `<script type="application/json">` block with the same
+  backslash-u003c escaping of `<` (no `</script>` breakout).
+- MapLibre GL JS (v6.x, exact version resolved at implementation time)
+  loaded from unpkg with pinned version **and SRI hashes**, matching the
+  Leaflet pins in the 2D writers.
+- Module docstring documents AWS Terrarium
+  (`s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png`,
+  `encoding: "terrarium"`) as the drop-in replacement terrain source if
+  Mapterhorn ever disappears. Terrarium is NOT coded as a live fallback.
+
+## Map composition (`_APP_JS`)
+
+- **Basemap:** OSM raster tiles — same URL template and attribution text
+  as `tiles.py`'s `osm` entry — draped over the terrain surface.
+- **Terrain + hillshade:** Mapterhorn (`raster-dem`, TileJSON at
+  `https://tiles.mapterhorn.com/tilejson.json`, keyless; Copernicus
+  GLO-30 base, genuinely global coverage including >60°N). Separate
+  terrain and hillshade sources per the MapLibre example idiom.
+- **Camera:** starts pitched (~60°) and fitted to the union of track
+  bounds.
+- **Tracks:** one line layer per flight in the same color rotation as the
+  2D map, rendered at per-point altitude (third GeoJSON coordinate).
+  Single-fix `Point` features (degenerate flights) render as a marker,
+  not a line — the data walk must not assume LineString.
+- **Popups:** click a track → popup with the same summary fields the 2D
+  map shows (name, start, duration, altitude summary).
+- **Flight toggle:** a plain HTML overlay panel with one checkbox per
+  flight (show/hide its layer). Not a ported Leaflet layer control.
+- **Attribution:** OSM contributors + Mapterhorn/Copernicus, always
+  visible per both providers' terms.
+
+## Altitude anchoring (the datum problem)
+
+DJI "absolute" altitude and the Copernicus DEM do not share a vertical
+datum exactly; rendered naively, tracks sit visibly under or above the
+ground. Fix — exploit the physical fact that every flight starts on the
+ground: after terrain loads, query `map.queryTerrainElevation()` at each
+flight's first point and vertically offset that entire flight so its
+start touches the terrain surface.
+
+- Per-flight offset, so mixed-site archives stay correct.
+- `--redact fuzz` shifts the lookup point ≤ ~100 m; the resulting ground
+  error is marginal and accepted.
+- A small corner note — "altitudes anchored to terrain at takeoff" —
+  keeps the adjustment honest.
+- If terrain is unavailable (see below) no offset is applied.
+
+## Degradation
+
+- **Mapterhorn unreachable:** catch the MapLibre source `error` event,
+  disable terrain, show a dismissible banner ("terrain tiles unavailable
+  — showing flat view"). Tracks, popups, and the toggle keep working as
+  a flat tilted map.
+- **Fully offline:** same posture as the 2D map today — basemap tiles
+  don't render, embedded data still loads, and the existing docs line
+  ("the map file needs a connection to render") covers it.
+- **WebGL unavailable:** MapLibre throws on construction; catch and show
+  a plain-HTML message naming the 2D map as the alternative.
+
+## Testing
+
+Python (pytest, mirroring `test_flightmap_html` structure):
+
+- CLI wiring: `--3d` default filename, `--output` override, UsageError on
+  non-HTML formats, `--tile-style` warning, JSONL `result.outputs`.
+- Generated HTML: embedded GeoJSON present and parseable, pinned MapLibre
+  URL + SRI attributes, Mapterhorn TileJSON URL, both attribution
+  strings, anchoring JS present, `<` escaping (no literal
+  `</script>` in data), single-fix flight handled.
+
+Browser (durable browser suite, Track B pattern): one test that loads a
+generated `flightmap-3d.html` and asserts the map initializes and the
+flight-toggle panel lists the expected flights. Terrain/WebGL behavior in
+headless CI degrades along the paths above — the test asserts presence,
+not rendered pixels.
+
+## Docs
+
+- `docs/user_guide.md`: flightmap section gains a 3D subsection (what it
+  is, the anchoring note, the terrain-tiles network dependency).
+- `docs/decision-table.md`: row for 2D vs 3D map.
+- `docs/geospatial.md`: 3D view section.
+- `README.md`: one-liner + flag in the flightmap section.
+- `HELP.md`: recipe line for "see my flights in 3D".
+
+## Out of scope / follow-ups
+
+- Playback in 3D (file only if the viewer earns it; `times_s` is already
+  in the data).
+- Basemap style choice in 3D.
+- GUI exposure: follow-up issue — Flight map options checkbox +
+  `CommandBuilder` + `ExistingMapFinder` probing `flightmap-3d.html`
+  (the WebView2 preview supports WebGL, so it will render inline).
+- Live Terrarium fallback source.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -23,6 +23,24 @@ folder onto `dji-embed.exe`**:
 dji-embed /path/to/footage    # -> flightmap.html (and photomap.html) open in the browser
 ```
 
+## 3D terrain view
+
+`dji-embed flightmap <folder> --3d` writes a second map, `flightmap-3d.html`,
+next to (never instead of) the regular `flightmap.html` — `-o` still picks
+the output path:
+
+```bash
+dji-embed flightmap /path/to/footage --3d    # -> footage/flightmap-3d.html
+```
+
+Instead of a flat basemap, tracks are draped on the terrain surface: tilt
+the camera and they follow the ground below, with altitude available from
+the track popups. Terrain tiles come from Mapterhorn (Copernicus elevation
+data) over the network — like every map here, it needs a connection to
+render — and if the terrain tiles can't load, the map falls back to a flat
+view with an on-map notice. `--tile-style` doesn't apply in 3D (it's
+ignored, with a warning).
+
 ## Common options
 
 - `-o DIR` – choose an output directory

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -36,6 +36,7 @@ from .geo import (
     serve_directory,
     write_flights_geojson,
     write_flights_html,
+    write_flights_3d_html,
     write_flights_kml,
     write_photos_geojson,
     parse_popup_fields,
@@ -834,6 +835,14 @@ def photomap(
     "detects it from each file's mtime; pass it explicitly when the files "
     "were copied through zip/cloud transfers that rewrote the mtimes.",
 )
+@click.option(
+    "--3d",
+    "three_d",
+    is_flag=True,
+    help="Write a 3D terrain map (MapLibre GL, draped tracks) instead of "
+    "the flat map. HTML only; defaults to flightmap-3d.html so the 2D "
+    "map is never overwritten.",
+)
 @_tile_style_option
 @_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
@@ -847,6 +856,7 @@ def flightmap(
     redact: str,
     join_gap: float,
     tz_offset: str,
+    three_d: bool,
     tile_style: str,
     progress_mode: str | None,
     verbose: bool,
@@ -870,6 +880,13 @@ def flightmap(
             offset = parse_utc_offset(tz_offset)
         except ValueError as e:
             raise click.BadParameter(str(e), param_hint="--tz-offset")
+        if three_d and fmt.lower() != "html":
+            raise click.UsageError(
+                "--3d renders only HTML; drop --format " + fmt.lower()
+            )
+        if three_d and tile_style.lower() != DEFAULT_TILE_STYLE:
+            progress.warning("--tile-style is ignored with --3d")
+            click.echo("Note: --tile-style is ignored with --3d", err=True)
         src = Path(directory)
         tracks, skipped = scan_flights(
             src,
@@ -918,14 +935,18 @@ def flightmap(
             ]
         else:
             f = fmt.lower()
-            out = Path(output) if output else src / f"flightmap.{f}"
+            default_name = "flightmap-3d.html" if three_d else f"flightmap.{f}"
+            out = Path(output) if output else src / default_name
             targets = [(f, out)]
         for f, out in targets:
             try:
                 if f == "html":
-                    write_flights_html(
-                        tracks, out, map_title, tile_style=tile_style.lower()
-                    )
+                    if three_d:
+                        write_flights_3d_html(tracks, out, map_title)
+                    else:
+                        write_flights_html(
+                            tracks, out, map_title, tile_style=tile_style.lower()
+                        )
                 elif f == "kml":
                     write_flights_kml(tracks, out, map_title)
                 else:

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -8,6 +8,7 @@ from .flightmap import (
     write_flights_geojson,
     write_flights_kml,
 )
+from .flightmap3d_html import flights_to_3d_html, write_flights_3d_html
 from .flightmap_html import flights_to_html, write_flights_html
 from .footprint import FOV_TABLE, Footprint, build_footprints, lens_for
 from .geojson import convert_to_geojson, track_to_geojson
@@ -69,5 +70,7 @@ __all__ = [
     "write_flights_kml",
     "flights_to_html",
     "write_flights_html",
+    "flights_to_3d_html",
+    "write_flights_3d_html",
     "serve_directory",
 ]

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -1,0 +1,272 @@
+"""Render a multi-flight track list as a standalone 3D terrain HTML map.
+
+Same embedding contract as :mod:`.flightmap_html` (issue #268): the combined
+flight GeoJSON sits in a ``<script type="application/json">`` block and a
+vanilla MapLibre GL JS app renders it — tracks draped over Mapterhorn
+terrain under a tilted camera. MapLibre, the OSM basemap, and the terrain
+tiles load from the network; the flight data itself is embedded.
+
+Tracks are draped on the terrain surface: MapLibre cannot render line
+layers at an elevation (upstream request maplibre/maplibre-gl-js#644), so
+altitude appears in the popups, not the geometry.
+
+Terrain source: Mapterhorn (keyless, Copernicus GLO-30 base, global
+coverage). Dormant fallback if Mapterhorn ever disappears: AWS Terrarium
+tiles — ``https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png``
+with ``"encoding": "terrarium"`` on the raster-dem sources.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from html import escape
+from pathlib import Path
+
+from .flightmap import flights_to_geojson
+from .flightmap_js import FLIGHT_POPUP_JS
+from .track import Track
+
+logger = logging.getLogger(__name__)
+
+# Pinned MapLibre GL JS release + Subresource Integrity hashes (UMD build;
+# v6+ is ESM-only and cannot be pinned as a single script tag).
+_MAPLIBRE_VERSION = "5.24.0"
+_MAPLIBRE_CSS_SRI = "sha256-qx5w1Z7EBGW65+cDDaLzzPKBM/1QLmK9WY7vut/XpzI="
+_MAPLIBRE_JS_SRI = "sha256-RamwepGJzlYFTGIKlHzPQeKR5YyV6bYVM7dAqqZe5cs="
+
+_MAPTERHORN_TILEJSON = "https://tiles.mapterhorn.com/tilejson.json"
+# Single host on purpose: OSM deprecated the a/b/c subdomain round-robin.
+_OSM_TILES = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+
+_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>3D flight map — {title}</title>
+<!-- MapLibre + OSM basemap + Mapterhorn terrain load from the network; the
+     flight data is embedded below, so this file is portable but not fully
+     offline. -->
+<link rel="stylesheet"
+      href="https://unpkg.com/maplibre-gl@{maplibre}/dist/maplibre-gl.css" integrity="{css_sri}"
+      crossorigin="" />
+<style>
+  html, body {{ height: 100%; margin: 0; }}
+  #map {{ height: 100%; }}
+  .flight-popup {{ font: 13px/1.5 sans-serif; }}
+  .fallback {{ font: 15px/1.6 sans-serif; margin: 2em auto; max-width: 34em; }}
+  .flights-panel {{ position: absolute; top: 10px; left: 10px; z-index: 5;
+                   background: #fff; border-radius: 4px; padding: 8px 12px;
+                   box-shadow: 0 1px 5px rgba(0,0,0,.4);
+                   font: 13px/1.8 sans-serif; max-height: 60%;
+                   overflow-y: auto; }}
+  .flights-panel label {{ display: block; cursor: pointer; }}
+  .map-note {{ position: absolute; top: 10px; left: 50%;
+              transform: translateX(-50%); z-index: 6; background: #fffbe6;
+              border: 1px solid #e0d8a8; border-radius: 4px;
+              padding: 6px 28px 6px 12px; font: 13px/1.4 sans-serif; }}
+  .map-note button {{ position: absolute; right: 6px; top: 4px; border: none;
+                     background: none; cursor: pointer; font-size: 14px; }}
+</style>
+</head>
+<body>
+<div id="map"></div>
+<script type="application/json" id="flight-data">
+{data}
+</script>
+<script src="https://unpkg.com/maplibre-gl@{maplibre}/dist/maplibre-gl.js" integrity="{js_sri}"
+        crossorigin=""></script>
+<script>
+{app_js}
+</script>
+</body>
+</html>
+"""
+
+_APP_JS = """
+const data = JSON.parse(document.getElementById('flight-data').textContent);
+__SHARED_JS__
+
+// Collect flights: draped 2D geometry only — the third GeoJSON coordinate
+// (altitude) is deliberately unused here (maplibre-gl-js#644).
+const flights = [];
+const allCoords = [];
+(data.features || []).forEach((f, i) => {
+  if (!f.geometry) return;
+  const p = f.properties || {};
+  const entry = {
+    id: 'flight-' + i,
+    name: p.name || `flight ${i + 1}`,
+    color: PALETTE[i % PALETTE.length],
+    props: p,
+  };
+  if (f.geometry.type === 'LineString') {
+    entry.geometry = { type: 'LineString',
+                       coordinates: f.geometry.coordinates.map(c => [c[0], c[1]]) };
+  } else {                                             // single-fix clip
+    const c = f.geometry.coordinates;
+    entry.geometry = { type: 'Point', coordinates: [c[0], c[1]] };
+  }
+  flights.push(entry);
+  const cs = entry.geometry.type === 'LineString'
+    ? entry.geometry.coordinates : [entry.geometry.coordinates];
+  allCoords.push(...cs);
+});
+
+function showNote(text, dismissible) {
+  const note = document.createElement('div');
+  note.className = 'map-note';
+  note.appendChild(document.createTextNode(text));
+  if (dismissible) {
+    const x = document.createElement('button');
+    x.textContent = '×';
+    x.setAttribute('aria-label', 'Dismiss');
+    x.addEventListener('click', () => note.remove());
+    note.appendChild(x);
+  }
+  document.body.appendChild(note);
+}
+
+let map = null;
+try {
+  const options = {
+    container: 'map',
+    style: {
+      version: 8,
+      sources: {
+        osm: { type: 'raster', tiles: ['__OSM_TILES__'], tileSize: 256,
+               maxzoom: 19,
+               attribution: '&copy; OpenStreetMap contributors' },
+        terrain: { type: 'raster-dem', url: '__MAPTERHORN__',
+                   attribution: 'Terrain &copy; Mapterhorn (Copernicus DEM)' },
+        hillshade: { type: 'raster-dem', url: '__MAPTERHORN__' },
+      },
+      layers: [
+        { id: 'osm', type: 'raster', source: 'osm' },
+        { id: 'hillshade', type: 'hillshade', source: 'hillshade',
+          paint: { 'hillshade-exaggeration': 0.35 } },
+      ],
+    },
+    pitch: 60,
+    maxPitch: 75,
+  };
+  if (allCoords.length) {
+    const bounds = allCoords.reduce(
+      (b, c) => b.extend(c),
+      new maplibregl.LngLatBounds(allCoords[0], allCoords[0]));
+    options.bounds = bounds;
+    options.fitBoundsOptions = { padding: 60, pitch: 60, maxZoom: 15 };
+  } else {
+    options.center = [0, 20];
+    options.zoom = 1.5;
+  }
+  map = new maplibregl.Map(options);
+} catch (e) {
+  // No WebGL (or MapLibre failed to start): plain-HTML fallback.
+  document.getElementById('map').innerHTML =
+    '<p class="fallback">This 3D view needs WebGL, which this browser ' +
+    'does not provide. The flat map (flightmap.html) shows the same ' +
+    'flights without it.</p>';
+}
+
+if (map) {
+  map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }));
+
+  let terrainFailed = false;
+  map.on('error', ev => {
+    // Mapterhorn unreachable → drop to a flat (still tilted) view once.
+    const src = ev.sourceId || (ev.source && ev.source.id);
+    if ((src === 'terrain' || src === 'hillshade') && !terrainFailed) {
+      terrainFailed = true;
+      map.setTerrain(null);
+      if (map.getLayer('hillshade')) map.removeLayer('hillshade');
+      showNote('Terrain tiles unavailable — showing flat view.', true);
+    }
+  });
+
+  map.on('load', () => {
+    map.setTerrain({ source: 'terrain', exaggeration: 1 });
+    flights.forEach(f => {
+      map.addSource(f.id, { type: 'geojson', data: {
+        type: 'Feature', geometry: f.geometry, properties: {} } });
+      if (f.geometry.type === 'LineString') {
+        map.addLayer({ id: f.id, type: 'line', source: f.id,
+          layout: { 'line-cap': 'round', 'line-join': 'round' },
+          paint: { 'line-color': f.color, 'line-width': 3 } });
+      } else {
+        map.addLayer({ id: f.id, type: 'circle', source: f.id,
+          paint: { 'circle-color': f.color, 'circle-radius': 6 } });
+      }
+      map.on('click', f.id, ev => {
+        new maplibregl.Popup({ maxWidth: '320px' })
+          .setLngLat(ev.lngLat).setHTML(popupHtml(f.props)).addTo(map);
+      });
+      map.on('mouseenter', f.id, () => {
+        map.getCanvas().style.cursor = 'pointer';
+      });
+      map.on('mouseleave', f.id, () => {
+        map.getCanvas().style.cursor = '';
+      });
+    });
+    buildPanel();
+  });
+}
+
+function buildPanel() {
+  if (!flights.length) return;
+  const panel = document.createElement('div');
+  panel.id = 'flights-panel';
+  panel.className = 'flights-panel';
+  flights.forEach(f => {
+    const label = document.createElement('label');
+    const box = document.createElement('input');
+    box.type = 'checkbox';
+    box.checked = true;
+    box.addEventListener('change', () => {
+      map.setLayoutProperty(f.id, 'visibility',
+                            box.checked ? 'visible' : 'none');
+    });
+    label.appendChild(box);
+    const swatch = document.createElement('span');
+    swatch.textContent = ' \\u25a0 ';
+    swatch.style.color = f.color;
+    label.appendChild(swatch);
+    label.appendChild(document.createTextNode(f.name));
+    panel.appendChild(label);
+  });
+  document.body.appendChild(panel);
+}
+"""
+
+
+def flights_to_3d_html(tracks: list[Track], title: str) -> str:
+    """Return a complete 3D-terrain HTML flight map (draped tracks)."""
+    geojson = flights_to_geojson(tracks)
+    # Escape "<" to "\\u003c" (a JSON Unicode escape) so JSON.parse round-trips
+    # it while no literal "</script>" can break out of the data block.
+    data = json.dumps(geojson).replace("<", "\\u003c")
+    app_js = (
+        _APP_JS.replace("__SHARED_JS__", FLIGHT_POPUP_JS)
+        .replace("__OSM_TILES__", _OSM_TILES)
+        .replace("__MAPTERHORN__", _MAPTERHORN_TILEJSON)
+    )
+    return _TEMPLATE.format(
+        title=escape(title),
+        maplibre=_MAPLIBRE_VERSION,
+        css_sri=_MAPLIBRE_CSS_SRI,
+        js_sri=_MAPLIBRE_JS_SRI,
+        data=data,
+        app_js=app_js,
+    )
+
+
+def write_flights_3d_html(
+    tracks: list[Track], output_path: Path, title: str
+) -> Path:
+    """Write *tracks* as a 3D HTML map to *output_path* and return it."""
+    output_path.write_text(
+        flights_to_3d_html(tracks, title), encoding="utf-8"
+    )
+    logger.info("3D HTML flight map created: %s", output_path)
+    return output_path

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -16,6 +16,7 @@ from html import escape
 from pathlib import Path
 
 from .flightmap import flights_to_geojson
+from .flightmap_js import FLIGHT_POPUP_JS
 from .tiles import DEFAULT_TILE_STYLE, tile_layer_js
 from .track import Track
 
@@ -74,39 +75,7 @@ const data = JSON.parse(document.getElementById('flight-data').textContent);
 const map = L.map('map');
 __TILE_LAYER__
 
-const esc = s => String(s).replace(/[&<>"']/g,
-  ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
-
-// 12 visually distinct track colours, cycled when a folder has more flights.
-const PALETTE = ['#e6194b', '#3cb44b', '#4363d8', '#f58231', '#911eb4',
-                 '#42d4f4', '#f032e6', '#bfef45', '#469990', '#9a6324',
-                 '#800000', '#000075'];
-
-function fmtDuration(total) {
-  const h = Math.floor(total / 3600);
-  const m = Math.floor((total % 3600) / 60);
-  const s = total % 60;
-  const mm = h ? String(m).padStart(2, '0') : String(m);
-  return (h ? h + ':' + mm : mm) + ':' + String(s).padStart(2, '0');
-}
-
-function popupHtml(p) {
-  let html = `<div class="flight-popup"><b>${esc(p.name || '')}</b>`;
-  if (p.start) html += `<br>${esc(p.start)}`;
-  if (p.duration_s != null) html += `<br>duration: ${fmtDuration(p.duration_s)}`;
-  if (p.height_min != null) {
-    html += `<br>height: ${p.height_min} to ${p.height_max} m above takeoff`;
-  } else if (p.alt_min != null) {
-    html += `<br>altitude: ${p.alt_min} to ${p.alt_max} m (as logged)`;
-  }
-  html += `<br>${p.points} GPS point${p.points === 1 ? '' : 's'}`;
-  if (p.segments) {
-    html += `<br>recorded across ${p.segments.length} files: ` +
-            `${esc(p.segments[0])} → ${esc(p.segments[p.segments.length - 1])}`;
-  }
-  html += '</div>';
-  return html;
-}
+__SHARED_JS__
 
 const overlays = {};
 const allLatLngs = [];
@@ -285,7 +254,8 @@ def flights_to_html(
         css_sri=_LEAFLET_CSS_SRI,
         js_sri=_LEAFLET_JS_SRI,
         data=data,
-        app_js=_APP_JS.replace("__TILE_LAYER__", tile_layer_js(tile_style)),
+        app_js=_APP_JS.replace("__TILE_LAYER__", tile_layer_js(tile_style))
+        .replace("__SHARED_JS__", FLIGHT_POPUP_JS),
     )
 
 

--- a/src/dji_metadata_embedder/geo/flightmap_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap_js.py
@@ -1,0 +1,43 @@
+"""JS helpers shared by the 2D and 3D flightmap HTML writers.
+
+One source of truth for the popup renderer and track palette so the two
+templates cannot drift apart. The snippet is plain browser JS embedded by
+string concatenation — it must stay dependency-free and must not reference
+Leaflet or MapLibre.
+"""
+
+from __future__ import annotations
+
+FLIGHT_POPUP_JS = """const esc = s => String(s).replace(/[&<>"']/g,
+  ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+
+// 12 visually distinct track colours, cycled when a folder has more flights.
+const PALETTE = ['#e6194b', '#3cb44b', '#4363d8', '#f58231', '#911eb4',
+                 '#42d4f4', '#f032e6', '#bfef45', '#469990', '#9a6324',
+                 '#800000', '#000075'];
+
+function fmtDuration(total) {
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const mm = h ? String(m).padStart(2, '0') : String(m);
+  return (h ? h + ':' + mm : mm) + ':' + String(s).padStart(2, '0');
+}
+
+function popupHtml(p) {
+  let html = `<div class="flight-popup"><b>${esc(p.name || '')}</b>`;
+  if (p.start) html += `<br>${esc(p.start)}`;
+  if (p.duration_s != null) html += `<br>duration: ${fmtDuration(p.duration_s)}`;
+  if (p.height_min != null) {
+    html += `<br>height: ${p.height_min} to ${p.height_max} m above takeoff`;
+  } else if (p.alt_min != null) {
+    html += `<br>altitude: ${p.alt_min} to ${p.alt_max} m (as logged)`;
+  }
+  html += `<br>${p.points} GPS point${p.points === 1 ? '' : 's'}`;
+  if (p.segments) {
+    html += `<br>recorded across ${p.segments.length} files: ` +
+            `${esc(p.segments[0])} → ${esc(p.segments[p.segments.length - 1])}`;
+  }
+  html += '</div>';
+  return html;
+}"""

--- a/tests/browser/test_flightmap_3d.py
+++ b/tests/browser/test_flightmap_3d.py
@@ -1,0 +1,64 @@
+"""3D flightmap (issue #268) behaviour in a real headless Chromium.
+
+The map boots over MapLibre, lists flights in the ``#flights-panel``
+checkbox panel, and degrades to the flat-view ``.map-note`` banner when its
+terrain source errors. The harness (see ``conftest.py``) aborts every
+non-unpkg, non-image external request, so the Mapterhorn TileJSON fetch is
+always blocked here — that deterministically exercises the terrain-failure
+path on every run, it is not a workaround.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect  # noqa: E402
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+
+def _flight(name: str, lat: float, lon: float, points: int) -> Track:
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name=name, points=[
+        TrackPoint(lat=lat, lon=lon + i * 0.0006, alt=100.0 + i,
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i * 10.0))
+        for i in range(points)
+    ])
+
+
+def test_3d_map_boots_and_lists_flights(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, 5), _flight("DJI_0002", 11.0, 21.0, 5)],
+        "trip",
+    )
+    serve_map(html)
+    expect(page.locator("#flights-panel")).to_be_visible(timeout=15000)
+    assert page.locator("#flights-panel input[type=checkbox]").count() == 2
+    assert page.locator("#map canvas").count() >= 1
+
+
+def test_3d_terrain_failure_shows_flat_view_banner(serve_map, page):
+    html = flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 5)], "trip")
+    serve_map(html)
+    expect(page.locator(".map-note")).to_contain_text(
+        "Terrain tiles unavailable", timeout=15000
+    )
+
+
+def test_3d_toggle_hides_a_flight(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, 5), _flight("DJI_0002", 11.0, 21.0, 5)],
+        "trip",
+    )
+    serve_map(html)
+    expect(page.locator("#flights-panel")).to_be_visible(timeout=15000)
+    page.locator("#flights-panel input[type=checkbox]").first.uncheck()
+    assert page.evaluate(
+        "() => map.getLayoutProperty('flight-0', 'visibility')"
+    ) == "none"

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -209,3 +209,57 @@ def test_flightmap_tile_style_rejects_unknown(tmp_path):
     )
     assert res.exit_code != 0
     assert "watercolor" in res.output
+
+
+def test_flightmap_3d_writes_sibling_file(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A, "DJI_0002.SRT": FLIGHT_B})
+    res = CliRunner().invoke(main, ["flightmap", str(tmp_path), "--3d"])
+    assert res.exit_code == 0, res.output
+    out = tmp_path / "flightmap-3d.html"
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert "maplibre-gl@5.24.0" in text
+    assert "leaflet" not in text.lower()
+    assert not (tmp_path / "flightmap.html").exists()  # 2D untouched
+
+
+def test_flightmap_3d_output_override(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    out = tmp_path / "custom.html"
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "--3d", "-o", str(out)]
+    )
+    assert res.exit_code == 0, res.output
+    assert out.exists()
+
+
+def test_flightmap_3d_rejects_non_html_formats(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    for fmt in ("kml", "geojson", "all"):
+        res = CliRunner().invoke(
+            main, ["flightmap", str(tmp_path), "--3d", "-f", fmt]
+        )
+        assert res.exit_code != 0
+        assert "--3d" in res.output
+
+
+def test_flightmap_3d_warns_on_tile_style(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main,
+        ["flightmap", str(tmp_path), "--3d", "--tile-style", "opentopomap"],
+    )
+    assert res.exit_code == 0, res.output
+    assert "--tile-style is ignored" in res.output
+    assert (tmp_path / "flightmap-3d.html").exists()
+
+
+def test_flightmap_3d_jsonl_reports_output(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "--3d", "--progress", "jsonl"]
+    )
+    assert res.exit_code == 0, res.output
+    events = [json.loads(line) for line in res.output.splitlines() if line]
+    result = next(e for e in events if e["event"] == "result")
+    assert result["outputs"][0].endswith("flightmap-3d.html")

--- a/tests/test_geo_flightmap3d_html.py
+++ b/tests/test_geo_flightmap3d_html.py
@@ -1,0 +1,102 @@
+import json
+import re
+
+from dji_metadata_embedder.geo.flightmap3d_html import (
+    flights_to_3d_html,
+    write_flights_3d_html,
+)
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+
+def _track(name="DJI_0001", lat=10.0, lon=20.0, n=2):
+    pts = [
+        TrackPoint(
+            lat=lat + i * 0.001,
+            lon=lon + i * 0.001,
+            alt=5.0 + i,
+            timestamp=f"00:00:{i:02d},000",
+        )
+        for i in range(n)
+    ]
+    return Track(name=name, points=pts)
+
+
+def _embedded_data(html: str) -> dict:
+    m = re.search(
+        r'<script type="application/json" id="flight-data">\s*(.*?)\s*</script>',
+        html, re.S,
+    )
+    assert m, "embedded data block missing"
+    return json.loads(m.group(1))
+
+
+def test_3d_html_embeds_one_feature_per_flight():
+    html = flights_to_3d_html([_track("A"), _track("B", lat=11.0)], "trip")
+    data = _embedded_data(html)
+    assert len(data["features"]) == 2
+
+
+def test_3d_html_pins_maplibre_with_sri():
+    html = flights_to_3d_html([_track()], "t")
+    assert 'src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js" integrity="sha256-' in html
+    assert 'href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css" integrity="sha256-' in html
+    assert "leaflet" not in html.lower()
+
+
+def test_3d_html_uses_mapterhorn_terrain_with_attribution():
+    html = flights_to_3d_html([_track()], "t")
+    assert "https://tiles.mapterhorn.com/tilejson.json" in html
+    assert "raster-dem" in html
+    assert "OpenStreetMap contributors" in html
+    assert "Mapterhorn" in html
+
+
+def test_3d_html_escapes_script_close_in_data():
+    t = _track(name="</script><script>alert(1)")
+    html = flights_to_3d_html([t], "t")
+    assert "</script><script>alert(1)" not in html
+    assert _embedded_data(html)["features"][0]["properties"]["name"].startswith("</script>")
+
+
+def test_3d_html_title_is_escaped():
+    html = flights_to_3d_html([_track()], "<b>trip</b>")
+    assert "<b>trip</b>" not in html
+    assert "&lt;b&gt;trip&lt;/b&gt;" in html
+
+
+def test_3d_single_fix_flight_survives():
+    html = flights_to_3d_html([_track(n=1)], "t")
+    data = _embedded_data(html)
+    assert data["features"][0]["geometry"]["type"] == "Point"
+    assert "circle" in html  # degenerate flights render as a circle layer
+
+
+def test_3d_html_has_degradation_paths():
+    html = flights_to_3d_html([_track()], "t")
+    assert "Terrain tiles unavailable" in html   # flat-view banner text
+    assert "WebGL" in html                        # no-WebGL fallback message
+
+
+def test_3d_html_has_flight_toggle_panel():
+    html = flights_to_3d_html([_track()], "t")
+    assert "flights-panel" in html
+
+
+def test_3d_html_does_not_render_at_altitude():
+    # Spec amendment: draped tracks only — anchoring/elevation code is banned.
+    html = flights_to_3d_html([_track()], "t")
+    assert "queryTerrainElevation" not in html
+    assert "line-z-offset" not in html
+
+
+def test_3d_empty_tracks_still_valid_document():
+    html = flights_to_3d_html([], "t")
+    assert html.startswith("<!DOCTYPE html>")
+    assert _embedded_data(html)["features"] == []
+
+
+def test_write_flights_3d_html(tmp_path):
+    out = tmp_path / "flightmap-3d.html"
+    result = write_flights_3d_html([_track()], out, "trip")
+    assert result == out
+    assert out.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")


### PR DESCRIPTION
## Summary

`dji-embed flightmap --3d` writes **`flightmap-3d.html`** — flight tracks draped over real 3D terrain (MapLibre GL 5.24.0, Mapterhorn/Copernicus tiles, keyless, no build step) — alongside, never instead of, the 2D Leaflet map.

- **Spec:** `docs/superpowers/specs/2026-07-23-flightmap-3d-design.md`, including the load-bearing amendment: MapLibre cannot render lines at altitude (upstream [maplibre-gl-js#644](https://github.com/maplibre/maplibre-gl-js/issues/644)), so tracks are **draped** on the terrain surface with altitude in the popups; and v6 is ESM-only, so the pin is the maintained v5 UMD line with SRI hashes.
- Shared `FLIGHT_POPUP_JS` module keeps 2D/3D popups from drifting (2D output verified byte-identical).
- Degradation: terrain tiles unreachable → flat view + dismissible notice; no WebGL → plain-HTML message; offline → same posture as the 2D map.
- `--3d` is HTML-only (`--format kml|geojson|all` errors); `--tile-style` warns and is ignored; all other flightmap options (incl. `--redact fuzz`, `--progress jsonl`) apply identically.
- Tests: 11 structural pytest cases (incl. a draped-only enforcement test), 5 CLI cases, 3 durable browser tests (the hermetic harness deterministically exercises the terrain-failure banner). Docs: user guide, decision table, geospatial, README, HELP.

Built subagent-driven per plan; per-task reviews all clean first pass; final whole-branch review (opus): READY TO MERGE, gates 685 passed / ruff / mypy clean.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)