### PR TITLE
Ghost Camera cockpit view in the 3D flightmap (#372)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -268,6 +268,27 @@ with an on-map notice. Browsers without WebGL get a plain HTML message
 instead. `--tile-style` has no effect in 3D (ignored, with a warning), and
 there's no playback in the 3D view.
 
+### Ghost camera — see what the drone saw
+
+In the 3D map, every flight's popup has a **View from here** button. It flies
+the map camera to the drone's recorded pose at that moment — position, height
+above takeoff, gimbal direction, and the camera's field of view — so the
+rendered terrain shows what the real camera saw. Step through the flight with
+the ‹ › buttons or arrow keys (hold to scrub); press Esc or × to return to
+the overview.
+
+This doubles as a verification aid: if the rendered ridgelines match the
+skyline in your footage, the telemetry is telling the truth about where the
+camera was.
+
+The heads-up display always shows the *recorded* values and badges anything
+that is not: *pitch clamped* (the recorded gimbal angle exceeds what the map
+camera allows), *estimated view* (this format logs no gimbal direction, so
+the view faces along the flight path), and *position fuzzed ~100 m* (the map
+was generated with `--redact fuzz`). Heights come from the terrain model plus
+the logged height above takeoff; without terrain, the logged altitude is used
+as-is.
+
 ## Photo map (`photomap`)
 
 ```bash

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -274,7 +274,8 @@ In the 3D map, every flight's popup has a **View from here** button. It flies
 the map camera to the drone's recorded pose at that moment — position, height
 above takeoff, gimbal direction, and the camera's field of view — so the
 rendered terrain shows what the real camera saw. Step through the flight with
-the ‹ › buttons or arrow keys (hold to scrub); press Esc or × to return to
+the ‹ › buttons or arrow keys (hold an arrow key to scrub); press Esc or
+× to return to
 the overview.
 
 This doubles as a verification aid: if the rendered ridgelines match the

--- a/docs/superpowers/specs/2026-07-26-ghost-camera-lite-design.md
+++ b/docs/superpowers/specs/2026-07-26-ghost-camera-lite-design.md
@@ -81,18 +81,24 @@ properties. To map a queried feature back to the embedded data, the template
 gives each feature a stable id equal to its index in the collection (queried
 features do not otherwise carry their collection index).
 
-**Pose.** Position via `maplibregl.MercatorCoordinate.fromLngLat`, with
-camera height = *terrain elevation at the flight's takeoff point* (one
+**Pose.** *(Amended 2026-07-26 after the Task-1 spike: MapLibre GL JS never
+ported Mapbox's free-camera API — `getFreeCameraOptions` does not exist,
+upstream request maplibre/maplibre-gl-js#1414. Exact placement instead uses
+the API MapLibre added for this purpose.)* The camera is placed with
+`map.calculateCameraOptionsFromCameraLngLatAltRotation(cameraLngLat,
+cameraAltitudeM, bearing, pitch)` → `jumpTo`/`easeTo` — same fidelity: the
+camera sits exactly at the drone's position with the gimbal's orientation.
+Camera height = *terrain elevation at the flight's takeoff point* (one
 `map.queryTerrainElevation` per flight, cached) + `agl_m[i]`. This is
 self-consistent with the rendered terrain, so a disagreement between DJI's
 altitude datum and Mapterhorn's cannot put the ghost underground. Fallbacks:
 absolute altitude from `coordinates` when `agl_m` is absent; terrain-less
 (flat) mode works too — `queryTerrainElevation` returns null → absolute
-altitude. Orientation via `FreeCameraOptions.setPitchBearing`: bearing =
-`gyaw_deg[i]`, camera pitch = `90 + gpitch_deg[i]` (gimbal −90° nadir → 0,
-0° horizon → 90), clamped to the maximum the spike establishes. Vertical FOV
-set from `vfov_deg` on entry (if the spike confirms
-`setVerticalFieldOfView` exists) and restored on exit.
+altitude. Orientation: bearing = `gyaw_deg[i]`, camera pitch =
+`90 + gpitch_deg[i]` (gimbal −90° nadir → 0, 0° horizon → 90), clamped to
+the maximum the spike establishes. Vertical FOV set from `vfov_deg` on entry
+(if the spike confirms `setVerticalFieldOfView` exists) and restored on
+exit.
 
 **Missing gimbal data** (some SRT variants carry none): the button stays
 available — yaw falls back to the course bearing toward the next point,
@@ -102,8 +108,8 @@ otherwise lose the feature; the badge keeps it honest.
 
 **Cockpit scrub.** ←/→ keys and on-screen ‹ › buttons step one sample, with
 hold-to-repeat; each step is a ~150 ms micro-ease. Entering and exiting ghost
-mode is a ~1.2 s hand-rolled position-lerp + orientation-slerp (the free
-camera has no built-in easing). While ghost mode is active the normal map
+mode is a ~1.2 s eased transition (`easeTo` over the computed camera
+options). While ghost mode is active the normal map
 interaction handlers are disabled so they cannot fight the free camera. Esc
 or the HUD's ✕ eases back to the saved overview camera, re-enables handlers,
 and restores the FOV.
@@ -131,14 +137,15 @@ Mapterhorn being unreachable; ghost mode still works in that flat state
 A headless-browser probe against the pinned MapLibre 5.24.0 UMD build,
 results recorded in the plan before any template work:
 
-1. Free-camera pitch range — are orientations past the regular 85° limit
-   honoured?
+1. Camera-pitch range — are pitches past the regular 85° limit honoured
+   (via `setMaxPitch` + `jumpTo`)?
 2. `queryTerrainElevation` behaviour with terrain enabled and disabled.
 3. Does `setVerticalFieldOfView` exist on this build?
 
-Documented fallback if probe 1 fails: the standard-camera approximation
-(`easeTo` on a look-at target projected along the gimbal ray), accepting the
-85° pitch cap and approximate position.
+*Spike outcome 2026-07-26 (probe A):* the Mapbox free-camera API is absent
+from MapLibre GL JS entirely; `calculateCameraOptionsFromCameraLngLatAltRotation`
+is present in the pinned 5.24.0 bundle and is the placement mechanism (see
+the amended Pose section). The remaining probes rerun against it.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-26-ghost-camera-lite-design.md
+++ b/docs/superpowers/specs/2026-07-26-ghost-camera-lite-design.md
@@ -106,8 +106,9 @@ pitch to a fixed −30° down-tilt (tunable constant), and the HUD badges the
 view as estimated. Decided over hiding the button because whole formats would
 otherwise lose the feature; the badge keeps it honest.
 
-**Cockpit scrub.** ←/→ keys and on-screen ‹ › buttons step one sample, with
-hold-to-repeat; each step is a ~150 ms micro-ease. Entering and exiting ghost
+**Cockpit scrub.** ←/→ keys and on-screen ‹ › buttons step one sample
+(holding an arrow key repeats; buttons are single-step by design); each
+step is a ~150 ms micro-ease. Entering and exiting ghost
 mode is a ~1.2 s eased transition (`easeTo` over the computed camera
 options). While ghost mode is active the normal map
 interaction handlers are disabled so they cannot fight the free camera. Esc

--- a/docs/superpowers/specs/2026-07-26-ghost-camera-lite-design.md
+++ b/docs/superpowers/specs/2026-07-26-ghost-camera-lite-design.md
@@ -1,0 +1,160 @@
+# Flightmap 3D "Ghost Camera" cockpit view — design
+
+**Date:** 2026-07-26
+**Issue:** [#372](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/372)
+**Status:** Approved
+
+## Problem
+
+The 3D flight map (#268, v2.1.0) drapes tracks on the terrain surface because
+MapLibre cannot render line layers at altitude (upstream
+maplibre/maplibre-gl-js#644). The altitude, gimbal yaw/pitch, and focal-length
+telemetry we already parse into every `TrackPoint` is therefore invisible in
+the 3D geometry — it only surfaces as popup numbers.
+
+MapLibre's *free camera* API has no such limitation: it can place the map
+camera at an arbitrary position and orientation. That is exactly a drone pose.
+
+**Ghost Camera** flies the map camera to the drone's recorded pose so the user
+sees what the camera saw, rendered from terrain, and can scrub through
+neighbouring seconds from the drone's seat. Besides the delight, this is
+verification made visual: if the rendered ridgelines match the footage's
+skyline, the telemetry is truthful — provenance, not targeting, per the
+project's use-for-good direction.
+
+This is stage 1 of a 3D arc agreed 2026-07-26. Later stages (separate specs):
+true-altitude ribbon/curtain via a hand-rolled custom WebGL layer, "Camera's
+Gaze" footprint-sweep playback + search-footage-by-place, and crossfading from
+the rendered pose to the real photo/video frame.
+
+## Scope
+
+- Per-point gimbal/AGL data added to the flight GeoJSON (shared by the HTML
+  viewers and the `-f geojson` export, same precedent as `times_s`).
+- Ghost mode in the **3D template only**: enter from the track popup, cockpit
+  scrub with keyboard/buttons, HUD, exit back to the overview camera.
+- No new dependencies, no new pinned assets (SRI-count test unchanged), no new
+  CLI flags — ships inside the existing `--3d` output. The GUI gets it for
+  free through the 3D toggle and WebView preview.
+
+Out of scope (deferred, in arc order or later): free-look while parked,
+playback/animation in the 3D map, the custom WebGL layer, media crossfade,
+any 2D-map changes.
+
+## Design
+
+### 1. Data model — `geo/flightmap.py::flights_to_geojson`
+
+Each LineString feature's properties gain, following the `times_s` pattern:
+
+- `gyaw_deg`, `gpitch_deg`, `agl_m` — per-point parallel arrays aligned with
+  `coordinates`. An array is emitted only when at least one point in the
+  flight has the value; points without it hold `null`. Rounded to 0.1° /
+  0.1 m to keep archive-scale files sane.
+- `vfov_deg` — per-flight scalar: the camera's vertical field of view derived
+  from the flight's median `focal_len` via the `footprint.py` lens model
+  (35 mm-equivalent focal length + sensor aspect). Omitted when no point
+  carries `focal_len`.
+- The degenerate single-fix `Point` feature gets none of these (same as
+  `times_s` today).
+
+The FeatureCollection gains a top-level `redacted` property carrying the
+redaction mode (`"none"` / `"fuzz"`; `"drop"` never reaches the writer with
+points). The HUD uses it so a fuzzed pose is never presented as exact.
+
+These properties flow into the standalone `-f geojson` export too — same
+precedent as `times_s`; documented in the docstring. No other Python changes:
+redaction already happens once, upstream, in `Track`.
+
+### 2. Ghost mode — 3D template JS (`geo/flightmap3d_html.py`)
+
+**Entry.** The 3D template's popup assembly appends a "View from here" button
+after `popupHtml(p)` — the shared `flightmap_js.py` snippet is untouched, so
+the 2D map is unaffected. On click, the nearest track point to the clicked
+`lngLat` is the starting sample. The button renders for LineString flights
+only (a single-fix Point has no arrays to scrub).
+
+**Data access gotcha.** MapLibre JSON-stringifies nested arrays in feature
+properties returned by `queryRenderedFeatures`. Ghost JS therefore reads its
+arrays from the embedded `FeatureCollection` script block, never from queried
+properties. To map a queried feature back to the embedded data, the template
+gives each feature a stable id equal to its index in the collection (queried
+features do not otherwise carry their collection index).
+
+**Pose.** Position via `maplibregl.MercatorCoordinate.fromLngLat`, with
+camera height = *terrain elevation at the flight's takeoff point* (one
+`map.queryTerrainElevation` per flight, cached) + `agl_m[i]`. This is
+self-consistent with the rendered terrain, so a disagreement between DJI's
+altitude datum and Mapterhorn's cannot put the ghost underground. Fallbacks:
+absolute altitude from `coordinates` when `agl_m` is absent; terrain-less
+(flat) mode works too — `queryTerrainElevation` returns null → absolute
+altitude. Orientation via `FreeCameraOptions.setPitchBearing`: bearing =
+`gyaw_deg[i]`, camera pitch = `90 + gpitch_deg[i]` (gimbal −90° nadir → 0,
+0° horizon → 90), clamped to the maximum the spike establishes. Vertical FOV
+set from `vfov_deg` on entry (if the spike confirms
+`setVerticalFieldOfView` exists) and restored on exit.
+
+**Missing gimbal data** (some SRT variants carry none): the button stays
+available — yaw falls back to the course bearing toward the next point,
+pitch to a fixed −30° down-tilt (tunable constant), and the HUD badges the
+view as estimated. Decided over hiding the button because whole formats would
+otherwise lose the feature; the badge keeps it honest.
+
+**Cockpit scrub.** ←/→ keys and on-screen ‹ › buttons step one sample, with
+hold-to-repeat; each step is a ~150 ms micro-ease. Entering and exiting ghost
+mode is a ~1.2 s hand-rolled position-lerp + orientation-slerp (the free
+camera has no built-in easing). While ghost mode is active the normal map
+interaction handlers are disabled so they cannot fight the free camera. Esc
+or the HUD's ✕ eases back to the saved overview camera, re-enables handlers,
+and restores the FOV.
+
+### 3. HUD
+
+One overlay element, mounted on entry and unmounted on exit, styled like the
+existing flights panel (plain CSS, no assets):
+
+- **Always:** flight name; sample position as elapsed time ("0:42 / 3:10",
+  from `times_s` + the flight's start); height — AGL when `agl_m` is present,
+  otherwise absolute altitude, labelled which; recorded gimbal yaw/pitch —
+  always the *true recorded* numbers, never the clamped ones.
+- **Badges, only when they apply:** "pitch clamped to N°"; "estimated view —
+  no gimbal data"; "position fuzzed ~100 m" (from `redacted`).
+- **Controls:** the ‹ › step buttons and ✕ exit live on the HUD, so touch
+  users get buttons and keyboard users get arrows/Esc.
+
+**Failure posture.** The existing terrain-failure banner already covers
+Mapterhorn being unreachable; ghost mode still works in that flat state
+(skylines just aren't meaningful, which the banner communicates).
+
+### 4. Spike — task 1 of the implementation plan
+
+A headless-browser probe against the pinned MapLibre 5.24.0 UMD build,
+results recorded in the plan before any template work:
+
+1. Free-camera pitch range — are orientations past the regular 85° limit
+   honoured?
+2. `queryTerrainElevation` behaviour with terrain enabled and disabled.
+3. Does `setVerticalFieldOfView` exist on this build?
+
+Documented fallback if probe 1 fails: the standard-camera approximation
+(`easeTo` on a look-at target projected along the gimbal ray), accepting the
+85° pitch cap and approximate position.
+
+## Testing
+
+- **Python unit tests:** array presence/alignment/null-padding/rounding,
+  emitted-only-when-any-value, `vfov_deg` derivation, `redacted` property,
+  single-fix Point exclusion; golden-file updates for exporters sharing
+  `flights_to_geojson`.
+- **Browser suite:** open the 3D fixture; click a track → button present;
+  enter ghost mode → free-camera position matches the expected Mercator pose
+  within tolerance; step → HUD advances; Esc → overview camera restored.
+  SRI-count test unchanged.
+- **E2E:** Marcus eyeballs real footage — the ridgeline match is the
+  acceptance criterion. WebView2 ghost-mode behaviour piggybacks on the
+  pending #366 real-hardware preview check.
+
+## Docs
+
+Flightmap docs section (what the ghost view is, the provenance framing, the
+estimated-view and fuzzed badges) + changelog entry.

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -942,15 +942,19 @@ def flightmap(
             try:
                 if f == "html":
                     if three_d:
-                        write_flights_3d_html(tracks, out, map_title)
+                        write_flights_3d_html(
+                            tracks, out, map_title, redact=redact.lower()
+                        )
                     else:
                         write_flights_html(
-                            tracks, out, map_title, tile_style=tile_style.lower()
+                            tracks, out, map_title,
+                            tile_style=tile_style.lower(),
+                            redact=redact.lower(),
                         )
                 elif f == "kml":
                     write_flights_kml(tracks, out, map_title)
                 else:
-                    write_flights_geojson(tracks, out)
+                    write_flights_geojson(tracks, out, redact=redact.lower())
             except OSError as e:
                 raise click.ClickException(f"Could not write {out}: {e}")
         progress.result(

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -16,10 +16,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from statistics import median
 from xml.sax.saxutils import escape
 
 from .. import utilities
 from ..utilities import load_samples, redact_coords
+from .footprint import DEFAULT_LENS, fov_degrees
 from .geometry import haversine_m
 from .track import Track, TrackPoint, _cue_seconds, build_track_from_samples
 
@@ -319,12 +321,39 @@ def _relative_times(points: list[TrackPoint]) -> list[float]:
     return times
 
 
+def _add_ghost_props(properties: dict, points: list[TrackPoint]) -> None:
+    """Per-point camera-pose arrays for the 3D ghost view (#372).
+
+    Same contract as ``times_s``: parallel to ``coordinates``, null-padded so
+    indices stay aligned, emitted only when at least one point has the value.
+    ``vfov_deg`` is per-flight (median focal length) — DJI zooms mid-flight
+    rarely enough that one value per flight is honest.
+    """
+    for key, attr in (
+        ("gyaw_deg", "gimbal_yaw"),
+        ("gpitch_deg", "gimbal_pitch"),
+        ("agl_m", "rel_alt"),
+    ):
+        vals = [
+            None if getattr(p, attr) is None else round(getattr(p, attr), 1)
+            for p in points
+        ]
+        if any(v is not None for v in vals):
+            properties[key] = vals
+    focals = [p.focal_len for p in points if p.focal_len is not None]
+    if focals:
+        properties["vfov_deg"] = round(
+            fov_degrees(DEFAULT_LENS, median(focals))[1], 1
+        )
+
+
 def flights_to_geojson(tracks: list[Track]) -> dict:
     """Return a GeoJSON ``FeatureCollection`` with one feature per flight.
 
     Each flight is a ``LineString`` carrying name/start/duration/altitude
     summary properties plus ``times_s`` — per-point seconds relative to the
     flight start — which drives the HTML viewer's playback animation (#267).
+    LineStrings also carry per-point ghost-camera pose arrays (``gyaw_deg``/``gpitch_deg``/``agl_m``) and a per-flight ``vfov_deg`` when the telemetry has them (#372).
     A single-fix clip degrades to a ``Point`` (RFC 7946 §3.1.4 requires two
     or more positions in a LineString) and carries no times. Unlike the
     single-track exporter no per-sample Point features are emitted — at
@@ -337,6 +366,7 @@ def flights_to_geojson(tracks: list[Track]) -> dict:
         if len(coords) >= 2:
             geometry: dict = {"type": "LineString", "coordinates": coords}
             properties["times_s"] = _relative_times(track.points)
+            _add_ghost_props(properties, track.points)
         else:
             geometry = {"type": "Point", "coordinates": coords[0]}
         features.append(

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -347,7 +347,7 @@ def _add_ghost_props(properties: dict, points: list[TrackPoint]) -> None:
         )
 
 
-def flights_to_geojson(tracks: list[Track]) -> dict:
+def flights_to_geojson(tracks: list[Track], redact: str = "none") -> dict:
     """Return a GeoJSON ``FeatureCollection`` with one feature per flight.
 
     Each flight is a ``LineString`` carrying name/start/duration/altitude
@@ -358,6 +358,7 @@ def flights_to_geojson(tracks: list[Track]) -> dict:
     or more positions in a LineString) and carries no times. Unlike the
     single-track exporter no per-sample Point features are emitted — at
     archive scale they would swamp the map and the file.
+    The top-level ``redacted`` member records the CLI redaction mode so viewers can badge fuzzed positions honestly (#372).
     """
     features: list[dict] = []
     for track in tracks:
@@ -376,13 +377,16 @@ def flights_to_geojson(tracks: list[Track]) -> dict:
                 "properties": properties,
             }
         )
-    return {"type": "FeatureCollection", "features": features}
+    return {"type": "FeatureCollection", "redacted": redact,
+            "features": features}
 
 
-def write_flights_geojson(tracks: list[Track], output_path: Path) -> Path:
+def write_flights_geojson(
+    tracks: list[Track], output_path: Path, redact: str = "none"
+) -> Path:
     """Write *tracks* as GeoJSON to *output_path* and return it."""
     output_path.write_text(
-        json.dumps(flights_to_geojson(tracks), indent=2), encoding="utf-8"
+        json.dumps(flights_to_geojson(tracks, redact=redact), indent=2), encoding="utf-8"
     )
     logger.info("GeoJSON flight map created: %s", output_path)
     return output_path

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -429,7 +429,7 @@ function ghostExit() {
                bearing: saved.bearing, duration: GHOST_ENTER_MS });
   map.once('moveend', () => {
     // Interrupting this ease (MapLibre fires moveend for aborted eases
-    // too — e.g. a rapid ghost re-entry) must not restore mid-session:
+    // too, e.g. a rapid ghost re-entry) must not restore mid-session:
     // that would unlock the camera inside the new ghost session.
     if (ghost.active) return;
     map.setMaxPitch(saved.maxPitch);

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -8,7 +8,9 @@ tiles load from the network; the flight data itself is embedded.
 
 Tracks are draped on the terrain surface: MapLibre cannot render line
 layers at an elevation (upstream request maplibre/maplibre-gl-js#644), so
-altitude appears in the popups, not the geometry.
+altitude appears in the popups, not the geometry. The ghost view (#372)
+sidesteps that limit with ``calculateCameraOptionsFromCameraLngLatAltRotation``:
+geometry stays draped, but the camera itself flies the recorded poses.
 
 Terrain source: Mapterhorn (keyless, Copernicus GLO-30 base, global
 coverage). Dormant fallback if Mapterhorn ever disappears: AWS Terrarium
@@ -68,6 +70,7 @@ _TEMPLATE = """<!DOCTYPE html>
               padding: 6px 28px 6px 12px; font: 13px/1.4 sans-serif; }}
   .map-note button {{ position: absolute; right: 6px; top: 4px; border: none;
                      background: none; cursor: pointer; font-size: 14px; }}
+  .ghost-open {{ display: block; margin-top: 6px; cursor: pointer; }}
 </style>
 </head>
 <body>
@@ -86,6 +89,7 @@ _TEMPLATE = """<!DOCTYPE html>
 
 _APP_JS = """
 const data = JSON.parse(document.getElementById('flight-data').textContent);
+const REDACTED = data.redacted || 'none';
 __SHARED_JS__
 
 // Collect flights: draped 2D geometry only — the third GeoJSON coordinate
@@ -104,6 +108,12 @@ const allCoords = [];
   if (f.geometry.type === 'LineString') {
     entry.geometry = { type: 'LineString',
                        coordinates: f.geometry.coordinates.map(c => [c[0], c[1]]) };
+    entry.pts = f.geometry.coordinates;      // full [lon, lat, alt] triples
+    entry.times = p.times_s || null;
+    entry.gyaw = p.gyaw_deg || null;
+    entry.gpitch = p.gpitch_deg || null;
+    entry.agl = p.agl_m || null;
+    entry.vfov = p.vfov_deg || null;
   } else {                                             // single-fix clip
     const c = f.geometry.coordinates;
     entry.geometry = { type: 'Point', coordinates: [c[0], c[1]] };
@@ -187,7 +197,7 @@ if (map) {
 
   map.on('load', () => {
     map.setTerrain({ source: 'terrain', exaggeration: 1 });
-    flights.forEach(f => {
+    flights.forEach((f, fi) => {
       map.addSource(f.id, { type: 'geojson', data: {
         type: 'Feature', geometry: f.geometry, properties: {} } });
       if (f.geometry.type === 'LineString') {
@@ -199,8 +209,21 @@ if (map) {
           paint: { 'circle-color': f.color, 'circle-radius': 6 } });
       }
       map.on('click', f.id, ev => {
-        new maplibregl.Popup({ maxWidth: '320px' })
-          .setLngLat(ev.lngLat).setHTML(popupHtml(f.props)).addTo(map);
+        const el = document.createElement('div');
+        el.innerHTML = popupHtml(f.props);
+        const popup = new maplibregl.Popup({ maxWidth: '320px' })
+          .setLngLat(ev.lngLat).setDOMContent(el).addTo(map);
+        if (f.pts) {
+          const btn = document.createElement('button');
+          btn.className = 'ghost-open';
+          btn.textContent = 'View from here';
+          const ll = ev.lngLat;
+          btn.addEventListener('click', () => {
+            popup.remove();
+            ghostEnter(fi, nearestSample(f, ll));
+          });
+          el.appendChild(btn);
+        }
       });
       map.on('mouseenter', f.id, () => {
         map.getCanvas().style.cursor = 'pointer';
@@ -236,6 +259,129 @@ function buildPanel() {
     panel.appendChild(label);
   });
   document.body.appendChild(panel);
+}
+
+// --- Ghost Camera (#372): fly the free camera to the recorded drone pose ---
+const GHOST_MAX_PITCH = 100;  // spike: setMaxPitch(120) OK, pitch 100 honoured
+const GHOST_EST_PITCH = -30;  // assumed down-tilt when gimbal data is absent
+const GHOST_HANDLERS = ['dragPan', 'dragRotate', 'scrollZoom', 'keyboard',
+                        'doubleClickZoom', 'touchZoomRotate'];
+const ghost = { active: false, flight: null, idx: 0, saved: null,
+                savedFov: null, takeoffElev: null, hud: null,
+                applied: null };
+
+function nearestSample(fl, ll) {
+  const cosLat = Math.cos(ll.lat * Math.PI / 180);
+  let best = 0, bestD = Infinity;
+  fl.pts.forEach((c, i) => {
+    const dx = (c[0] - ll.lng) * cosLat, dy = c[1] - ll.lat;
+    const d = dx * dx + dy * dy;
+    if (d < bestD) { bestD = d; best = i; }
+  });
+  return best;
+}
+
+function courseBearing(pts, i) {
+  const a = pts[Math.min(i, pts.length - 2)];
+  const b = pts[Math.min(i + 1, pts.length - 1)];
+  const toRad = Math.PI / 180;
+  const dLon = (b[0] - a[0]) * toRad;
+  const la1 = a[1] * toRad, la2 = b[1] * toRad;
+  const y = Math.sin(dLon) * Math.cos(la2);
+  const x = Math.cos(la1) * Math.sin(la2)
+          - Math.sin(la1) * Math.cos(la2) * Math.cos(dLon);
+  return ((Math.atan2(y, x) * 180 / Math.PI) + 360) % 360;
+}
+
+function samplePose(fl, i) {
+  const c = fl.pts[i];
+  let altitude;
+  const aglHere = fl.agl && fl.agl[i] != null ? fl.agl[i] : null;
+  if (ghost.takeoffElev != null && aglHere != null) {
+    altitude = ghost.takeoffElev + aglHere;   // terrain-consistent height
+  } else {
+    altitude = c[2];                          // logged absolute altitude
+  }
+  let bearing, gp, estimated = false;
+  if (fl.gyaw && fl.gyaw[i] != null) bearing = fl.gyaw[i];
+  else { bearing = courseBearing(fl.pts, i); estimated = true; }
+  if (fl.gpitch && fl.gpitch[i] != null) gp = fl.gpitch[i];
+  else { gp = GHOST_EST_PITCH; estimated = true; }
+  const wantPitch = 90 + gp;    // gimbal -90 (nadir) -> 0, 0 (horizon) -> 90
+  return {
+    lngLat: [c[0], c[1]], altitude,
+    bearing, pitch: Math.max(0, Math.min(wantPitch, GHOST_MAX_PITCH)),
+    clamped: wantPitch > GHOST_MAX_PITCH, estimated, aglHere,
+    gimbalYaw: fl.gyaw ? fl.gyaw[i] : null,
+    gimbalPitch: fl.gpitch ? fl.gpitch[i] : null,
+  };
+}
+
+function applyPose(pose, ms) {
+  // roll=0 explicitly: MapLibre 5.24.0 emits a 'roll' key even when the arg
+  // is omitted, and jumpTo/easeTo crash on setRoll(NaN).
+  const opts = map.calculateCameraOptionsFromCameraLngLatAltRotation(
+    pose.lngLat, pose.altitude, pose.bearing, pose.pitch, 0);
+  ghost.applied = { lng: pose.lngLat[0], lat: pose.lngLat[1],
+                    altitude: pose.altitude, bearing: pose.bearing,
+                    pitch: pose.pitch };
+  if (ms) map.easeTo(Object.assign({}, opts, { duration: ms }));
+  else map.jumpTo(opts);
+}
+
+function ghostKeys(ev) {
+  if (ev.key === 'Escape') { ghostExit(); ev.preventDefault(); }
+  else if (ev.key === 'ArrowLeft') { ghostStep(-1); ev.preventDefault(); }
+  else if (ev.key === 'ArrowRight') { ghostStep(1); ev.preventDefault(); }
+}
+
+function ghostEnter(flightIdx, sampleIdx) {
+  const fl = flights[flightIdx];
+  if (ghost.active || !fl || !fl.pts) return;
+  ghost.active = true;
+  ghost.flight = fl;
+  ghost.idx = sampleIdx;
+  ghost.saved = { center: map.getCenter(), zoom: map.getZoom(),
+                  pitch: map.getPitch(), bearing: map.getBearing(),
+                  maxPitch: map.getMaxPitch() };
+  map.setMaxPitch(GHOST_MAX_PITCH);
+  GHOST_HANDLERS.forEach(h => map[h] && map[h].disable());
+  const p0 = fl.pts[0];
+  // Gate on getTerrain(): with terrain failed/off, queryTerrainElevation
+  // returns 0 (spike round 3) and would fake a sea-level takeoff.
+  const elev = map.getTerrain && map.getTerrain()
+    ? map.queryTerrainElevation([p0[0], p0[1]]) : null;
+  ghost.takeoffElev = typeof elev === 'number' ? elev : null;
+  if (fl.vfov && typeof map.setVerticalFieldOfView === 'function') {
+    ghost.savedFov = map.getVerticalFieldOfView();
+    map.setVerticalFieldOfView(fl.vfov);
+  }
+  window.addEventListener('keydown', ghostKeys);
+  applyPose(samplePose(fl, ghost.idx));
+}
+
+function ghostStep(d) {
+  if (!ghost.active) return;
+  const n = ghost.flight.pts.length;
+  const next = Math.max(0, Math.min(ghost.idx + d, n - 1));
+  if (next === ghost.idx) return;
+  ghost.idx = next;
+  applyPose(samplePose(ghost.flight, next));
+}
+
+function ghostExit() {
+  if (!ghost.active) return;
+  ghost.active = false;
+  window.removeEventListener('keydown', ghostKeys);
+  if (ghost.savedFov != null
+      && typeof map.setVerticalFieldOfView === 'function') {
+    map.setVerticalFieldOfView(ghost.savedFov);
+    ghost.savedFov = null;
+  }
+  map.jumpTo({ center: ghost.saved.center, zoom: ghost.saved.zoom,
+               pitch: ghost.saved.pitch, bearing: ghost.saved.bearing });
+  map.setMaxPitch(ghost.saved.maxPitch);   // after jumpTo: pitch is legal again
+  GHOST_HANDLERS.forEach(h => map[h] && map[h].enable());
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -71,6 +71,17 @@ _TEMPLATE = """<!DOCTYPE html>
   .map-note button {{ position: absolute; right: 6px; top: 4px; border: none;
                      background: none; cursor: pointer; font-size: 14px; }}
   .ghost-open {{ display: block; margin-top: 6px; cursor: pointer; }}
+  .ghost-hud {{ position: absolute; bottom: 14px; left: 50%;
+               transform: translateX(-50%); z-index: 6;
+               background: rgba(20,20,24,.85); color: #fff;
+               border-radius: 6px; padding: 8px 14px;
+               font: 13px/1.6 sans-serif; display: flex; gap: 12px;
+               align-items: center; max-width: 92vw; flex-wrap: wrap; }}
+  .ghost-hud button {{ border: none; background: #444; color: #fff;
+                      border-radius: 4px; cursor: pointer; font-size: 14px;
+                      padding: 2px 9px; }}
+  .ghost-badge {{ background: #b58900; color: #fff; border-radius: 3px;
+                 padding: 0 6px; font-size: 11px; }}
 </style>
 </head>
 <body>
@@ -375,6 +386,7 @@ function ghostEnter(flightIdx, sampleIdx) {
     map.setVerticalFieldOfView(fl.vfov);
   }
   applyPose(samplePose(fl, ghost.idx));
+  mountHud();
 }
 
 function ghostStep(d) {
@@ -384,6 +396,7 @@ function ghostStep(d) {
   if (next === ghost.idx) return;
   ghost.idx = next;
   applyPose(samplePose(ghost.flight, next));
+  updateHud();
 }
 
 function ghostExit() {
@@ -399,8 +412,69 @@ function ghostExit() {
                pitch: ghost.saved.pitch, bearing: ghost.saved.bearing });
   map.setMaxPitch(ghost.saved.maxPitch);   // after jumpTo: pitch is legal again
   GHOST_HANDLERS.forEach(h => map[h] && map[h].enable());
+  unmountHud();
   ghost.flight = null;
   ghost.takeoffElev = null;
+}
+
+function mountHud() {
+  const hud = document.createElement('div');
+  hud.id = 'ghost-hud';
+  hud.className = 'ghost-hud';
+  const mk = (id, text, fn) => {
+    const b = document.createElement('button');
+    b.id = id; b.textContent = text;
+    b.addEventListener('click', fn);
+    return b;
+  };
+  const info = document.createElement('span');
+  info.id = 'ghost-info';
+  const badges = document.createElement('span');
+  badges.id = 'ghost-badges';
+  const exit = mk('ghost-exit', '\\u00d7', ghostExit);
+  exit.setAttribute('aria-label', 'Exit ghost view');
+  hud.append(mk('ghost-prev', '\\u2039', () => ghostStep(-1)),
+             info, badges,
+             mk('ghost-next', '\\u203a', () => ghostStep(1)),
+             exit);
+  document.body.appendChild(hud);
+  ghost.hud = hud;
+  updateHud();
+}
+
+function unmountHud() {
+  if (ghost.hud) { ghost.hud.remove(); ghost.hud = null; }
+}
+
+function updateHud() {
+  if (!ghost.hud) return;
+  const fl = ghost.flight, i = ghost.idx;
+  const pose = samplePose(fl, i);
+  let txt = fl.name;
+  if (fl.times) {
+    txt += ' \\u00b7 ' + fmtDuration(Math.round(fl.times[i])) + ' / '
+         + fmtDuration(Math.round(fl.times[fl.times.length - 1]));
+  }
+  txt += ' \\u00b7 ' + (pose.aglHere != null
+    ? pose.aglHere.toFixed(0) + ' m above takeoff'
+    : fl.pts[i][2].toFixed(0) + ' m (as logged)');
+  if (pose.gimbalYaw != null || pose.gimbalPitch != null) {
+    const deg = v => v != null ? v.toFixed(0) + '\\u00b0' : '\\u2014';
+    txt += ' \\u00b7 gimbal ' + deg(pose.gimbalYaw) + ' / '
+         + deg(pose.gimbalPitch);
+  }
+  ghost.hud.querySelector('#ghost-info').textContent = txt;
+  const badges = ghost.hud.querySelector('#ghost-badges');
+  badges.textContent = '';
+  const badge = t => {
+    const s = document.createElement('span');
+    s.className = 'ghost-badge';
+    s.textContent = t;
+    badges.appendChild(s);
+  };
+  if (pose.clamped) badge('pitch clamped to ' + GHOST_MAX_PITCH + '\\u00b0');
+  if (pose.estimated) badge('estimated view \\u2014 no gimbal data');
+  if (REDACTED === 'fuzz') badge('position fuzzed ~100 m');
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -373,14 +373,24 @@ function ghostEnter(flightIdx, sampleIdx) {
   ghost.takeoffElev = ghostTakeoffElev(fl);
   if (ghost.takeoffElev != null && map.areTilesLoaded
       && !map.areTilesLoaded()) {
-    // The takeoff DEM tile may not be in yet, and qte returns 0 until it
-    // is (cold cache -> camera underground). Re-sample once the map
-    // settles and re-apply the current pose.
-    map.once('idle', () => {
+    // 'idle' can park under eased transitions before late DEM tiles land
+    // (the render loop stops at moveend), so poll on a timer instead:
+    // firm up the takeoff height once tiles deliver it, then ease to the
+    // corrected pose. A genuine sea-level 0 just keeps the initial pose.
+    let tries = 20;
+    const retry = () => {
       if (!ghost.active || ghost.flight !== fl) return;
-      ghost.takeoffElev = ghostTakeoffElev(fl);
-      applyPose(samplePose(fl, ghost.idx));
-    });
+      const elev = ghostTakeoffElev(fl);
+      if (typeof elev === 'number' && elev !== 0) {
+        if (elev !== ghost.takeoffElev) {
+          ghost.takeoffElev = elev;
+          applyPose(samplePose(fl, ghost.idx), GHOST_STEP_MS);
+        }
+      } else if (--tries > 0) {
+        setTimeout(retry, 250);
+      }
+    };
+    setTimeout(retry, 250);
   }
   if (fl.vfov && typeof map.setVerticalFieldOfView === 'function') {
     ghost.savedFov = map.getVerticalFieldOfView();

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -350,13 +350,17 @@ function ghostEnter(flightIdx, sampleIdx) {
   ghost.active = true;
   ghost.flight = fl;
   ghost.idx = Math.max(0, Math.min(sampleIdx, fl.pts.length - 1));
+  // Attach Escape/arrows before any failure-prone work: if anything below
+  // throws, the user can still exit instead of a frozen handlerless map.
+  window.addEventListener('keydown', ghostKeys);
   ghost.saved = { center: map.getCenter(), zoom: map.getZoom(),
                   pitch: map.getPitch(), bearing: map.getBearing(),
                   maxPitch: map.getMaxPitch() };
   map.setMaxPitch(GHOST_MAX_PITCH);
   GHOST_HANDLERS.forEach(h => map[h] && map[h].disable());
   ghost.takeoffElev = ghostTakeoffElev(fl);
-  if (ghost.takeoffElev != null && !map.areTilesLoaded()) {
+  if (ghost.takeoffElev != null && map.areTilesLoaded
+      && !map.areTilesLoaded()) {
     // The takeoff DEM tile may not be in yet, and qte returns 0 until it
     // is (cold cache -> camera underground). Re-sample once the map
     // settles and re-apply the current pose.
@@ -370,7 +374,6 @@ function ghostEnter(flightIdx, sampleIdx) {
     ghost.savedFov = map.getVerticalFieldOfView();
     map.setVerticalFieldOfView(fl.vfov);
   }
-  window.addEventListener('keydown', ghostKeys);
   applyPose(samplePose(fl, ghost.idx));
 }
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -240,9 +240,11 @@ function buildPanel() {
 """
 
 
-def flights_to_3d_html(tracks: list[Track], title: str) -> str:
+def flights_to_3d_html(
+    tracks: list[Track], title: str, redact: str = "none"
+) -> str:
     """Return a complete 3D-terrain HTML flight map (draped tracks)."""
-    geojson = flights_to_geojson(tracks)
+    geojson = flights_to_geojson(tracks, redact=redact)
     # Escape "<" to "\\u003c" (a JSON Unicode escape) so JSON.parse round-trips
     # it while no literal "</script>" can break out of the data block.
     data = json.dumps(geojson).replace("<", "\\u003c")
@@ -262,11 +264,11 @@ def flights_to_3d_html(tracks: list[Track], title: str) -> str:
 
 
 def write_flights_3d_html(
-    tracks: list[Track], output_path: Path, title: str
+    tracks: list[Track], output_path: Path, title: str, redact: str = "none"
 ) -> Path:
     """Write *tracks* as a 3D HTML map to *output_path* and return it."""
     output_path.write_text(
-        flights_to_3d_html(tracks, title), encoding="utf-8"
+        flights_to_3d_html(tracks, title, redact=redact), encoding="utf-8"
     )
     logger.info("3D HTML flight map created: %s", output_path)
     return output_path

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -365,9 +365,14 @@ function ghostEnter(flightIdx, sampleIdx) {
   // Attach Escape/arrows before any failure-prone work: if anything below
   // throws, the user can still exit instead of a frozen handlerless map.
   window.addEventListener('keydown', ghostKeys);
-  ghost.saved = { center: map.getCenter(), zoom: map.getZoom(),
-                  pitch: map.getPitch(), bearing: map.getBearing(),
-                  maxPitch: map.getMaxPitch() };
+  if (!ghost.saved) {
+    // Survives exit -> rapid re-enter while the exit ease still runs, so
+    // a re-entry never captures a mid-transition camera as "the view to
+    // restore". Cleared only when a restore actually completes.
+    ghost.saved = { center: map.getCenter(), zoom: map.getZoom(),
+                    pitch: map.getPitch(), bearing: map.getBearing(),
+                    maxPitch: map.getMaxPitch() };
+  }
   map.setMaxPitch(GHOST_MAX_PITCH);
   GHOST_HANDLERS.forEach(h => map[h] && map[h].disable());
   ghost.takeoffElev = ghostTakeoffElev(fl);
@@ -423,8 +428,13 @@ function ghostExit() {
   map.easeTo({ center: saved.center, zoom: saved.zoom, pitch: saved.pitch,
                bearing: saved.bearing, duration: GHOST_ENTER_MS });
   map.once('moveend', () => {
+    // Interrupting this ease (MapLibre fires moveend for aborted eases
+    // too — e.g. a rapid ghost re-entry) must not restore mid-session:
+    // that would unlock the camera inside the new ghost session.
+    if (ghost.active) return;
     map.setMaxPitch(saved.maxPitch);
     GHOST_HANDLERS.forEach(h => map[h] && map[h].enable());
+    ghost.saved = null;
   });
   unmountHud();
   ghost.flight = null;

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -335,23 +335,37 @@ function ghostKeys(ev) {
   else if (ev.key === 'ArrowRight') { ghostStep(1); ev.preventDefault(); }
 }
 
-function ghostEnter(flightIdx, sampleIdx) {
-  const fl = flights[flightIdx];
-  if (ghost.active || !fl || !fl.pts) return;
-  ghost.active = true;
-  ghost.flight = fl;
-  ghost.idx = sampleIdx;
-  ghost.saved = { center: map.getCenter(), zoom: map.getZoom(),
-                  pitch: map.getPitch(), bearing: map.getBearing(),
-                  maxPitch: map.getMaxPitch() };
-  map.setMaxPitch(GHOST_MAX_PITCH);
-  GHOST_HANDLERS.forEach(h => map[h] && map[h].disable());
+function ghostTakeoffElev(fl) {
   const p0 = fl.pts[0];
   // Gate on getTerrain(): with terrain failed/off, queryTerrainElevation
   // returns 0 (spike round 3) and would fake a sea-level takeoff.
   const elev = map.getTerrain && map.getTerrain()
     ? map.queryTerrainElevation([p0[0], p0[1]]) : null;
-  ghost.takeoffElev = typeof elev === 'number' ? elev : null;
+  return typeof elev === 'number' ? elev : null;
+}
+
+function ghostEnter(flightIdx, sampleIdx) {
+  const fl = flights[flightIdx];
+  if (ghost.active || !fl || !fl.pts) return;
+  ghost.active = true;
+  ghost.flight = fl;
+  ghost.idx = Math.max(0, Math.min(sampleIdx, fl.pts.length - 1));
+  ghost.saved = { center: map.getCenter(), zoom: map.getZoom(),
+                  pitch: map.getPitch(), bearing: map.getBearing(),
+                  maxPitch: map.getMaxPitch() };
+  map.setMaxPitch(GHOST_MAX_PITCH);
+  GHOST_HANDLERS.forEach(h => map[h] && map[h].disable());
+  ghost.takeoffElev = ghostTakeoffElev(fl);
+  if (ghost.takeoffElev != null && !map.areTilesLoaded()) {
+    // The takeoff DEM tile may not be in yet, and qte returns 0 until it
+    // is (cold cache -> camera underground). Re-sample once the map
+    // settles and re-apply the current pose.
+    map.once('idle', () => {
+      if (!ghost.active || ghost.flight !== fl) return;
+      ghost.takeoffElev = ghostTakeoffElev(fl);
+      applyPose(samplePose(fl, ghost.idx));
+    });
+  }
   if (fl.vfov && typeof map.setVerticalFieldOfView === 'function') {
     ghost.savedFov = map.getVerticalFieldOfView();
     map.setVerticalFieldOfView(fl.vfov);
@@ -382,6 +396,8 @@ function ghostExit() {
                pitch: ghost.saved.pitch, bearing: ghost.saved.bearing });
   map.setMaxPitch(ghost.saved.maxPitch);   // after jumpTo: pitch is legal again
   GHOST_HANDLERS.forEach(h => map[h] && map[h].enable());
+  ghost.flight = null;
+  ghost.takeoffElev = null;
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -275,6 +275,7 @@ function buildPanel() {
 // --- Ghost Camera (#372): fly the free camera to the recorded drone pose ---
 const GHOST_MAX_PITCH = 100;  // spike: setMaxPitch(120) OK, pitch 100 honoured
 const GHOST_EST_PITCH = -30;  // assumed down-tilt when gimbal data is absent
+const GHOST_ENTER_MS = 1200, GHOST_STEP_MS = 150;
 const GHOST_HANDLERS = ['dragPan', 'dragRotate', 'scrollZoom', 'keyboard',
                         'doubleClickZoom', 'touchZoomRotate'];
 const ghost = { active: false, flight: null, idx: 0, saved: null,
@@ -385,7 +386,7 @@ function ghostEnter(flightIdx, sampleIdx) {
     ghost.savedFov = map.getVerticalFieldOfView();
     map.setVerticalFieldOfView(fl.vfov);
   }
-  applyPose(samplePose(fl, ghost.idx));
+  applyPose(samplePose(fl, ghost.idx), GHOST_ENTER_MS);
   mountHud();
 }
 
@@ -395,7 +396,7 @@ function ghostStep(d) {
   const next = Math.max(0, Math.min(ghost.idx + d, n - 1));
   if (next === ghost.idx) return;
   ghost.idx = next;
-  applyPose(samplePose(ghost.flight, next));
+  applyPose(samplePose(ghost.flight, next), GHOST_STEP_MS);
   updateHud();
 }
 
@@ -408,10 +409,13 @@ function ghostExit() {
     map.setVerticalFieldOfView(ghost.savedFov);
     ghost.savedFov = null;
   }
-  map.jumpTo({ center: ghost.saved.center, zoom: ghost.saved.zoom,
-               pitch: ghost.saved.pitch, bearing: ghost.saved.bearing });
-  map.setMaxPitch(ghost.saved.maxPitch);   // after jumpTo: pitch is legal again
-  GHOST_HANDLERS.forEach(h => map[h] && map[h].enable());
+  const saved = ghost.saved;
+  map.easeTo({ center: saved.center, zoom: saved.zoom, pitch: saved.pitch,
+               bearing: saved.bearing, duration: GHOST_ENTER_MS });
+  map.once('moveend', () => {
+    map.setMaxPitch(saved.maxPitch);
+    GHOST_HANDLERS.forEach(h => map[h] && map[h].enable());
+  });
   unmountHud();
   ghost.flight = null;
   ghost.takeoffElev = null;

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -419,6 +419,9 @@ function ghostExit() {
   if (!ghost.active) return;
   ghost.active = false;
   window.removeEventListener('keydown', ghostKeys);
+  // Keep this FOV restore ABOVE the easeTo and once('moveend') below:
+  // setVerticalFieldOfView fires moveend synchronously, and a listener
+  // registered first would consume it and self-restore mid-ease.
   if (ghost.savedFov != null
       && typeof map.setVerticalFieldOfView === 'function') {
     map.setVerticalFieldOfView(ghost.savedFov);

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -237,14 +237,15 @@ if (runs.length && maxT > 0) {
 
 
 def flights_to_html(
-    tracks: list[Track], title: str, *, tile_style: str = DEFAULT_TILE_STYLE
+    tracks: list[Track], title: str, *, tile_style: str = DEFAULT_TILE_STYLE,
+    redact: str = "none"
 ) -> str:
     """Return a complete self-contained HTML flight map.
 
     ``tile_style`` (issue #311): a :data:`~.tiles.TILE_STYLES` key selecting
     the basemap drawn under the tracks.
     """
-    geojson = flights_to_geojson(tracks)
+    geojson = flights_to_geojson(tracks, redact=redact)
     # Escape "<" to "\\u003c" (a JSON Unicode escape) so JSON.parse round-trips
     # it while no literal "</script>" can break out of the data block.
     data = json.dumps(geojson).replace("<", "\\u003c")
@@ -265,10 +266,11 @@ def write_flights_html(
     title: str,
     *,
     tile_style: str = DEFAULT_TILE_STYLE,
+    redact: str = "none"
 ) -> Path:
     """Write *tracks* as an HTML map to *output_path* and return it."""
     output_path.write_text(
-        flights_to_html(tracks, title, tile_style=tile_style), encoding="utf-8"
+        flights_to_html(tracks, title, tile_style=tile_style, redact=redact), encoding="utf-8"
     )
     logger.info("HTML flight map created: %s", output_path)
     return output_path

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -15,8 +15,11 @@ extra and are unaffected.
 import base64
 import hashlib
 import http.server
+import json
 import re
+import struct
 import threading
+import zlib
 from pathlib import Path
 
 import pytest
@@ -62,6 +65,69 @@ def _fetch_asset(url: str, integrity: str) -> Path:
     return dest
 
 
+def _dem_png(elev_m: float) -> bytes:
+    """256x256 constant-elevation PNG in mapbox raster-dem encoding.
+
+    The 3D template's terrain sources declare no ``encoding``, so MapLibre
+    decodes tiles as mapbox: h = -10000 + (R*65536 + G*256 + B) * 0.1.
+    """
+    v = round((elev_m + 10000) / 0.1)
+    r, g, b = (v >> 16) & 255, (v >> 8) & 255, v & 255
+    row = b"\x00" + bytes((r, g, b)) * 256  # filter byte 0 + RGB pixels
+    raw = row * 256
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data)) + tag + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", 256, 256, 8, 2, 0, 0, 0)  # 8-bit RGB
+    return (
+        b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(raw)) + chunk(b"IEND", b"")
+    )
+
+
+_STRIP_HILLSHADE_JS = """
+(() => {
+  // SwiftShader (headless CI WebGL) hangs when the hillshade layer renders
+  // real DEM data under pitch — MapLibre 'load' never fires. Terrain-stub
+  // runs strip hillshade: it is presentation-only for these tests.
+  const wrapMap = (M) => {
+    const W = function (opts) {
+      if (opts && opts.style && opts.style.layers) {
+        opts.style.layers = opts.style.layers.filter(
+          (l) => l.type !== 'hillshade');
+        if (opts.style.sources) delete opts.style.sources.hillshade;
+      }
+      return new M(opts);
+    };
+    W.prototype = M.prototype;
+    Object.assign(W, M);
+    return W;
+  };
+  let lib;
+  Object.defineProperty(window, 'maplibregl', {
+    configurable: true,
+    get() { return lib; },
+    set(v) {
+      lib = v;
+      if (!v || typeof v !== 'object') return;
+      if (v.Map) { v.Map = wrapMap(v.Map); return; }
+      let realMap;
+      Object.defineProperty(v, 'Map', {
+        configurable: true,
+        enumerable: true,
+        get() { return realMap; },
+        set(M) { realMap = wrapMap(M); },
+      });
+    },
+  });
+})();
+"""
+
+
 class _QuietHandler(http.server.SimpleHTTPRequestHandler):
     def log_message(self, *args):  # noqa: ARG002 - silence per-request stderr
         pass
@@ -87,11 +153,18 @@ def serve_map(map_server, page):
     """Serve an HTML string and open it, with external traffic stubbed.
 
     ``on`` targets a different Page (e.g. one from a touch-emulating
-    context) instead of the default ``page`` fixture.
+    context) instead of the default ``page`` fixture. ``terrain_stub``
+    opts into fulfilling the Mapterhorn TileJSON + DEM tile requests with
+    a constant-elevation PNG (mapbox raster-dem encoding) instead of the
+    default abort, so terrain-dependent behaviour becomes testable.
+    Terrain-stub runs also strip the ``hillshade`` source/layer before the
+    map constructs: headless SwiftShader hangs rendering it against real
+    DEM data under pitch, and it is presentation-only, so these runs never
+    see it (see ``_STRIP_HILLSHADE_JS``).
     """
     root, base_url = map_server
 
-    def _serve(html: str, *, on=None) -> str:
+    def _serve(html: str, *, on=None, terrain_stub: float | None = None) -> str:
         import uuid
 
         target = on if on is not None else page
@@ -117,6 +190,27 @@ def serve_map(map_server, page):
             return r.abort()
 
         target.route("**/*", route)
+
+        if terrain_stub is not None:
+            target.add_init_script(_STRIP_HILLSHADE_JS)
+            dem = _dem_png(terrain_stub)
+            tilejson = json.dumps({
+                "tilejson": "2.2.0",
+                "tiles": ["https://tiles.mapterhorn.com/dem/{z}/{x}/{y}.png"],
+                "minzoom": 0,
+                "maxzoom": 12,
+            }).encode()
+
+            def terrain_route(r):
+                if r.request.url.endswith("tilejson.json"):
+                    return r.fulfill(body=tilejson,
+                                     content_type="application/json")
+                return r.fulfill(body=dem, content_type="image/png")
+
+            target.route(
+                lambda u: "tiles.mapterhorn.com" in u, terrain_route
+            )
+
         url = f"{base_url}/{name}"
         target.goto(url)
         return url

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -21,6 +21,7 @@ import struct
 import threading
 import zlib
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -208,7 +209,8 @@ def serve_map(map_server, page):
                 return r.fulfill(body=dem, content_type="image/png")
 
             target.route(
-                lambda u: "tiles.mapterhorn.com" in u, terrain_route
+                lambda u: urlsplit(u).hostname == "tiles.mapterhorn.com",
+                terrain_route,
             )
 
         url = f"{base_url}/{name}"

--- a/tests/browser/test_flightmap_3d.py
+++ b/tests/browser/test_flightmap_3d.py
@@ -70,7 +70,7 @@ def test_terrain_stub_gives_real_elevation(serve_map, page):
     # queryTerrainElevation returns 0 (not null) until DEM tiles are live
     # (spike round 3), so poll for the stub's height directly.
     page.wait_for_function(
-        "() => window.map && map.queryTerrainElevation"
+        "() => typeof map !== 'undefined' && map && map.queryTerrainElevation"
         " && Math.abs(map.queryTerrainElevation([20.0, 10.0]) - 100) < 2",
         timeout=20000,
     )

--- a/tests/browser/test_flightmap_3d.py
+++ b/tests/browser/test_flightmap_3d.py
@@ -62,3 +62,17 @@ def test_3d_toggle_hides_a_flight(serve_map, page):
     assert page.evaluate(
         "() => map.getLayoutProperty('flight-0', 'visibility')"
     ) == "none"
+
+
+def test_terrain_stub_gives_real_elevation(serve_map, page):
+    html = flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 5)], "trip")
+    serve_map(html, terrain_stub=100.0)
+    # queryTerrainElevation returns 0 (not null) until DEM tiles are live
+    # (spike round 3), so poll for the stub's height directly.
+    page.wait_for_function(
+        "() => window.map && map.queryTerrainElevation"
+        " && Math.abs(map.queryTerrainElevation([20.0, 10.0]) - 100) < 2",
+        timeout=20000,
+    )
+    # Terrain did not fail, so the flat-view banner must not be up.
+    assert page.locator(".map-note").count() == 0

--- a/tests/browser/test_flightmap_ghost.py
+++ b/tests/browser/test_flightmap_ghost.py
@@ -116,7 +116,8 @@ def test_ghost_step_and_esc_restores(serve_map, page):
 def test_ghost_cold_cache_resamples_takeoff_elevation(serve_map, page):
     # Pin the cold-DEM branch: with tiles reported unloaded and the first
     # elevation query returning 0 (what MapLibre does pre-load), the pose
-    # must start from the wrong height and converge after 'idle' re-sample.
+    # must start from the wrong height and converge once the timer
+    # re-sample sees the real elevation.
     html = flights_to_3d_html(
         [_flight(gyaw=90.0, gpitch=-60.0, agl_base=50.0)], "trip"
     )
@@ -126,11 +127,9 @@ def test_ghost_cold_cache_resamples_takeoff_elevation(serve_map, page):
         " && Math.abs(map.queryTerrainElevation([20.0, 10.0]) - 100) < 2",
         timeout=20000,
     )
-    # Wait for a known-quiescent map: this test forces areTilesLoaded ->
-    # false on a map that has already settled, so the subsequent jumpTo is
-    # guaranteed to dirty it and produce a fresh 'idle'. Production never
-    # hits this state — the branch only registers while tiles are truly in
-    # flight, when further frames (and an eventual 'idle') are guaranteed.
+    # Wait for a known-quiescent map before faking a cold cache: makes the
+    # override's first read deterministic (cold -> exactly 0) independent
+    # of any loading still in flight from the waits above.
     page.wait_for_function(
         "() => map.loaded() && !map.isMoving()", timeout=10000
     )

--- a/tests/browser/test_flightmap_ghost.py
+++ b/tests/browser/test_flightmap_ghost.py
@@ -56,7 +56,7 @@ def test_ghost_button_in_popup_and_enters(serve_map, page):
 
 
 def test_ghost_pose_flat_fallback_uses_logged_altitude(serve_map, page):
-    # Terrain failed (default harness) -> queryTerrainElevation is null ->
+    # Terrain failed (default harness) -> getTerrain() is null ->
     # camera height falls back to the logged absolute altitude.
     html = flights_to_3d_html([_flight(gyaw=90.0, gpitch=-60.0)], "trip")
     _boot(serve_map, page, html)

--- a/tests/browser/test_flightmap_ghost.py
+++ b/tests/browser/test_flightmap_ghost.py
@@ -126,10 +126,11 @@ def test_ghost_cold_cache_resamples_takeoff_elevation(serve_map, page):
         " && Math.abs(map.queryTerrainElevation([20.0, 10.0]) - 100) < 2",
         timeout=20000,
     )
-    # Let the map's internal loaded()/isMoving() bookkeeping settle before
-    # racing it: triggering ghostEnter() in the same tick as the terrain
-    # query above intermittently lands inside a pending render cycle, so
-    # jumpTo() doesn't get a fresh 'idle' to hook the re-sample onto.
+    # Wait for a known-quiescent map: this test forces areTilesLoaded ->
+    # false on a map that has already settled, so the subsequent jumpTo is
+    # guaranteed to dirty it and produce a fresh 'idle'. Production never
+    # hits this state — the branch only registers while tiles are truly in
+    # flight, when further frames (and an eventual 'idle') are guaranteed.
     page.wait_for_function(
         "() => map.loaded() && !map.isMoving()", timeout=10000
     )
@@ -146,4 +147,55 @@ def test_ghost_cold_cache_resamples_takeoff_elevation(serve_map, page):
     assert first == 52  # cold: fake takeoff elev 0 + rel_alt (50 + 2)
     page.wait_for_function(
         "() => Math.abs(ghost.applied.altitude - 152) < 2", timeout=20000
+    )
+
+
+def test_ghost_hud_content_and_buttons(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight(gyaw=90.0, gpitch=-60.0, agl_base=50.0)], "trip"
+    )
+    _boot(serve_map, page, html)
+    page.evaluate("() => ghostEnter(0, 0)")
+    hud = page.locator("#ghost-hud")
+    expect(hud).to_be_visible(timeout=10000)
+    expect(hud).to_contain_text("DJI_0001")
+    expect(hud).to_contain_text("m above takeoff")
+    lon0 = page.evaluate("() => ghost.applied.lng")
+    page.locator("#ghost-next").click()
+    page.wait_for_function(
+        f"() => ghost.applied.lng > {lon0} + 0.0001",
+        timeout=10000,
+    )
+    page.locator("#ghost-exit").click()
+    page.wait_for_function("() => map.dragPan.isEnabled()", timeout=10000)
+    expect(page.locator("#ghost-hud")).to_have_count(0)
+
+
+def test_ghost_badges(serve_map, page):
+    # No gimbal data -> estimated badge; +20 deg gimbal wants pitch 110 ->
+    # clamped badge; redact="fuzz" -> fuzzed badge.
+    html = flights_to_3d_html(
+        [_flight(name="NOGIMBAL"), _flight(name="UPWARD", gpitch=20.0)],
+        "trip", redact="fuzz",
+    )
+    _boot(serve_map, page, html)
+    page.evaluate("() => ghostEnter(0, 0)")
+    expect(page.locator("#ghost-badges")).to_contain_text(
+        "estimated view", timeout=10000
+    )
+    expect(page.locator("#ghost-badges")).to_contain_text("fuzzed")
+    page.evaluate("() => ghostExit()")
+    page.evaluate("() => ghostEnter(1, 0)")
+    expect(page.locator("#ghost-badges")).to_contain_text(
+        "pitch clamped", timeout=10000
+    )
+
+
+def test_ghost_hud_logged_altitude_label(serve_map, page):
+    # No rel_alt -> the HUD must label the height "(as logged)".
+    html = flights_to_3d_html([_flight(gyaw=90.0, gpitch=-60.0)], "trip")
+    _boot(serve_map, page, html)
+    page.evaluate("() => ghostEnter(0, 0)")
+    expect(page.locator("#ghost-hud")).to_contain_text(
+        "(as logged)", timeout=10000
     )

--- a/tests/browser/test_flightmap_ghost.py
+++ b/tests/browser/test_flightmap_ghost.py
@@ -198,3 +198,33 @@ def test_ghost_hud_logged_altitude_label(serve_map, page):
     expect(page.locator("#ghost-hud")).to_contain_text(
         "(as logged)", timeout=10000
     )
+
+
+def test_ghost_rapid_reenter_keeps_lock_and_original_view(serve_map, page):
+    # MapLibre fires moveend for interrupted eases too: exiting and
+    # immediately re-entering must not run the stale exit-restore inside
+    # the new session (camera unlock), and the eventual exit must restore
+    # the ORIGINAL pre-ghost view, not a mid-transition one.
+    html = flights_to_3d_html([_flight(gyaw=90.0, gpitch=-60.0)], "trip")
+    _boot(serve_map, page, html)
+    before = page.evaluate(
+        "() => ({p: map.getPitch(), b: map.getBearing(),"
+        " mp: map.getMaxPitch()})"
+    )
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function(
+        "() => Math.abs(map.getBearing() - 90) < 0.5", timeout=10000
+    )
+    page.evaluate("() => { ghostExit(); ghostEnter(0, 2); }")
+    # The stale moveend (if unguarded) fires synchronously inside the
+    # re-enter's easeTo, so these asserts are deterministic.
+    assert page.evaluate("() => map.dragPan.isEnabled()") is False
+    assert page.evaluate("() => map.getMaxPitch()") == 100
+    page.evaluate("() => ghostExit()")
+    page.wait_for_function(
+        f"() => map.dragPan.isEnabled()"
+        f" && Math.abs(map.getPitch() - {before['p']}) < 0.5"
+        f" && Math.abs(map.getBearing() - {before['b']}) < 0.5"
+        f" && map.getMaxPitch() === {before['mp']}",
+        timeout=10000,
+    )

--- a/tests/browser/test_flightmap_ghost.py
+++ b/tests/browser/test_flightmap_ghost.py
@@ -1,0 +1,113 @@
+"""Ghost Camera cockpit view (#372) in headless Chromium.
+
+Pose assertions poll via wait_for_function so they hold for both the
+jump-cut implementation and the eased one added later.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect  # noqa: E402
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+
+def _flight(name="DJI_0001", *, points=5, gyaw=None, gpitch=None,
+            agl_base=None, focal=None):
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name=name, points=[
+        TrackPoint(
+            lat=10.0, lon=20.0 + i * 0.0006, alt=100.0 + i,
+            timestamp=f"00:00:{i:02d},000",
+            utc=t0 + timedelta(seconds=i * 10.0),
+            gimbal_yaw=gyaw, gimbal_pitch=gpitch,
+            rel_alt=None if agl_base is None else agl_base + i,
+            focal_len=focal,
+        )
+        for i in range(points)
+    ])
+
+
+def _boot(serve_map, page, html, **kw):
+    serve_map(html, **kw)
+    expect(page.locator("#flights-panel")).to_be_visible(timeout=20000)
+
+
+def test_ghost_button_in_popup_and_enters(serve_map, page):
+    html = flights_to_3d_html([_flight(gyaw=90.0, gpitch=-60.0)], "trip")
+    _boot(serve_map, page, html)
+    xy = page.evaluate(
+        "() => { const p = map.project([20.0012, 10.0]);"
+        " return [p.x, p.y]; }"
+    )
+    page.mouse.click(xy[0], xy[1])
+    btn = page.locator(".maplibregl-popup .ghost-open")
+    expect(btn).to_be_visible(timeout=10000)
+    btn.click()
+    page.wait_for_function(
+        "() => Math.abs(map.getBearing() - 90) < 0.5", timeout=10000
+    )
+
+
+def test_ghost_pose_flat_fallback_uses_logged_altitude(serve_map, page):
+    # Terrain failed (default harness) -> queryTerrainElevation is null ->
+    # camera height falls back to the logged absolute altitude.
+    html = flights_to_3d_html([_flight(gyaw=90.0, gpitch=-60.0)], "trip")
+    _boot(serve_map, page, html)
+    page.evaluate("() => ghostEnter(0, 2)")
+    page.wait_for_function(
+        "() => ghost.applied && Math.abs(ghost.applied.altitude - 102) < 0.5"
+        " && Math.abs(map.getBearing() - 90) < 0.5"
+        " && Math.abs(map.getPitch() - 30) < 0.5",
+        timeout=10000,
+    )
+
+
+def test_ghost_pose_uses_terrain_plus_agl(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight(gyaw=90.0, gpitch=-60.0, agl_base=50.0)], "trip"
+    )
+    _boot(serve_map, page, html, terrain_stub=100.0)
+    # Poll for the stub's height: qte returns 0 (not null) pre-load.
+    page.wait_for_function(
+        "() => map.queryTerrainElevation"
+        " && Math.abs(map.queryTerrainElevation([20.0, 10.0]) - 100) < 2",
+        timeout=20000,
+    )
+    page.evaluate("() => ghostEnter(0, 2)")
+    # takeoff terrain 100 m + rel_alt (50 + 2) = 152 m.
+    page.wait_for_function(
+        "() => ghost.applied && Math.abs(ghost.applied.altitude - 152) < 2",
+        timeout=10000,
+    )
+
+
+def test_ghost_step_and_esc_restores(serve_map, page):
+    html = flights_to_3d_html([_flight(gyaw=90.0, gpitch=-60.0)], "trip")
+    _boot(serve_map, page, html)
+    before = page.evaluate(
+        "() => ({b: map.getBearing(), p: map.getPitch(), z: map.getZoom()})"
+    )
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function(
+        "() => Math.abs(map.getBearing() - 90) < 0.5", timeout=10000
+    )
+    assert page.evaluate("() => map.dragPan.isEnabled()") is False
+    lon0 = page.evaluate("() => ghost.applied.lng")
+    page.keyboard.press("ArrowRight")
+    page.wait_for_function(
+        f"() => ghost.applied.lng > {lon0} + 0.0001", timeout=10000
+    )
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        f"() => map.dragPan.isEnabled()"
+        f" && Math.abs(map.getPitch() - {before['p']}) < 0.5"
+        f" && Math.abs(map.getBearing() - {before['b']}) < 0.5",
+        timeout=10000,
+    )

--- a/tests/browser/test_flightmap_ghost.py
+++ b/tests/browser/test_flightmap_ghost.py
@@ -111,3 +111,39 @@ def test_ghost_step_and_esc_restores(serve_map, page):
         f" && Math.abs(map.getBearing() - {before['b']}) < 0.5",
         timeout=10000,
     )
+
+
+def test_ghost_cold_cache_resamples_takeoff_elevation(serve_map, page):
+    # Pin the cold-DEM branch: with tiles reported unloaded and the first
+    # elevation query returning 0 (what MapLibre does pre-load), the pose
+    # must start from the wrong height and converge after 'idle' re-sample.
+    html = flights_to_3d_html(
+        [_flight(gyaw=90.0, gpitch=-60.0, agl_base=50.0)], "trip"
+    )
+    _boot(serve_map, page, html, terrain_stub=100.0)
+    page.wait_for_function(
+        "() => map.queryTerrainElevation"
+        " && Math.abs(map.queryTerrainElevation([20.0, 10.0]) - 100) < 2",
+        timeout=20000,
+    )
+    # Let the map's internal loaded()/isMoving() bookkeeping settle before
+    # racing it: triggering ghostEnter() in the same tick as the terrain
+    # query above intermittently lands inside a pending render cycle, so
+    # jumpTo() doesn't get a fresh 'idle' to hook the re-sample onto.
+    page.wait_for_function(
+        "() => map.loaded() && !map.isMoving()", timeout=10000
+    )
+    first = page.evaluate(
+        """() => {
+      map.areTilesLoaded = () => false;
+      const real = map.queryTerrainElevation.bind(map);
+      let cold = true;
+      map.queryTerrainElevation = ll => (cold ? (cold = false, 0) : real(ll));
+      ghostEnter(0, 2);
+      return ghost.applied.altitude;
+    }"""
+    )
+    assert first == 52  # cold: fake takeoff elev 0 + rel_alt (50 + 2)
+    page.wait_for_function(
+        "() => Math.abs(ghost.applied.altitude - 152) < 2", timeout=20000
+    )

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -421,3 +421,72 @@ def test_writers_create_files(tmp_path):
     kml = write_flights_kml(tracks, tmp_path / "f.kml", title="t")
     assert json.loads(geo.read_text(encoding="utf-8"))["type"] == "FeatureCollection"
     assert "<kml" in kml.read_text(encoding="utf-8")
+
+
+def _ghost_track(**overrides):
+    from datetime import datetime, timedelta
+
+    from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    defaults = dict(gimbal_yaw=None, gimbal_pitch=None, rel_alt=None,
+                    focal_len=None)
+    defaults.update(overrides)
+    pts = [
+        TrackPoint(lat=10.0, lon=20.0 + i * 0.001, alt=100.0 + i,
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=float(i)), **defaults)
+        for i in range(3)
+    ]
+    return Track(name="GHOST", points=pts)
+
+
+def test_geojson_pose_arrays_rounded_and_aligned():
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+    from dji_metadata_embedder.geo.track import Track, TrackPoint
+    from datetime import datetime
+
+    pts = [
+        TrackPoint(lat=10.0, lon=20.0, alt=100.0, timestamp="00:00:00,000",
+                   utc=datetime(2026, 6, 15, 12, 0, 0),
+                   gimbal_yaw=90.0, gimbal_pitch=-60.0, rel_alt=50.0),
+        TrackPoint(lat=10.0, lon=20.001, alt=101.0, timestamp="00:00:01,000",
+                   utc=datetime(2026, 6, 15, 12, 0, 1),
+                   gimbal_yaw=91.56, gimbal_pitch=None, rel_alt=51.234),
+    ]
+    fc = flights_to_geojson([Track(name="GHOST", points=pts)])
+    props = fc["features"][0]["properties"]
+    assert props["gyaw_deg"] == [90.0, 91.6]
+    assert props["gpitch_deg"] == [-60.0, None]  # null-padded, stays aligned
+    assert props["agl_m"] == [50.0, 51.2]
+    n = len(fc["features"][0]["geometry"]["coordinates"])
+    assert len(props["gyaw_deg"]) == len(props["agl_m"]) == n
+
+
+def test_geojson_pose_arrays_absent_without_data():
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    fc = flights_to_geojson([_ghost_track()])
+    props = fc["features"][0]["properties"]
+    for key in ("gyaw_deg", "gpitch_deg", "agl_m", "vfov_deg"):
+        assert key not in props
+
+
+def test_geojson_pose_arrays_not_on_single_fix_point():
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    track = _ghost_track(gimbal_yaw=45.0, gimbal_pitch=-30.0, rel_alt=20.0)
+    track.points = track.points[:1]
+    fc = flights_to_geojson([track])
+    assert fc["features"][0]["geometry"]["type"] == "Point"
+    for key in ("gyaw_deg", "gpitch_deg", "agl_m", "vfov_deg"):
+        assert key not in fc["features"][0]["properties"]
+
+
+def test_geojson_vfov_from_median_focal():
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    fc = flights_to_geojson([_ghost_track(focal_len=24.0)])
+    # DEFAULT_LENS aspect 4:3 -> full-frame height 27 mm;
+    # vfov = 2*atan(27 / (2*24)) = 58.7 deg.
+    assert fc["features"][0]["properties"]["vfov_deg"] == 58.7

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -490,3 +490,17 @@ def test_geojson_vfov_from_median_focal():
     # DEFAULT_LENS aspect 4:3 -> full-frame height 27 mm;
     # vfov = 2*atan(27 / (2*24)) = 58.7 deg.
     assert fc["features"][0]["properties"]["vfov_deg"] == 58.7
+
+
+def test_geojson_redacted_property():
+    assert flights_to_geojson([_ghost_track()])["redacted"] == "none"
+    assert (
+        flights_to_geojson([_ghost_track()], redact="fuzz")["redacted"]
+        == "fuzz"
+    )
+
+
+def test_write_flights_geojson_threads_redact(tmp_path):
+    out = tmp_path / "flights.geojson"
+    write_flights_geojson([_ghost_track()], out, redact="fuzz")
+    assert json.loads(out.read_text(encoding="utf-8"))["redacted"] == "fuzz"

--- a/tests/test_geo_flightmap3d_html.py
+++ b/tests/test_geo_flightmap3d_html.py
@@ -83,9 +83,12 @@ def test_3d_html_has_flight_toggle_panel():
 
 
 def test_3d_html_does_not_render_at_altitude():
-    # Spec amendment: draped tracks only — anchoring/elevation code is banned.
+    # Spec amendment: draped tracks only — line geometry never anchors at
+    # elevation. Ghost Camera (#372) legitimately calls
+    # queryTerrainElevation for camera placement (see
+    # tests/browser/test_flightmap_ghost.py); that's a separate concern
+    # from how track *lines* render, which this still guards.
     html = flights_to_3d_html([_track()], "t")
-    assert "queryTerrainElevation" not in html
     assert "line-z-offset" not in html
 
 


### PR DESCRIPTION
Closes #372. Spec: `docs/superpowers/specs/2026-07-26-ghost-camera-lite-design.md` (first commit on this branch, amended post-spike).

## What

- **"View from here"** button in the 3D map's track popups: the camera flies to the drone's exact recorded pose — position, terrain-anchored height (terrain-at-takeoff + AGL, never DJI's raw absolute altitude when avoidable), gimbal bearing/pitch, and the flight's real vertical FOV — then ←/→ / ‹ › scrub the flight from the cockpit. Esc/× eases back to the overview.
- **Honesty-badge HUD**: always the recorded values; badges for "pitch clamped to 100°", "estimated view — no gimbal data", "position fuzzed ~100 m" (from the new top-level `redacted` GeoJSON member).
- **Data side**: `flights_to_geojson` gains per-point `gyaw_deg`/`gpitch_deg`/`agl_m` (null-padded `times_s` pattern), per-flight `vfov_deg` (median focal via the footprint lens model), and `redacted` threaded through all writers + CLI.
- **Harness**: opt-in constant-elevation terrain stub (hand-rolled mapbox-encoded DEM PNG) so the terrain path is deterministically tested; SwiftShader hillshade hang worked around test-side.

## Notable engineering finds (all pinned by tests)

- MapLibre GL JS never ported Mapbox's free-camera API (upstream maplibre-gl-js#1414) — exact pose placement uses `calculateCameraOptionsFromCameraLngLatAltRotation` + `jumpTo`/`easeTo`, with **explicit `roll=0`** (5.24.0 emits a `roll` key even when omitted → `setRoll(NaN)` crash).
- `queryTerrainElevation` returns **0, not null**, with terrain off/cold — pose logic gates on `map.getTerrain()` and re-samples on a bounded timer (MapLibre's `idle` can park under eased transitions before late DEM tiles land).
- MapLibre fires `moveend` for **interrupted** eases too — rapid exit→re-enter is guarded (persist-until-restored saved view + active-session guard) so the cockpit lock can't drop mid-session.

## Verification

- Gate: ruff, mypy, 701 passed (4 CI legs' suite), browser suite 22/22 incl. new ghost tests (pose math vs terrain stub, cold-cache re-sample pin, rapid re-enter regression, HUD badges).
- Subagent-driven build: per-task spec+quality reviews, adversarial whole-branch final review — READY TO MERGE, zero Critical/Important.

## Manual checklist (Marcus)

- [ ] Real-footage ridgeline test: open `C:\TEMP\GhostTest\flightmap-3d.html` (generated from the fresh D:\ flights), enter ghost view, compare rendered terrain to the actual footage skyline.
- [ ] WebView2 spot-check: GUI → Flightmap → 3D toggle → preview → ghost view behaves (piggybacks the pending #366 real-hardware check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rwc2fGM8qwTtSH7fkX7Waz