### PR TITLE
ci: harden workflows per CodeQL findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:  # yamllint disable-line rule:truthy
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release-exe.yml
+++ b/.github/workflows/release-exe.yml
@@ -44,11 +44,19 @@ jobs:
       - name: Determine release version
         id: meta
         shell: pwsh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            $ver = '${{ inputs.version }}'
+          if ($env:EVENT_NAME -eq 'workflow_dispatch') {
+            $ver = $env:INPUT_VERSION
           } else {
-            $ver = '${{ github.event.workflow_run.head_branch }}'.TrimStart('v')
+            $ver = $env:HEAD_BRANCH.TrimStart('v')
+          }
+          # The version feeds later step interpolations: accept strict X.Y.Z only.
+          if ($ver -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') {
+            throw "unexpected version: $ver"
           }
           "version=$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           "tag=v$ver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append


### PR DESCRIPTION
CodeQL code scanning (enabled 2026-07-23) flagged 13 alerts; this PR fixes the two buckets that warrant code changes.

## Changes

- **release-exe.yml** — the `Determine release version` step interpolated `github.event.workflow_run.head_branch` directly into PowerShell. It now goes through an `env:` var and is validated against strict `^[0-9]+\.[0-9]+\.[0-9]+$` before feeding later step interpolations — the same pattern `release-installer.yml` already uses. Resolves the critical `actions/code-injection` alert (#4). Real-world risk was low (only a tag push to this repo can trigger the chain), so this is defense-in-depth.
- **ci.yml** — adds a top-level `permissions: contents: read` block so jobs stop inheriting the default writable `GITHUB_TOKEN`. Resolves the three `actions/missing-workflow-permissions` alerts (#1–#3).

## Alerts handled outside this PR (dismissed)

- #5–#8 (release-installer.yml code injection): won't fix — the flagged interpolations only ever carry a value already env-routed and regex-validated to strict X.Y.Z; CodeQL can't see through the gate.
- #9–#13 (`py/incomplete-url-substring-sanitization`): false positives — they are test assertions checking that generated HTML embeds the expected tile/CDN host, not URL sanitization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)