### PR TITLE
Flight sculpture: AGL curtain + true-altitude ribbon in the 3D map (#375)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -307,8 +307,10 @@ rising ground and the curtain visibly shortens as the clearance closes.
 
 Where the terrain model is unavailable the curtain falls back to plain height
 above takeoff. Segments where the drone works out to be at or below the
-rendered ground — a rooftop launch, or a datum artefact near a cliff — are
-left out rather than drawn flat, so the curtain breaks there.
+rendered ground — a rooftop launch, a datum artefact near a cliff, or a low
+flight over forest (the terrain model is a surface model, so it includes tree
+canopy and buildings) — are left out rather than drawn flat, so the curtain
+breaks there.
 
 Use the **Sculpture** checkbox in the flights panel to hide it. A flight's own
 checkbox hides its track and its sculpture together, and the sculpture steps

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -290,6 +290,30 @@ was generated with `--redact fuzz`). Heights come from the terrain model plus
 the logged height above takeoff; without terrain, the logged altitude is used
 as-is.
 
+### Flight sculpture — altitude you can see
+
+The 3D map draws each flight as a **sculpture**: a translucent curtain rising
+from the ground to the drone, capped by a solid ribbon at flight altitude, in
+the flight's own colour. Draped tracks all look alike from above — a 30 m
+hover and a 300 m transit trace the same line. The curtain gives that line a
+height, so the shape of the flight stands up out of the landscape.
+
+Curtain height is the logged height **above takeoff** (`rel_alt`), measured
+from the terrain surface beneath it rather than from sea level. That keeps the
+sculpture honest over hills: it stands on the ground the drone actually flew
+over, so it cannot drift from the terrain the way an absolute altitude with a
+mismatched datum would.
+
+Use the **Sculpture** checkbox in the flights panel to hide it. A flight's own
+checkbox hides its track and its sculpture together, and the sculpture steps
+out of the way while you are in the ghost view.
+
+Flights whose SRT format carries no `rel_alt` get no sculpture; if none of the
+flights on a map has it, the checkbox does not appear at all.
+
+Terrain hides the sculpture the way it hides anything else: a ridge between
+you and the flight blocks it from view.
+
 ## Photo map (`photomap`)
 
 ```bash

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -298,11 +298,17 @@ the flight's own colour. Draped tracks all look alike from above — a 30 m
 hover and a 300 m transit trace the same line. The curtain gives that line a
 height, so the shape of the flight stands up out of the landscape.
 
-Curtain height is the logged height **above takeoff** (`rel_alt`), measured
-from the terrain surface beneath it rather than from sea level. That keeps the
-sculpture honest over hills: it stands on the ground the drone actually flew
-over, so it cannot drift from the terrain the way an absolute altitude with a
-mismatched datum would.
+The ribbon sits at the drone's true altitude, and the curtain beneath it
+measures real ground clearance. The map derives that from the logged height
+above takeoff (`rel_alt`) plus the terrain elevation at the takeoff point,
+which keeps it consistent with the landscape you are looking at instead of
+trusting an absolute altitude whose datum may not match. Fly level toward
+rising ground and the curtain visibly shortens as the clearance closes.
+
+Where the terrain model is unavailable the curtain falls back to plain height
+above takeoff. Segments where the drone works out to be at or below the
+rendered ground — a rooftop launch, or a datum artefact near a cliff — are
+left out rather than drawn flat, so the curtain breaks there.
 
 Use the **Sculpture** checkbox in the flights panel to hide it. A flight's own
 checkbox hides its track and its sculpture together, and the sculpture steps

--- a/docs/superpowers/specs/2026-07-26-flight-sculpture-design.md
+++ b/docs/superpowers/specs/2026-07-26-flight-sculpture-design.md
@@ -158,7 +158,7 @@ when you zoom out to see the whole flight, too wide and it is a slab up close.
 
 ### 3. Layers and controls
 
-Two layers per flight, `sculpture-curtain-<i>` and `sculpture-ribbon-<i>`,
+Two layers per flight, `sculpt-<i>-curtain` and `sculpt-<i>-ribbon`,
 added after the flight's track layer. Per-flight layers (rather than two
 shared layers filtered by a property) keep the existing panel checkbox logic —
 which today flips one `visibility` — a straight extension.
@@ -192,7 +192,8 @@ which today flips one `visibility` — a straight extension.
 ## Testing
 
 - **Browser suite:** sculpture layers exist with type `fill-extrusion`;
-  per-segment `height` tracks `agl_m`; the global toggle hides and restores;
+  per-segment `height` tracks the converted `hgt`; the global toggle hides
+  and restores;
   a per-flight checkbox hides that flight's sculpture; per-flight state
   survives a global off/on cycle; ghost enter hides the sculpture and exit
   restores it; a flight without AGL produces no sculpture layers and no

--- a/docs/superpowers/specs/2026-07-26-flight-sculpture-design.md
+++ b/docs/superpowers/specs/2026-07-26-flight-sculpture-design.md
@@ -98,6 +98,37 @@ thickness would compute a negative base. Clamped, such a segment renders as a
 ground-standing block, which is what a 4 m hover should look like.
 
 Mean AGL per segment matches the centroid-sampling the shader already does.
+
+**Amendment 2026-07-26 (post-Task-6 review): heights are converted to true
+altitude.** As first written this design put `agl_m` straight into
+`fill-extrusion-height`, which was wrong. `agl_m` is height above the
+*takeoff point*, but `fill-extrusion` anchors to the *local terrain under
+each segment*, so the curtain top landed at `local_ground + rel_alt` instead
+of the drone's real altitude of `takeoff_elevation + rel_alt`. The two agree
+only where the ground sits at takeoff level.
+
+That is not merely a labelling error. DJI drones hold altitude, not ground
+clearance, so a level flight toward a rising ridge keeps a constant `rel_alt`
+while its real clearance shrinks. The original geometry would have drawn a
+constant-height curtain riding up the hillside — showing steady clearance
+exactly where the truth is a closing gap, which inverts the safety-relevant
+reading in a feature framed around verification.
+
+Each segment's extrusion height is therefore
+`(takeoff_elevation + mean_AGL) - local_terrain_elevation`, both elevations
+read with `map.queryTerrainElevation` (gated on `map.getTerrain()`, since it
+returns 0 rather than null when terrain is off or tiles are cold). The
+shader then re-adds the local elevation, so the top lands at true altitude
+and the curtain's length is genuine ground clearance. With terrain
+unavailable both elevations are absent and the height falls back to plain
+`mean_AGL`, which is correct there because `get_elevation` returns 0. A
+segment computing a non-positive height — below the rendered surface, from a
+datum artefact or a rooftop launch — is skipped rather than drawn flat.
+
+Cold DEM tiles make the first build a flat-mode approximation, so the
+sculpture re-samples on a bounded timer and rebuilds once tiles land. `idle`
+is not usable for this: it parks under the load-time `fitBounds` ease, a
+gotcha established in #372.
 Tracks are decimated to one point per second upstream (`_decimate_points`), so
 a 20-minute flight yields ~1200 segments — well inside `fill-extrusion`'s
 building-scale budget.

--- a/docs/superpowers/specs/2026-07-26-flight-sculpture-design.md
+++ b/docs/superpowers/specs/2026-07-26-flight-sculpture-design.md
@@ -1,0 +1,180 @@
+# Flightmap 3D "flight sculpture" — design
+
+**Date:** 2026-07-26
+**Issue:** [#375](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/375)
+**Status:** Approved
+
+## Problem
+
+The 3D flight map (#268, v2.1.0) drapes tracks on the terrain surface because
+MapLibre cannot render line layers at altitude (upstream
+maplibre/maplibre-gl-js#644). Ghost Camera (#372) put the viewer *at* the
+drone's altitude, but the flight's shape in the air is still invisible from
+the outside: from the overview camera a 30 m hover and a 300 m transit look
+identical.
+
+The **flight sculpture** makes altitude a thing you can see: a translucent
+light curtain rising from the ground to the drone, capped by a solid ribbon at
+true flight altitude. It reads as an object over the landscape — the shape of
+the flight, standing up out of the terrain — while remaining a literal plot of
+recorded `rel_alt`. Verification made visual again, per the project's
+use-for-good direction: a curtain that stands on the ground where the drone
+was tells you the altitude telemetry agrees with the terrain.
+
+This is stage 2 of the 3D arc agreed 2026-07-26. Later stages (separate
+specs): "Camera's Gaze" footprint-sweep playback and search-footage-by-place,
+then crossfading a ghost pose to the real photo/video frame.
+
+## Scope
+
+- Sculpture geometry in the **3D template only**, built in JS at load time.
+- No new GeoJSON properties, no new CLI flags, no new dependencies, no new
+  pinned assets (SRI-count test unchanged). Ships inside the existing `--3d`
+  output; the GUI gets it through the 3D toggle and WebView preview.
+- One new global toggle in the existing flights panel.
+
+Out of scope (deferred): colour ramps encoding speed/altitude/time, animation
+or playback of the sculpture, any 2D-map changes, altitude geometry in the
+`-f geojson` export, media crossfade.
+
+## Design
+
+### 1. Vehicle — `fill-extrusion`, not a custom WebGL layer
+
+The arc notes assumed a small hand-rolled custom WebGL layer (anti-bloat: no
+deck.gl). A spike against the pinned MapLibre 5.24.0 UMD build, run through
+the `terrain_stub` browser fixture Ghost Camera added, ruled that out.
+
+**Custom `'3d'` layers are unusable with terrain enabled.** MapLibre calls the
+layer's `render()` and the matrix is correct, but with the default depth state
+every fragment is depth-rejected: nothing draws, at any altitude. Confirmed by
+reading the centre pixel back immediately after `drawArrays` — it still holds
+the already-composited terrain scene, so the rejection is against terrain's
+depth, not a projection error. The escape hatches each cost something:
+
+| mode (terrain on) | near quad | far quad | verdict |
+| --- | --- | --- | --- |
+| MapLibre default | 0 px | 0 px | invisible |
+| `disable(DEPTH_TEST)` | 1506 px | 8346 px | draws, far paints over near |
+| `clear(DEPTH_BUFFER_BIT)` | 8142 px | 1710 px | self-sorts, no terrain occlusion |
+
+(The `clear` row matches the terrain-off baseline of 8088/1730, i.e. correct
+self-sorting.) A custom layer can be visible, self-sorted, or terrain-occluded
+— never all three.
+
+**`fill-extrusion` renders correctly under terrain** and carries data-driven
+`-base` and `-height`, verified in the same spike. Its vertex shader applies
+`get_elevation(a_centroid)`, so base and height are measured **from the
+terrain surface, not sea level**, with elevation sampled at each polygon's
+centroid. That is exactly the semantics the sculpture wants: the `agl_m` array
+Ghost Camera already emits drops straight in, with no `queryTerrainElevation`
+calls and none of the cold-DEM race that cost Ghost Camera a review round.
+
+Both custom layers and `fill-extrusion` are absent from MapLibre's
+render-to-texture whitelist (`background`, `fill`, `line`, `raster`,
+`hillshade`, `color-relief`), so both draw in the main pass after the terrain
+mesh; only `fill-extrusion` survives it.
+
+### 2. Geometry — 3D template JS (`geo/flightmap3d_html.py`)
+
+Built in JS at load time from the flight entry's existing `pts` (full
+`[lon, lat, alt]` triples) and `agl` arrays. Nothing is added to the embedded
+GeoJSON, so archive-scale files do not grow and the `flights_to_geojson`
+contract is untouched.
+
+For each consecutive point pair where **both** ends have a non-null AGL, one
+rectangular "plank" polygon centred on the segment, of width *W* (below),
+carrying the pair's mean AGL as a property. Both layers read that one feature
+through different expressions, so the geometry is built and stored once:
+
+| layer | `fill-extrusion-base` | `fill-extrusion-height` | opacity | vertical-gradient |
+| --- | --- | --- | --- | --- |
+| curtain | `0` | `['get', 'agl']` | 0.35 | on |
+| ribbon | `['max', 0, ['-', ['get', 'agl'], 6]]` | `['get', 'agl']` | 1.0 | off |
+
+The ribbon's base is clamped at 0 because `fill-extrusion-base` has a
+style-spec minimum of 0 — without the clamp a hover below the 6 m ribbon
+thickness would compute a negative base. Clamped, such a segment renders as a
+ground-standing block, which is what a 4 m hover should look like.
+
+Mean AGL per segment matches the centroid-sampling the shader already does.
+Tracks are decimated to one point per second upstream (`_decimate_points`), so
+a 20-minute flight yields ~1200 segments — well inside `fill-extrusion`'s
+building-scale budget.
+
+**Colour and the fade.** Each flight keeps the identity colour it already has
+in the panel and the 2D map, applied per feature via `['get', ...]`. The
+ground-ward fade comes from MapLibre's built-in
+`fill-extrusion-vertical-gradient`, which darkens an extrusion's sides toward
+its base. A true alpha fade is not available: the fill-extrusion fragment
+shader hardcodes `v_color`'s alpha to `1.0` (so `fill-extrusion-color` alpha
+is ignored) and `fill-extrusion-opacity` is `data-constant`, i.e. layer-level
+only. Stacking banded layers at different opacities would buy a real alpha
+ramp at 3× the geometry plus z-fighting at the seams; the built-in gradient is
+taken instead. Note the gradient term saturates for tall extrusions
+(`pow(height/150, 0.5)`), so on high flights the fade concentrates in the
+lower part of the curtain — acceptable, and honest about where the ground is.
+
+**Width is zoom-adaptive.** *W* is recomputed on `zoomend` to hold roughly 3
+screen pixels, clamped to [4 m, 60 m], and pushed with `setData`. A fixed
+metre width fails at both ends: too thin and the sculpture vanishes exactly
+when you zoom out to see the whole flight, too wide and it is a slab up close.
+
+### 3. Layers and controls
+
+Two layers per flight, `sculpture-curtain-<i>` and `sculpture-ribbon-<i>`,
+added after the flight's track layer. Per-flight layers (rather than two
+shared layers filtered by a property) keep the existing panel checkbox logic —
+which today flips one `visibility` — a straight extension.
+
+- **Per-flight checkbox** (existing): hides that flight's track *and* both of
+  its sculpture layers together.
+- **Global "Sculpture" checkbox** (new, appended to the panel below a
+  separator): hides every sculpture layer, respecting per-flight state — a
+  flight already unchecked stays hidden when the sculpture is switched back
+  on. On by default: showing the flight's relationship to the terrain is what
+  `--3d` is for.
+- **Ghost mode**: entering hides all sculpture layers (a solid ribbon at the
+  camera's exact altitude would sit across the cockpit view), exiting restores
+  them subject to both toggles.
+
+### 4. Failure posture and edge cases
+
+- **No AGL for a flight** (SRT variants without `rel_alt`): that flight gets no
+  sculpture layers. If *no* flight has AGL, the global toggle is not added at
+  all rather than offering a control that does nothing.
+- **Null AGL at a point:** the segment is skipped, breaking the curtain there
+  rather than interpolating across a gap of unknown length.
+- **Single-fix `Point` flights:** no sculpture (no segments), same exclusion as
+  `times_s` and the ghost arrays.
+- **Terrain unavailable:** the existing flat-view banner already covers it, and
+  the sculpture degrades correctly — `get_elevation` returns 0, so extrusions
+  sit on the flat plane at the same AGL.
+- **`redact="fuzz"`:** coordinates are already fuzzed upstream in `Track`, so
+  the sculpture inherits the fuzzing with no special handling.
+
+## Testing
+
+- **Browser suite:** sculpture layers exist with type `fill-extrusion`;
+  per-segment `height` tracks `agl_m`; the global toggle hides and restores;
+  a per-flight checkbox hides that flight's sculpture; per-flight state
+  survives a global off/on cycle; ghost enter hides the sculpture and exit
+  restores it; a flight without AGL produces no sculpture layers and no
+  toggle; zoom change updates the plank width. SRI-count test unchanged.
+- **New fixture — stepped DEM.** The existing `terrain_stub` serves a constant
+  elevation, which cannot test occlusion at all. A stepped variant (two
+  elevations across a tile boundary, tilejson `maxzoom` raised so a step falls
+  inside the viewport) settles the one open risk: whether terrain occludes the
+  extrusions, i.e. whether a ridge hides the ribbon behind it. The fixture is
+  reusable for the rest of the arc. If occlusion turns out not to work, the
+  sculpture still ships — it would read as an X-ray view through hills, which
+  is a visual regret, not a correctness bug — and the finding is recorded.
+- **E2E:** Marcus eyeballs the real hilly-terrain footage staged for #372; the
+  curtain standing on the ground under the track is the acceptance criterion.
+  WebView2 behaviour piggybacks on the pending #366 hardware check.
+
+## Docs
+
+Flightmap docs section covering what the sculpture shows, that curtain height
+is AGL (not absolute altitude) and why, the toggle, and the no-`rel_alt`
+limitation. `docs/geospatial.md`, beside the Ghost camera section.

--- a/docs/superpowers/specs/2026-07-26-flight-sculpture-design.md
+++ b/docs/superpowers/specs/2026-07-26-flight-sculpture-design.md
@@ -84,13 +84,18 @@ contract is untouched.
 
 For each consecutive point pair where **both** ends have a non-null AGL, one
 rectangular "plank" polygon centred on the segment, of width *W* (below),
-carrying the pair's mean AGL as a property. Both layers read that one feature
-through different expressions, so the geometry is built and stored once:
+carrying its height as a property. Both layers read that one feature through
+different expressions, so the geometry is built and stored once:
 
 | layer | `fill-extrusion-base` | `fill-extrusion-height` | opacity | vertical-gradient |
 | --- | --- | --- | --- | --- |
-| curtain | `0` | `['get', 'agl']` | 0.35 | on |
-| ribbon | `['max', 0, ['-', ['get', 'agl'], 6]]` | `['get', 'agl']` | 1.0 | off |
+| curtain | `0` | `['get', 'hgt']` | 0.35 | on |
+| ribbon | `['get', 'rbase']` | `['get', 'hgt']` | 1.0 | off |
+
+(`hgt` is height above the local surface — see the amendment below, which
+replaced the original raw `agl` with a true-altitude conversion. `rbase` is
+the ribbon's clamped base, computed in JS rather than as a `max` expression
+so no expression-language support needs assuming.)
 
 The ribbon's base is clamped at 0 because `fill-extrusion-base` has a
 style-spec minimum of 0 — without the clamp a hover below the 6 m ribbon

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -371,8 +371,9 @@ function ghostKeys(ev) {
 }
 
 function terrainElevAt(lngLat) {
-  // Gate on getTerrain(): queryTerrainElevation returns 0, not null, when
-  // terrain is off or its tiles are still cold (#372 spike round 3).
+  // Gate on getTerrain(): queryTerrainElevation returns null when terrain is
+  // off, but 0 (not null) when terrain is on and its tiles are still cold
+  // (#372 spike round 3).
   if (!(map.getTerrain && map.getTerrain())) return null;
   const e = map.queryTerrainElevation(lngLat);
   return typeof e === 'number' ? e : null;
@@ -606,9 +607,14 @@ function planksFor(fl, widthM) {
 }
 
 function addSculpture(fl, fi) {
+  // Gate on the DATA, not on this build's output: with terrain in play a
+  // build can legitimately come back empty (canopy-height flight, cold
+  // tiles) and a later settle must still be able to populate it. Bailing
+  // here would strand the flight without a source, and with it the panel's
+  // Sculpture toggle.
+  if (!(fl.pts && fl.agl && fl.agl.some(v => v != null))) return;
   if (sculpture.widthM == null) sculpture.widthM = sculptWidthM();
   const feats = planksFor(fl, sculpture.widthM);
-  if (!feats.length) return;
   const src = 'sculpt-' + fi;
   map.addSource(src, { type: 'geojson',
     data: { type: 'FeatureCollection', features: feats } });
@@ -661,16 +667,26 @@ function rebuildSculpture() {
 }
 
 function sculptSettle() {
-  // Cold DEM tiles make queryTerrainElevation return 0, so the first build
+  // Cold DEM tiles make queryTerrainElevation answer 0, so the first build
   // is a flat-mode approximation. Re-sample on a bounded timer and rebuild
-  // once tiles land. 'idle' cannot be used: it parks under the load-time
-  // fitBounds ease (#372). A genuine sea-level takeoff is indistinguishable
-  // from "not loaded yet" here, and simply keeps the first build.
+  // when the terrain firms up. 'idle' cannot be used: it parks under the
+  // load-time fitBounds ease (#372). areTilesLoaded() alone is not enough
+  // either -- it counts errored tiles as loaded and can flicker true before
+  // the DEM is usable -- so require a non-zero sample. A genuine sea-level
+  // takeoff is indistinguishable from "not loaded yet" and simply settles
+  // on the final pass. A partially warm DEM can also give mixed readings
+  // (inflated heights, or segments briefly dropped); the rebuild fixes it.
   if (!(map.getTerrain && map.getTerrain())) return;
+  const probe = flights.find(fl => fl.pts && fl.agl);
+  if (!probe) return;
   let tries = 20;
   const retry = () => {
-    if (map.areTilesLoaded && map.areTilesLoaded()) { setSculptData(); return; }
-    if (--tries > 0) setTimeout(retry, 250);
+    const e = takeoffElev(probe);
+    if ((typeof e === 'number' && e !== 0) || --tries <= 0) {
+      setSculptData();
+      return;
+    }
+    setTimeout(retry, 250);
   };
   setTimeout(retry, 250);
 }

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -382,13 +382,13 @@ function ghostEnter(flightIdx, sampleIdx) {
   const fl = flights[flightIdx];
   if (ghost.active || !fl || !fl.pts) return;
   ghost.active = true;
-  applySculptVisibility();   // a ribbon at the camera's own altitude would
-                            // sit across the cockpit view
   ghost.flight = fl;
   ghost.idx = Math.max(0, Math.min(sampleIdx, fl.pts.length - 1));
   // Attach Escape/arrows before any failure-prone work: if anything below
   // throws, the user can still exit instead of a frozen handlerless map.
   window.addEventListener('keydown', ghostKeys);
+  applySculptVisibility();   // a ribbon at the camera's own altitude would
+                            // sit across the cockpit view
   if (!ghost.saved) {
     // Survives exit -> rapid re-enter while the exit ease still runs, so
     // a re-entry never captures a mid-transition camera as "the view to
@@ -442,7 +442,6 @@ function ghostStep(d) {
 function ghostExit() {
   if (!ghost.active) return;
   ghost.active = false;
-  applySculptVisibility();
   window.removeEventListener('keydown', ghostKeys);
   // Keep this FOV restore ABOVE the easeTo and once('moveend') below:
   // setVerticalFieldOfView fires moveend synchronously, and a listener
@@ -463,6 +462,7 @@ function ghostExit() {
     map.setMaxPitch(saved.maxPitch);
     GHOST_HANDLERS.forEach(h => map[h] && map[h].enable());
     ghost.saved = null;
+    applySculptVisibility();
   });
   unmountHud();
   ghost.flight = null;

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -115,6 +115,7 @@ const allCoords = [];
     name: p.name || `flight ${i + 1}`,
     color: PALETTE[i % PALETTE.length],
     props: p,
+    shown: true,
   };
   if (f.geometry.type === 'LineString') {
     entry.geometry = { type: 'LineString',
@@ -242,6 +243,7 @@ if (map) {
       map.on('mouseleave', f.id, () => {
         map.getCanvas().style.cursor = '';
       });
+      addSculpture(f, fi);
     });
     buildPanel();
   });
@@ -502,6 +504,98 @@ function updateHud() {
   if (pose.clamped) badge('pitch clamped to ' + GHOST_MAX_PITCH + '\\u00b0');
   if (pose.estimated) badge('estimated view \\u2014 no gimbal data');
   if (REDACTED === 'fuzz') badge('position fuzzed ~100 m');
+}
+
+// --- Flight sculpture (#375): AGL curtain + true-altitude ribbon ---
+// fill-extrusion base/height are measured from the terrain surface (the
+// shader applies get_elevation(a_centroid)), so agl_m drops straight in --
+// no queryTerrainElevation, no cold-DEM race. A custom WebGL layer cannot
+// be used here at all: with terrain on, MapLibre depth-rejects every
+// fragment of a custom '3d' layer (spike, #375).
+const SCULPT_RIBBON_M = 6;    // solid slab thickness at flight altitude
+const SCULPT_PX = 3;          // target plank width, screen pixels
+const SCULPT_MIN_M = 4, SCULPT_MAX_M = 60;
+const sculpture = { on: true, widthM: null };
+
+function sculptWidthM() {
+  // Hold a roughly constant screen width: a fixed metre width vanishes
+  // when you zoom out to see the whole flight, and becomes a slab up close.
+  const mPerPx = 40075016.686 * Math.cos(map.getCenter().lat * Math.PI / 180)
+               / (512 * Math.pow(2, map.getZoom()));
+  return Math.max(SCULPT_MIN_M,
+                  Math.min(mPerPx * SCULPT_PX, SCULPT_MAX_M));
+}
+
+function planksFor(fl, widthM) {
+  // One rectangle per consecutive pair that has AGL at both ends.
+  const feats = [];
+  if (!fl.pts || !fl.agl) return feats;
+  const half = widthM / 2;
+  for (let i = 0; i < fl.pts.length - 1; i++) {
+    const a = fl.pts[i], b = fl.pts[i + 1];
+    const aglA = fl.agl[i], aglB = fl.agl[i + 1];
+    // A null AGL breaks the curtain: the gap length is unknown, so
+    // interpolating across it would invent altitude.
+    if (aglA == null || aglB == null) continue;
+    const mLat = 111320;
+    const mLon = 111320 * Math.cos((a[1] + b[1]) / 2 * Math.PI / 180);
+    const dx = (b[0] - a[0]) * mLon, dy = (b[1] - a[1]) * mLat;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    if (!len) continue;                 // duplicate fix: no direction
+    const ox = -dy / len * half / mLon, oy = dx / len * half / mLat;
+    const agl = (aglA + aglB) / 2;
+    feats.push({
+      type: 'Feature',
+      // rbase is clamped here rather than in a paint expression: the
+      // style spec forbids a negative fill-extrusion-base, and a hover
+      // lower than the ribbon thickness would compute one.
+      properties: { agl: agl, rbase: Math.max(0, agl - SCULPT_RIBBON_M) },
+      geometry: { type: 'Polygon', coordinates: [[
+        [a[0] + ox, a[1] + oy], [b[0] + ox, b[1] + oy],
+        [b[0] - ox, b[1] - oy], [a[0] - ox, a[1] - oy],
+        [a[0] + ox, a[1] + oy],
+      ]] },
+    });
+  }
+  return feats;
+}
+
+function addSculpture(fl, fi) {
+  if (sculpture.widthM == null) sculpture.widthM = sculptWidthM();
+  const feats = planksFor(fl, sculpture.widthM);
+  if (!feats.length) return;
+  const src = 'sculpt-' + fi;
+  map.addSource(src, { type: 'geojson',
+    data: { type: 'FeatureCollection', features: feats } });
+  map.addLayer({ id: src + '-curtain', type: 'fill-extrusion', source: src,
+    paint: { 'fill-extrusion-color': fl.color,
+             'fill-extrusion-base': 0,
+             'fill-extrusion-height': ['get', 'agl'],
+             'fill-extrusion-opacity': 0.35,
+             // Built-in gradient darkens the sides toward the ground: the
+             // fade cannot be alpha (the shader hardcodes colour alpha to
+             // 1.0 and fill-extrusion-opacity is layer-level only).
+             'fill-extrusion-vertical-gradient': true } });
+  map.addLayer({ id: src + '-ribbon', type: 'fill-extrusion', source: src,
+    paint: { 'fill-extrusion-color': fl.color,
+             'fill-extrusion-base': ['get', 'rbase'],
+             'fill-extrusion-height': ['get', 'agl'],
+             'fill-extrusion-opacity': 1,
+             'fill-extrusion-vertical-gradient': false } });
+  fl.sculptSrc = src;
+}
+
+function applySculptVisibility() {
+  flights.forEach(fl => {
+    if (!fl.sculptSrc) return;
+    // Ghost mode hides it: a solid ribbon at the camera's own altitude
+    // would sit across the cockpit view.
+    const v = (sculpture.on && fl.shown && !ghost.active) ? 'visible' : 'none';
+    ['-curtain', '-ribbon'].forEach(sfx => {
+      const id = fl.sculptSrc + sfx;
+      if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', v);
+    });
+  });
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -537,13 +537,19 @@ function planksFor(fl, widthM) {
     // A null AGL breaks the curtain: the gap length is unknown, so
     // interpolating across it would invent altitude.
     if (aglA == null || aglB == null) continue;
+    const agl = (aglA + aglB) / 2;
+    // A negative mean AGL (rooftop/cliff-top launch: rel_alt is signed and
+    // not clamped upstream) breaks the curtain too: fill-extrusion cannot
+    // render below the terrain surface at all (the style spec floors base
+    // at 0), so a below-takeoff segment has no honest representation.
+    // Breaking the curtain is truthful; inventing a zero-height slab is not.
+    if (agl < 0) continue;
     const mLat = 111320;
     const mLon = 111320 * Math.cos((a[1] + b[1]) / 2 * Math.PI / 180);
     const dx = (b[0] - a[0]) * mLon, dy = (b[1] - a[1]) * mLat;
     const len = Math.sqrt(dx * dx + dy * dy);
     if (!len) continue;                 // duplicate fix: no direction
     const ox = -dy / len * half / mLon, oy = dx / len * half / mLat;
-    const agl = (aglA + aglB) / 2;
     feats.push({
       type: 'Feature',
       // rbase is clamped here rather than in a paint expression: the

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -382,6 +382,8 @@ function ghostEnter(flightIdx, sampleIdx) {
   const fl = flights[flightIdx];
   if (ghost.active || !fl || !fl.pts) return;
   ghost.active = true;
+  applySculptVisibility();   // a ribbon at the camera's own altitude would
+                            // sit across the cockpit view
   ghost.flight = fl;
   ghost.idx = Math.max(0, Math.min(sampleIdx, fl.pts.length - 1));
   // Attach Escape/arrows before any failure-prone work: if anything below
@@ -440,6 +442,7 @@ function ghostStep(d) {
 function ghostExit() {
   if (!ghost.active) return;
   ghost.active = false;
+  applySculptVisibility();
   window.removeEventListener('keydown', ghostKeys);
   // Keep this FOV restore ABOVE the easeTo and once('moveend') below:
   // setVerticalFieldOfView fires moveend synchronously, and a listener

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -245,6 +245,7 @@ if (map) {
       });
       addSculpture(f, fi);
     });
+    map.on('zoomend', rebuildSculpture);
     buildPanel();
   });
 }
@@ -601,6 +602,19 @@ function applySculptVisibility() {
       const id = fl.sculptSrc + sfx;
       if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', v);
     });
+  });
+}
+
+function rebuildSculpture() {
+  const w = sculptWidthM();
+  // Ignore trivial changes: setData on every zoom frame would churn.
+  if (sculpture.widthM != null && Math.abs(w - sculpture.widthM) < 0.5) return;
+  sculpture.widthM = w;
+  flights.forEach(fl => {
+    if (!fl.sculptSrc) return;
+    const src = map.getSource(fl.sculptSrc);
+    if (src) src.setData({ type: 'FeatureCollection',
+                           features: planksFor(fl, w) });
   });
 }
 """

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -248,6 +248,7 @@ if (map) {
       addSculpture(f, fi);
     });
     map.on('zoomend', rebuildSculpture);
+    sculptSettle();
     buildPanel();
   });
 }
@@ -369,13 +370,17 @@ function ghostKeys(ev) {
   else if (ev.key === 'ArrowRight') { ghostStep(1); ev.preventDefault(); }
 }
 
-function ghostTakeoffElev(fl) {
+function terrainElevAt(lngLat) {
+  // Gate on getTerrain(): queryTerrainElevation returns 0, not null, when
+  // terrain is off or its tiles are still cold (#372 spike round 3).
+  if (!(map.getTerrain && map.getTerrain())) return null;
+  const e = map.queryTerrainElevation(lngLat);
+  return typeof e === 'number' ? e : null;
+}
+
+function takeoffElev(fl) {
   const p0 = fl.pts[0];
-  // Gate on getTerrain(): with terrain failed/off, queryTerrainElevation
-  // returns 0 (spike round 3) and would fake a sea-level takeoff.
-  const elev = map.getTerrain && map.getTerrain()
-    ? map.queryTerrainElevation([p0[0], p0[1]]) : null;
-  return typeof elev === 'number' ? elev : null;
+  return terrainElevAt([p0[0], p0[1]]);
 }
 
 function ghostEnter(flightIdx, sampleIdx) {
@@ -399,7 +404,7 @@ function ghostEnter(flightIdx, sampleIdx) {
   }
   map.setMaxPitch(GHOST_MAX_PITCH);
   GHOST_HANDLERS.forEach(h => map[h] && map[h].disable());
-  ghost.takeoffElev = ghostTakeoffElev(fl);
+  ghost.takeoffElev = takeoffElev(fl);
   if (ghost.takeoffElev != null && map.areTilesLoaded
       && !map.areTilesLoaded()) {
     // 'idle' can park under eased transitions before late DEM tiles land
@@ -409,7 +414,7 @@ function ghostEnter(flightIdx, sampleIdx) {
     let tries = 20;
     const retry = () => {
       if (!ghost.active || ghost.flight !== fl) return;
-      const elev = ghostTakeoffElev(fl);
+      const elev = takeoffElev(fl);
       if (typeof elev === 'number' && elev !== 0) {
         if (elev !== ghost.takeoffElev) {
           ghost.takeoffElev = elev;
@@ -530,11 +535,12 @@ function updateHud() {
 }
 
 // --- Flight sculpture (#375): AGL curtain + true-altitude ribbon ---
-// fill-extrusion base/height are measured from the terrain surface (the
-// shader applies get_elevation(a_centroid)), so agl_m drops straight in --
-// no queryTerrainElevation, no cold-DEM race. A custom WebGL layer cannot
-// be used here at all: with terrain on, MapLibre depth-rejects every
-// fragment of a custom '3d' layer (spike, #375).
+// fill-extrusion base/height are measured from the LOCAL terrain surface
+// under each segment (the shader applies get_elevation(a_centroid)), but
+// agl_m is height above the single TAKEOFF point -- planksFor() converts
+// through terrainElevAt() so the rendered height is true ground clearance.
+// A custom WebGL layer cannot be used here at all: with terrain on,
+// MapLibre depth-rejects every fragment of a custom '3d' layer (spike, #375).
 const SCULPT_RIBBON_M = 6;    // solid slab thickness at flight altitude
 const SCULPT_PX = 3;          // target plank width, screen pixels
 const SCULPT_MIN_M = 4, SCULPT_MAX_M = 60;
@@ -554,6 +560,7 @@ function planksFor(fl, widthM) {
   const feats = [];
   if (!fl.pts || !fl.agl) return feats;
   const half = widthM / 2;
+  const tElev = takeoffElev(fl);
   for (let i = 0; i < fl.pts.length - 1; i++) {
     const a = fl.pts[i], b = fl.pts[i + 1];
     const aglA = fl.agl[i], aglB = fl.agl[i + 1];
@@ -561,12 +568,21 @@ function planksFor(fl, widthM) {
     // interpolating across it would invent altitude.
     if (aglA == null || aglB == null) continue;
     const agl = (aglA + aglB) / 2;
-    // A negative mean AGL (rooftop/cliff-top launch: rel_alt is signed and
-    // not clamped upstream) breaks the curtain too: fill-extrusion cannot
-    // render below the terrain surface at all (the style spec floors base
-    // at 0), so a below-takeoff segment has no honest representation.
-    // Breaking the curtain is truthful; inventing a zero-height slab is not.
-    if (agl < 0) continue;
+    const lElev = tElev == null
+      ? null : terrainElevAt([(a[0] + b[0]) / 2, (a[1] + b[1]) / 2]);
+    // agl is height above TAKEOFF, but fill-extrusion measures from the
+    // LOCAL surface under this segment. Converting through both elevations
+    // puts the ribbon at the drone's true altitude, so the curtain's length
+    // is real ground clearance: fly level at a rising ridge and it shortens.
+    // With terrain off both are null and agl is already right, because
+    // get_elevation returns 0 and the extrusion measures from sea level.
+    const hgt = (tElev != null && lElev != null)
+      ? (tElev + agl) - lElev : agl;
+    // Non-positive: the drone is at or below the rendered surface (rooftop
+    // launch, or a DEM/datum artefact near a cliff). fill-extrusion cannot
+    // render below the terrain at all, so break the curtain rather than
+    // invent a flat slab.
+    if (hgt <= 0) continue;
     const mLat = 111320;
     const mLon = 111320 * Math.cos((a[1] + b[1]) / 2 * Math.PI / 180);
     const dx = (b[0] - a[0]) * mLon, dy = (b[1] - a[1]) * mLat;
@@ -578,7 +594,7 @@ function planksFor(fl, widthM) {
       // rbase is clamped here rather than in a paint expression: the
       // style spec forbids a negative fill-extrusion-base, and a hover
       // lower than the ribbon thickness would compute one.
-      properties: { agl: agl, rbase: Math.max(0, agl - SCULPT_RIBBON_M) },
+      properties: { hgt: hgt, rbase: Math.max(0, hgt - SCULPT_RIBBON_M) },
       geometry: { type: 'Polygon', coordinates: [[
         [a[0] + ox, a[1] + oy], [b[0] + ox, b[1] + oy],
         [b[0] - ox, b[1] - oy], [a[0] - ox, a[1] - oy],
@@ -599,7 +615,7 @@ function addSculpture(fl, fi) {
   map.addLayer({ id: src + '-curtain', type: 'fill-extrusion', source: src,
     paint: { 'fill-extrusion-color': fl.color,
              'fill-extrusion-base': 0,
-             'fill-extrusion-height': ['get', 'agl'],
+             'fill-extrusion-height': ['get', 'hgt'],
              'fill-extrusion-opacity': 0.35,
              // Built-in gradient darkens the sides toward the ground: the
              // fade cannot be alpha (the shader hardcodes colour alpha to
@@ -608,7 +624,7 @@ function addSculpture(fl, fi) {
   map.addLayer({ id: src + '-ribbon', type: 'fill-extrusion', source: src,
     paint: { 'fill-extrusion-color': fl.color,
              'fill-extrusion-base': ['get', 'rbase'],
-             'fill-extrusion-height': ['get', 'agl'],
+             'fill-extrusion-height': ['get', 'hgt'],
              'fill-extrusion-opacity': 1,
              'fill-extrusion-vertical-gradient': false } });
   fl.sculptSrc = src;
@@ -627,17 +643,36 @@ function applySculptVisibility() {
   });
 }
 
+function setSculptData() {
+  flights.forEach(fl => {
+    if (!fl.sculptSrc) return;
+    const src = map.getSource(fl.sculptSrc);
+    if (src) src.setData({ type: 'FeatureCollection',
+                           features: planksFor(fl, sculpture.widthM) });
+  });
+}
+
 function rebuildSculpture() {
   const w = sculptWidthM();
   // Ignore trivial changes: setData on every zoom frame would churn.
   if (sculpture.widthM != null && Math.abs(w - sculpture.widthM) < 0.5) return;
   sculpture.widthM = w;
-  flights.forEach(fl => {
-    if (!fl.sculptSrc) return;
-    const src = map.getSource(fl.sculptSrc);
-    if (src) src.setData({ type: 'FeatureCollection',
-                           features: planksFor(fl, w) });
-  });
+  setSculptData();
+}
+
+function sculptSettle() {
+  // Cold DEM tiles make queryTerrainElevation return 0, so the first build
+  // is a flat-mode approximation. Re-sample on a bounded timer and rebuild
+  // once tiles land. 'idle' cannot be used: it parks under the load-time
+  // fitBounds ease (#372). A genuine sea-level takeoff is indistinguishable
+  // from "not loaded yet" here, and simply keeps the first build.
+  if (!(map.getTerrain && map.getTerrain())) return;
+  let tries = 20;
+  const retry = () => {
+    if (map.areTilesLoaded && map.areTilesLoaded()) { setSculptData(); return; }
+    if (--tries > 0) setTimeout(retry, 250);
+  };
+  setTimeout(retry, 250);
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -64,6 +64,8 @@ _TEMPLATE = """<!DOCTYPE html>
                    font: 13px/1.8 sans-serif; max-height: 60%;
                    overflow-y: auto; }}
   .flights-panel label {{ display: block; cursor: pointer; }}
+  .flights-panel hr {{ border: none; border-top: 1px solid #ddd;
+                      margin: 6px 0; }}
   .map-note {{ position: absolute; top: 10px; left: 50%;
               transform: translateX(-50%); z-index: 6; background: #fffbe6;
               border: 1px solid #e0d8a8; border-radius: 4px;
@@ -261,8 +263,10 @@ function buildPanel() {
     box.type = 'checkbox';
     box.checked = true;
     box.addEventListener('change', () => {
+      f.shown = box.checked;
       map.setLayoutProperty(f.id, 'visibility',
                             box.checked ? 'visible' : 'none');
+      applySculptVisibility();
     });
     label.appendChild(box);
     const swatch = document.createElement('span');
@@ -272,6 +276,21 @@ function buildPanel() {
     label.appendChild(document.createTextNode(f.name));
     panel.appendChild(label);
   });
+  if (flights.some(f => f.sculptSrc)) {
+    panel.appendChild(document.createElement('hr'));
+    const label = document.createElement('label');
+    const box = document.createElement('input');
+    box.type = 'checkbox';
+    box.id = 'sculpture-toggle';
+    box.checked = sculpture.on;
+    box.addEventListener('change', () => {
+      sculpture.on = box.checked;
+      applySculptVisibility();
+    });
+    label.appendChild(box);
+    label.appendChild(document.createTextNode(' Sculpture'));
+    panel.appendChild(label);
+  }
   document.body.appendChild(panel);
 }
 

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -66,15 +66,22 @@ def _fetch_asset(url: str, integrity: str) -> Path:
     return dest
 
 
-def _dem_png(elev_m: float) -> bytes:
-    """256x256 constant-elevation PNG in mapbox raster-dem encoding.
-
-    The 3D template's terrain sources declare no ``encoding``, so MapLibre
-    decodes tiles as mapbox: h = -10000 + (R*65536 + G*256 + B) * 0.1.
-    """
+def _dem_rgb(elev_m: float) -> tuple[int, int, int]:
+    """Mapbox raster-dem encoding: h = -10000 + (R*65536 + G*256 + B) * 0.1."""
     v = round((elev_m + 10000) / 0.1)
-    r, g, b = (v >> 16) & 255, (v >> 8) & 255, v & 255
-    row = b"\x00" + bytes((r, g, b)) * 256  # filter byte 0 + RGB pixels
+    return (v >> 16) & 255, (v >> 8) & 255, v & 255
+
+
+def _dem_png(elev_m: float, high_m: float | None = None) -> bytes:
+    """256x256 raster-dem tile.
+
+    Constant *elev_m* by default. With *high_m*, the left half of the tile is
+    ``elev_m`` and the right half ``high_m`` — a vertical cliff down the
+    middle of every tile, which is what makes terrain occlusion testable.
+    """
+    lo = _dem_rgb(elev_m)
+    hi = _dem_rgb(high_m if high_m is not None else elev_m)
+    row = b"\x00" + bytes(lo) * 128 + bytes(hi) * 128
     raw = row * 256
 
     def chunk(tag: bytes, data: bytes) -> bytes:
@@ -158,14 +165,21 @@ def serve_map(map_server, page):
     opts into fulfilling the Mapterhorn TileJSON + DEM tile requests with
     a constant-elevation PNG (mapbox raster-dem encoding) instead of the
     default abort, so terrain-dependent behaviour becomes testable.
-    Terrain-stub runs also strip the ``hillshade`` source/layer before the
-    map constructs: headless SwiftShader hangs rendering it against real
-    DEM data under pitch, and it is presentation-only, so these runs never
-    see it (see ``_STRIP_HILLSHADE_JS``).
+    ``terrain_steps=(low_m, high_m)`` is the mutually-exclusive alternative:
+    it fulfils a DEM whose left half is ``low_m`` and right half ``high_m``
+    (a cliff down the middle of every tile) at ``maxzoom`` 15 so each tile
+    spans ~1.2 km and the cliff falls inside the viewport — this is what
+    makes terrain occlusion testable. Passing both ``terrain_stub`` and
+    ``terrain_steps`` is a ``ValueError``. Terrain-stub/-steps runs also
+    strip the ``hillshade`` source/layer before the map constructs: headless
+    SwiftShader hangs rendering it against real DEM data under pitch, and it
+    is presentation-only, so these runs never see it (see
+    ``_STRIP_HILLSHADE_JS``).
     """
     root, base_url = map_server
 
-    def _serve(html: str, *, on=None, terrain_stub: float | None = None) -> str:
+    def _serve(html: str, *, on=None, terrain_stub: float | None = None,
+               terrain_steps: tuple[float, float] | None = None) -> str:
         import uuid
 
         target = on if on is not None else page
@@ -192,14 +206,21 @@ def serve_map(map_server, page):
 
         target.route("**/*", route)
 
-        if terrain_stub is not None:
+        if terrain_stub is not None and terrain_steps is not None:
+            raise ValueError("pass terrain_stub or terrain_steps, not both")
+        if terrain_stub is not None or terrain_steps is not None:
             target.add_init_script(_STRIP_HILLSHADE_JS)
-            dem = _dem_png(terrain_stub)
+            if terrain_steps is not None:
+                dem = _dem_png(terrain_steps[0], terrain_steps[1])
+                maxzoom = 15   # ~1.2 km tiles: a cliff fits in the viewport
+            else:
+                dem = _dem_png(terrain_stub)
+                maxzoom = 12
             tilejson = json.dumps({
                 "tilejson": "2.2.0",
                 "tiles": ["https://tiles.mapterhorn.com/dem/{z}/{x}/{y}.png"],
                 "minzoom": 0,
-                "maxzoom": 12,
+                "maxzoom": maxzoom,
             }).encode()
 
             def terrain_route(r):
@@ -208,6 +229,9 @@ def serve_map(map_server, page):
                                      content_type="application/json")
                 return r.fulfill(body=dem, content_type="image/png")
 
+            # Registered AFTER the catch-all route above: Playwright matches
+            # routes in REVERSE registration order, so this must come last
+            # to take priority over the catch-all's abort.
             target.route(
                 lambda u: urlsplit(u).hostname == "tiles.mapterhorn.com",
                 terrain_route,

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -106,3 +106,95 @@ def test_terrain_occludes_fill_extrusion(serve_map, page):
         f"terrain did NOT occlude the extrusion ({occluded} px visible "
         "behind a 600 m cliff)"
     )
+
+
+def test_sculpture_layers_exist(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [5.0, 20.0, 45.0, 30.0, 12.0])],
+        "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map"
+        " && map.getLayer('sculpt-0-curtain')", timeout=15000)
+    assert page.evaluate(
+        "() => map.getLayer('sculpt-0-curtain').type") == "fill-extrusion"
+    assert page.evaluate(
+        "() => map.getLayer('sculpt-0-ribbon').type") == "fill-extrusion"
+
+
+def test_source_is_populated_from_the_flight(serve_map, page):
+    """The planks actually reach the map source, not just the builder."""
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [5.0, 20.0, 45.0, 30.0, 12.0])],
+        "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map"
+        " && map.getLayer('sculpt-0-curtain')", timeout=15000)
+    page.wait_for_function(
+        "() => map.querySourceFeatures('sculpt-0').length > 0", timeout=15000)
+
+
+def test_curtain_height_tracks_agl(serve_map, page):
+    agls = [5.0, 20.0, 45.0, 30.0, 12.0]
+    html = flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, agls)], "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map"
+        " && map.getLayer('sculpt-0-curtain')", timeout=15000)
+    # planksFor is called directly rather than querySourceFeatures, which
+    # can return the same plank once per covering tile.
+    peak = page.evaluate(
+        "() => Math.max.apply(null,"
+        " planksFor(flights[0], 10).map(f => f.properties.agl))")
+    # Segment AGL is the mean of its endpoints, so the tallest plank is the
+    # mean of the two highest adjacent samples: (20+45)/2 and (45+30)/2 -> 37.5
+    assert abs(peak - 37.5) < 0.1
+
+
+def test_ribbon_base_never_negative(serve_map, page):
+    """A hover below the ribbon thickness must not compute a negative base."""
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [1.0, 2.0, 1.5, 2.5, 1.0])], "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map"
+        " && map.getLayer('sculpt-0-curtain')", timeout=15000)
+    lo = page.evaluate(
+        "() => Math.min.apply(null,"
+        " planksFor(flights[0], 10).map(f => f.properties.rbase))")
+    assert lo == 0
+
+
+def test_flight_without_agl_gets_no_sculpture(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [None] * 5)], "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.getLayer('flight-0')",
+        timeout=15000)
+    assert page.evaluate("() => !!map.getLayer('sculpt-0-curtain')") is False
+
+
+def test_single_fix_flight_gets_no_sculpture(serve_map, page):
+    """A one-point flight is a Point feature: no segments, no sculpture."""
+    html = flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, [12.0])],
+                              "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.getLayer('flight-0')",
+        timeout=15000)
+    assert page.evaluate("() => !!map.getLayer('sculpt-0-curtain')") is False
+
+
+def test_null_agl_point_breaks_the_curtain(serve_map, page):
+    """A null AGL splits the curtain rather than interpolating across it."""
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [10.0, 10.0, None, 10.0, 10.0])],
+        "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map"
+        " && map.getLayer('sculpt-0-curtain')", timeout=15000)
+    # 4 possible segments; the two touching the null point are dropped.
+    assert page.evaluate("() => planksFor(flights[0], 10).length") == 2

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -1,0 +1,108 @@
+"""Flight sculpture (#375): AGL curtain + true-altitude ribbon in 3D."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+TILE_DEG = 360 / 2 ** 15   # z15 tile width; DEM cliff sits at each midpoint
+
+
+def _flight(name: str, lat: float, lon: float, agls: list[float | None],
+            step: float = 0.0006) -> Track:
+    """Synthetic flight; ``agls[i]`` becomes point i's rel_alt (AGL)."""
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name=name, points=[
+        TrackPoint(lat=lat, lon=lon + i * step, alt=100.0 + (a or 0),
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i * 1.0), rel_alt=a)
+        for i, a in enumerate(agls)
+    ])
+
+
+_PROBE_JS = """
+(() => {
+  window.__probe = (lon, lat) => {
+    map.addSource('probe', { type: 'geojson', data: {
+      type: 'Feature', properties: {},
+      geometry: { type: 'Polygon', coordinates: [[
+        [lon - 0.001, lat - 0.001], [lon + 0.001, lat - 0.001],
+        [lon + 0.001, lat + 0.001], [lon - 0.001, lat + 0.001],
+        [lon - 0.001, lat - 0.001]]] } } });
+    // Pure green: no PALETTE entry can be mistaken for it, so a flight's
+    // own sculpture cannot pollute the count.
+    map.addLayer({ id: 'probe', type: 'fill-extrusion', source: 'probe',
+      paint: { 'fill-extrusion-color': '#00ff00',
+               'fill-extrusion-base': 0, 'fill-extrusion-height': 100,
+               'fill-extrusion-opacity': 1 } });
+  };
+  window.__probeCount = () => {
+    const gc = map.getCanvas();
+    const c = document.createElement('canvas');
+    c.width = gc.width; c.height = gc.height;
+    c.getContext('2d').drawImage(gc, 0, 0);
+    const d = c.getContext('2d').getImageData(0, 0, c.width, c.height).data;
+    let n = 0;
+    for (let i = 0; i < d.length; i += 4) {
+      if (d[i] < 60 && d[i + 1] > 200 && d[i + 2] < 60) n++;
+    }
+    return n;
+  };
+})();
+"""
+
+_PRESERVE_JS = """
+(() => {
+  const orig = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function (type, attrs) {
+    if (type && type.indexOf('webgl') === 0) {
+      attrs = Object.assign({}, attrs, { preserveDrawingBuffer: true });
+    }
+    return orig.call(this, type, attrs);
+  };
+})();
+"""
+
+
+def test_terrain_occludes_fill_extrusion(serve_map, page):
+    """A 600 m cliff between camera and target must hide the target."""
+    lat = 10.0
+    tile_lon = TILE_DEG * 1660          # an arbitrary tile's left edge
+    cam_lon = tile_lon + TILE_DEG * 0.2      # low half of this tile
+    target_lon = tile_lon + TILE_DEG * 1.2   # low half of the NEXT tile
+    page.add_init_script(_PRESERVE_JS)
+    html = flights_to_3d_html([_flight("DJI_0001", lat, cam_lon, [10.0] * 5)],
+                              "trip")
+    serve_map(html, terrain_steps=(0.0, 600.0))
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.isStyleLoaded()",
+        timeout=20000)
+    page.evaluate(_PROBE_JS)
+    page.evaluate("a => window.__probe(a[0], a[1])", [target_lon, lat])
+    # Stand at 20 m in the valley and look horizontally down it.
+    page.evaluate(
+        "a => { map.setMaxPitch(100); map.jumpTo("
+        "map.calculateCameraOptionsFromCameraLngLatAltRotation("
+        "[a[0], a[1]], 20, 90, 88, 0)); }", [cam_lon, lat])
+    page.wait_for_function("() => map.loaded() && !map.isMoving()",
+                           timeout=20000)
+    page.wait_for_timeout(2000)
+    occluded = page.evaluate("() => window.__probeCount()")
+
+    map_off = "() => { map.setTerrain(null); map.triggerRepaint(); }"
+    page.evaluate(map_off)
+    page.wait_for_timeout(2000)
+    visible = page.evaluate("() => window.__probeCount()")
+
+    print(f"\nOCCLUSION PROBE: terrain on={occluded} px, off={visible} px")
+    assert visible > 0, "control failed: target invisible even without terrain"
+    assert occluded == 0, (
+        f"terrain did NOT occlude the extrusion ({occluded} px visible "
+        "behind a 600 m cliff)"
+    )

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -198,3 +198,68 @@ def test_null_agl_point_breaks_the_curtain(serve_map, page):
         " && map.getLayer('sculpt-0-curtain')", timeout=15000)
     # 4 possible segments; the two touching the null point are dropped.
     assert page.evaluate("() => planksFor(flights[0], 10).length") == 2
+
+
+def test_sculpture_paint_properties_are_wired_correctly(serve_map, page):
+    """Pin the actual paint expressions, not just that the layers exist."""
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [5.0, 20.0, 45.0, 30.0, 12.0])],
+        "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map"
+        " && map.getLayer('sculpt-0-curtain')", timeout=15000)
+    curtain_base = page.evaluate(
+        "() => map.getPaintProperty('sculpt-0-curtain', 'fill-extrusion-base')")
+    curtain_height = page.evaluate(
+        "() => map.getPaintProperty('sculpt-0-curtain', 'fill-extrusion-height')")
+    ribbon_base = page.evaluate(
+        "() => map.getPaintProperty('sculpt-0-ribbon', 'fill-extrusion-base')")
+    ribbon_height = page.evaluate(
+        "() => map.getPaintProperty('sculpt-0-ribbon', 'fill-extrusion-height')")
+    assert curtain_base == 0
+    assert curtain_height == ["get", "agl"]
+    assert ribbon_base == ["get", "rbase"]
+    assert ribbon_height == ["get", "agl"]
+
+
+def test_ribbon_base_is_exactly_agl_minus_ribbon_thickness_when_tall(
+        serve_map, page):
+    """A tall segment's rbase must track agl - 6 exactly.
+
+    ``test_ribbon_base_never_negative`` uses a fixture where every segment
+    clamps to 0, so a constant ``rbase: 0`` implementation would satisfy it.
+    This picks AGLs well above the 6 m ribbon thickness so the clamp never
+    engages, forcing the real formula.
+    """
+    agls = [50.0, 80.0, 120.0, 90.0, 60.0]
+    html = flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, agls)], "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map"
+        " && map.getLayer('sculpt-0-curtain')", timeout=15000)
+    planks = page.evaluate("() => planksFor(flights[0], 10)")
+    assert len(planks) == 4
+    for plank in planks:
+        props = plank["properties"]
+        assert props["rbase"] == pytest.approx(props["agl"] - 6)
+
+
+def test_negative_agl_segments_produce_no_planks(serve_map, page):
+    """Finding 1 regression guard: a below-takeoff segment breaks the curtain.
+
+    A rooftop/cliff-top launch can log a negative rel_alt (the repo's own
+    golden fixture carries rel_alt: -400.0). fill-extrusion cannot render
+    below the terrain surface, so a segment whose mean AGL is negative must
+    be dropped exactly like a null-AGL segment is.
+    """
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [10.0, -400.0, 10.0, 10.0, 10.0])],
+        "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.getLayer('flight-0')",
+        timeout=15000)
+    # 4 possible segments; the two touching the negative-mean-AGL point
+    # (indices 0-1 and 1-2) are dropped, leaving 2.
+    assert page.evaluate("() => planksFor(flights[0], 10).length") == 2

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -300,3 +300,54 @@ def test_negative_agl_segments_produce_no_planks(serve_map, page):
     # 4 possible segments; the two touching the negative-mean-AGL point
     # (indices 0-1 and 1-2) are dropped, leaving 2.
     assert page.evaluate("() => planksFor(flights[0], 10).length") == 2
+
+
+def _vis(page, layer="sculpt-0-curtain"):
+    return page.evaluate(
+        "id => map.getLayoutProperty(id, 'visibility') || 'visible'", layer)
+
+
+def test_global_toggle_hides_and_restores_sculpture(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [10.0] * 5)], "trip")
+    serve_map(html)
+    page.wait_for_selector("#sculpture-toggle", timeout=15000)
+    assert _vis(page) == "visible"
+    page.locator("#sculpture-toggle").uncheck()
+    assert _vis(page) == "none"
+    assert _vis(page, "sculpt-0-ribbon") == "none"
+    page.locator("#sculpture-toggle").check()
+    assert _vis(page) == "visible"
+
+
+def test_per_flight_checkbox_hides_its_sculpture(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [10.0] * 5),
+         _flight("DJI_0002", 11.0, 21.0, [10.0] * 5)], "trip")
+    serve_map(html)
+    page.wait_for_selector("#sculpture-toggle", timeout=15000)
+    page.locator("#flights-panel input[type=checkbox]").first.uncheck()
+    assert _vis(page, "sculpt-0-curtain") == "none"
+    assert _vis(page, "sculpt-1-curtain") == "visible"
+
+
+def test_per_flight_state_survives_a_global_cycle(serve_map, page):
+    """Re-enabling the sculpture must not un-hide an unchecked flight."""
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [10.0] * 5),
+         _flight("DJI_0002", 11.0, 21.0, [10.0] * 5)], "trip")
+    serve_map(html)
+    page.wait_for_selector("#sculpture-toggle", timeout=15000)
+    page.locator("#flights-panel input[type=checkbox]").first.uncheck()
+    page.locator("#sculpture-toggle").uncheck()
+    page.locator("#sculpture-toggle").check()
+    assert _vis(page, "sculpt-0-curtain") == "none"
+    assert _vis(page, "sculpt-1-curtain") == "visible"
+
+
+def test_no_toggle_when_no_flight_has_agl(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [None] * 5)], "trip")
+    serve_map(html)
+    page.wait_for_selector("#flights-panel", timeout=15000)
+    assert page.locator("#sculpture-toggle").count() == 0

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -351,3 +351,27 @@ def test_no_toggle_when_no_flight_has_agl(serve_map, page):
     serve_map(html)
     page.wait_for_selector("#flights-panel", timeout=15000)
     assert page.locator("#sculpture-toggle").count() == 0
+
+
+def test_ghost_mode_hides_sculpture_and_exit_restores_it(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [10.0] * 5)], "trip")
+    serve_map(html)
+    page.wait_for_selector("#sculpture-toggle", timeout=15000)
+    assert _vis(page) == "visible"
+    page.evaluate("() => ghostEnter(0, 2)")
+    assert _vis(page) == "none"
+    page.evaluate("() => ghostExit()")
+    assert _vis(page) == "visible"
+
+
+def test_ghost_exit_respects_a_disabled_sculpture(serve_map, page):
+    """Leaving ghost mode must not switch a hidden sculpture back on."""
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [10.0] * 5)], "trip")
+    serve_map(html)
+    page.wait_for_selector("#sculpture-toggle", timeout=15000)
+    page.locator("#sculpture-toggle").uncheck()
+    page.evaluate("() => ghostEnter(0, 2)")
+    page.evaluate("() => ghostExit()")
+    assert _vis(page) == "none"

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -362,6 +362,10 @@ def test_ghost_mode_hides_sculpture_and_exit_restores_it(serve_map, page):
     page.evaluate("() => ghostEnter(0, 2)")
     assert _vis(page) == "none"
     page.evaluate("() => ghostExit()")
+    # The exit ease still has the camera up at the drone's altitude; the
+    # ribbon must not pop back until that ease actually finishes.
+    assert _vis(page) == "none"
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
     assert _vis(page) == "visible"
 
 

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -217,10 +217,30 @@ def test_sculpture_paint_properties_are_wired_correctly(serve_map, page):
         "() => map.getPaintProperty('sculpt-0-ribbon', 'fill-extrusion-base')")
     ribbon_height = page.evaluate(
         "() => map.getPaintProperty('sculpt-0-ribbon', 'fill-extrusion-height')")
+    # opacity and vertical-gradient are the only two paint properties that
+    # distinguish the translucent curtain from the solid ribbon: without
+    # pinning them, swapping the two layers' paint would still pass every
+    # other assertion in this test.
+    curtain_opacity = page.evaluate(
+        "() => map.getPaintProperty("
+        "'sculpt-0-curtain', 'fill-extrusion-opacity')")
+    curtain_gradient = page.evaluate(
+        "() => map.getPaintProperty("
+        "'sculpt-0-curtain', 'fill-extrusion-vertical-gradient')")
+    ribbon_opacity = page.evaluate(
+        "() => map.getPaintProperty("
+        "'sculpt-0-ribbon', 'fill-extrusion-opacity')")
+    ribbon_gradient = page.evaluate(
+        "() => map.getPaintProperty("
+        "'sculpt-0-ribbon', 'fill-extrusion-vertical-gradient')")
     assert curtain_base == 0
     assert curtain_height == ["get", "agl"]
     assert ribbon_base == ["get", "rbase"]
     assert ribbon_height == ["get", "agl"]
+    assert curtain_opacity == 0.35
+    assert curtain_gradient is True
+    assert ribbon_opacity == 1
+    assert ribbon_gradient is False
 
 
 def test_ribbon_base_is_exactly_agl_minus_ribbon_thickness_when_tall(
@@ -243,6 +263,23 @@ def test_ribbon_base_is_exactly_agl_minus_ribbon_thickness_when_tall(
     for plank in planks:
         props = plank["properties"]
         assert props["rbase"] == pytest.approx(props["agl"] - 6)
+
+
+def test_zooming_out_widens_planks_in_metres(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [10.0] * 5)], "trip")
+    serve_map(html)
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.getLayer("
+        "'sculpt-0-curtain')", timeout=15000)
+    page.evaluate("() => map.jumpTo({zoom: 16})")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    near = page.evaluate("() => sculpture.widthM")
+    page.evaluate("() => map.jumpTo({zoom: 11})")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    far = page.evaluate("() => sculpture.widthM")
+    assert far > near, f"planks did not widen when zooming out: {near} -> {far}"
+    assert far <= 60 and near >= 4, "width escaped its clamp"
 
 
 def test_negative_agl_segments_produce_no_planks(serve_map, page):

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -335,6 +335,34 @@ def test_height_converts_to_true_altitude_over_terrain(serve_map, page):
     assert max(hs) > 500, f"height was not converted to true altitude: {hs}"
 
 
+def test_true_altitude_reaches_the_source(serve_map, page):
+    """The converted heights must land in the map source, not just planksFor.
+
+    ``test_height_converts_to_true_altitude_over_terrain`` reads planksFor(...)
+    directly, which proves the conversion formula but not that it actually
+    reaches map.getSource(...). querySourceFeatures can return the same plank
+    once per covering tile, but that does not matter for a max().
+    """
+    lat = 10.0
+    tile_lon = TILE_DEG * 1660
+    start_lon = tile_lon + TILE_DEG * 1.75          # high side
+    step = TILE_DEG * 0.12                          # ~5 steps into the valley
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", lat, start_lon, [50.0] * 6, step=step)], "trip")
+    serve_map(html, terrain_steps=(0.0, 600.0))
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.getLayer("
+        "'sculpt-0-curtain')", timeout=20000)
+    page.wait_for_function(
+        "() => map.getTerrain() && map.areTilesLoaded()", timeout=20000)
+    page.evaluate("() => setSculptData()")
+    hs = page.evaluate(
+        "() => map.querySourceFeatures('sculpt-0')"
+        ".map(f => f.properties.hgt)")
+    assert hs, "no features in source"
+    assert max(hs) > 500, f"true altitude did not reach the source: {hs}"
+
+
 def _vis(page, layer="sculpt-0-curtain"):
     return page.evaluate(
         "id => map.getLayoutProperty(id, 'visibility') || 'visible'", layer)

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -146,7 +146,7 @@ def test_curtain_height_tracks_agl(serve_map, page):
     # can return the same plank once per covering tile.
     peak = page.evaluate(
         "() => Math.max.apply(null,"
-        " planksFor(flights[0], 10).map(f => f.properties.agl))")
+        " planksFor(flights[0], 10).map(f => f.properties.hgt))")
     # Segment AGL is the mean of its endpoints, so the tallest plank is the
     # mean of the two highest adjacent samples: (20+45)/2 and (45+30)/2 -> 37.5
     assert abs(peak - 37.5) < 0.1
@@ -234,9 +234,9 @@ def test_sculpture_paint_properties_are_wired_correctly(serve_map, page):
         "() => map.getPaintProperty("
         "'sculpt-0-ribbon', 'fill-extrusion-vertical-gradient')")
     assert curtain_base == 0
-    assert curtain_height == ["get", "agl"]
+    assert curtain_height == ["get", "hgt"]
     assert ribbon_base == ["get", "rbase"]
-    assert ribbon_height == ["get", "agl"]
+    assert ribbon_height == ["get", "hgt"]
     assert curtain_opacity == 0.35
     assert curtain_gradient is True
     assert ribbon_opacity == 1
@@ -245,7 +245,7 @@ def test_sculpture_paint_properties_are_wired_correctly(serve_map, page):
 
 def test_ribbon_base_is_exactly_agl_minus_ribbon_thickness_when_tall(
         serve_map, page):
-    """A tall segment's rbase must track agl - 6 exactly.
+    """A tall segment's rbase must track hgt - 6 exactly.
 
     ``test_ribbon_base_never_negative`` uses a fixture where every segment
     clamps to 0, so a constant ``rbase: 0`` implementation would satisfy it.
@@ -262,7 +262,7 @@ def test_ribbon_base_is_exactly_agl_minus_ribbon_thickness_when_tall(
     assert len(planks) == 4
     for plank in planks:
         props = plank["properties"]
-        assert props["rbase"] == pytest.approx(props["agl"] - 6)
+        assert props["rbase"] == pytest.approx(props["hgt"] - 6)
 
 
 def test_zooming_out_widens_planks_in_metres(serve_map, page):
@@ -300,6 +300,39 @@ def test_negative_agl_segments_produce_no_planks(serve_map, page):
     # 4 possible segments; the two touching the negative-mean-AGL point
     # (indices 0-1 and 1-2) are dropped, leaving 2.
     assert page.evaluate("() => planksFor(flights[0], 10).length") == 2
+
+
+def test_height_converts_to_true_altitude_over_terrain(serve_map, page):
+    """Crossing from a 600 m plateau into a valley must lengthen the curtain.
+
+    The drone holds its height above takeoff, so its clearance over the
+    valley floor is 600 m greater than over the plateau it launched from.
+    """
+    lat = 10.0
+    tile_lon = TILE_DEG * 1660
+    # queryTerrainElevation resolves DEM tiles one zoom level coarser than
+    # the source's maxzoom (empirically verified: probing terrainElevAt
+    # across this stub shows a clean 0/600 step every TWO z15 tile-widths,
+    # not one), so the low/high split actually falls a full tile-width east
+    # of tile_lon rather than mid-tile. Start on the high side of that
+    # boundary and walk east into the low side.
+    start_lon = tile_lon + TILE_DEG * 1.75          # high side
+    step = TILE_DEG * 0.12                          # ~5 steps into the valley
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", lat, start_lon, [50.0] * 6, step=step)], "trip")
+    serve_map(html, terrain_steps=(0.0, 600.0))
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.getLayer("
+        "'sculpt-0-curtain')", timeout=20000)
+    page.wait_for_function(
+        "() => map.getTerrain() && map.areTilesLoaded()", timeout=20000)
+    page.evaluate("() => setSculptData()")
+    hs = page.evaluate(
+        "() => planksFor(flights[0], 10).map(f => f.properties.hgt)")
+    assert hs, "no planks built"
+    # Plateau segments: ~50 m of clearance. Valley segments: ~650 m.
+    assert min(hs) < 200, f"no plateau-height planks: {hs}"
+    assert max(hs) > 500, f"height was not converted to true altitude: {hs}"
 
 
 def _vis(page, layer="sculpt-0-curtain"):

--- a/tests/test_geo_flightmap3d_html.py
+++ b/tests/test_geo_flightmap3d_html.py
@@ -98,6 +98,13 @@ def test_3d_empty_tracks_still_valid_document():
     assert _embedded_data(html)["features"] == []
 
 
+def test_3d_html_carries_the_sculpture_layers():
+    html = flights_to_3d_html([_track()], "trip")
+    assert "sculpt-" in html
+    assert "fill-extrusion-vertical-gradient" in html
+    assert "sculpture-toggle" in html
+
+
 def test_write_flights_3d_html(tmp_path):
     out = tmp_path / "flightmap-3d.html"
     result = write_flights_3d_html([_track()], out, "trip")


### PR DESCRIPTION
Closes #375. Stage 2 of the 3D arc (stage 1 was Ghost Camera #372).

Draped tracks all look alike from above — a 30 m hover and a 300 m transit
trace the same line. The **flight sculpture** gives that line a height: a
translucent curtain rising from the ground to the drone, capped by a solid
ribbon at flight altitude, in each flight's colour.

## Approach: `fill-extrusion`, not a custom WebGL layer

A spike ruled out the hand-rolled custom layer the arc notes assumed. With
terrain on, MapLibre depth-rejects **every fragment** of a custom `'3d'`
layer — it renders nothing at any altitude:

| mode (terrain on) | near quad | far quad | verdict |
| --- | --- | --- | --- |
| MapLibre default | 0 px | 0 px | invisible |
| `disable(DEPTH_TEST)` | 1506 | 8346 | draws, far paints over near |
| `clear(DEPTH_BUFFER_BIT)` | 8142 | 1710 | self-sorts, no terrain occlusion |

`fill-extrusion` renders correctly under terrain and has data-driven
`-base`/`-height`, so the feature ships with **no custom shaders, no new
dependencies, no new pinned assets, and no new CLI flags**.

## Heights are true altitude, not raw AGL

`agl_m` is height above the *takeoff point*, but `fill-extrusion` anchors to
the *local terrain under each segment*. Feeding one into the other put the
curtain top at `local_ground + rel_alt` instead of the drone's real altitude.

That mattered more than a label: DJI drones hold altitude, not ground
clearance, so a level flight toward a rising ridge keeps a constant `rel_alt`
while its real clearance shrinks. The naive geometry drew **constant
clearance exactly where the truth is a closing gap**. Each segment is now
`hgt = (takeoffElev + meanAGL) - localElev`, so the shader's re-added
centroid elevation cancels, the ribbon lands at true altitude, and the
curtain's length is genuine ground clearance.

## Behaviour

- On by default; a global **Sculpture** checkbox hides it, and it is not
  added at all when no flight carries `rel_alt`.
- A flight's own checkbox hides its track and sculpture together, and that
  state survives a global off/on cycle.
- Hidden during the Ghost Camera view — a ribbon at the camera's own altitude
  would sit across the cockpit — and restored at the **end** of the exit ease,
  not the start.
- Plank width is zoom-adaptive (~3 px, clamped 4-60 m), so the sculpture does
  not vanish when you zoom out to see the whole flight.
- Terrain unavailable degrades to plain height above takeoff. Segments at or
  below the rendered surface are skipped rather than drawn flat — the terrain
  model includes canopy and buildings, so a low flight over forest breaks the
  curtain there.

## Testing

20 new browser tests, plus a **stepped-DEM fixture** (`serve_map(...,
terrain_steps=(low, high))`) that makes terrain occlusion testable at all —
the existing constant-elevation stub cannot. It settled the design's one open
risk: terrain **does** occlude the sculpture (0 px behind a 600 m cliff vs
8202 px without terrain).

Gate: 722 passed / 3 pre-existing environment-gated skips, browser 42/42,
ruff and mypy clean.

## Review found five real defects

Signed off by per-task reviews plus a whole-branch review (READY TO MERGE,
zero Critical/Important):

1. Negative `rel_alt` (rooftop/clifftop launch — the repo's own golden fixture
   has `-400.0`) produced a ribbon with `base > height`.
2. Paint wiring was pinned by no test; a curtain/ribbon paint swap would have
   passed the whole suite.
3. The ghost-exit restore flashed the ribbon across the view mid-ease.
4. The altitude-datum error above.
5. `addSculpture` bailed without creating a source, so a canopy-height flight
   lost its sculpture *and its toggle* permanently, unrecoverably.

Feature is UNRELEASED — rides the next version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rwc2fGM8qwTtSH7fkX7Waz