### PR TITLE
feat(gui): 3D terrain map toggle in the Flight map panel

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -37,7 +37,8 @@ Two ways to use it — same engine:
    pick a mode (*Flight map*, *Photo map*, *Embed telemetry*,
    *Convert telemetry*, *Verify footage*, *Setup*), and press the action
    button; finished maps render right in the app's preview pane, with an
-   *Open in browser* pop-out. No terminal. The workspace also accepts a
+   *Open in browser* pop-out. The Flight map mode has a *3D terrain map* toggle for a MapLibre
+   terrain view (`flightmap-3d.html`). No terminal. The workspace also accepts a
    single telemetry file (`.SRT`/`.MP4`/`.MOV`) as the source, and
    *Convert telemetry* turns it (or a folder) into GPX, CSV, GeoJSON, KML,
    an HTML map, or CoT. *Verify footage* answers three questions about what

--- a/HELP.md
+++ b/HELP.md
@@ -37,8 +37,9 @@ Two ways to use it — same engine:
    pick a mode (*Flight map*, *Photo map*, *Embed telemetry*,
    *Convert telemetry*, *Verify footage*, *Setup*), and press the action
    button; finished maps render right in the app's preview pane, with an
-   *Open in browser* pop-out. The Flight map mode has a *3D terrain map* toggle for a MapLibre
-   terrain view (`flightmap-3d.html`). No terminal. The workspace also accepts a
+   *Open in browser* pop-out. The Flight map mode has a *3D terrain map*
+   toggle for a MapLibre terrain view (`flightmap-3d.html`). No terminal.
+   The workspace also accepts a
    single telemetry file (`.SRT`/`.MP4`/`.MOV`) as the source, and
    *Convert telemetry* turns it (or a folder) into GPX, CSV, GeoJSON, KML,
    an HTML map, or CoT. *Verify footage* answers three questions about what

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -25,7 +25,10 @@ Drop a folder (or a single `.SRT`/`.MP4` file) into **Source** and the
 likely mode is picked for you. The **Mode** strip offers:
 
 - **Flight map** — one interactive map of every flight in the folder,
-  with playback. Needs videos with their `.SRT` flight logs.
+  with playback. Needs videos with their `.SRT` flight logs. A **3D
+  terrain map** toggle renders the flights draped over real terrain
+  instead (writes `flightmap-3d.html`, so the flat map is never
+  overwritten).
 - **Photo map** — your still photos pinned on a map, including a full
   360° panorama viewer for drone panoramas.
 - **Embed telemetry** — writes each flight log's GPS track into the video

--- a/docs/superpowers/specs/2026-07-25-gui-flightmap-3d-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-25-gui-flightmap-3d-toggle-design.md
@@ -71,7 +71,7 @@ Verified against `cli.py` (v2.1.0):
   (composes with the panel-level `!IsBusy`).
 - Advanced "Also export KML + GeoJSON" `CheckBox`: same `IsEnabled`
   binding.
-- One quiet note (FontSize 12, Opacity 0.7 — the `LinkReachNote`
+- One quiet note (FontSize 11, Opacity 0.5 — the `LinkReachNote`
   precedent), visible only while 3D is on: *"Map style and KML/GeoJSON
   export don't apply to the 3D map."* It exists because the export toggle
   hides inside the collapsed Advanced expander, where its greying would

--- a/docs/superpowers/specs/2026-07-25-gui-flightmap-3d-toggle-design.md
+++ b/docs/superpowers/specs/2026-07-25-gui-flightmap-3d-toggle-design.md
@@ -1,0 +1,135 @@
+# GUI: Flight map 3D terrain toggle (#366)
+
+**Date:** 2026-07-25
+**Issue:** #366 — follow-up to #268 / PR #365 (CLI `flightmap --3d`, shipped in v2.1.0)
+**Scope:** GUI-only, one PR. The CLI is untouched.
+
+## Goal
+
+Expose `flightmap --3d` in the desktop app's Flight map mode: a curated
+toggle that switches the run to the MapLibre 3D terrain map
+(`flightmap-3d.html`), with the CLI transparency strip, the existing-map
+panel, and the inline preview all following along.
+
+## CLI facts the design rests on
+
+Verified against `cli.py` (v2.1.0):
+
+- `--3d` writes **only** `flightmap-3d.html` in that run (instead of, not
+  alongside, `flightmap.html`). The default filename keeps the 2D map from
+  being overwritten.
+- `--3d` with `--format` other than `html` (including `all`) raises a
+  **UsageError** — an illegal argv, not a warning.
+- `--3d` with a non-default `--tile-style` is a **warning** (flag ignored):
+  the 3D map has its own terrain/hillshade rendering.
+- `--redact fuzz`, `--join-gap`, `--tz-offset`, `--title`, and `--output`
+  all apply normally in 3D.
+- The JSONL `result` event carries the written path, so the GUI's existing
+  `Outputs` → `PrimePreviewAsync` plumbing previews the 3D map with no
+  changes.
+
+## Decisions (design round, 2026-07-25)
+
+1. **Conflicting options disable + suppress** (Marcus's pick): while 3D is
+   on, the Map style combo and the Advanced "Also export KML + GeoJSON"
+   checkbox grey out, and the builder omits `--tile-style`/`--format` from
+   the argv. User choices are preserved and return when 3D is unchecked.
+   The strip stays honest: it never shows a flag the CLI would ignore or
+   reject.
+2. **Suppression lives in `CommandBuilder.FlightMap`** (approach A):
+   `FlightMapOptions` stays a faithful snapshot of the UI; knowledge of CLI
+   flag semantics belongs in the builder, whose charter is "single source
+   of truth for the argv". Directly golden-testable.
+
+## Design
+
+### Options state
+
+- `FlightMapOptions` gains `bool ThreeD`, default `false` in `Defaults` —
+  the untouched-argv invariant `flightmap <folder> -r` is unchanged.
+- `FlightMapOptionsViewModel` gains `[ObservableProperty] bool ThreeD`
+  (default `false`) and passes it through `ToOptions()`.
+- Like every option except `Output`, `ThreeD` survives a folder change.
+
+### CommandBuilder.FlightMap
+
+- Emits `--3d` immediately after `-r` (fixed position for golden tests):
+  an untouched 3D run reads `flightmap <folder> -r --3d`.
+- When `opts.ThreeD` is true, the `--tile-style` and `--format all`
+  branches are skipped regardless of their values. All other flags pass
+  through unchanged.
+- Every argv reachable from the panel remains legal by construction — no
+  new pre-run guards needed.
+
+### Panel (WorkspaceView.axaml, Flight map options)
+
+- New `ToggleSwitch`, label **"3D terrain map"**, `Name` +
+  `AutomationProperties.Name` per house pattern. Placed in the curated
+  section directly under "Include subfolders" and above Map style, so the
+  greyed combo sits under its cause.
+- Map style `ComboBox`: `IsEnabled` bound to `!FlightOptions.ThreeD`
+  (composes with the panel-level `!IsBusy`).
+- Advanced "Also export KML + GeoJSON" `CheckBox`: same `IsEnabled`
+  binding.
+- One quiet note (FontSize 12, Opacity 0.7 — the `LinkReachNote`
+  precedent), visible only while 3D is on: *"Map style and KML/GeoJSON
+  export don't apply to the 3D map."* It exists because the export toggle
+  hides inside the collapsed Advanced expander, where its greying would
+  otherwise be invisible.
+
+### ExistingMapFinder
+
+- Third probe: `<folder>/flightmap-3d.html`, title **"Flight map (3D)"**,
+  staleness against `NewestFlightLogUtc` exactly like the 2D probe.
+- List order: Flight map, Flight map (3D), Photo map.
+- Doc comment updated: the deterministic default paths are now three.
+- Out-of-scope unchanged (#328 spec): maps redirected by "Save map to"
+  are not discovered.
+
+### Save picker
+
+- The "Save the flight map as" picker's suggested filename
+  (`WorkspaceView.axaml.cs`, currently hardcoded `flightmap.html`)
+  becomes `flightmap-3d.html` while the toggle is on.
+
+### Preview
+
+- No plumbing changes. WebView2 is Chromium, so WebGL renders the
+  MapLibre map; terrain tiles arrive over the network, and the HTML's own
+  terrain-failure banner covers the offline case.
+- Real-hardware verification of the inline 3D preview stays a manual
+  checklist item (issue #366) for Marcus.
+
+## Tests (TDD, house pattern)
+
+- **CommandBuilderTests goldens:** `--3d` position after `-r`; the
+  suppression case (`ThreeD` + non-default tile style + `ExportAll` →
+  argv contains neither `--tile-style` nor `--format`); pass-through case
+  (`ThreeD` + fuzz + join-gap + title + output all emitted); defaults
+  unchanged.
+- **FlightMapOptionsViewModelTests:** `ThreeD` defaults false;
+  `ToOptions()` carries it.
+- **ExistingMapFinderTests:** 3D probe found / absent / stale; ordering
+  with all three present.
+- **XAML binding tests (#336 pattern):** named toggle +
+  `Assert.Same`-style binding check to `FlightOptions.ThreeD`;
+  disabled-state assertions for the Map style combo and export checkbox
+  with 3D on.
+- **A11y contract:** picks the new named control up automatically (it is
+  unconditionally visible in Flight map mode — no new representative
+  window state needed).
+- The strip needs no separate test: it renders builder output, and #334's
+  strip/run parity concern is unchanged by this slice.
+
+## Docs
+
+- One-line mentions in `HELP.md` and `docs/desktop-app.md` (Flight map
+  mode: 3D terrain toggle).
+
+## Non-goals
+
+- No CLI changes; no `--3d` for photomap (doesn't exist).
+- No pitch/hillshade tuning controls (taste constants accepted 2026-07-25
+  after Marcus's real-footage check).
+- No re-probe of existing maps after a run (known #328 limitation,
+  unchanged).

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -149,6 +149,64 @@ public class CommandBuilderTests
             CommandBuilder.FlightMap("/x", opts));
     }
 
+    // #366: --3d switches the run to the MapLibre terrain map. It sits
+    // right after -r (fixed position for these goldens), and it suppresses
+    // the two flags the CLI would reject or ignore: --format all is a
+    // UsageError with --3d, --tile-style a warning. The strip must never
+    // show either alongside --3d.
+    [Fact]
+    public void Three_d_emits_the_flag_after_recursive()
+    {
+        var opts = FlightMapOptions.Defaults with { ThreeD = true };
+        Assert.Equal(["flightmap", "/x", "-r", "--3d"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Three_d_without_recursive_follows_the_folder()
+    {
+        var opts = FlightMapOptions.Defaults with
+        {
+            Recursive = false,
+            ThreeD = true,
+        };
+        Assert.Equal(["flightmap", "/x", "--3d"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Three_d_suppresses_tile_style_and_export_all()
+    {
+        var opts = FlightMapOptions.Defaults with
+        {
+            ThreeD = true,
+            TileStyle = "opentopomap",
+            ExportAll = true,
+        };
+        var args = CommandBuilder.FlightMap("/x", opts);
+        Assert.DoesNotContain("--tile-style", args);
+        Assert.DoesNotContain("--format", args);
+    }
+
+    [Fact]
+    public void Three_d_passes_the_compatible_flags_through()
+    {
+        var opts = FlightMapOptions.Defaults with
+        {
+            ThreeD = true,
+            Privacy = MapPrivacy.Fuzz,
+            JoinGap = 0,
+            TzOffset = "+02:00",
+            Title = "Trip",
+            Output = "/out/flightmap-3d.html",
+        };
+        Assert.Equal(
+            ["flightmap", "/x", "-r", "--3d", "--redact", "fuzz",
+             "--join-gap", "0", "--tz-offset", "+02:00", "--title", "Trip",
+             "--output", "/out/flightmap-3d.html"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
     [Fact]
     public void Title_is_emitted_when_set_and_stays_one_argument()
     {
@@ -176,7 +234,7 @@ public class CommandBuilderTests
     public void All_options_compose_in_a_stable_order()
     {
         var opts = new FlightMapOptions(
-            Recursive: false, TileStyle: "cyclosm", Privacy: MapPrivacy.Fuzz,
+            Recursive: false, ThreeD: false, TileStyle: "cyclosm", Privacy: MapPrivacy.Fuzz,
             JoinGap: 0, ExportAll: true, TzOffset: "-8", Title: "T", Output: "/o.html");
         Assert.Equal(
             ["flightmap", "/x", "--tile-style", "cyclosm", "--redact", "fuzz",

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -183,9 +183,8 @@ public class CommandBuilderTests
             TileStyle = "opentopomap",
             ExportAll = true,
         };
-        var args = CommandBuilder.FlightMap("/x", opts);
-        Assert.DoesNotContain("--tile-style", args);
-        Assert.DoesNotContain("--format", args);
+        Assert.Equal(["flightmap", "/x", "-r", "--3d"],
+            CommandBuilder.FlightMap("/x", opts));
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/ExistingMapFinderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ExistingMapFinderTests.cs
@@ -145,4 +145,44 @@ public class ExistingMapFinderTests : IDisposable
 
         Assert.False(map.Stale);
     }
+
+    // #366: the 3D map is the third deterministic default output. Same
+    // staleness source as the 2D flight map — both are built from the
+    // flight logs.
+    [Fact]
+    public void Finds_the_3d_flight_map_with_its_title_and_path()
+    {
+        var path = Map("flightmap-3d.html", Recent);
+
+        var map = Assert.Single(ExistingMapFinder.Find(_dir, Contents()));
+
+        Assert.Equal(path, map.Path);
+        Assert.Equal("Flight map (3D)", map.Title);
+        Assert.Equal(Recent, map.WrittenUtc);
+        Assert.False(map.Stale);
+    }
+
+    [Fact]
+    public void A_3d_map_older_than_the_flight_logs_is_stale()
+    {
+        Map("flightmap-3d.html", Old);
+
+        var map = Assert.Single(
+            ExistingMapFinder.Find(_dir, Contents(newestFlightLog: Recent)));
+
+        Assert.True(map.Stale);
+    }
+
+    [Fact]
+    public void Lists_flight_then_3d_then_photo()
+    {
+        Map("photomap.html", Recent);
+        Map("flightmap-3d.html", Recent);
+        Map("flightmap.html", Recent);
+
+        var maps = ExistingMapFinder.Find(_dir, Contents());
+
+        Assert.Equal(["Flight map", "Flight map (3D)", "Photo map"],
+            maps.Select(m => m.Title).ToArray());
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
@@ -16,6 +16,7 @@ public class FlightMapOptionsViewModelTests
     {
         var vm = new FlightMapOptionsViewModel();
         Assert.True(vm.Recursive);
+        Assert.False(vm.ThreeD);
         Assert.Equal("osm", vm.SelectedTileStyle.Key);
         Assert.Equal(MapPrivacy.Keep, vm.SelectedPrivacy.Value);
         Assert.Equal(15, vm.JoinGap);
@@ -41,6 +42,7 @@ public class FlightMapOptionsViewModelTests
         var vm = new FlightMapOptionsViewModel
         {
             Recursive = false,
+            ThreeD = true,
             JoinGap = 0,
             ExportAll = true,
             TzOffset = "-8",
@@ -51,8 +53,8 @@ public class FlightMapOptionsViewModelTests
         vm.SelectedPrivacy = vm.PrivacyOptions.Single(p => p.Value == MapPrivacy.Fuzz);
 
         Assert.Equal(
-            new FlightMapOptions(false, "cyclosm", MapPrivacy.Fuzz, 0, true,
-                "-8", "Trip", "/out/map.html"),
+            new FlightMapOptions(false, true, "cyclosm", MapPrivacy.Fuzz, 0,
+                true, "-8", "Trip", "/out/map.html"),
             vm.ToOptions());
     }
 

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -623,6 +623,50 @@ public class WorkspaceScreenTests
         Assert.Contains("--title Alps", vm.CommandPreview);
     }
 
+    // #366: the 3D toggle binds to the options VM, surfaces --3d in the
+    // strip, and greys the two controls whose flags the builder suppresses
+    // (Map style: CLI-ignored; export all: CLI UsageError). Choices made
+    // before entering 3D must come back when it is unchecked.
+    [AvaloniaFact]
+    public void Three_d_toggle_binds_and_greys_the_flat_map_options()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+
+        var toggle = window.GetVisualDescendants().OfType<ToggleSwitch>()
+            .Single(t => t.Name == "FlightThreeDToggle");
+        Assert.False(toggle.IsChecked);
+        var note = window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "FlightThreeDNote");
+        Assert.False(note.IsVisible);
+
+        toggle.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.FlightOptions.ThreeD);
+        Assert.Contains("--3d", vm.CommandPreview);
+        Assert.True(note.IsVisible);
+
+        var style = window.GetVisualDescendants().OfType<ComboBox>()
+            .Single(c => c.Name == "FlightStyleCombo");
+        Assert.False(style.IsEnabled);
+
+        var advanced = window.GetVisualDescendants().OfType<Expander>()
+            .Single(e => e.Name == "FlightAdvanced");
+        advanced.IsExpanded = true;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        var exportAll = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "FlightExportAllCheck");
+        Assert.False(exportAll.IsEnabled);
+
+        toggle.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.DoesNotContain("--3d", vm.CommandPreview);
+        Assert.True(style.IsEnabled);
+        Assert.True(exportAll.IsEnabled);
+        Assert.False(note.IsVisible);
+    }
+
     [AvaloniaFact]
     public void Flight_map_clear_output_button_is_bound_to_its_command()
     {

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -37,6 +37,10 @@ public static class CommandBuilder
     /// M3b). Flags are omitted at their defaults so an untouched run reads
     /// <c>flightmap &lt;folder&gt; -r</c>, exactly like M3a. Order is fixed for
     /// golden tests. No <c>--progress</c>: the runner appends that.
+    /// When <paramref name="opts"/>.ThreeD is set, <c>--tile-style</c> and
+    /// <c>--format all</c> are suppressed — the CLI ignores the first and
+    /// rejects the second with <c>--3d</c> — so every argv this method
+    /// returns is legal by construction (#366).
     /// </summary>
     public static string[] FlightMap(string folder, FlightMapOptions opts)
     {
@@ -45,7 +49,11 @@ public static class CommandBuilder
         {
             args.Add("-r");
         }
-        if (opts.TileStyle != FlightMapOptions.Defaults.TileStyle)
+        if (opts.ThreeD)
+        {
+            args.Add("--3d");
+        }
+        if (!opts.ThreeD && opts.TileStyle != FlightMapOptions.Defaults.TileStyle)
         {
             args.Add("--tile-style");
             args.Add(opts.TileStyle);
@@ -60,7 +68,7 @@ public static class CommandBuilder
             args.Add("--join-gap");
             args.Add(opts.JoinGap.ToString(CultureInfo.InvariantCulture));
         }
-        if (opts.ExportAll)
+        if (!opts.ThreeD && opts.ExportAll)
         {
             args.Add("--format");
             args.Add("all");

--- a/gui/DjiEmbed.Gui/Services/ExistingMapFinder.cs
+++ b/gui/DjiEmbed.Gui/Services/ExistingMapFinder.cs
@@ -10,8 +10,9 @@ public sealed record ExistingMap(
 
 /// <summary>
 /// Finds maps a previous run left in the chosen folder. The GUI never passes
-/// <c>-o</c> by default, so the CLI's defaults apply and the two paths are
-/// deterministic: <c>flightmap.html</c> and <c>photomap.html</c>, written
+/// <c>-o</c> by default, so the CLI's defaults apply and the three paths are
+/// deterministic: <c>flightmap.html</c>, <c>flightmap-3d.html</c> (#366),
+/// and <c>photomap.html</c>, written
 /// directly in the mapped folder. A map redirected elsewhere by either map
 /// mode's "Save map to" override is deliberately out of scope (#328 spec) —
 /// finding those would need a persisted record of past outputs.
@@ -26,6 +27,11 @@ public static class ExistingMapFinder
                 contents.NewestFlightLogUtc) is { } flight)
         {
             found.Add(flight);
+        }
+        if (Probe(directory, "flightmap-3d.html", "Flight map (3D)",
+                contents.NewestFlightLogUtc) is { } flight3d)
+        {
+            found.Add(flight3d);
         }
         if (Probe(directory, "photomap.html", "Photo map",
                 contents.NewestPhotoUtc) is { } photo)

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
@@ -14,6 +14,10 @@ public enum MapPrivacy
 /// is a pure function of this record — golden-testable. Every field maps to an
 /// existing <c>flightmap</c> flag; defaults reproduce M3a's hardcoded argv.
 /// </summary>
+/// <param name="ThreeD">Write the MapLibre 3D terrain map
+/// (<c>flightmap-3d.html</c>) instead of the flat map. The CLI ignores
+/// <c>--tile-style</c> and rejects <c>--format all</c> with <c>--3d</c>,
+/// so the builder suppresses both while this is set.</param>
 /// <param name="TileStyle">A <c>tiles.py</c> key: <c>osm</c> (default),
 /// <c>osm-hot</c>, <c>opentopomap</c>, or <c>cyclosm</c>.</param>
 /// <param name="JoinGap">Seconds to chain size-split recordings; 15 = the CLI
@@ -23,6 +27,7 @@ public enum MapPrivacy
 /// <param name="TzOffset"><c>auto</c> (default) or an explicit UTC offset.</param>
 public sealed record FlightMapOptions(
     bool Recursive,
+    bool ThreeD,
     string TileStyle,
     MapPrivacy Privacy,
     int JoinGap,
@@ -33,6 +38,7 @@ public sealed record FlightMapOptions(
 {
     public static readonly FlightMapOptions Defaults = new(
         Recursive: true,
+        ThreeD: false,
         TileStyle: "osm",
         Privacy: MapPrivacy.Keep,
         JoinGap: 15,

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
@@ -27,6 +27,9 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
     public partial bool Recursive { get; set; } = true;
 
     [ObservableProperty]
+    public partial bool ThreeD { get; set; }
+
+    [ObservableProperty]
     public partial TileChoice SelectedTileStyle { get; set; }
 
     [ObservableProperty]
@@ -55,6 +58,7 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
 
     public FlightMapOptions ToOptions() => new(
         Recursive: Recursive,
+        ThreeD: ThreeD,
         TileStyle: SelectedTileStyle.Key,
         Privacy: SelectedPrivacy.Value,
         JoinGap: JoinGap,

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -256,11 +256,28 @@
                                     </DockPanel>
 
                                     <StackPanel Spacing="4">
+                                        <DockPanel>
+                                            <ToggleSwitch Name="FlightThreeDToggle"
+                                                          AutomationProperties.Name="3D terrain map"
+                                                          DockPanel.Dock="Right"
+                                                          IsChecked="{Binding FlightOptions.ThreeD}" />
+                                            <TextBlock Text="3D terrain map"
+                                                       VerticalAlignment="Center" />
+                                        </DockPanel>
+                                        <TextBlock Name="FlightThreeDNote"
+                                                   Text="Map style and KML/GeoJSON export don't apply to the 3D map."
+                                                   IsVisible="{Binding FlightOptions.ThreeD}"
+                                                   TextWrapping="Wrap"
+                                                   Opacity="0.5" FontSize="11" />
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="4">
                                         <TextBlock Text="Map style" Opacity="0.7"
                                                    FontSize="12" />
                                         <ComboBox Name="FlightStyleCombo"
                                                   AutomationProperties.Name="Map style"
                                                   HorizontalAlignment="Stretch"
+                                                  IsEnabled="{Binding !FlightOptions.ThreeD}"
                                                   ItemsSource="{Binding FlightOptions.TileStyles}"
                                                   SelectedItem="{Binding FlightOptions.SelectedTileStyle}">
                                             <ComboBox.ItemTemplate>
@@ -309,6 +326,7 @@
                                         <StackPanel Spacing="12" Margin="0,8,0,0">
                                             <CheckBox Name="FlightExportAllCheck"
                                                       IsChecked="{Binding FlightOptions.ExportAll}"
+                                                      IsEnabled="{Binding !FlightOptions.ThreeD}"
                                                       Content="Also export KML + GeoJSON" />
 
                                             <StackPanel Spacing="4">

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -160,8 +160,11 @@ public partial class WorkspaceView : UserControl
 
     private async void OnChooseOutputClick(object? sender, RoutedEventArgs e)
     {
+        // The suggested name tracks the toggle: a 3D run's default output
+        // is flightmap-3d.html (#366). Handler untestable headless (#335).
         if (DataContext is WorkspaceViewModel vm
-            && await SavePicker(this, "Save the flight map as", "flightmap.html")
+            && await SavePicker(this, "Save the flight map as",
+                vm.FlightOptions.ThreeD ? "flightmap-3d.html" : "flightmap.html")
                 is { } path)
         {
             vm.FlightOptions.Output = path;


### PR DESCRIPTION
Closes #366. Follow-up to #268/#365 — exposes the CLI's `flightmap --3d` (shipped in v2.1.0) in the desktop app.

## What's in it

- **"3D terrain map" toggle** in the Flight map curated options. `CommandBuilder.FlightMap` emits `--3d` right after `-r`, and the CLI transparency strip reflects it live.
- **Conflict handling (disable + suppress):** while 3D is on, the Map style combo and the Advanced "Also export KML + GeoJSON" checkbox grey out, and the builder omits `--tile-style`/`--format all` from the argv — the CLI ignores the first and rejects the second with `--3d`, so every reachable argv stays legal by construction. User choices are preserved and return when 3D is unchecked. A quiet in-panel note explains why the controls greyed.
- **Existing-map discovery:** `ExistingMapFinder` now probes `flightmap-3d.html` too — the ALREADY IN THIS FOLDER panel lists "Flight map (3D)" with the same flight-log staleness rule as the 2D map.
- **Save picker** suggests `flightmap-3d.html` while the toggle is on.
- **Docs:** HELP.md + docs/desktop-app.md mentions.

No preview plumbing changes: the run's JSONL `result` path flows through the existing `Outputs` → `PrimePreviewAsync` path.

Spec: `docs/superpowers/specs/2026-07-25-gui-flightmap-3d-toggle-design.md`.

## Tests

- Builder goldens: `--3d` position, suppression case (full-golden), compatible-flags pass-through, untouched default `flightmap <folder> -r` unchanged.
- VM defaults + `ToOptions` round-trip; finder found/stale/ordering; screen test flips the toggle from the control side and asserts VM, strip, both greyed controls, and note visibility both ways; a11y contract picks up the named toggle.
- Gates: GUI Release suite **473 passed / 0 failed / 16 skipped, 0 warnings**; `mkdocs build --strict` clean. Built TDD, per-task spec+quality reviews plus a final whole-branch review (verdict: ready to merge, no Critical/Important findings).

## Manual follow-up (post-merge, on real hardware)

- [ ] Verify the inline WebView2 preview renders the 3D map (WebGL) — the one thing headless CI can't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiDbAbZ43ZdLhuxnjfYo14