### PR TITLE
Camera's Gaze: playback, footprint sweep and search-footage-by-place in the 3D map

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ it's a handful of copy-paste commands. For a guided tour see
 - **See every flight on one map** — point `dji-embed flightmap` at a folder of
   footage and get a single interactive map with each flight as its own
   coloured track *(experimental)*.
+- **Camera's gaze** in the 3D map: play a flight back, watch the camera's
+  ground footprint sweep the terrain, and click any spot to see which seconds
+  of recording covered it.
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
   folder of stills on one clustered map, thumbnails included; 360° panoramas
   get their own marker color and toggle, and open in an interactive viewer.

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -265,8 +265,7 @@ popups. Terrain comes from Mapterhorn (Copernicus elevation data), loaded
 keylessly over the network — like the 2D map it needs a connection to
 render, and if the terrain tiles can't load, it falls back to a flat view
 with an on-map notice. Browsers without WebGL get a plain HTML message
-instead. `--tile-style` has no effect in 3D (ignored, with a warning), and
-there's no playback in the 3D view.
+instead. `--tile-style` has no effect in 3D (ignored, with a warning).
 
 ### Ghost camera — see what the drone saw
 
@@ -321,6 +320,43 @@ flights on a map has it, the checkbox does not appear at all.
 
 Terrain hides the sculpture the way it hides anything else: a ridge between
 you and the flight blocks it from view.
+
+### Camera's gaze — what the camera saw, and when
+
+The 3D map has a playback control at the bottom left: play/pause, a speed
+button cycling 1×, 5×, 20×, 60×, a scrubber, a time readout, and — with more
+than one flight on the map — a picker for which one is playing. As the clock
+runs, the camera's ground footprint for that second is drawn on the terrain,
+with four rays connecting the camera to its corners.
+
+Press play while you are in the ghost view and the camera rides the recorded
+flight in real time instead of stepping sample by sample. An arrow key still
+pauses playback and hands control back to you, but it also carries the clock
+to the sample you stepped to, so the ground patch stays in agreement with
+where the camera is now looking. Clicking **View from here** on a flight that
+is already playing seeks the clock to the sample you clicked rather than
+leaving the camera to be overridden by wherever the clock currently is.
+Leaving the ghost view keeps the clock running from outside.
+
+**Click any spot on the ground** and the map answers which recording covered
+it: `in frame 14 s over 3 passes`, with each pass a button that jumps the
+clock there (and rides it, if you are in the ghost view). The stretches of
+flight line that filmed the spot light up at the same time. Clicking ground
+that was never in frame says so.
+
+Two honesty limits. The gaze is switched off entirely with `--redact fuzz`,
+because a footprint projected from a coordinate that has been moved ~100 m is
+a confident claim about ground the camera never saw; the flights panel says
+so when that happens, and playback still works. And where the telemetry
+carries no gimbal attitude — every Mini-series drone at the time of
+writing — the footprint is drawn from the same estimated 30-degree down-tilt
+the ghost view assumes, with a dashed outline and an "estimated footprint"
+badge naming what was guessed; a clip can lose gimbal data partway through,
+so a spot's answer says "estimated" when every pass over it was guessed and
+"some passes estimated" when only some were. Footprints also assume flat
+ground at the drone's height reference, the same simplification the
+`--footprint` KML/GeoJSON export makes, so on terrain that rises into the
+frame the drawn patch is an approximation rather than the true footprint.
 
 ## Photo map (`photomap`)
 

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -325,9 +325,9 @@ you and the flight blocks it from view.
 
 The 3D map has a playback control at the bottom left: play/pause, a speed
 button cycling 1×, 5×, 20×, 60×, a scrubber, a time readout, and — with more
-than one flight on the map — a picker for which one is playing. As the clock
-runs, the camera's ground footprint for that second is drawn on the terrain,
-with four rays connecting the camera to its corners.
+than one playable flight on the map — a picker for which one is playing. As
+the clock runs, the camera's ground footprint for that second is drawn on the
+terrain, with four rays connecting the camera to its corners.
 
 Press play while you are in the ghost view and the camera rides the recorded
 flight in real time instead of stepping sample by sample. An arrow key still
@@ -344,19 +344,25 @@ clock there (and rides it, if you are in the ghost view). The stretches of
 flight line that filmed the spot light up at the same time. Clicking ground
 that was never in frame says so.
 
-Two honesty limits. The gaze is switched off entirely with `--redact fuzz`,
-because a footprint projected from a coordinate that has been moved ~100 m is
-a confident claim about ground the camera never saw; the flights panel says
-so when that happens, and playback still works. And where the telemetry
-carries no gimbal attitude — every Mini-series drone at the time of
-writing — the footprint is drawn from the same estimated 30-degree down-tilt
-the ghost view assumes, with a dashed outline and an "estimated footprint"
-badge naming what was guessed; a clip can lose gimbal data partway through,
-so a spot's answer says "estimated" when every pass over it was guessed and
-"some passes estimated" when only some were. Footprints also assume flat
-ground at the drone's height reference, the same simplification the
-`--footprint` KML/GeoJSON export makes, so on terrain that rises into the
-frame the drawn patch is an approximation rather than the true footprint.
+Two honesty limits, and a footprint can be an estimate for either of two
+reasons. The gaze is switched off entirely with `--redact fuzz`, because a
+footprint projected from a coordinate that has been moved ~100 m is a
+confident claim about ground the camera never saw; the flights panel says so
+when that happens, and playback still works. And where the telemetry carries
+no gimbal attitude — every Mini-series drone at the time of writing — the
+footprint is drawn from the same estimated 30-degree down-tilt the ghost view
+assumes. A missing focal length has the same effect on the footprint's shape:
+it is drawn from a generic wide lens instead of the camera's true field of
+view, which makes the patch a little larger than the true frame — this is the
+common case for sidecar-less MP4 clips, which log real gimbal attitude but no
+focal length. Either reason (or both) marks the footprint with a dashed
+outline and an "estimated footprint" badge naming what was guessed; a clip
+can lose gimbal data or focal length partway through, so a spot's answer says
+"estimated" when every pass over it was guessed and "some passes estimated"
+when only some were. Footprints also assume flat ground at the drone's height
+reference, the same simplification the `--footprint` KML/GeoJSON export
+makes, so on terrain that rises into the frame the drawn patch is an
+approximation rather than the true footprint.
 
 ## Photo map (`photomap`)
 

--- a/docs/superpowers/specs/2026-07-27-cameras-gaze-design.md
+++ b/docs/superpowers/specs/2026-07-27-cameras-gaze-design.md
@@ -1,0 +1,396 @@
+# Camera's Gaze — design
+
+**Date:** 2026-07-27
+**Issue:** [#378](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/378)
+**Status:** Approved
+
+## Problem
+
+The 3D flight map can now put you at the drone's altitude (Ghost Camera, #372)
+and show the shape of the flight in the air (flight sculpture, #375). It still
+cannot answer the question people actually ask of their own footage: **what was
+the camera looking at, and when did it film this spot?**
+
+Camera's Gaze answers both. A time cursor sweeps the flight; the camera's
+ground footprint is drawn on the terrain as it goes, with the four frustum
+corner rays connecting camera to ground; and clicking any spot returns every
+second of recording that had it in frame. The second half is the provenance
+payoff — "which frames show this place" is the question a verifier asks — and
+it falls out for free once footprints exist for every sample.
+
+The 3D map also has no playback at all today; the flat map has had it since
+#267 (`docs/geospatial.md` says so in as many words). The time cursor closes
+that gap, and pressing play inside the ghost view rides the recorded flight in
+real time instead of arrow-keying sample by sample.
+
+This is stage 3 of the 3D arc agreed 2026-07-26. Stage 4 (separate spec)
+crossfades a ghost pose to the real photo or video frame.
+
+## Scope
+
+- Playback, gaze patch, beam and click-a-spot lookup in the **3D template
+  only** (`geo/flightmap3d_html.py`), built in JS.
+- **One new GeoJSON property**: `hfov_deg`, beside the existing `vfov_deg`.
+- No new CLI flags, no new dependencies, no new pinned assets (the SRI-count
+  test stays unchanged). Ships inside the existing `--3d` output; the GUI gets
+  it through the 3D toggle and WebView preview.
+- `footprint.py`, the `--footprint` export path, and the flat map are
+  untouched.
+
+Out of scope (deferred): the flat map's "All flights (compare)" playback mode
+(a patch and beam per flight at once is visual noise, and the cockpit can only
+ride one flight); a persistent "everything this flight saw" coverage union
+layer; interpolating footprints between samples; media crossfade (stage 4);
+true gimbal attitude for Mini-series drones (#374).
+
+## Design
+
+### 1. Data — one new GeoJSON property
+
+`_add_ghost_props` (`geo/flightmap.py:324`) already emits per-point
+`gyaw_deg` / `gpitch_deg` / `agl_m` and per-flight `vfov_deg` from the median
+focal length. It gains `hfov_deg` from the same `fov_degrees(DEFAULT_LENS,
+median(focals))` call, under the same honesty rule — emitted only when the
+telemetry carries focal lengths:
+
+```python
+focals = [p.focal_len for p in points if p.focal_len is not None]
+if focals:
+    hfov, vfov = fov_degrees(DEFAULT_LENS, median(focals))
+    properties["hfov_deg"] = round(hfov, 1)
+    properties["vfov_deg"] = round(vfov, 1)
+```
+
+The property therefore also appears in `-f geojson` exports and in the flat
+map's embedded data, where it is unused. That is acceptable and documented:
+it is one number per flight, and splitting the emitter into 2D and 3D variants
+to hide it would cost more than it saves. Any existing test that asserts an
+exact property set on a flight feature needs updating with it.
+
+The template picks it up beside the existing pose arrays:
+`entry.hfov = p.hfov_deg || null;`.
+
+Nothing else moves to Python. In particular the footprint rings are **not**
+embedded: at ~115 bytes per second per flight a 20-clip folder map would gain
+roughly 700 KB of derivable data, several times the size of the track
+coordinates themselves, and the browser can recompute them in under 5 ms.
+
+### 2. Footprint projection in the browser — `gazeRing(fl, i)`
+
+A port of `frustum_ground_ring` (`geo/geometry.py:21`), frustum path only.
+Python's nadir-rectangle branch is not needed: a pitch is always available,
+real or estimated, so there is one code path instead of two.
+
+Parameter resolution, in order, each fallback marking the ring estimated:
+
+| Input | Source | Fallback |
+| --- | --- | --- |
+| AGL | `fl.agl[i]` | none — no ring |
+| gimbal pitch | `fl.gpitch[i]` | `GHOST_EST_PITCH` (−30°) |
+| bearing | `fl.gyaw[i] % 360` | `courseBearing(fl.pts, i)` |
+| HFOV / VFOV | `fl.hfov` / `fl.vfov` | `GAZE_FALLBACK_HFOV` / `_VFOV` |
+
+Return shape:
+
+```js
+{ ring: null | [[lon, lat] × 5],   // closed, far-left..near-left as in Python
+  reason: null | 'no altitude' | 'camera above horizon',
+  estimated: boolean,
+  estNotes: [] }                   // e.g. ['no gimbal pitch', 'assumed lens']
+```
+
+No ring is produced for a sample `build_footprints` would also skip: AGL
+null or ≤ 0 (`reason: 'no altitude'`), or pitch at/above the horizon
+(`reason: 'camera above horizon'` — reachable only from real telemetry, since
+the −30° estimate never is). Ground range clamps at
+`GAZE_MAX_RANGE_FACTOR * agl`, mirroring `MAX_RANGE_AGL_FACTOR = 8.0`, so a
+near-horizon frame degrades to a capped trapezoid instead of an unbounded one.
+
+The projection itself mirrors the Python line for line — camera-frame corner
+rays `(sh, sv) ∈ {(-1,1), (1,1), (1,-1), (-1,-1)}`, each ray's ground distance
+`min(agl / -dz * horiz, maxRange)` when it descends and `maxRange` when it does
+not, then yaw-rotated and converted to degrees through `111320` m per degree of
+latitude and `111320 · cos(lat)` per degree of longitude.
+
+Fallback FOV constants mirror the generic 20 mm-equivalent 4:3 `DEFAULT_LENS`:
+
+```js
+const GAZE_FALLBACK_HFOV = 84.0;   // fov_degrees(DEFAULT_LENS, None)[0]
+const GAZE_FALLBACK_VFOV = 68.0;   // fov_degrees(DEFAULT_LENS, None)[1]
+```
+
+Rings are computed once per flight at load — `fl.rings[i]` for every sample —
+because the click-a-spot lookup needs all of them and the maths is pure trig
+with no terrain queries.
+
+**Honest limitation, inherited from Python:** corner rays are projected onto a
+flat ground plane at the drone's AGL reference and then draped by the fill
+layer. On steep terrain the drawn patch differs from the true footprint. The
+same approximation is already shipping in `--footprint` KML/GeoJSON.
+
+### 3. Playback — `pb`
+
+Ported from the flat map's animator (`geo/flightmap_html.py:123-235`) with its
+semantics kept deliberately identical, so a user who learns one map's playback
+knows the other's:
+
+- Eligibility (`runs`): a LineString flight with `times` of the same length as
+  its points and a positive last time.
+- `PB_SPEEDS = [1, 5, 20, 60]`, cycled by one button.
+- A `requestAnimationFrame` clock advancing `pb.t` by wall time × speed,
+  pausing when it reaches the end, restarting from 0 when play is pressed at
+  the end.
+- `positionAt(run, t)` with a monotonic `run.cursor` hint, seek-backwards
+  reset included.
+- Element ids `pb-play`, `pb-speed`, `pb-slider`, `pb-time`, `pb-flight`, plus
+  `pb-note` for the estimated/skip badge.
+
+Differences from the flat map, both forced by the medium:
+
+- The control is a plain `.playback` div positioned bottom-left (there is no
+  `L.control`). The ghost HUD is bottom-centre, so they do not collide.
+- The picker has no "All flights (compare)" option (see Scope).
+
+The cursor dot is layer `gaze-cursor-dot` (`circle`) over a one-point
+`gaze-cursor` source, styled like the flat map's marker (radius 7, white 2 px
+stroke, flight-colour fill), updated every frame.
+
+**The patch and beam update on sample change, not per frame.** Each ring *is*
+one second of recording, so interpolating rings would invent geometry; and it
+bounds the work at 60× speed to ~60 small `setData` calls a second instead of
+3600. `renderCursor()` runs every frame; `renderGaze()` runs when
+`sampleIndexAt(run, pb.t)` — the index of the sample at or before the cursor —
+changes.
+
+### 4. Riding the cockpit
+
+While playback is running with `ghost.active` and `ghost.flight === run`, each
+frame builds an interpolated pose and applies it with **`jumpTo`, never
+`easeTo`**: an ease would fight the clock and churn `moveend`, which is where
+this file's existing scars are (`ghostExit`'s aborted-ease guard,
+`geo/flightmap3d_html.py:463`).
+
+```js
+function posePlayback(fl, t) {
+  const i = sampleIndexAt(fl, t);
+  if (i >= fl.pts.length - 1) return samplePose(fl, fl.pts.length - 1);
+  const t0 = fl.times[i], t1 = fl.times[i + 1];
+  const f = t1 > t0 ? (t - t0) / (t1 - t0) : 1;   // as in positionAt()
+  const p0 = samplePose(fl, i), p1 = samplePose(fl, i + 1);
+  const d = ((p1.bearing - p0.bearing + 540) % 360) - 180;   // shortest arc
+  return Object.assign({}, p0, {
+    lngLat: [lerp(p0.lngLat[0], p1.lngLat[0], f),
+             lerp(p0.lngLat[1], p1.lngLat[1], f)],
+    altitude: lerp(p0.altitude, p1.altitude, f),
+    bearing: p0.bearing + d * f,
+    pitch: lerp(p0.pitch, p1.pitch, f) });
+}
+```
+
+`lerp` is a two-line local helper; `Object.assign` rather than object spread
+matches `applyPose`'s existing style. The final sample returns its own pose
+directly, since there is no following sample to interpolate toward.
+
+Building the pose from two `samplePose` calls reuses every existing fallback
+(takeoff-elevation conversion, estimated pitch, pitch clamping) rather than
+duplicating them. `ghost.idx` is kept in step with the integer sample so the
+HUD and arrow keys stay coherent, and `updateHud()` fires only when that index
+changes.
+
+Three interaction rules, each chosen to stay clear of the ease hazards
+`ghostEnter`/`ghostExit` already document:
+
+- Entering the cockpit **while playing** jumps in (`applyPose(pose, 0)`)
+  instead of easing over `GHOST_ENTER_MS`. You are riding; the cinematic ease
+  would be overridden by the next frame anyway.
+- An arrow-key step **pauses** playback. Manual control wins.
+- Exiting while playing keeps the clock running third-person. `ghostExit`
+  needs no change: the per-frame drive stops the moment `ghost.active` goes
+  false, and the existing `once('moveend')` restore guard still applies.
+
+### 5. The gaze patch and the beam
+
+**One shared source pair, not one per flight.** Playback runs a single flight
+at a time, so there is only ever one cursor: a `gaze` source (the ring) and a
+`beam` source, recoloured through `setPaintProperty` when the selected run
+changes. The patch is rendered at `pb.t = 0` at load, before play is ever
+pressed, so the feature is discoverable.
+
+Patch layers:
+
+- `gaze-fill` — `fill`, `fill-color` = run colour, `fill-opacity`
+  `GAZE_PATCH_OPACITY = 0.25`. `fill` is in MapLibre's render-to-texture
+  whitelist, so it drapes onto the terrain correctly and needs no elevation
+  query at all.
+- `gaze-edge` — `line`, 1.5 px, run colour. Estimated rings get a dashed
+  edge: `setPaintProperty('gaze-edge', 'line-dasharray', estimated ? [2, 2]
+  : null)`, where `null` restores the style-spec default (solid). It is flipped
+  only when that state changes, so there is no per-frame churn, and the test
+  asserts the round trip in **both** directions — a reset that silently fails
+  would leave every later ring looking estimated.
+
+Both are inserted with `beforeId = flights[0].id` (when that layer exists) so
+the tracks stay readable through the patch.
+
+**The beam.** `fill-extrusion` can only make vertical prisms measured from the
+terrain surface, so each of the four corner rays is staircased into
+`GAZE_BEAM_STEPS = 16` short prisms from the camera down to that ring corner.
+
+Heights reuse the sculpture's conversion exactly (`planksFor`,
+`geo/flightmap3d_html.py:559`) — the drone's true altitude minus the local
+surface, because the shader re-adds the centroid's elevation:
+
+- `tElev = takeoffElev(fl)`; camera true altitude `tElev + agl`; camera local
+  surface `terrainElevAt(camera)`; corner local surface
+  `terrainElevAt(corner)`.
+- Along a ray, altitude interpolates from the camera's true altitude to the
+  corner's ground elevation, and the local surface interpolates between the
+  two sampled elevations, so `h(s) = alt(s) − local(s)` is `agl`-equivalent
+  clearance at the camera and exactly 0 at the corner.
+- Elevation is sampled **twice per ray, not once per step** — 8
+  `queryTerrainElevation` calls per sample instead of 64, which matters at 60×
+  speed.
+- Flat-mode fallback when terrain is off or any elevation is unknown:
+  `h(s) = agl · (1 − s)`, which is exactly right when the extrusion measures
+  from sea level.
+- Each prism carries `base = max(0, min(h₀, h₁))` and `hgt = max(h₀, h₁)`, so
+  consecutive prisms share altitude at their joint and the silhouette is
+  continuous rather than a ladder with gaps. `fill-extrusion-base` has a
+  style-spec minimum of 0, hence the clamp in JS. A step whose `hgt` computes
+  ≤ 0 is dropped — the same honesty rule that breaks the curtain when the
+  drone is below the rendered (canopy-inclusive) surface.
+- Width reuses `sculptWidthM()`, so the rays hold a constant screen thickness
+  across zooms, and the perpendicular offset maths matches `planksFor`.
+
+Layer `beam-ray` — `fill-extrusion`, base and height data-driven,
+`fill-extrusion-opacity` `GAZE_BEAM_OPACITY = 0.5`,
+`fill-extrusion-vertical-gradient: false`.
+
+Up to 64 small polygons per sample, rebuilt only on sample change.
+
+### 6. Click a spot → the seconds that filmed it
+
+A general `map.on('click')` handler, which bails when
+`map.queryRenderedFeatures(ev.point)` hits a flight-line layer (those already
+own a popup with **View from here**) and when positions are fuzzed.
+
+For every flight with rings, ray-cast point-in-polygon against each ring;
+consecutive hit samples merge into passes. In-frame seconds are counted per
+sample interval (`times[i+1] − times[i]`, the previous interval for the last
+sample) so a single-sample hit reads as about a second rather than zero.
+
+Popup, built with DOM nodes and `textContent` rather than interpolated HTML
+(flight names come from filenames):
+
+> **DJI_0001** — in frame 14 s over 3 passes
+> `0:12–0:18`  `1:04–1:09`  `2:31–2:33`
+
+Each pass is a button: select that flight in the picker, seek the clock to the
+pass start, and start playing. If you are already in the cockpit on that
+flight, that *is* riding it — no separate control needed. The list caps at
+`GAZE_MAX_PASSES = 12` with a "+N more" note, so a hover over one spot cannot
+produce a thousand buttons. When the matched flight's rings were estimated,
+the popup says so. A miss gets an explicit answer — "No recorded frame covered
+this spot" — rather than silence.
+
+Simultaneously a `gaze-hits` source highlights the matching stretches of
+flight line: one LineString per pass, extended one sample either side so a
+single-sample hit is still visible, `line-color` data-driven from the flight's
+colour, 6 px at 0.55 opacity, inserted with the same
+`beforeId = flights[0].id` so the track still reads on top of its halo.
+Cleared on popup close and replaced on the next lookup.
+
+### 7. Visibility and rebuild triggers
+
+`applyGazeVisibility()`, called from the same places `applySculptVisibility()`
+is:
+
+- `gaze-fill` / `gaze-edge`: visible when a run is selected, that flight is
+  shown in the panel, and positions are not fuzzed. A sample with no ring is
+  handled by emptying the source (§8), not by toggling visibility — one
+  mechanism per concern.
+- `beam-ray`: the same conditions **plus `!ghost.active`** — a beam
+  originating at your own eye would fill the cockpit view, the same reason the
+  sculpture steps aside.
+
+Rebuild triggers for `renderGaze()`:
+
+- the integer sample index changes during playback or a seek;
+- the selected run changes;
+- `zoomend`, sharing `rebuildSculpture`'s 0.5 m width threshold, so the beam's
+  screen thickness tracks the sculpture's;
+- the terminal branch of `sculptSettle()`, so the **load-time** beam corrects
+  once the DEM firms up. It rides that existing bounded retry rather than
+  starting a second timer. During playback no settle is needed at all — every
+  sample change rebuilds the beam, so it self-corrects as tiles warm.
+
+### 8. Failure posture and edge cases
+
+| Condition | Behaviour |
+| --- | --- |
+| `--redact fuzz` | No patch, no beam, no lookup. Playback still works. A dimmed line in the flights panel says why. A footprint projected from a coordinate moved ~100 m is a confident claim about ground that was not filmed; `--footprint` already refuses redacted exports. |
+| No `times_s` | Not playable and not gazeable — there is no "which second" to answer. |
+| Times but no `agl_m` | Playable, no gaze. |
+| Single-fix clip (Point) | Excluded from both, as it already is from the ghost view. |
+| Sample with null/≤ 0 AGL, or camera at/above horizon | That second's sources are cleared rather than frozen on the last good ring, and `#pb-note` names the reason, so a vanishing patch reads as information. |
+| Terrain off, or DEM cold | Patch unaffected (draped `fill`, no elevation query). Beam falls back to flat mode and corrects on the next rebuild. |
+| No flight has times | No playback control, no gaze; the map is exactly what it is today. |
+| No WebGL | Existing plain-HTML fallback covers everything. |
+
+## Testing
+
+Two new files on the `browser` marker, using the `serve_map` / `terrain_stub` /
+`terrain_steps` fixtures already in `tests/browser/conftest.py`:
+`tests/browser/test_flightmap_3d_playback.py` and
+`tests/browser/test_flightmap_gaze.py`.
+
+**Cross-language parity is the load-bearing test.** Browser tests run in the
+same Python process as the package, so the test imports `frustum_ground_ring`
+directly, calls `page.evaluate("gazeRing(...)")` on the same inputs, and
+compares corner by corner to 1e-9°. Cases: a nadir frame, an oblique frame, and
+a near-horizon frame that exercises the 8 × AGL clamp. A second probe reads
+`GAZE_FALLBACK_HFOV` / `GAZE_FALLBACK_VFOV` off the page and asserts them
+against `fov_degrees(DEFAULT_LENS, None)`. Without these two the JS port is
+free to drift from the Python it mirrors.
+
+Playback: the clock advances and pauses at the end; the slider seeks; the speed
+button cycles `[1, 5, 20, 60]`; the picker switches flights and resets the
+clock; a flight without times is absent from the picker; a map with no
+playable flight has no control at all.
+
+Cockpit riding: the applied pose tracks the samples as the clock runs; an
+arrow-key step pauses; entering while playing jumps rather than eases (assert
+no ease is in flight); exiting while playing leaves the clock running and
+restores the saved view.
+
+Gaze: the patch polygon matches the parity test's ring for a known sample; an
+above-horizon sample clears the source and sets `#pb-note`; a null-AGL sample
+clears it; the edge's dash state flips with estimated-ness; the patch is
+present at load before play is pressed.
+
+Beam: prisms exist for a known sample; `base`/`hgt` are continuous along a ray
+(each step's base equals the neighbour's height at the joint); the beam is
+hidden while `ghost.active` and visible again after exit; flat mode with
+terrain off puts `hgt` at `agl` at the camera end; a below-surface step is
+dropped over the `terrain_steps` cliff.
+
+Lookup: a click inside a known ring returns the expected pass list; a click
+outside every ring returns the miss message; a pass button seeks the clock and
+starts playback; the highlight appears and clears on popup close; a click on a
+flight line still opens the flight popup, not the lookup; `--redact fuzz`
+yields no gaze layers while playback still works.
+
+Python: one unit test in `tests/test_geo_flightmap.py` for `hfov_deg` emission
+(present with focal lengths, absent without), beside the existing `vfov_deg`
+assertions.
+
+## Docs
+
+`docs/geospatial.md`: the 3D section's closing claim that "there's no playback
+in the 3D view" (line 269) stops being true and must be rewritten. A new
+**Camera's gaze** subsection follows the ghost-camera and sculpture ones,
+covering the time cursor, riding the flight from the cockpit, the patch and
+beam, clicking a spot to find footage, and the two honesty gates (fuzzed
+positions turn it off; missing gimbal attitude makes it an estimate). README's
+feature list gains one line. The changelog is generated at release time and
+needs no manual edit.

--- a/docs/superpowers/specs/2026-07-27-cameras-gaze-design.md
+++ b/docs/superpowers/specs/2026-07-27-cameras-gaze-design.md
@@ -243,19 +243,29 @@ surface, because the shader re-adds the centroid's elevation:
 - `tElev = takeoffElev(fl)`; camera true altitude `tElev + agl`; camera local
   surface `terrainElevAt(camera)`; corner local surface
   `terrainElevAt(corner)`.
-- Along a ray, altitude interpolates from the camera's true altitude to the
-  corner's ground elevation, and the local surface interpolates between the
-  two sampled elevations, so `h(s) = alt(s) − local(s)` is `agl`-equivalent
-  clearance at the camera and exactly 0 at the corner.
-- Elevation is sampled **twice per ray, not once per step** — 8
-  `queryTerrainElevation` calls per sample instead of 64, which matters at 60×
-  speed.
+- Along a ray, altitude interpolates linearly from the camera's true altitude
+  to the corner's ground elevation, and each prism's height is that altitude
+  minus **the terrain actually under it**:
+  `h(s) = alt(s) − terrainElevAt(pointAt(s))`, evaluated once at each of the
+  `GAZE_BEAM_STEPS + 1` step boundaries and shared between neighbouring
+  prisms, so joints match exactly by construction.
+- **Elevation must be sampled per step, not interpolated between the two ends.**
+  Two-sample interpolation looks like a cheap win (8 lookups per sample
+  instead of 68) but it cancels algebraically —
+  `h(s) = [A + (E_corner − A)s] − [E_cam + (E_corner − E_cam)s] =
+  (A − E_cam)(1 − s)` — dropping the corner elevation entirely, so the ray
+  would ignore every ridge and valley it crosses and hug the ground contour
+  instead of flying straight. That is the same error class the sculpture's
+  `agl_m` conversion fixed: constant clearance drawn where the truth is a
+  closing gap. 68 `queryTerrainElevation` calls per rebuild is ~4k cheap DEM
+  lookups a second at 60× speed, which is affordable.
 - Flat-mode fallback when terrain is off or any elevation is unknown:
   `h(s) = agl · (1 − s)`, which is exactly right when the extrusion measures
   from sea level.
-- Each prism carries `base = max(0, min(h₀, h₁))` and `hgt = max(h₀, h₁)`, so
-  consecutive prisms share altitude at their joint and the silhouette is
-  continuous rather than a ladder with gaps. `fill-extrusion-base` has a
+- Each prism carries `base = max(0, min(h₀, h₁))` and `hgt = max(h₀, h₁)`.
+  Because neighbours share the boundary value, their spans always touch or
+  overlap (`max(base) ≤ min(hgt)`) and the silhouette is continuous rather
+  than a ladder with gaps — including where terrain makes `h` non-monotonic. `fill-extrusion-base` has a
   style-spec minimum of 0, hence the clamp in JS. A step whose `hgt` computes
   ≤ 0 is dropped — the same honesty rule that breaks the curtain when the
   drone is below the rendered (canopy-inclusive) surface.
@@ -368,11 +378,14 @@ above-horizon sample clears the source and sets `#pb-note`; a null-AGL sample
 clears it; the edge's dash state flips with estimated-ness; the patch is
 present at load before play is pressed.
 
-Beam: prisms exist for a known sample; `base`/`hgt` are continuous along a ray
-(each step's base equals the neighbour's height at the joint); the beam is
-hidden while `ghost.active` and visible again after exit; flat mode with
-terrain off puts `hgt` at `agl` at the camera end; a below-surface step is
-dropped over the `terrain_steps` cliff.
+Beam: prisms exist for a known sample; spans touch or overlap at every joint
+along a ray (exact equality on flat ground and on the constant-elevation stub,
+where `h` decays monotonically); the beam is hidden while `ghost.active` and
+visible again after exit; flat mode with terrain off puts `hgt` at `agl` at the
+camera end, and the constant-elevation stub must produce the *same* heights as
+terrain-off — the invariance that would fail if the elevation conversion were
+dropped; a below-surface step is dropped over the `terrain_steps` cliff, so the
+ray stops at the wall instead of tunnelling through it.
 
 Lookup: a click inside a known ring returns the expected pass list; a click
 outside every ring returns the miss message; a pass button seeks the clock and

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -326,8 +326,9 @@ def _add_ghost_props(properties: dict, points: list[TrackPoint]) -> None:
 
     Same contract as ``times_s``: parallel to ``coordinates``, null-padded so
     indices stay aligned, emitted only when at least one point has the value.
-    ``vfov_deg`` is per-flight (median focal length) — DJI zooms mid-flight
-    rarely enough that one value per flight is honest.
+    ``hfov_deg``/``vfov_deg`` are per-flight (median focal length) — DJI
+    zooms mid-flight rarely enough that one value per flight is honest. The
+    3D gaze sizes the camera footprint from them (#378).
     """
     for key, attr in (
         ("gyaw_deg", "gimbal_yaw"),
@@ -342,9 +343,9 @@ def _add_ghost_props(properties: dict, points: list[TrackPoint]) -> None:
             properties[key] = vals
     focals = [p.focal_len for p in points if p.focal_len is not None]
     if focals:
-        properties["vfov_deg"] = round(
-            fov_degrees(DEFAULT_LENS, median(focals))[1], 1
-        )
+        hfov, vfov = fov_degrees(DEFAULT_LENS, median(focals))
+        properties["hfov_deg"] = round(hfov, 1)
+        properties["vfov_deg"] = round(vfov, 1)
 
 
 def flights_to_geojson(tracks: list[Track], redact: str = "none") -> dict:
@@ -353,7 +354,7 @@ def flights_to_geojson(tracks: list[Track], redact: str = "none") -> dict:
     Each flight is a ``LineString`` carrying name/start/duration/altitude
     summary properties plus ``times_s`` — per-point seconds relative to the
     flight start — which drives the HTML viewer's playback animation (#267).
-    LineStrings also carry per-point ghost-camera pose arrays (``gyaw_deg``/``gpitch_deg``/``agl_m``) and a per-flight ``vfov_deg`` when the telemetry has them (#372).
+    LineStrings also carry per-point ghost-camera pose arrays (``gyaw_deg``/``gpitch_deg``/``agl_m``) and per-flight ``hfov_deg``/``vfov_deg`` when the telemetry has them (#372).
     A single-fix clip degrades to a ``Point`` (RFC 7946 §3.1.4 requires two
     or more positions in a LineString) and carries no times. Unlike the
     single-track exporter no per-sample Point features are emitted — at

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -407,6 +407,7 @@ function ghostEnter(flightIdx, sampleIdx) {
   window.addEventListener('keydown', ghostKeys);
   applySculptVisibility();   // a ribbon at the camera's own altitude would
                             // sit across the cockpit view
+  applyGazeVisibility();
   if (!ghost.saved) {
     // Survives exit -> rapid re-enter while the exit ease still runs, so
     // a re-entry never captures a mid-transition camera as "the view to
@@ -443,12 +444,15 @@ function ghostEnter(flightIdx, sampleIdx) {
     ghost.savedFov = map.getVerticalFieldOfView();
     map.setVerticalFieldOfView(fl.vfov);
   }
-  applyPose(samplePose(fl, ghost.idx), GHOST_ENTER_MS);
+  // Riding: jump in. The cinematic ease would be overridden by the next
+  // playback frame, and eases here are the moveend hazard.
+  applyPose(samplePose(fl, ghost.idx), pb.playing ? 0 : GHOST_ENTER_MS);
   mountHud();
 }
 
 function ghostStep(d) {
   if (!ghost.active) return;
+  if (pb.playing) pbPause();       // manual control wins over the clock
   const n = ghost.flight.pts.length;
   const next = Math.max(0, Math.min(ghost.idx + d, n - 1));
   if (next === ghost.idx) return;
@@ -481,6 +485,7 @@ function ghostExit() {
     GHOST_HANDLERS.forEach(h => map[h] && map[h].enable());
     ghost.saved = null;
     applySculptVisibility();
+    applyGazeVisibility();
   });
   unmountHud();
   ghost.flight = null;
@@ -985,6 +990,51 @@ function pbRender() {
     pb.sample = s;
     renderGaze();
   }
+  pbDriveGhost();
+}
+
+function lerp(a, b, f) { return a + (b - a) * f; }
+
+function posePlayback(fl, t) {
+  // Built from two samplePose() calls so every existing fallback -- takeoff
+  // elevation, the -30 pitch estimate, the pitch clamp -- applies unchanged.
+  const i = sampleIndexAt(fl, t);
+  if (i >= fl.pts.length - 1) return samplePose(fl, fl.pts.length - 1);
+  const t0 = fl.times[i], t1 = fl.times[i + 1];
+  const f = t1 > t0 ? (t - t0) / (t1 - t0) : 1;
+  const p0 = samplePose(fl, i), p1 = samplePose(fl, i + 1);
+  const d = ((p1.bearing - p0.bearing + 540) % 360) - 180;   // shortest arc
+  return Object.assign({}, p0, {
+    lngLat: [lerp(p0.lngLat[0], p1.lngLat[0], f),
+             lerp(p0.lngLat[1], p1.lngLat[1], f)],
+    altitude: lerp(p0.altitude, p1.altitude, f),
+    bearing: p0.bearing + d * f,
+    pitch: lerp(p0.pitch, p1.pitch, f),
+  });
+}
+
+function pbDriveGhost() {
+  if (!ghost.active || ghost.flight !== pb.run) return;
+  // jumpTo, never easeTo: an ease would fight the clock and churn moveend,
+  // which is where this file's ghost-exit guard already earned its scars.
+  applyPose(posePlayback(pb.run, pb.t), 0);
+  if (pb.sample !== ghost.idx) {
+    ghost.idx = pb.sample;
+    updateHud();
+  }
+}
+
+function applyGazeVisibility() {
+  const v = (pb.run && pb.run.shown) ? 'visible' : 'none';
+  // The beam originates at the camera, so it hides in the cockpit for the
+  // same reason the sculpture does; the patch is what you came to see.
+  const beam = (v === 'visible' && !ghost.active) ? 'visible' : 'none';
+  [['gaze-fill', v], ['gaze-edge', v], ['gaze-cursor-dot', v],
+   ['gaze-hits-line', v], ['beam-ray', beam]].forEach(pair => {
+    if (map.getLayer(pair[0])) {
+      map.setLayoutProperty(pair[0], 'visibility', pair[1]);
+    }
+  });
 }
 
 function pbPause() {

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -66,6 +66,7 @@ _TEMPLATE = """<!DOCTYPE html>
   .flights-panel label {{ display: block; cursor: pointer; }}
   .flights-panel hr {{ border: none; border-top: 1px solid #ddd;
                       margin: 6px 0; }}
+  .panel-note {{ opacity: .7; font-size: 11px; }}
   .map-note {{ position: absolute; top: 10px; left: 50%;
               transform: translateX(-50%); z-index: 6; background: #fffbe6;
               border: 1px solid #e0d8a8; border-radius: 4px;
@@ -284,6 +285,7 @@ function buildPanel() {
       map.setLayoutProperty(f.id, 'visibility',
                             box.checked ? 'visible' : 'none');
       applySculptVisibility();
+      applyGazeVisibility();
     });
     label.appendChild(box);
     const swatch = document.createElement('span');
@@ -293,6 +295,12 @@ function buildPanel() {
     label.appendChild(document.createTextNode(f.name));
     panel.appendChild(label);
   });
+  if (REDACTED !== 'none' && runs.length) {
+    const note = document.createElement('div');
+    note.className = 'panel-note';
+    note.textContent = 'Camera gaze off \\u2014 positions fuzzed';
+    panel.appendChild(note);
+  }
   if (flights.some(f => f.sculptSrc)) {
     panel.appendChild(document.createElement('hr'));
     const label = document.createElement('label');
@@ -1163,8 +1171,12 @@ function mountPlayback() {
   map.addLayer({ id: 'gaze-cursor-dot', type: 'circle', source: 'gaze-cursor',
     paint: { 'circle-radius': 7, 'circle-color': pb.run.color,
              'circle-stroke-color': '#fff', 'circle-stroke-width': 2 } });
-  addGazeLayers();
-  map.on('click', gazeLookup);
+  if (REDACTED === 'none') {
+    // Fuzzed coordinates would make every footprint a confident claim about
+    // ground the camera never saw. The clock still works.
+    addGazeLayers();
+    map.on('click', gazeLookup);
+  }
   pbRender();
 }
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -468,19 +468,18 @@ function ghostStep(d) {
   const next = Math.max(0, Math.min(ghost.idx + d, n - 1));
   if (next === ghost.idx) return;
   ghost.idx = next;
-  applyPose(samplePose(ghost.flight, next), GHOST_STEP_MS);
-  updateHud();
   if (pb.run === ghost.flight) {
     // Keep the clock in step with the cockpit, so the gaze patch on the
-    // ground matches the second the camera is now looking from. pbRender()
-    // ends in pbDriveGhost(), which re-applies this exact pose via jumpTo
-    // (posePlayback(fl, times[next]) is numerically identical to
-    // samplePose(fl, next) -- see posePlayback) -- that lands on the same
-    // target as the ease just started above, so it finishes the step
-    // rather than fighting it.
+    // ground matches the second the camera is now looking from.
+    // pbRender(true) SKIPS the per-frame ghost drive on purpose: that drive
+    // jumpTo's to this same pose, and being instant it would beat the eased
+    // step below, turning every arrow key into a hard cut. The patch is data
+    // and updates now; the camera is motion and glides.
     pb.t = ghost.flight.times[next];
-    pbRender();
+    pbRender(true);
   }
+  applyPose(samplePose(ghost.flight, next), GHOST_STEP_MS);
+  updateHud();
 }
 
 function ghostExit() {
@@ -993,7 +992,10 @@ function pbRecolour() {
   }
 }
 
-function pbRender() {
+function pbRender(skipGhost) {
+  // skipGhost lets a caller refresh the cursor, patch and readout WITHOUT
+  // driving the cockpit camera -- see ghostStep, whose own eased move would
+  // otherwise be beaten to the same target by the instant drive below.
   if (!pb.run) return;
   const src = map.getSource('gaze-cursor');
   if (src) src.setData({ type: 'Feature', properties: {},
@@ -1012,7 +1014,7 @@ function pbRender() {
     pb.sample = s;
     renderGaze();
   }
-  pbDriveGhost();
+  if (!skipGhost) pbDriveGhost();
 }
 
 function lerp(a, b, f) { return a + (b - a) * f; }

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -84,6 +84,16 @@ _TEMPLATE = """<!DOCTYPE html>
                       padding: 2px 9px; }}
   .ghost-badge {{ background: #b58900; color: #fff; border-radius: 3px;
                  padding: 0 6px; font-size: 11px; }}
+  .playback {{ position: absolute; bottom: 14px; left: 10px; z-index: 6;
+              background: #fff; border-radius: 4px; padding: 6px 10px;
+              box-shadow: 0 1px 5px rgba(0,0,0,.4); display: flex;
+              gap: 6px; align-items: center; flex-wrap: wrap;
+              font: 13px/1.4 sans-serif; max-width: 92vw; }}
+  .playback button {{ border: none; background: none; cursor: pointer;
+                     font-size: 15px; padding: 0 4px; }}
+  .playback input[type=range] {{ width: 140px; }}
+  .playback span {{ font-variant-numeric: tabular-nums; }}
+  .playback select {{ font: inherit; max-width: 160px; }}
 </style>
 </head>
 <body>
@@ -251,6 +261,7 @@ if (map) {
     map.on('zoomend', rebuildSculpture);
     sculptSettle();
     buildPanel();
+    mountPlayback();
   });
 }
 
@@ -764,6 +775,162 @@ function gazeRing(fl, i) {
   ring.push(ring[0]);
   return { ring: ring, reason: null, estimated: notes.length > 0,
            estNotes: notes };
+}
+
+// --- Playback (#378): the flat map's animator (#267/#327), MapLibre-side ---
+// Semantics are deliberately identical to geo/flightmap_html.py so a user who
+// learns one map's playback knows the other's: same eligibility rule, same
+// speeds, same rAF clock, same pause-at-end. No "All flights (compare)" mode
+// here -- a gaze patch and beam per flight at once is noise, and the cockpit
+// can only ride one flight.
+const PB_SPEEDS = [1, 5, 20, 60];
+const runs = flights.filter(f => f.pts && Array.isArray(f.times)
+  && f.times.length === f.pts.length
+  && f.times[f.times.length - 1] > 0);
+const pb = { t: 0, playing: false, speed: 1, raf: null, last: 0,
+             run: null, cursor: 0, sample: -1 };
+
+function pbMax() {
+  return pb.run ? pb.run.times[pb.run.times.length - 1] : 0;
+}
+
+function sampleIndexAt(fl, t) {
+  // Index of the sample at or before t, with a monotonic cursor hint so a
+  // playing clock does not rescan the array every frame.
+  const times = fl.times;
+  if (t <= times[0]) { pb.cursor = 0; return 0; }
+  if (t >= times[times.length - 1]) return times.length - 1;
+  let i = pb.cursor;
+  if (times[i] > t) i = 0;                    // seeked backwards
+  while (times[i + 1] <= t) i++;
+  pb.cursor = i;
+  return i;
+}
+
+function positionAt(fl, t) {
+  const i = sampleIndexAt(fl, t), pts = fl.pts;
+  if (i >= pts.length - 1) return [pts[i][0], pts[i][1]];
+  const t0 = fl.times[i], t1 = fl.times[i + 1];
+  const f = t1 > t0 ? (t - t0) / (t1 - t0) : 1;
+  const a = pts[i], b = pts[i + 1];
+  return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f];
+}
+
+function pbRecolour() {
+  if (map.getLayer('gaze-cursor-dot')) {
+    map.setPaintProperty('gaze-cursor-dot', 'circle-color', pb.run.color);
+  }
+}
+
+function pbRender() {
+  if (!pb.run) return;
+  const src = map.getSource('gaze-cursor');
+  if (src) src.setData({ type: 'Feature', properties: {},
+    geometry: { type: 'Point', coordinates: positionAt(pb.run, pb.t) } });
+  const slider = document.getElementById('pb-slider');
+  if (slider) slider.value = String(pb.t);
+  const time = document.getElementById('pb-time');
+  if (time) {
+    time.textContent = fmtDuration(Math.round(pb.t)) + ' / '
+                     + fmtDuration(Math.round(pbMax()));
+  }
+  pb.sample = sampleIndexAt(pb.run, pb.t);
+}
+
+function pbPause() {
+  pb.playing = false;
+  const b = document.getElementById('pb-play');
+  if (b) b.textContent = '\\u25b6';
+  if (pb.raf) cancelAnimationFrame(pb.raf);
+  pb.raf = null;
+}
+
+function pbTick(now) {
+  if (!pb.playing) return;
+  pb.t = Math.min(pbMax(), pb.t + (now - pb.last) / 1000 * pb.speed);
+  pb.last = now;
+  pbRender();
+  if (pb.t >= pbMax()) { pbPause(); return; }
+  pb.raf = requestAnimationFrame(pbTick);
+}
+
+function pbPlay() {
+  if (!pb.run) return;
+  if (pb.t >= pbMax()) { pb.t = 0; pb.cursor = 0; }
+  pb.playing = true;
+  const b = document.getElementById('pb-play');
+  if (b) b.textContent = '\\u275a\\u275a';
+  pb.last = performance.now();
+  pb.raf = requestAnimationFrame(pbTick);
+}
+
+function mountPlayback() {
+  if (!runs.length) return;
+  pb.run = runs[0];
+  const div = document.createElement('div');
+  div.id = 'playback';
+  div.className = 'playback';
+  const mk = (tag, id) => {
+    const e = document.createElement(tag);
+    e.id = id;
+    return e;
+  };
+  const play = mk('button', 'pb-play');
+  play.type = 'button';
+  play.title = 'Play flight';
+  play.textContent = '\\u25b6';
+  const speed = mk('button', 'pb-speed');
+  speed.type = 'button';
+  speed.title = 'Playback speed';
+  speed.textContent = '1\\u00d7';
+  const slider = mk('input', 'pb-slider');
+  slider.type = 'range';
+  slider.min = '0';
+  slider.step = '0.1';
+  slider.value = '0';
+  slider.max = String(pbMax());
+  slider.title = 'Seek';
+  const time = mk('span', 'pb-time');
+  const note = mk('span', 'pb-note');
+  note.className = 'ghost-badge';
+  note.style.display = 'none';
+  div.append(play, speed, slider, time, note);
+  if (runs.length > 1) {
+    const sel = mk('select', 'pb-flight');
+    sel.title = 'Flight to play';
+    runs.forEach((r, i) => {
+      const o = document.createElement('option');
+      o.value = String(i);
+      o.textContent = r.name;
+      sel.appendChild(o);
+    });
+    sel.addEventListener('change', () => {
+      pbPause();                          // switching resets the clock
+      pb.run = runs[Number(sel.value)];
+      pb.t = 0;
+      pb.cursor = 0;
+      pb.sample = -1;
+      slider.max = String(pbMax());
+      pbRecolour();
+      pbRender();
+    });
+    div.appendChild(sel);
+  }
+  play.addEventListener('click', () => pb.playing ? pbPause() : pbPlay());
+  speed.addEventListener('click', () => {
+    pb.speed = PB_SPEEDS[(PB_SPEEDS.indexOf(pb.speed) + 1) % PB_SPEEDS.length];
+    speed.textContent = pb.speed + '\\u00d7';
+  });
+  slider.addEventListener('input', () => {
+    pb.t = Number(slider.value);
+    pbRender();
+  });
+  document.body.appendChild(div);
+  map.addSource('gaze-cursor', { type: 'geojson', data: emptyFC() });
+  map.addLayer({ id: 'gaze-cursor-dot', type: 'circle', source: 'gaze-cursor',
+    paint: { 'circle-radius': 7, 'circle-color': pb.run.color,
+             'circle-stroke-color': '#fff', 'circle-stroke-width': 2 } });
+  pbRender();
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -676,6 +676,7 @@ function rebuildSculpture() {
   if (sculpture.widthM != null && Math.abs(w - sculpture.widthM) < 0.5) return;
   sculpture.widthM = w;
   setSculptData();
+  renderGaze();
 }
 
 function sculptSettle() {
@@ -696,6 +697,10 @@ function sculptSettle() {
     const e = takeoffElev(probe);
     if ((typeof e === 'number' && e !== 0) || --tries <= 0) {
       setSculptData();
+      // The load-time beam was built against cold tiles; it rides this same
+      // bounded retry rather than starting a second timer. During playback
+      // every sample change rebuilds it anyway.
+      renderGaze();
       return;
     }
     setTimeout(retry, 250);
@@ -789,6 +794,15 @@ function addGazeLayers() {
              'fill-opacity': GAZE_PATCH_OPACITY } }, before);
   map.addLayer({ id: 'gaze-edge', type: 'line', source: 'gaze',
     paint: { 'line-color': pb.run.color, 'line-width': 1.5 } }, before);
+  // Beam is fill-extrusion and draws in the main pass, so it needs no
+  // beforeId.
+  map.addSource('beam', { type: 'geojson', data: emptyFC() });
+  map.addLayer({ id: 'beam-ray', type: 'fill-extrusion', source: 'beam',
+    paint: { 'fill-extrusion-color': pb.run.color,
+             'fill-extrusion-base': ['get', 'base'],
+             'fill-extrusion-height': ['get', 'hgt'],
+             'fill-extrusion-opacity': GAZE_BEAM_OPACITY,
+             'fill-extrusion-vertical-gradient': false } });
 }
 
 function setGazeNote(text) {
@@ -815,6 +829,11 @@ function renderGaze() {
     if (src) src.setData(emptyFC());
     setGazeNote(g.reason);
   }
+  const bsrc = map.getSource('beam');
+  if (bsrc) {
+    bsrc.setData({ type: 'FeatureCollection',
+                   features: beamFor(pb.run, pb.sample, g.ring) });
+  }
   if (g.estimated !== gaze.dashed) {
     gaze.dashed = g.estimated;
     // null restores the style-spec default (solid). The reset direction is
@@ -822,6 +841,73 @@ function renderGaze() {
     map.setPaintProperty('gaze-edge', 'line-dasharray',
                          g.estimated ? [2, 2] : null);
   }
+}
+
+// fill-extrusion can only make VERTICAL prisms measured from the terrain
+// surface, so a slanted ray has to be staircased. Each of the four frustum
+// corner rays becomes GAZE_BEAM_STEPS short prisms; neighbours share their
+// boundary height, so the spans touch or overlap and the silhouette is
+// continuous rather than a ladder.
+const GAZE_BEAM_STEPS = 16;
+const GAZE_BEAM_OPACITY = 0.5;
+
+function beamFor(fl, i, ring) {
+  const feats = [];
+  if (!ring) return feats;
+  const agl = fl.agl[i], c = fl.pts[i];
+  const tElev = takeoffElev(fl);
+  const camLocal = tElev == null ? null : terrainElevAt([c[0], c[1]]);
+  const camTrue = (tElev == null || camLocal == null) ? null : tElev + agl;
+  const half = sculptWidthM() / 2;
+  const mLat = GAZE_M_PER_DEG_LAT;
+  for (let r = 0; r < 4; r++) {
+    const corner = ring[r];
+    const at = s => [c[0] + (corner[0] - c[0]) * s,
+                     c[1] + (corner[1] - c[1]) * s];
+    const cornerElev = camTrue == null ? null : terrainElevAt(corner);
+    // Height at each step BOUNDARY, shared by the two prisms that meet there
+    // so joints match by construction. The local surface is sampled per
+    // boundary and never interpolated end to end: interpolating cancels the
+    // corner elevation algebraically -- h(s) collapses to (A - E_cam)(1 - s)
+    // -- and the ray would follow the ground contour instead of flying
+    // straight over the ridges and valleys it crosses.
+    const hs = [];
+    for (let k = 0; k <= GAZE_BEAM_STEPS; k++) {
+      const s = k / GAZE_BEAM_STEPS;
+      if (camTrue == null || cornerElev == null) {
+        // Terrain off: the extrusion measures from sea level, so raw AGL is
+        // already the right clearance.
+        hs.push(agl * (1 - s));
+        continue;
+      }
+      const local = terrainElevAt(at(s));
+      const alt = camTrue + (cornerElev - camTrue) * s;
+      hs.push(local == null ? agl * (1 - s) : alt - local);
+    }
+    for (let k = 0; k < GAZE_BEAM_STEPS; k++) {
+      const hgt = Math.max(hs[k], hs[k + 1]);
+      // At or below the rendered surface: fill-extrusion cannot draw there,
+      // so the ray honestly stops instead of tunnelling through the ground.
+      if (hgt <= 0) continue;
+      const a = at(k / GAZE_BEAM_STEPS), b = at((k + 1) / GAZE_BEAM_STEPS);
+      const mLon = mLat * Math.cos((a[1] + b[1]) / 2 * Math.PI / 180);
+      const dx = (b[0] - a[0]) * mLon, dy = (b[1] - a[1]) * mLat;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (!len) continue;
+      const ox = -dy / len * half / mLon, oy = dx / len * half / mLat;
+      feats.push({ type: 'Feature',
+        // base is clamped in JS: the style spec forbids a negative
+        // fill-extrusion-base.
+        properties: { base: Math.max(0, Math.min(hs[k], hs[k + 1])),
+                      hgt: hgt },
+        geometry: { type: 'Polygon', coordinates: [[
+          [a[0] + ox, a[1] + oy], [b[0] + ox, b[1] + oy],
+          [b[0] - ox, b[1] - oy], [a[0] - ox, a[1] - oy],
+          [a[0] + ox, a[1] + oy],
+        ]] } });
+    }
+  }
+  return feats;
 }
 
 // --- Playback (#378): the flat map's animator (#267/#327), MapLibre-side ---
@@ -870,6 +956,9 @@ function pbRecolour() {
   if (map.getLayer('gaze-fill')) {
     map.setPaintProperty('gaze-fill', 'fill-color', pb.run.color);
     map.setPaintProperty('gaze-edge', 'line-color', pb.run.color);
+  }
+  if (map.getLayer('beam-ray')) {
+    map.setPaintProperty('beam-ray', 'fill-extrusion-color', pb.run.color);
   }
 }
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -94,6 +94,10 @@ _TEMPLATE = """<!DOCTYPE html>
   .playback input[type=range] {{ width: 140px; }}
   .playback span {{ font-variant-numeric: tabular-nums; }}
   .playback select {{ font: inherit; max-width: 160px; }}
+  .gaze-pass {{ font: inherit; margin: 3px 4px 0 0; cursor: pointer;
+               border: 1px solid #bbb; border-radius: 3px;
+               background: #f6f6f6; padding: 1px 6px; }}
+  .gaze-est {{ margin-top: 4px; opacity: .7; font-size: 11px; }}
 </style>
 </head>
 <body>
@@ -821,6 +825,11 @@ const gaze = { dashed: false };
 function addGazeLayers() {
   // Below the flight lines: a track must stay readable through its own patch.
   const before = map.getLayer(flights[0].id) ? flights[0].id : undefined;
+  map.addSource('gaze-hits', { type: 'geojson', data: emptyFC() });
+  map.addLayer({ id: 'gaze-hits-line', type: 'line', source: 'gaze-hits',
+    layout: { 'line-cap': 'round', 'line-join': 'round' },
+    paint: { 'line-color': ['get', 'color'], 'line-width': 6,
+             'line-opacity': 0.55 } }, before);
   map.addSource('gaze', { type: 'geojson', data: emptyFC() });
   map.addLayer({ id: 'gaze-fill', type: 'fill', source: 'gaze',
     paint: { 'fill-color': pb.run.color,
@@ -1155,7 +1164,149 @@ function mountPlayback() {
     paint: { 'circle-radius': 7, 'circle-color': pb.run.color,
              'circle-stroke-color': '#fff', 'circle-stroke-width': 2 } });
   addGazeLayers();
+  map.on('click', gazeLookup);
   pbRender();
+}
+
+// --- Click a spot, get the seconds that filmed it (#378) ---
+const GAZE_MAX_PASSES = 12;
+
+function pointInRing(ring, lng, lat) {
+  // Ray casting over the four edges of a closed ring. Footprints are tens to
+  // hundreds of metres across, so planar lon/lat is exact enough.
+  let inside = false;
+  const n = ring.length - 1;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = ring[i][0], yi = ring[i][1];
+    const xj = ring[j][0], yj = ring[j][1];
+    if (((yi > lat) !== (yj > lat))
+        && lng < (xj - xi) * (lat - yi) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function gazeRingsFor(fl) {
+  // Memoised on first lookup: a map nobody clicks pays nothing, and a map
+  // clicked twice pays once.
+  if (!fl.rings) fl.rings = fl.pts.map((p, i) => gazeRing(fl, i).ring);
+  return fl.rings;
+}
+
+function gazePasses(fl, lngLat) {
+  const rings = gazeRingsFor(fl), times = fl.times;
+  const hits = [];
+  rings.forEach((ring, i) => {
+    if (ring && pointInRing(ring, lngLat.lng, lngLat.lat)) hits.push(i);
+  });
+  if (!hits.length) return [];
+  // Seconds are counted per sample interval, so a single-sample hit reads as
+  // about a second rather than zero.
+  const dt = i => (i + 1 < times.length) ? times[i + 1] - times[i]
+    : (i > 0 ? times[i] - times[i - 1] : 1);
+  const passes = [];
+  let start = hits[0], prev = hits[0], secs = 0;
+  hits.forEach(i => {
+    if (i > prev + 1) {
+      passes.push({ i0: start, i1: prev, t0: times[start], t1: times[prev],
+                    secs: secs });
+      start = i;
+      secs = 0;
+    }
+    secs += dt(i);
+    prev = i;
+  });
+  passes.push({ i0: start, i1: prev, t0: times[start], t1: times[prev],
+                secs: secs });
+  return passes;
+}
+
+function gazeSeek(fl, t) {
+  if (pb.run !== fl) {
+    pb.run = fl;
+    const sel = document.getElementById('pb-flight');
+    if (sel) sel.value = String(runs.indexOf(fl));
+    const slider = document.getElementById('pb-slider');
+    if (slider) slider.max = String(pbMax());
+    pbRecolour();
+  }
+  pb.t = t;
+  pb.cursor = 0;
+  pb.sample = -1;
+  pbRender();
+  // In the cockpit on this flight, playing IS riding it -- no second control.
+  if (!pb.playing) pbPlay();
+}
+
+function gazeHighlight(entries) {
+  const src = map.getSource('gaze-hits');
+  if (!src) return;
+  const feats = [];
+  entries.forEach(e => e.passes.forEach(p => {
+    // One sample either side, so a single-sample hit is still a visible line.
+    const a = Math.max(0, p.i0 - 1);
+    const b = Math.min(e.fl.pts.length - 1, p.i1 + 1);
+    feats.push({ type: 'Feature', properties: { color: e.fl.color },
+      geometry: { type: 'LineString',
+        coordinates: e.fl.pts.slice(a, b + 1).map(c => [c[0], c[1]]) } });
+  }));
+  src.setData({ type: 'FeatureCollection', features: feats });
+}
+
+function gazeLookup(ev) {
+  const lineIds = flights.map(f => f.id).filter(id => map.getLayer(id));
+  if (lineIds.length
+      && map.queryRenderedFeatures(ev.point, { layers: lineIds }).length) {
+    return;                    // the flight line owns this click
+  }
+  const el = document.createElement('div');
+  el.className = 'flight-popup';
+  const entries = [];
+  runs.forEach(fl => {
+    if (!fl.shown) return;
+    const passes = gazePasses(fl, ev.lngLat);
+    if (!passes.length) return;
+    entries.push({ fl: fl, passes: passes });
+    const head = document.createElement('div');
+    const name = document.createElement('strong');
+    name.textContent = fl.name;
+    head.appendChild(name);
+    const total = passes.reduce((a, p) => a + p.secs, 0);
+    head.appendChild(document.createTextNode(
+      ' \\u2014 in frame ' + Math.round(total) + ' s over ' + passes.length
+      + (passes.length === 1 ? ' pass' : ' passes')));
+    el.appendChild(head);
+    const row = document.createElement('div');
+    passes.slice(0, GAZE_MAX_PASSES).forEach(p => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'gaze-pass';
+      b.textContent = fmtDuration(Math.round(p.t0)) + '\\u2013'
+                    + fmtDuration(Math.round(p.t1));
+      b.addEventListener('click', () => gazeSeek(fl, p.t0));
+      row.appendChild(b);
+    });
+    if (passes.length > GAZE_MAX_PASSES) {
+      row.appendChild(document.createTextNode(
+        ' +' + (passes.length - GAZE_MAX_PASSES) + ' more'));
+    }
+    el.appendChild(row);
+    if (gazeRing(fl, passes[0].i0).estimated) {
+      const est = document.createElement('div');
+      est.className = 'gaze-est';
+      est.textContent = 'estimated \\u2014 no gimbal data';
+      el.appendChild(est);
+    }
+  });
+  if (!entries.length) {
+    el.appendChild(document.createTextNode(
+      'No recorded frame covered this spot.'));
+  }
+  gazeHighlight(entries);
+  const popup = new maplibregl.Popup({ maxWidth: '320px' })
+    .setLngLat(ev.lngLat).setDOMContent(el).addTo(map);
+  popup.on('close', () => gazeHighlight([]));
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -445,20 +445,42 @@ function ghostEnter(flightIdx, sampleIdx) {
     map.setVerticalFieldOfView(fl.vfov);
   }
   // Riding: jump in. The cinematic ease would be overridden by the next
-  // playback frame, and eases here are the moveend hazard.
-  applyPose(samplePose(fl, ghost.idx), pb.playing ? 0 : GHOST_ENTER_MS);
+  // playback frame, and eases here are the moveend hazard. Only true when
+  // the clock is actually driving THIS flight -- a different flight's clock
+  // running must not skip the cinematic entry for nothing.
+  const riding = pb.playing && pb.run === fl;
+  if (riding) {
+    // The click wins: seek playback to the clicked sample instead of
+    // snapping the camera back to pb.t on the very next driven frame.
+    pb.t = fl.times[ghost.idx];
+  }
+  applyPose(samplePose(fl, ghost.idx), riding ? 0 : GHOST_ENTER_MS);
   mountHud();
 }
 
 function ghostStep(d) {
   if (!ghost.active) return;
-  if (pb.playing) pbPause();       // manual control wins over the clock
+  // Manual control wins over the clock -- but only the clock driving THIS
+  // flight; stepping in one flight's cockpit must not stop another
+  // flight's playback.
+  if (pb.playing && pb.run === ghost.flight) pbPause();
   const n = ghost.flight.pts.length;
   const next = Math.max(0, Math.min(ghost.idx + d, n - 1));
   if (next === ghost.idx) return;
   ghost.idx = next;
   applyPose(samplePose(ghost.flight, next), GHOST_STEP_MS);
   updateHud();
+  if (pb.run === ghost.flight) {
+    // Keep the clock in step with the cockpit, so the gaze patch on the
+    // ground matches the second the camera is now looking from. pbRender()
+    // ends in pbDriveGhost(), which re-applies this exact pose via jumpTo
+    // (posePlayback(fl, times[next]) is numerically identical to
+    // samplePose(fl, next) -- see posePlayback) -- that lands on the same
+    // target as the ease just started above, so it finishes the step
+    // rather than fighting it.
+    pb.t = ghost.flight.times[next];
+    pbRender();
+  }
 }
 
 function ghostExit() {

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -783,6 +783,13 @@ function gazeRing(fl, i) {
 }
 
 const GAZE_PATCH_OPACITY = 0.25;
+// fill-extrusion can only make VERTICAL prisms measured from the terrain
+// surface, so a slanted ray has to be staircased. Each of the four frustum
+// corner rays becomes GAZE_BEAM_STEPS short prisms; neighbours share their
+// boundary height, so the spans touch or overlap and the silhouette is
+// continuous rather than a ladder.
+const GAZE_BEAM_STEPS = 16;
+const GAZE_BEAM_OPACITY = 0.5;
 const gaze = { dashed: false };
 
 function addGazeLayers() {
@@ -843,21 +850,12 @@ function renderGaze() {
   }
 }
 
-// fill-extrusion can only make VERTICAL prisms measured from the terrain
-// surface, so a slanted ray has to be staircased. Each of the four frustum
-// corner rays becomes GAZE_BEAM_STEPS short prisms; neighbours share their
-// boundary height, so the spans touch or overlap and the silhouette is
-// continuous rather than a ladder.
-const GAZE_BEAM_STEPS = 16;
-const GAZE_BEAM_OPACITY = 0.5;
-
 function beamFor(fl, i, ring) {
   const feats = [];
   if (!ring) return feats;
   const agl = fl.agl[i], c = fl.pts[i];
   const tElev = takeoffElev(fl);
-  const camLocal = tElev == null ? null : terrainElevAt([c[0], c[1]]);
-  const camTrue = (tElev == null || camLocal == null) ? null : tElev + agl;
+  const camTrue = tElev == null ? null : tElev + agl;
   const half = sculptWidthM() / 2;
   const mLat = GAZE_M_PER_DEG_LAT;
   for (let r = 0; r < 4; r++) {
@@ -865,6 +863,12 @@ function beamFor(fl, i, ring) {
     const at = s => [c[0] + (corner[0] - c[0]) * s,
                      c[1] + (corner[1] - c[1]) * s];
     const cornerElev = camTrue == null ? null : terrainElevAt(corner);
+    // gazeRing projected onto the flat plane at tElev; where the DEM at that
+    // corner is above the camera the corner cannot be a ground hit at all
+    // (pitch is always negative here), so fall back to gazeRing's own datum
+    // rather than aiming the ray upward.
+    const farElev = (cornerElev != null && cornerElev > camTrue) ? tElev
+                                                                  : cornerElev;
     // Height at each step BOUNDARY, shared by the two prisms that meet there
     // so joints match by construction. The local surface is sampled per
     // boundary and never interpolated end to end: interpolating cancels the
@@ -881,7 +885,7 @@ function beamFor(fl, i, ring) {
         continue;
       }
       const local = terrainElevAt(at(s));
-      const alt = camTrue + (cornerElev - camTrue) * s;
+      const alt = camTrue + (farElev - camTrue) * s;
       hs.push(local == null ? agl * (1 - s) : alt - local);
     }
     for (let k = 0; k < GAZE_BEAM_STEPS; k++) {

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -1189,16 +1189,26 @@ function pointInRing(ring, lng, lat) {
 
 function gazeRingsFor(fl) {
   // Memoised on first lookup: a map nobody clicks pays nothing, and a map
-  // clicked twice pays once.
-  if (!fl.rings) fl.rings = fl.pts.map((p, i) => gazeRing(fl, i).ring);
+  // clicked twice pays once. The estimated flag is kept PER SAMPLE, not
+  // discarded: gimbal yaw and pitch are per-sample optional fields, so a clip
+  // that drops attitude for part of a flight has some rings drawn from real
+  // data and others from the assumed GHOST_EST_PITCH tilt. Reading one
+  // sample's flag would let the popup omit the warning for extrapolated
+  // frames, which is exactly the claim this feature must not make.
+  if (!fl.rings) {
+    fl.rings = fl.pts.map((p, i) => {
+      const g = gazeRing(fl, i);
+      return { ring: g.ring, estimated: g.estimated };
+    });
+  }
   return fl.rings;
 }
 
 function gazePasses(fl, lngLat) {
   const rings = gazeRingsFor(fl), times = fl.times;
   const hits = [];
-  rings.forEach((ring, i) => {
-    if (ring && pointInRing(ring, lngLat.lng, lngLat.lat)) hits.push(i);
+  rings.forEach((r, i) => {
+    if (r.ring && pointInRing(r.ring, lngLat.lng, lngLat.lat)) hits.push(i);
   });
   if (!hits.length) return [];
   // Seconds are counted per sample interval, so a single-sample hit reads as
@@ -1206,19 +1216,24 @@ function gazePasses(fl, lngLat) {
   const dt = i => (i + 1 < times.length) ? times[i + 1] - times[i]
     : (i > 0 ? times[i] - times[i - 1] : 1);
   const passes = [];
-  let start = hits[0], prev = hits[0], secs = 0;
+  let start = hits[0], prev = hits[0], secs = 0, est = false;
+  // A pass counts as estimated if ANY of its matched samples was: the warning
+  // has to cover the weakest frame it is offering, not the first one.
+  const close = () => passes.push({
+    i0: start, i1: prev, t0: times[start], t1: times[prev], secs: secs,
+    est: est });
   hits.forEach(i => {
     if (i > prev + 1) {
-      passes.push({ i0: start, i1: prev, t0: times[start], t1: times[prev],
-                    secs: secs });
+      close();
       start = i;
       secs = 0;
+      est = false;
     }
     secs += dt(i);
+    est = est || rings[i].estimated;
     prev = i;
   });
-  passes.push({ i0: start, i1: prev, t0: times[start], t1: times[prev],
-                secs: secs });
+  close();
   return passes;
 }
 
@@ -1292,10 +1307,17 @@ function gazeLookup(ev) {
         ' +' + (passes.length - GAZE_MAX_PASSES) + ' more'));
     }
     el.appendChild(row);
-    if (gazeRing(fl, passes[0].i0).estimated) {
+    // Warn on ANY estimated pass, and say whether it is all of them: a clip
+    // can lose gimbal attitude partway through, so "some" is often the honest
+    // word. Checking a single sample would silently drop the warning for
+    // extrapolated frames the user is about to go looking for.
+    const estCount = passes.filter(p => p.est).length;
+    if (estCount) {
       const est = document.createElement('div');
       est.className = 'gaze-est';
-      est.textContent = 'estimated \\u2014 no gimbal data';
+      est.textContent = (estCount === passes.length ? 'estimated'
+                                                    : 'some passes estimated')
+                      + ' \\u2014 no gimbal data';
       el.appendChild(est);
     }
   });

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -99,6 +99,7 @@ _TEMPLATE = """<!DOCTYPE html>
                border: 1px solid #bbb; border-radius: 3px;
                background: #f6f6f6; padding: 1px 6px; }}
   .gaze-est {{ margin-top: 4px; opacity: .7; font-size: 11px; }}
+  .gaze-skip {{ margin-top: 4px; opacity: .7; font-size: 11px; }}
 </style>
 </head>
 <body>
@@ -286,6 +287,11 @@ function buildPanel() {
                             box.checked ? 'visible' : 'none');
       applySculptVisibility();
       applyGazeVisibility();
+      // A lookup highlight can span several flights, so there is no cheap
+      // way to tell here which of its passes still belong to a shown flight
+      // -- clearing it is the simple, honest choice: it can always be
+      // reopened by clicking the spot again (#378 whole-branch review, M1).
+      gazeHighlight([]);
     });
     label.appendChild(box);
     const swatch = document.createElement('span');
@@ -1007,6 +1013,12 @@ function pbRecolour() {
   if (map.getLayer('beam-ray')) {
     map.setPaintProperty('beam-ray', 'fill-extrusion-color', pb.run.color);
   }
+  // Not a paint concern: this is the run-change hook. pbRecolour() is called
+  // from exactly the two places pb.run is reassigned (the picker and
+  // gazeSeek), so re-deriving gaze visibility from the NEW run here is what
+  // keeps a hidden flight's gaze off, and a shown flight's gaze on, across a
+  // switch (#378 whole-branch review, I2).
+  applyGazeVisibility();
 }
 
 function pbRender(skipGhost) {
@@ -1070,8 +1082,13 @@ function applyGazeVisibility() {
   // The beam originates at the camera, so it hides in the cockpit for the
   // same reason the sculpture does; the patch is what you came to see.
   const beam = (v === 'visible' && !ghost.active) ? 'visible' : 'none';
+  // gaze-hits-line is NOT here: a lookup highlight can span several flights
+  // at once, so it has no single pb.run to follow. It stays laid out
+  // 'visible' always; its own source data (emptied by gazeHighlight([]) on
+  // panel toggle -- see buildPanel -- and on popup close) is what controls
+  // whether anything is actually drawn (#378 whole-branch review, M1).
   [['gaze-fill', v], ['gaze-edge', v], ['gaze-cursor-dot', v],
-   ['gaze-hits-line', v], ['beam-ray', beam]].forEach(pair => {
+   ['beam-ray', beam]].forEach(pair => {
     if (map.getLayer(pair[0])) {
       map.setLayoutProperty(pair[0], 'visibility', pair[1]);
     }
@@ -1182,6 +1199,16 @@ function mountPlayback() {
 
 // --- Click a spot, get the seconds that filmed it (#378) ---
 const GAZE_MAX_PASSES = 12;
+// The popup from the PREVIOUS lookup, if one is still open. MapLibre's own
+// closeOnClick binds a plain (not one-time) 'click' listener when a popup
+// opens, so on a second click that listener is still registered ALONGSIDE
+// gazeLookup's -- and because gazeLookup was registered first (once, at
+// mount), it runs first, then the stale popup's close listener runs after
+// it in the SAME dispatch and unconditionally empties gaze-hits, wiping the
+// highlight this click just set. Closing the previous popup ourselves,
+// synchronously, before computing anything for the new click sidesteps that
+// listener-order dependency entirely instead of relying on it.
+let gazePopup = null;
 
 function pointInRing(ring, lng, lat) {
   // Ray casting over the four edges of a closed ring. Footprints are tens to
@@ -1210,7 +1237,7 @@ function gazeRingsFor(fl) {
   if (!fl.rings) {
     fl.rings = fl.pts.map((p, i) => {
       const g = gazeRing(fl, i);
-      return { ring: g.ring, estimated: g.estimated };
+      return { ring: g.ring, estimated: g.estimated, estNotes: g.estNotes };
     });
   }
   return fl.rings;
@@ -1228,25 +1255,49 @@ function gazePasses(fl, lngLat) {
   const dt = i => (i + 1 < times.length) ? times[i + 1] - times[i]
     : (i > 0 ? times[i] - times[i - 1] : 1);
   const passes = [];
-  let start = hits[0], prev = hits[0], secs = 0, est = false;
-  // A pass counts as estimated if ANY of its matched samples was: the warning
-  // has to cover the weakest frame it is offering, not the first one.
+  let start = hits[0], prev = hits[0], secs = 0, est = false, notes = [];
+  // A pass counts as estimated if ANY of its matched samples was, and its
+  // estNotes is the UNION of every matched sample's reasons: the warning has
+  // to name the weakest frame it is offering, not just the first one (the
+  // same reasoning gazeRingsFor's own comment gives for keeping the flag per
+  // sample -- see #378 whole-branch review, I1).
   const close = () => passes.push({
     i0: start, i1: prev, t0: times[start], t1: times[prev], secs: secs,
-    est: est });
+    est: est, estNotes: notes });
   hits.forEach(i => {
     if (i > prev + 1) {
       close();
       start = i;
       secs = 0;
       est = false;
+      notes = [];
     }
     secs += dt(i);
     est = est || rings[i].estimated;
+    rings[i].estNotes.forEach(n => { if (!notes.includes(n)) notes.push(n); });
     prev = i;
   });
   close();
   return passes;
+}
+
+function gazeSkipCounts() {
+  // Everything gazeLookup's search loop below does NOT look at, bucketed by
+  // why: hidden playable flights, playable flights with no agl_m at all
+  // (spec: "Times but no agl_m -> Playable, no gaze" -- gazeRing can never
+  // produce a ring for one), and flights that never made it into `runs` in
+  // the first place -- a single-fix clip, or a track whose times do not line
+  // up with its points -- which cannot appear in that loop at all. The miss
+  // message below must not claim more than this function actually counts
+  // (#378 whole-branch review, C1).
+  const runSet = new Set(runs);
+  let hidden = 0, noHeight = 0;
+  runs.forEach(fl => {
+    if (!fl.shown) hidden++;
+    else if (!fl.agl) noHeight++;
+  });
+  flights.forEach(fl => { if (!runSet.has(fl)) noHeight++; });
+  return { hidden: hidden, noHeight: noHeight, total: hidden + noHeight };
 }
 
 function gazeSeek(fl, t) {
@@ -1287,6 +1338,7 @@ function gazeLookup(ev) {
       && map.queryRenderedFeatures(ev.point, { layers: lineIds }).length) {
     return;                    // the flight line owns this click
   }
+  if (gazePopup) gazePopup.remove();   // see gazePopup's own comment above
   const el = document.createElement('div');
   el.className = 'flight-popup';
   const entries = [];
@@ -1325,22 +1377,55 @@ function gazeLookup(ev) {
     // extrapolated frames the user is about to go looking for.
     const estCount = passes.filter(p => p.est).length;
     if (estCount) {
+      // The reason is the union of every LISTED pass's notes -- not a
+      // hardcoded "no gimbal data", which is false whenever the estimate
+      // actually came from an assumed lens (mp4_telemetry.py logs real
+      // gimbal attitude but no focal length on every sidecar-less MP4 clip;
+      // #378 whole-branch review, I1). Only the listed passes, because those
+      // are the only ones with a visible button.
+      const notes = [];
+      passes.slice(0, GAZE_MAX_PASSES).forEach(p => {
+        if (!p.est) return;
+        p.estNotes.forEach(n => { if (!notes.includes(n)) notes.push(n); });
+      });
       const est = document.createElement('div');
       est.className = 'gaze-est';
-      est.textContent = (estCount === passes.length ? 'estimated'
-                                                    : 'some passes estimated')
-                      + ' \\u2014 no gimbal data';
+      let text = estCount === passes.length ? 'estimated'
+                                            : 'some passes estimated';
+      if (notes.length) text += ' \\u2014 ' + notes.join(', ');
+      est.textContent = text;
       el.appendChild(est);
     }
   });
   if (!entries.length) {
     el.appendChild(document.createTextNode(
-      'No recorded frame covered this spot.'));
+      'No footprint on this map covers this spot.'));
+    // Say what was actually searched, not just what was not found: a false
+    // "no" is the worst answer this feature can give (#378 whole-branch
+    // review, C1).
+    const skip = gazeSkipCounts();
+    if (skip.total) {
+      const parts = [];
+      if (skip.hidden) {
+        parts.push(skip.hidden
+          + (skip.hidden === 1 ? ' hidden flight' : ' hidden flights'));
+      }
+      if (skip.noHeight) {
+        parts.push(skip.noHeight + (skip.noHeight === 1
+          ? ' flight with no height data' : ' flights with no height data'));
+      }
+      const note = document.createElement('div');
+      note.className = 'gaze-skip';
+      note.textContent = skip.total
+        + (skip.total === 1 ? ' flight was' : ' flights were')
+        + ' not searched \\u2014 ' + parts.join(', ') + '.';
+      el.appendChild(note);
+    }
   }
   gazeHighlight(entries);
-  const popup = new maplibregl.Popup({ maxWidth: '320px' })
+  gazePopup = new maplibregl.Popup({ maxWidth: '320px' })
     .setLngLat(ev.lngLat).setDOMContent(el).addTo(map);
-  popup.on('close', () => gazeHighlight([]));
+  gazePopup.on('close', () => { gazeHighlight([]); gazePopup = null; });
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -128,6 +128,7 @@ const allCoords = [];
     entry.gpitch = p.gpitch_deg || null;
     entry.agl = p.agl_m || null;
     entry.vfov = p.vfov_deg || null;
+    entry.hfov = p.hfov_deg || null;
   } else {                                             // single-fix clip
     const c = f.geometry.coordinates;
     entry.geometry = { type: 'Point', coordinates: [c[0], c[1]] };
@@ -689,6 +690,80 @@ function sculptSettle() {
     setTimeout(retry, 250);
   };
   setTimeout(retry, 250);
+}
+
+// --- Camera's Gaze (#378): the ground the camera actually saw ---
+// gazeRing() is a port of geometry.frustum_ground_ring -- the four frustum
+// corner rays projected onto flat ground at the drone's AGL reference, then
+// draped by the fill layer. A cross-language parity test compares it to the
+// Python corner by corner, because the same projection ships in --footprint
+// exports and the two must not drift. Rings are NOT embedded in the HTML:
+// they are derivable, and at ~115 bytes per second per flight a folder map
+// would grow by hundreds of KB.
+// Missing attitude falls back to GHOST_EST_PITCH, not to footprint.py's nadir
+// assumption: the cockpit already assumes -30, and a patch under the drone
+// while the cockpit looks at the horizon is two claims in one frame.
+const GAZE_FALLBACK_HFOV = 84.0;    // fov_degrees(DEFAULT_LENS, None): the
+const GAZE_FALLBACK_VFOV = 68.0;    // generic 20 mm-equivalent 4:3 lens
+const GAZE_MAX_RANGE_FACTOR = 8.0;  // mirrors MAX_RANGE_AGL_FACTOR
+const GAZE_M_PER_DEG_LAT = 111320;
+
+function emptyFC() { return { type: 'FeatureCollection', features: [] }; }
+
+function gazeRing(fl, i) {
+  const notes = [];
+  const agl = (fl.agl && fl.agl[i] != null) ? fl.agl[i] : null;
+  if (agl == null || agl <= 0) {
+    return { ring: null, reason: 'no altitude', estimated: false,
+             estNotes: notes };
+  }
+  let pitch;
+  if (fl.gpitch && fl.gpitch[i] != null) pitch = fl.gpitch[i];
+  else { pitch = GHOST_EST_PITCH; notes.push('no gimbal pitch'); }
+  if (pitch >= 0) {
+    // At or above the horizon there is no ground intersection to speak of;
+    // build_footprints() skips these frames and so do we.
+    return { ring: null, reason: 'camera above horizon',
+             estimated: notes.length > 0, estNotes: notes };
+  }
+  let bearing;
+  if (fl.gyaw && fl.gyaw[i] != null) bearing = fl.gyaw[i] % 360;
+  else { bearing = courseBearing(fl.pts, i); notes.push('no gimbal yaw'); }
+  let hfov = fl.hfov, vfov = fl.vfov;
+  if (!hfov || !vfov) {
+    hfov = GAZE_FALLBACK_HFOV;
+    vfov = GAZE_FALLBACK_VFOV;
+    notes.push('assumed lens');
+  }
+  const c = fl.pts[i];
+  const maxRange = GAZE_MAX_RANGE_FACTOR * agl;
+  const toRad = Math.PI / 180;
+  const th = pitch * toRad;
+  const tanH = Math.tan(hfov * toRad / 2), tanV = Math.tan(vfov * toRad / 2);
+  const fwdN = Math.cos(th), fwdZ = Math.sin(th);   // optical axis, pre-yaw
+  const upN = -Math.sin(th), upZ = Math.cos(th);    // camera-up, pre-yaw
+  const psi = bearing * toRad;
+  const cosP = Math.cos(psi), sinP = Math.sin(psi);
+  const mLon = GAZE_M_PER_DEG_LAT * Math.max(Math.cos(c[1] * toRad), 1e-6);
+  const ring = [];
+  [[-1, 1], [1, 1], [1, -1], [-1, -1]].forEach(sc => {
+    const de = sc[0] * tanH;
+    const dn = fwdN + sc[1] * tanV * upN;
+    const dz = fwdZ + sc[1] * tanV * upZ;
+    const horiz = Math.hypot(de, dn);
+    // A ray that climbs never meets the ground: clamp it along its azimuth
+    // so a near-horizon frame degrades to a capped trapezoid, not an
+    // unbounded one.
+    const dist = dz < 0 ? Math.min(agl / -dz * horiz, maxRange) : maxRange;
+    const e0 = horiz > 1e-12 ? de / horiz * dist : 0;
+    const n0 = horiz > 1e-12 ? dn / horiz * dist : 0;
+    const east = e0 * cosP + n0 * sinP;
+    const north = -e0 * sinP + n0 * cosP;
+    ring.push([c[0] + east / mLon, c[1] + north / GAZE_M_PER_DEG_LAT]);
+  });
+  ring.push(ring[0]);
+  return { ring: ring, reason: null, estimated: notes.length > 0,
+           estNotes: notes };
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -777,6 +777,53 @@ function gazeRing(fl, i) {
            estNotes: notes };
 }
 
+const GAZE_PATCH_OPACITY = 0.25;
+const gaze = { dashed: false };
+
+function addGazeLayers() {
+  // Below the flight lines: a track must stay readable through its own patch.
+  const before = map.getLayer(flights[0].id) ? flights[0].id : undefined;
+  map.addSource('gaze', { type: 'geojson', data: emptyFC() });
+  map.addLayer({ id: 'gaze-fill', type: 'fill', source: 'gaze',
+    paint: { 'fill-color': pb.run.color,
+             'fill-opacity': GAZE_PATCH_OPACITY } }, before);
+  map.addLayer({ id: 'gaze-edge', type: 'line', source: 'gaze',
+    paint: { 'line-color': pb.run.color, 'line-width': 1.5 } }, before);
+}
+
+function setGazeNote(text) {
+  const note = document.getElementById('pb-note');
+  if (!note) return;
+  note.textContent = text || '';
+  note.style.display = text ? '' : 'none';
+}
+
+function renderGaze() {
+  if (!pb.run || pb.sample < 0 || !map.getLayer('gaze-fill')) return;
+  const g = gazeRing(pb.run, pb.sample);
+  const src = map.getSource('gaze');
+  if (g.ring) {
+    if (src) {
+      src.setData({ type: 'Feature', properties: {},
+        geometry: { type: 'Polygon', coordinates: [g.ring] } });
+    }
+    setGazeNote(g.estimated
+      ? 'estimated footprint \\u2014 ' + g.estNotes.join(', ') : '');
+  } else {
+    // Empty the source rather than leave the last good ring standing: a
+    // frozen patch would claim the camera was still filming that ground.
+    if (src) src.setData(emptyFC());
+    setGazeNote(g.reason);
+  }
+  if (g.estimated !== gaze.dashed) {
+    gaze.dashed = g.estimated;
+    // null restores the style-spec default (solid). The reset direction is
+    // tested: a failure there would mark every later ring estimated.
+    map.setPaintProperty('gaze-edge', 'line-dasharray',
+                         g.estimated ? [2, 2] : null);
+  }
+}
+
 // --- Playback (#378): the flat map's animator (#267/#327), MapLibre-side ---
 // Semantics are deliberately identical to geo/flightmap_html.py so a user who
 // learns one map's playback knows the other's: same eligibility rule, same
@@ -820,6 +867,10 @@ function pbRecolour() {
   if (map.getLayer('gaze-cursor-dot')) {
     map.setPaintProperty('gaze-cursor-dot', 'circle-color', pb.run.color);
   }
+  if (map.getLayer('gaze-fill')) {
+    map.setPaintProperty('gaze-fill', 'fill-color', pb.run.color);
+    map.setPaintProperty('gaze-edge', 'line-color', pb.run.color);
+  }
 }
 
 function pbRender() {
@@ -834,7 +885,13 @@ function pbRender() {
     time.textContent = fmtDuration(Math.round(pb.t)) + ' / '
                      + fmtDuration(Math.round(pbMax()));
   }
-  pb.sample = sampleIndexAt(pb.run, pb.t);
+  const s = sampleIndexAt(pb.run, pb.t);
+  if (s !== pb.sample) {
+    // Each ring IS one second of recording; interpolating between them would
+    // invent geometry, and rebuilding per frame would churn at 60x speed.
+    pb.sample = s;
+    renderGaze();
+  }
 }
 
 function pbPause() {
@@ -930,6 +987,7 @@ function mountPlayback() {
   map.addLayer({ id: 'gaze-cursor-dot', type: 'circle', source: 'gaze-cursor',
     paint: { 'circle-radius': 7, 'circle-color': pb.run.color,
              'circle-stroke-color': '#fff', 'circle-stroke-width': 2 } });
+  addGazeLayers();
   pbRender();
 }
 """

--- a/tests/browser/test_flightmap_3d_playback.py
+++ b/tests/browser/test_flightmap_3d_playback.py
@@ -25,6 +25,20 @@ def _flight(name: str, lat: float, lon: float, points: int,
     ])
 
 
+def _flight_yaws(name: str, lat: float, lon: float, yaws: list) -> Track:
+    """Like `_flight`, but with a per-point gimbal yaw instead of a constant
+    one -- `_flight`'s constant 90.0 makes every posePlayback interpolation
+    run with `d == 0`, which never exercises the shortest-arc branch."""
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name=name, points=[
+        TrackPoint(lat=lat, lon=lon + i * 0.0006, alt=150.0,
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i), rel_alt=50.0,
+                   focal_len=24.0, gimbal_yaw=yaw, gimbal_pitch=-45.0)
+        for i, yaw in enumerate(yaws)
+    ])
+
+
 def _ready(page):
     page.wait_for_selector("#flights-panel", timeout=15000)
 
@@ -164,8 +178,14 @@ def test_entering_while_playing_jumps_instead_of_easing(serve_map, page):
     serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
     _ready(page)
     page.wait_for_function("() => !map.isMoving()", timeout=15000)
-    page.evaluate("() => { pb.speed = 1; pbPlay(); ghostEnter(0, 0); }")
-    assert page.evaluate("() => map.isMoving()") is False, "ghostEnter eased"
+    # In one round-trip: easeTo fires movestart synchronously, so isMoving()
+    # is unambiguous inside the same JS turn. Splitting this across two
+    # evaluate() calls would let a restored entry ease get aborted by the
+    # first driven frame (~16 ms) before the assertion ever ran.
+    moving = page.evaluate(
+        "() => { pb.speed = 1; pbPlay(); ghostEnter(0, 0);"
+        " return map.isMoving(); }")
+    assert moving is False, "ghostEnter eased"
     assert page.evaluate("() => ghost.active") is True
 
 
@@ -194,3 +214,58 @@ def test_beam_hides_in_the_cockpit(serve_map, page):
     page.evaluate("() => ghostExit()")
     page.wait_for_function("() => !map.isMoving()", timeout=15000)
     assert page.evaluate(vis, "beam-ray") == "visible"
+
+
+def test_bearing_scrub_takes_the_short_way_round(serve_map, page):
+    """posePlayback's wraparound arithmetic is the only non-obvious math in
+    this task, and every other fixture in this file uses a constant yaw
+    (d == 0 throughout), so it has never actually run. 350 -> 10 the short
+    way passes through 360/0; the long way would sweep through 180."""
+    serve_map(flights_to_3d_html(
+        [_flight_yaws("DJI_0001", 10.0, 20.0, [350.0, 10.0])], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    page.evaluate("() => { pb.t = 0.5; pbRender(); }")
+    bearing = page.evaluate("() => ghost.applied.bearing")
+    assert bearing > 355 or bearing < 15, (
+        f"bearing {bearing} swept through 180 instead of taking the short "
+        "way round 0/360")
+
+
+def test_ghost_rapid_reenter_while_playing_keeps_lock(serve_map, page):
+    """The paused rapid-cycle scenario is
+    test_ghost_rapid_reenter_keeps_lock_and_original_view in
+    test_flightmap_ghost.py. This task adds a second way to interrupt the
+    exit ease -- ghostEnter's jumpTo when pb.playing, instead of easeTo --
+    so it needs its own coverage: the camera must stay locked and the saved
+    view must not restore mid-session."""
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    before = page.evaluate(
+        "() => ({p: map.getPitch(), b: map.getBearing(),"
+        " mp: map.getMaxPitch()})")
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    # pbPlay() and the exit/re-enter cycle all in one round-trip: a Python
+    # round-trip between them could let the first ghostExit's 1.2 s ease
+    # complete for real, which would defeat the scenario.
+    result = page.evaluate("""() => {
+      pb.speed = 1; pbPlay();
+      ghostExit(); ghostEnter(0, 2);
+      return { dragPan: map.dragPan.isEnabled(),
+               maxPitch: map.getMaxPitch() };
+    }""")
+    # The stale moveend (if unguarded) fires synchronously inside the
+    # re-enter's jumpTo, same as the paused variant's easeTo, so these
+    # asserts are deterministic.
+    assert result["dragPan"] is False
+    assert result["maxPitch"] == 100
+    page.evaluate("() => ghostExit()")
+    page.wait_for_function(
+        f"() => map.dragPan.isEnabled()"
+        f" && Math.abs(map.getPitch() - {before['p']}) < 0.5"
+        f" && Math.abs(map.getBearing() - {before['b']}) < 0.5"
+        f" && map.getMaxPitch() === {before['mp']}",
+        timeout=15000,
+    )

--- a/tests/browser/test_flightmap_3d_playback.py
+++ b/tests/browser/test_flightmap_3d_playback.py
@@ -118,3 +118,79 @@ def test_picker_switches_flight_and_resets_the_clock(serve_map, page):
     assert page.evaluate("() => pb.run.name") == "DJI_0002"
     assert page.evaluate("() => Number(document.getElementById("
                          "'pb-slider').max)") == 2.0
+
+
+def test_playing_in_the_cockpit_flies_the_recorded_path(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    first = page.evaluate("() => ghost.applied.lng")
+    page.evaluate("() => { pb.t = 4; pbRender(); }")
+    later = page.evaluate("() => ghost.applied.lng")
+    assert later > first, "the cockpit did not follow the clock"
+    assert page.evaluate("() => ghost.idx") == 4
+    assert page.evaluate("() => ghost.active") is True
+
+
+def test_a_scrub_between_samples_interpolates(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    page.evaluate("() => { pb.t = 2.5; pbRender(); }")
+    got = page.evaluate("() => ghost.applied.lng")
+    lo = page.evaluate("() => flights[0].pts[2][0]")
+    hi = page.evaluate("() => flights[0].pts[3][0]")
+    assert lo < got < hi, "pose was snapped to a sample instead of interpolated"
+
+
+def test_arrow_step_pauses_playback(serve_map, page):
+    """Manual control wins: an arrow key while the clock runs would otherwise
+    be overwritten on the next frame."""
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    page.evaluate("() => { pb.speed = 1; pbPlay(); }")
+    assert page.evaluate("() => pb.playing") is True
+    page.keyboard.press("ArrowRight")
+    assert page.evaluate("() => pb.playing") is False
+
+
+def test_entering_while_playing_jumps_instead_of_easing(serve_map, page):
+    """A 1.2 s cinematic ease would be overridden by the next frame anyway,
+    and eases are where this file's moveend scars are."""
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    page.evaluate("() => { pb.speed = 1; pbPlay(); ghostEnter(0, 0); }")
+    assert page.evaluate("() => map.isMoving()") is False, "ghostEnter eased"
+    assert page.evaluate("() => ghost.active") is True
+
+
+def test_exiting_while_playing_keeps_the_clock(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    page.evaluate("() => { pb.speed = 5; pbPlay(); ghostExit(); }")
+    assert page.evaluate("() => pb.playing") is True
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    assert page.evaluate("() => ghost.active") is False
+    assert page.evaluate("() => ghost.saved") is None
+
+
+def test_beam_hides_in_the_cockpit(serve_map, page):
+    """A beam originating at your own eye would fill the frame -- the same
+    reason the sculpture steps aside. The patch stays: it is the point."""
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    vis = ("(id) => map.getLayoutProperty(id, 'visibility') || 'visible'")
+    assert page.evaluate(vis, "beam-ray") == "visible"
+    page.evaluate("() => ghostEnter(0, 2)")
+    assert page.evaluate(vis, "beam-ray") == "none"
+    assert page.evaluate(vis, "gaze-fill") == "visible"
+    page.evaluate("() => ghostExit()")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    assert page.evaluate(vis, "beam-ray") == "visible"

--- a/tests/browser/test_flightmap_3d_playback.py
+++ b/tests/browser/test_flightmap_3d_playback.py
@@ -94,7 +94,7 @@ def test_playback_pauses_at_the_end(serve_map, page):
     # ▶ is the play glyph; written as an escape so the test file stays
     # ASCII like the JS it checks.
     assert page.evaluate("() => document.getElementById('pb-play')"
-                         ".textContent") == "▶"
+                         ".textContent") == "\u25b6"
 
 
 def test_slider_seeks(serve_map, page):

--- a/tests/browser/test_flightmap_3d_playback.py
+++ b/tests/browser/test_flightmap_3d_playback.py
@@ -1,0 +1,120 @@
+"""Playback in the 3D map (#378): the flat map's animator, MapLibre-side."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+
+def _flight(name: str, lat: float, lon: float, points: int,
+            step: float = 0.0006) -> Track:
+    """Synthetic flight, one sample a second, AGL 50 m throughout."""
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name=name, points=[
+        TrackPoint(lat=lat, lon=lon + i * step, alt=150.0,
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i), rel_alt=50.0,
+                   focal_len=24.0, gimbal_yaw=90.0, gimbal_pitch=-45.0)
+        for i in range(points)
+    ])
+
+
+def _ready(page):
+    page.wait_for_selector("#flights-panel", timeout=15000)
+
+
+def test_control_mounts_with_a_playable_flight(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    assert page.locator("#playback").count() == 1
+    assert page.locator("#pb-play").count() == 1
+    assert page.locator("#pb-slider").count() == 1
+    # One flight: no picker.
+    assert page.locator("#pb-flight").count() == 0
+    assert page.evaluate("() => Number(document.getElementById("
+                         "'pb-slider').max)") == 5.0
+    assert page.evaluate("() => !!map.getLayer('gaze-cursor-dot')")
+
+
+def test_no_control_without_times(serve_map, page):
+    """A single-fix clip has no LineString and no times: there is no clock to
+    offer, so the control must not appear at all."""
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    track = Track(name="DJI_0002", points=[
+        TrackPoint(lat=10.0, lon=20.0, alt=150.0, timestamp="00:00:00,000",
+                   utc=t0, rel_alt=50.0)])
+    serve_map(flights_to_3d_html([track], "trip"))
+    page.wait_for_function("() => typeof map !== 'undefined' && map "
+                           "&& map.loaded()", timeout=15000)
+    assert page.locator("#playback").count() == 0
+    assert page.evaluate("() => runs.length") == 0
+
+
+def test_playing_advances_the_clock_and_moves_the_cursor(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    # GeoJSON source tiles are built asynchronously, so wait rather than
+    # sampling the instant after load.
+    page.wait_for_function(
+        "() => map.querySourceFeatures('gaze-cursor').length > 0",
+        timeout=5000)
+    page.evaluate("() => { pb.speed = 5; pbPlay(); }")
+    page.wait_for_function("() => pb.t > 1.5", timeout=5000)
+    page.evaluate("() => pbPause()")
+    assert page.evaluate("() => pb.sample") >= 1
+    assert page.evaluate("() => pb.playing") is False
+
+
+def test_playback_pauses_at_the_end(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 4)], "trip"))
+    _ready(page)
+    page.evaluate("() => { pb.speed = 60; pbPlay(); }")
+    page.wait_for_function("() => !pb.playing", timeout=5000)
+    assert abs(page.evaluate("() => pb.t") - 3.0) < 0.001
+    # ▶ is the play glyph; written as an escape so the test file stays
+    # ASCII like the JS it checks.
+    assert page.evaluate("() => document.getElementById('pb-play')"
+                         ".textContent") == "▶"
+
+
+def test_slider_seeks(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    page.evaluate("() => { const s = document.getElementById('pb-slider');"
+                  " s.value = '4'; s.dispatchEvent(new Event('input')); }")
+    assert abs(page.evaluate("() => pb.t") - 4.0) < 0.001
+    assert page.evaluate("() => pb.sample") == 4
+    assert page.evaluate("() => document.getElementById('pb-time')"
+                         ".textContent").startswith("0:04")
+
+
+def test_speed_button_cycles(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 4)], "trip"))
+    _ready(page)
+    seen = []
+    for _ in range(5):
+        page.click("#pb-speed")
+        seen.append(page.evaluate("() => pb.speed"))
+    assert seen == [5, 20, 60, 1, 5]
+
+
+def test_picker_switches_flight_and_resets_the_clock(serve_map, page):
+    serve_map(flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, 6), _flight("DJI_0002", 10.01, 20.0, 3)],
+        "trip"))
+    _ready(page)
+    assert page.locator("#pb-flight option").count() == 2
+    page.evaluate("() => { pb.t = 3; pbPlay(); }")
+    page.evaluate("() => { const s = document.getElementById('pb-flight');"
+                  " s.value = '1'; s.dispatchEvent(new Event('change')); }")
+    assert page.evaluate("() => pb.playing") is False
+    assert page.evaluate("() => pb.t") == 0
+    assert page.evaluate("() => pb.run.name") == "DJI_0002"
+    assert page.evaluate("() => Number(document.getElementById("
+                         "'pb-slider').max)") == 2.0

--- a/tests/browser/test_flightmap_3d_playback.py
+++ b/tests/browser/test_flightmap_3d_playback.py
@@ -172,6 +172,40 @@ def test_arrow_step_pauses_playback(serve_map, page):
     assert page.evaluate("() => pb.playing") is False
 
 
+def test_arrow_step_still_eases_and_moves_the_clock(serve_map, page):
+    """Stepping must stay a 150 ms glide, not become a hard cut.
+
+    Syncing the clock to the cockpit (so the ground patch matches the second
+    you are looking from) pulls in pbRender, whose per-frame ghost drive
+    jumpTo's to the *same* pose the step is easing toward -- being instant, it
+    would silently win and no other assertion in this suite could tell the
+    difference, since the destination is numerically identical. Hence
+    pbRender(true) at that call site, and hence this test.
+    """
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 6)], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    # Measure whether the camera has ALREADY ARRIVED when the step returns --
+    # not merely whether something is moving. isMoving() cannot tell the two
+    # apart: with the drive left in, jumpTo lands the camera instantly and the
+    # eased call that follows then glides from the target to the same target,
+    # which reports isMoving() === true while being visually a hard cut.
+    before, after = page.evaluate(
+        "() => { const a = map.getCenter().lng;"
+        " ghostStep(1);"
+        " return [a, map.getCenter().lng]; }")
+    step_deg = 0.0006                      # _flight's per-sample longitude step
+    assert abs(after - before) < step_deg / 10, (
+        f"arrow step teleported the camera ({before} -> {after}); the eased "
+        "move was beaten to its own target by the per-frame ghost drive")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    assert page.evaluate("() => ghost.idx") == 1
+    # ...and the clock followed, so the patch shows the second now in view.
+    assert abs(page.evaluate("() => pb.t") - 1.0) < 1e-9
+    assert page.evaluate("() => pb.sample") == 1
+
+
 def test_entering_while_playing_jumps_instead_of_easing(serve_map, page):
     """A 1.2 s cinematic ease would be overridden by the next frame anyway,
     and eases are where this file's moveend scars are."""

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -1,0 +1,127 @@
+"""Camera's Gaze (#378): footprint projection, patch, beam and lookup."""
+
+import math
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html  # noqa: E402
+from dji_metadata_embedder.geo.footprint import DEFAULT_LENS, fov_degrees  # noqa: E402
+from dji_metadata_embedder.geo.geometry import frustum_ground_ring  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+TILE_DEG = 360 / 2 ** 15   # z15 tile width; the DEM cliff sits at each midpoint
+
+
+def _flight(name: str, lat: float, lon: float, agls: list[float | None], *,
+            yaws: list[float | None] | None = None,
+            pitches: list[float | None] | None = None,
+            focal: float | None = None, step: float = 0.0006) -> Track:
+    """Synthetic flight: ``agls[i]`` is point i's rel_alt, one sample a second."""
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name=name, points=[
+        TrackPoint(lat=lat, lon=lon + i * step, alt=100.0 + (a or 0),
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i), rel_alt=a, focal_len=focal,
+                   gimbal_yaw=None if yaws is None else yaws[i],
+                   gimbal_pitch=None if pitches is None else pitches[i])
+        for i, a in enumerate(agls)
+    ])
+
+
+def _ready(page):
+    page.wait_for_selector("#flights-panel", timeout=15000)
+
+
+def test_gaze_ring_matches_the_python_projection(serve_map, page):
+    """The JS port must agree with geometry.frustum_ground_ring corner by
+    corner. This is the only thing standing between a hand-ported projection
+    and silent drift from the Python that ships in --footprint exports."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 3,
+                    yaws=[35.0] * 3, pitches=[-40.0] * 3, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    got = page.evaluate("() => gazeRing(flights[0], 1)")
+    assert got["reason"] is None
+    assert got["estimated"] is False
+    # Read the FOV back off the page: it is rounded to 0.1 deg on the way into
+    # the GeoJSON, so handing Python the unrounded value would compare two
+    # different lenses and the parity claim would be meaningless.
+    hfov = page.evaluate("() => flights[0].hfov")
+    vfov = page.evaluate("() => flights[0].vfov")
+    lon, lat = page.evaluate("() => flights[0].pts[1].slice(0, 2)")
+    expected = frustum_ground_ring(lat, lon, 50.0, 35.0, -40.0, hfov, vfov,
+                                   8.0 * 50.0)
+    assert len(got["ring"]) == len(expected) == 5
+    for (gx, gy), (ex, ey) in zip(got["ring"], expected):
+        assert abs(gx - ex) < 1e-9, f"lon {gx} != {ex}"
+        assert abs(gy - ey) < 1e-9, f"lat {gy} != {ey}"
+
+
+def test_gaze_ring_clamps_a_near_horizon_frame(serve_map, page):
+    """A 2-degree down-tilt would reach the horizon; the ring must stay inside
+    8 x AGL, matching MAX_RANGE_AGL_FACTOR."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 3,
+                    yaws=[0.0] * 3, pitches=[-2.0] * 3, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    got = page.evaluate("() => gazeRing(flights[0], 1)")
+    lon, lat = page.evaluate("() => flights[0].pts[1].slice(0, 2)")
+    for x, y in got["ring"]:
+        dx = (x - lon) * 111320 * math.cos(math.radians(lat))
+        dy = (y - lat) * 111320
+        assert math.hypot(dx, dy) <= 400.0 + 1e-6, "corner escaped the clamp"
+    hfov = page.evaluate("() => flights[0].hfov")
+    vfov = page.evaluate("() => flights[0].vfov")
+    expected = frustum_ground_ring(lat, lon, 50.0, 0.0, -2.0, hfov, vfov, 400.0)
+    for (gx, gy), (ex, ey) in zip(got["ring"], expected):
+        assert abs(gx - ex) < 1e-9 and abs(gy - ey) < 1e-9
+
+
+def test_no_ring_without_altitude(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [None, None, None],
+                    yaws=[0.0] * 3, pitches=[-45.0] * 3, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    got = page.evaluate("() => gazeRing(flights[0], 1)")
+    assert got["ring"] is None
+    assert got["reason"] == "no altitude"
+
+
+def test_no_ring_above_the_horizon(serve_map, page):
+    """footprint.py skips a frame whose camera is at or above the horizon; so
+    must the viewer, rather than drawing a trapezoid to the clamp distance."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 3,
+                    yaws=[0.0] * 3, pitches=[5.0] * 3, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    got = page.evaluate("() => gazeRing(flights[0], 1)")
+    assert got["ring"] is None
+    assert got["reason"] == "camera above horizon"
+
+
+def test_missing_attitude_is_estimated_not_hidden(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 3)   # no gimbal, no focal
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    got = page.evaluate("() => gazeRing(flights[0], 1)")
+    assert got["ring"] is not None
+    assert got["estimated"] is True
+    assert set(got["estNotes"]) == {"no gimbal pitch", "no gimbal yaw",
+                                    "assumed lens"}
+    # The estimate must be the SAME down-tilt the cockpit assumes, or the two
+    # views disagree in one frame.
+    assert page.evaluate("() => GHOST_EST_PITCH") == -30
+
+
+def test_fallback_lens_matches_the_python_default(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 3)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    hfov, vfov = fov_degrees(DEFAULT_LENS, None)
+    assert page.evaluate("() => GAZE_FALLBACK_HFOV") == round(hfov, 1)
+    assert page.evaluate("() => GAZE_FALLBACK_VFOV") == round(vfov, 1)

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -223,3 +223,98 @@ def test_note_names_the_estimate(serve_map, page):
                          ".textContent")
     assert note.startswith("estimated footprint")
     assert "no gimbal pitch" in note
+
+
+_BEAM_JS = ("() => beamFor(flights[0], pb.sample,"
+            " gazeRing(flights[0], pb.sample).ring).map(f => f.properties)")
+
+
+def test_beam_is_four_continuous_rays(serve_map, page):
+    """Four corner rays of 16 prisms each, and neighbours must share the
+    boundary height -- otherwise the silhouette is a ladder with gaps."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 5,
+                    yaws=[90.0] * 5, pitches=[-50.0] * 5, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    steps = page.evaluate("() => GAZE_BEAM_STEPS")
+    props = page.evaluate(_BEAM_JS)
+    assert len(props) == 4 * steps
+    for r in range(4):
+        ray = props[r * steps:(r + 1) * steps]
+        for a, b in zip(ray, ray[1:]):
+            assert abs(a["base"] - b["hgt"]) < 1e-6, f"gap in ray {r}"
+        # Terrain is off in this run, so the extrusion measures from sea level
+        # and the camera end sits at raw AGL.
+        assert abs(ray[0]["hgt"] - 50.0) < 1e-6
+        assert abs(ray[-1]["base"]) < 1e-6
+
+
+def test_beam_heights_survive_the_elevation_conversion(serve_map, page):
+    """A constant-elevation DEM must give the SAME heights as no DEM at all.
+    Skipping the takeoff/local conversion, or interpolating it end to end,
+    breaks this."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 5,
+                    yaws=[90.0] * 5, pitches=[-50.0] * 5, focal=24.0)
+    html = flights_to_3d_html([track], "trip")
+    serve_map(html, terrain_stub=100.0)
+    _ready(page)
+    # queryTerrainElevation decodes through float32, so a constant-100 stub
+    # comes back as 100.00000000000182, never exactly 100 -- compare with a
+    # tolerance rather than equality.
+    page.wait_for_function(
+        "() => Math.abs(terrainElevAt(map.getCenter()) - 100) < 1e-6",
+        timeout=15000)
+    page.evaluate("() => renderGaze()")
+    props = page.evaluate(_BEAM_JS)
+    steps = page.evaluate("() => GAZE_BEAM_STEPS")
+    for r in range(4):
+        ray = props[r * steps:(r + 1) * steps]
+        assert abs(ray[0]["hgt"] - 50.0) < 0.5
+        assert abs(ray[-1]["base"]) < 1e-6
+
+
+def test_beam_stops_at_a_cliff(serve_map, page):
+    """Where the DEM rises 600 m above the drone, every remaining prism is
+    below the surface: fill-extrusion cannot draw there, so the ray must end
+    rather than tunnel through the wall."""
+    # MapLibre resolves DEM tiles one zoom COARSER than the source maxzoom, so
+    # the stub's left/right split lands at the z14 tile midpoint -- one full
+    # TILE_DEG east of the enclosing z15 tile's west edge, NOT one TILE_DEG
+    # east of the flight's nominal longitude. Derive it rather than guessing.
+    west = -180 + math.floor((20.0 + 180) / TILE_DEG) * TILE_DEG
+    cliff = west + TILE_DEG
+    lon = cliff - TILE_DEG * 0.25      # drone a quarter tile west of the wall
+    track = _flight("DJI_0001", 10.0, lon, [50.0] * 5,
+                    yaws=[90.0] * 5, pitches=[-20.0] * 5, focal=24.0,
+                    step=0.0)
+    serve_map(flights_to_3d_html([track], "trip"), terrain_steps=(50.0, 650.0))
+    _ready(page)
+    # 50 (not 0) is the unambiguous "loaded" signal on the low side: 0 is
+    # indistinguishable from a cold tile (terrainElevAt's own contract).
+    page.wait_for_function(
+        "() => Math.abs(terrainElevAt(map.getCenter()) - 50) < 1e-6",
+        timeout=15000)
+    page.evaluate("() => renderGaze()")
+    props = page.evaluate(_BEAM_JS)
+    steps = page.evaluate("() => GAZE_BEAM_STEPS")
+    assert props, "the beam vanished entirely"
+    assert len(props) < 4 * steps, "no prism was dropped at the wall"
+    assert all(p["hgt"] > p["base"] for p in props)
+
+
+def test_beam_width_tracks_zoom(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 5,
+                    yaws=[90.0] * 5, pitches=[-50.0] * 5, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    page.evaluate("() => map.jumpTo({zoom: 16})")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    near = page.evaluate("() => sculptWidthM()")
+    page.evaluate("() => map.jumpTo({zoom: 11})")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    far = page.evaluate("() => sculptWidthM()")
+    assert far > near
+    # The zoomend rebuild must have refreshed the beam, not left it at the
+    # width it had on load.
+    page.wait_for_function(
+        "() => map.querySourceFeatures('beam').length > 0", timeout=5000)

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -291,11 +291,12 @@ def test_beam_stops_at_a_cliff(serve_map, page):
     spec's flat-ground-plane note).
     """
     # MapLibre resolves DEM tiles one zoom COARSER than the source maxzoom, so
-    # the stub's left/right split lands at the z14 tile midpoint -- one full
-    # TILE_DEG east of the enclosing z15 tile's west edge, NOT one TILE_DEG
-    # east of the flight's nominal longitude. Derive it rather than guessing.
-    west = -180 + math.floor((20.0 + 180) / TILE_DEG) * TILE_DEG
-    cliff = west + TILE_DEG
+    # the stub's left/right split lands at the z14 tile midpoint, NOT at
+    # the z15 tile's east edge -- those only coincide when the z15 tile is
+    # the WESTERN half of its z14 parent (true for lon 20.0, but not in
+    # general). Derive the midpoint on the z14 grid directly.
+    parent = 2 * TILE_DEG
+    cliff = -180 + math.floor((20.0 + 180) / parent) * parent + TILE_DEG
     lon = cliff - TILE_DEG * 0.05      # ~60 m west of the wall
     track = _flight("DJI_0001", 10.0, lon, [50.0] * 5,
                     yaws=[90.0] * 5, pitches=[-20.0] * 5, focal=24.0,
@@ -315,11 +316,18 @@ def test_beam_stops_at_a_cliff(serve_map, page):
     assert dropped >= 8, (
         f"only {dropped} of {4 * steps} prisms dropped at the wall -- the "
         "geometry is degenerate and this test proves little")
-    assert all(p["hgt"] > p["base"] for p in props)
+    # Exercises the Math.max(0, ...) clamp on base: the prism straddling the
+    # wall has a lower boundary height around -34 m in this fixture, and
+    # fill-extrusion-base has a style-spec minimum of 0. Without the clamp
+    # this fails.
+    assert all(p["base"] >= 0 for p in props)
 
     # The real claim: no surviving prism sits meaningfully past the wall.
-    # One step of overshoot is expected -- the step that straddles the
-    # crossing is kept whenever its western end is still above ground.
+    # A centroid can land at most half a step past the crossing -- the
+    # straddling step is kept whenever its western end is still above
+    # ground, and the step after it is dropped -- so 0.5 steps of slack
+    # is the tightest bound that cannot false-positive on the straddler
+    # while still catching a surviving prism a full step beyond it.
     centroids = page.evaluate(
         "() => beamFor(flights[0], pb.sample,"
         " gazeRing(flights[0], pb.sample).ring).map(f => {"
@@ -329,7 +337,7 @@ def test_beam_stops_at_a_cliff(serve_map, page):
         "() => { const r = gazeRing(flights[0], pb.sample).ring;"
         " return Math.max(...r.slice(0, 4).map(p => p[0]))"
         "      - flights[0].pts[pb.sample][0]; }")
-    slack = ray_len_deg / steps * 1.5
+    slack = ray_len_deg / steps * 0.5
     beyond = [c for c in centroids if c > cliff + slack]
     assert not beyond, (
         f"{len(beyond)} prisms sit past the wall at {cliff:.6f}: "
@@ -341,14 +349,35 @@ def test_beam_width_tracks_zoom(serve_map, page):
                     yaws=[90.0] * 5, pitches=[-50.0] * 5, focal=24.0)
     serve_map(flights_to_3d_html([track], "trip"))
     _ready(page)
+
+    def _beam_width():
+        # Cross-ray width of a beam prism: the gap between its two
+        # camera-side corners, r[0] and r[3] (the ring closes back to r[0]).
+        # This has to read the SOURCE's raw data -- ._data.geojson, exactly
+        # what the last setData() call passed in -- rather than
+        # querySourceFeatures(): a beam prism is only a few metres wide, and
+        # MapLibre's internal geojson-vt tessellation simplifies a feature
+        # that small down to under 4 points at low zoom (verified: every
+        # prism at zoom 11 reads back with 0-3 coordinates through
+        # querySourceFeatures, even though setData() was called with a
+        # proper quad). Reading ._data.geojson is a private field, but it
+        # is what makes this assertion possible to write honestly at all.
+        return page.evaluate(
+            "() => { const r = map.getSource('beam')._data.geojson"
+            ".features[0].geometry.coordinates[0];"
+            " return Math.hypot(r[0][0] - r[3][0], r[0][1] - r[3][1]); }")
+
     page.evaluate("() => map.jumpTo({zoom: 16})")
     page.wait_for_function("() => !map.isMoving()", timeout=15000)
     near = page.evaluate("() => sculptWidthM()")
+    near_beam = _beam_width()
     page.evaluate("() => map.jumpTo({zoom: 11})")
     page.wait_for_function("() => !map.isMoving()", timeout=15000)
     far = page.evaluate("() => sculptWidthM()")
+    far_beam = _beam_width()
     assert far > near
     # The zoomend rebuild must have refreshed the beam, not left it at the
-    # width it had on load.
-    page.wait_for_function(
-        "() => map.querySourceFeatures('beam').length > 0", timeout=5000)
+    # width it had on load: measure an actual prism's cross-ray width rather
+    # than merely checking the source is non-empty, which holds even for the
+    # load-time beam and would pass with the rebuild hook deleted.
+    assert far_beam > near_beam

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -125,3 +125,101 @@ def test_fallback_lens_matches_the_python_default(serve_map, page):
     hfov, vfov = fov_degrees(DEFAULT_LENS, None)
     assert page.evaluate("() => GAZE_FALLBACK_HFOV") == round(hfov, 1)
     assert page.evaluate("() => GAZE_FALLBACK_VFOV") == round(vfov, 1)
+
+
+def _wait_patch(page, present: bool):
+    """Wait for the gaze source to hold a ring (or not). GeoJSON source tiles
+    build asynchronously, so sampling the instant after a state change is a
+    flake."""
+    page.wait_for_function(
+        "(want) => (map.querySourceFeatures('gaze').length > 0) === want",
+        arg=present, timeout=5000)
+
+
+def test_patch_renders_at_the_projected_ring(serve_map, page):
+    """queryRenderedFeatures at the ring's centre must hit gaze-fill: the patch
+    has to be drawn where the projection says, not merely added as data."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 5,
+                    yaws=[90.0] * 5, pitches=[-50.0] * 5, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _wait_patch(page, True)      # present before play is ever pressed
+    hit = page.evaluate(
+        "() => { const r = gazeRing(flights[0], pb.sample).ring;"
+        " const c = r.slice(0, 4).reduce("
+        "   (a, p) => [a[0] + p[0] / 4, a[1] + p[1] / 4], [0, 0]);"
+        " const q = map.project(c);"
+        " return map.queryRenderedFeatures([q.x, q.y],"
+        "                                  {layers: ['gaze-fill']}).length; }")
+    assert hit > 0, "no gaze-fill under the ring centre"
+    off = page.evaluate(
+        "() => map.queryRenderedFeatures([2, 2],"
+        "                                {layers: ['gaze-fill']}).length")
+    assert off == 0, "gaze-fill covers a corner of the viewport it should not"
+
+
+def test_patch_clears_above_the_horizon(serve_map, page):
+    """A second the camera spent above the horizon must empty the source and
+    say why, not freeze on the previous ring."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 4,
+                    yaws=[0.0] * 4, pitches=[-45.0, -45.0, 10.0, 10.0],
+                    focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _wait_patch(page, True)
+    page.evaluate("() => { pb.t = 3; pbRender(); }")
+    _wait_patch(page, False)
+    assert page.evaluate("() => document.getElementById('pb-note')"
+                         ".textContent") == "camera above horizon"
+
+
+def test_patch_clears_without_altitude(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0, 50.0, None, None],
+                    yaws=[0.0] * 4, pitches=[-45.0] * 4, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    page.evaluate("() => { pb.t = 3; pbRender(); }")
+    _wait_patch(page, False)
+    assert page.evaluate("() => document.getElementById('pb-note')"
+                         ".textContent") == "no altitude"
+
+
+def test_a_flight_without_agl_is_playable_with_no_gaze(serve_map, page):
+    """An SRT format that carries no rel_alt at all: the clock still runs, and
+    the patch is simply never drawn (spec section 8)."""
+    track = _flight("DJI_0001", 10.0, 20.0, [None] * 5,
+                    yaws=[0.0] * 5, pitches=[-45.0] * 5, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    assert page.locator("#playback").count() == 1
+    assert page.evaluate("() => flights[0].agl") is None
+    _wait_patch(page, False)
+    page.evaluate("() => { pb.t = 3; pbRender(); }")
+    _wait_patch(page, False)
+
+
+def test_edge_dash_flips_both_ways(serve_map, page):
+    """The dashed edge marks an estimated ring. The reset direction matters as
+    much as the set: a null that failed to restore the default would leave
+    every later ring looking estimated."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 4,
+                    yaws=[0.0, 0.0, None, None],
+                    pitches=[-45.0, -45.0, -45.0, -45.0], focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    dash = "() => map.getPaintProperty('gaze-edge', 'line-dasharray')"
+    assert not page.evaluate(dash), "sample 0 has real yaw: edge must be solid"
+    page.evaluate("() => { pb.t = 3; pbRender(); }")
+    assert page.evaluate(dash), "estimated ring must dash the edge"
+    page.evaluate("() => { pb.t = 0; pbRender(); }")
+    assert not page.evaluate(dash), "dash was never reset"
+
+
+def test_note_names_the_estimate(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 4)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    note = page.evaluate("() => document.getElementById('pb-note')"
+                         ".textContent")
+    assert note.startswith("estimated footprint")
+    assert "no gimbal pitch" in note

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -274,16 +274,29 @@ def test_beam_heights_survive_the_elevation_conversion(serve_map, page):
 
 
 def test_beam_stops_at_a_cliff(serve_map, page):
-    """Where the DEM rises 600 m above the drone, every remaining prism is
-    below the surface: fill-extrusion cannot draw there, so the ray must end
-    rather than tunnel through the wall."""
+    """A ray aimed past a 600 m wall must END at the wall, not tunnel through
+    it: every prism beyond the crossing is below the rendered surface, and
+    fill-extrusion cannot draw below terrain at all.
+
+    The drone sits ~60 m west of the wall rather than a quarter tile, so the
+    crossing falls early in the ray and the drop rule is exercised on roughly
+    half the prisms. At a quarter tile the crossing lands at s~0.9 and only
+    2 of 64 prisms drop -- the assertion passes while proving almost nothing.
+
+    Known limitation this test deliberately does NOT assert away: gazeRing
+    projects onto a FLAT ground plane at the drone's height datum, so where
+    terrain rises into the frustum the far corner lands past the real hit
+    point and the ray climbs toward it. Fixing that needs DEM ray-marching,
+    which would change the patch too and is out of scope here (see the design
+    spec's flat-ground-plane note).
+    """
     # MapLibre resolves DEM tiles one zoom COARSER than the source maxzoom, so
     # the stub's left/right split lands at the z14 tile midpoint -- one full
     # TILE_DEG east of the enclosing z15 tile's west edge, NOT one TILE_DEG
     # east of the flight's nominal longitude. Derive it rather than guessing.
     west = -180 + math.floor((20.0 + 180) / TILE_DEG) * TILE_DEG
     cliff = west + TILE_DEG
-    lon = cliff - TILE_DEG * 0.25      # drone a quarter tile west of the wall
+    lon = cliff - TILE_DEG * 0.05      # ~60 m west of the wall
     track = _flight("DJI_0001", 10.0, lon, [50.0] * 5,
                     yaws=[90.0] * 5, pitches=[-20.0] * 5, focal=24.0,
                     step=0.0)
@@ -298,8 +311,29 @@ def test_beam_stops_at_a_cliff(serve_map, page):
     props = page.evaluate(_BEAM_JS)
     steps = page.evaluate("() => GAZE_BEAM_STEPS")
     assert props, "the beam vanished entirely"
-    assert len(props) < 4 * steps, "no prism was dropped at the wall"
+    dropped = 4 * steps - len(props)
+    assert dropped >= 8, (
+        f"only {dropped} of {4 * steps} prisms dropped at the wall -- the "
+        "geometry is degenerate and this test proves little")
     assert all(p["hgt"] > p["base"] for p in props)
+
+    # The real claim: no surviving prism sits meaningfully past the wall.
+    # One step of overshoot is expected -- the step that straddles the
+    # crossing is kept whenever its western end is still above ground.
+    centroids = page.evaluate(
+        "() => beamFor(flights[0], pb.sample,"
+        " gazeRing(flights[0], pb.sample).ring).map(f => {"
+        "   const r = f.geometry.coordinates[0];"
+        "   return r.slice(0, 4).reduce((a, p) => a + p[0] / 4, 0); })")
+    ray_len_deg = page.evaluate(
+        "() => { const r = gazeRing(flights[0], pb.sample).ring;"
+        " return Math.max(...r.slice(0, 4).map(p => p[0]))"
+        "      - flights[0].pts[pb.sample][0]; }")
+    slack = ray_len_deg / steps * 1.5
+    beyond = [c for c in centroids if c > cliff + slack]
+    assert not beyond, (
+        f"{len(beyond)} prisms sit past the wall at {cliff:.6f}: "
+        f"{[round(c, 6) for c in beyond[:5]]}")
 
 
 def test_beam_width_tracks_zoom(serve_map, page):

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -344,6 +344,27 @@ def test_beam_stops_at_a_cliff(serve_map, page):
         f"{[round(c, 6) for c in beyond[:5]]}")
 
 
+# Capture what renderGaze() actually hands the beam source. querySourceFeatures
+# cannot be used to measure prism width: a prism is a few metres across, and
+# MapLibre's geojson-vt tessellation simplifies a feature that small to under 4
+# points at low zoom. The source's `_data` holds the same thing, but it is a
+# private field and this project pins MapLibre by version + SRI -- a deliberate
+# bump would then fail here looking like a beam bug. Wrapping the public
+# setData is equivalent, survives version bumps, and additionally records
+# *whether the rebuild fired at all*, which is the behaviour under test.
+# Patching browser internals from a test is the established idiom in this
+# suite; see conftest's hillshade accessor trap and getContext patch.
+_BEAM_SPY_JS = """
+(() => {
+  const src = map.getSource('beam');
+  const orig = src.setData.bind(src);
+  window.__beamSets = 0;
+  window.__lastBeam = null;
+  src.setData = d => { window.__beamSets++; window.__lastBeam = d; return orig(d); };
+})();
+"""
+
+
 def test_beam_width_tracks_zoom(serve_map, page):
     track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 5,
                     yaws=[90.0] * 5, pitches=[-50.0] * 5, focal=24.0)
@@ -351,33 +372,29 @@ def test_beam_width_tracks_zoom(serve_map, page):
     _ready(page)
 
     def _beam_width():
-        # Cross-ray width of a beam prism: the gap between its two
-        # camera-side corners, r[0] and r[3] (the ring closes back to r[0]).
-        # This has to read the SOURCE's raw data -- ._data.geojson, exactly
-        # what the last setData() call passed in -- rather than
-        # querySourceFeatures(): a beam prism is only a few metres wide, and
-        # MapLibre's internal geojson-vt tessellation simplifies a feature
-        # that small down to under 4 points at low zoom (verified: every
-        # prism at zoom 11 reads back with 0-3 coordinates through
-        # querySourceFeatures, even though setData() was called with a
-        # proper quad). Reading ._data.geojson is a private field, but it
-        # is what makes this assertion possible to write honestly at all.
+        # Cross-ray width of a prism: the gap between its two camera-side
+        # corners, r[0] and r[3] (the ring closes back to r[0]).
         return page.evaluate(
-            "() => { const r = map.getSource('beam')._data.geojson"
+            "() => { const r = window.__lastBeam"
             ".features[0].geometry.coordinates[0];"
             " return Math.hypot(r[0][0] - r[3][0], r[0][1] - r[3][1]); }")
 
     page.evaluate("() => map.jumpTo({zoom: 16})")
     page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    page.evaluate(_BEAM_SPY_JS)
+    page.evaluate("() => renderGaze()")      # seed the spy with a known build
     near = page.evaluate("() => sculptWidthM()")
     near_beam = _beam_width()
-    page.evaluate("() => map.jumpTo({zoom: 11})")
+    page.evaluate("() => { window.__beamSets = 0; map.jumpTo({zoom: 11}); }")
     page.wait_for_function("() => !map.isMoving()", timeout=15000)
     far = page.evaluate("() => sculptWidthM()")
-    far_beam = _beam_width()
     assert far > near
-    # The zoomend rebuild must have refreshed the beam, not left it at the
-    # width it had on load: measure an actual prism's cross-ray width rather
-    # than merely checking the source is non-empty, which holds even for the
-    # load-time beam and would pass with the rebuild hook deleted.
-    assert far_beam > near_beam
+
+    # Two claims, and the first is the one the old `length > 0` assertion
+    # missed entirely: the zoomend rebuild must actually FIRE (delete the
+    # renderGaze() hook in rebuildSculpture and __beamSets stays 0), and what
+    # it hands the source must be rebuilt at the new width rather than the one
+    # it had on load.
+    assert page.evaluate("() => window.__beamSets") > 0, (
+        "zoomend did not refresh the beam source")
+    assert _beam_width() > near_beam

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -589,3 +589,41 @@ def test_clicking_the_track_still_opens_the_flight_popup(serve_map, page):
     assert page.locator(".maplibregl-popup").count() == 1
     assert page.locator(".ghost-open").count() == 1
     assert page.locator(".gaze-pass").count() == 0
+
+
+def test_fuzzed_positions_get_no_gaze_but_keep_playback(serve_map, page):
+    """A footprint projected from a coordinate moved ~100 m is a confident
+    claim about ground that was never filmed. --footprint already refuses
+    redacted exports; so does the viewer."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip", redact="fuzz"))
+    _ready(page)
+    for layer in ("gaze-fill", "gaze-edge", "beam-ray", "gaze-hits-line"):
+        assert page.evaluate("(id) => !map.getLayer(id)", layer), layer
+    assert page.locator("#playback").count() == 1
+    assert page.evaluate("() => !!map.getLayer('gaze-cursor-dot')")
+    assert "gaze" in page.locator("#flights-panel").inner_text().lower()
+    # A due-east, constant-latitude fixture line puts (20.001, 10.0) exactly
+    # on the rendered flight line, so a plain _click_at would open the
+    # flight's own (gaze-unrelated) popup and prove nothing about the gate.
+    # _click_inside_ring's off-line point works here too: it is derived from
+    # gazeRing(), which stays defined and callable even when the gate never
+    # wires it into a layer or a click handler.
+    _click_inside_ring(page, 2)
+    assert page.locator(".maplibregl-popup").count() == 0
+
+
+def test_hiding_the_flight_hides_its_gaze(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    vis = "(id) => map.getLayoutProperty(id, 'visibility') || 'visible'"
+    assert page.evaluate(vis, "gaze-fill") == "visible"
+    page.locator("#flights-panel input[type=checkbox]").first.uncheck()
+    assert page.evaluate(vis, "gaze-fill") == "none"
+    assert page.evaluate(vis, "beam-ray") == "none"
+    assert page.evaluate(vis, "gaze-cursor-dot") == "none"
+    page.locator("#flights-panel input[type=checkbox]").first.check()
+    assert page.evaluate(vis, "gaze-fill") == "visible"

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -529,6 +529,54 @@ def test_highlight_clears_when_the_popup_closes(serve_map, page):
         timeout=5000)
 
 
+def test_estimated_badge_covers_every_matched_sample(serve_map, page):
+    """A clip can lose gimbal attitude partway through, so the warning has to
+    reflect the weakest frame on offer -- not whichever sample happens to come
+    first. Reading one sample's flag let the popup answer with extrapolated
+    footprints and no warning at all, which is the one thing this feature must
+    never do.
+
+    Sample 0 keeps its real gimbal; the rest are dropped. The REAL sample
+    must come first: the defect read passes[0].i0, so a fixture whose first
+    matched sample was estimated would have shown the badge anyway and proved
+    nothing. Its pitch is set to
+    GHOST_EST_PITCH's own -30 so the geometry is identical across all four
+    samples -- what varies is only whether the attitude was recorded or
+    assumed. A nadir real sample would sit ~87 m from the estimated ones'
+    footprints and the click would match just one of them, testing nothing.
+    Combined with a hover (step=0), every ring covers the same ground, so one
+    click matches both a real and an estimated sample.
+    """
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 4,
+                    yaws=[90.0, 90.0, 90.0, 90.0],
+                    pitches=[-30.0, None, None, None], focal=24.0,
+                    step=0.0)                       # hover: all rings coincide
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    est = page.evaluate(
+        "() => [0, 1, 2, 3].map(i => gazeRing(flights[0], i).estimated)")
+    assert est == [False, True, True, True], (
+        f"fixture does not mix real and estimated attitude: {est}")
+    _click_inside_ring(page, 0)
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    assert page.locator(".gaze-est").count() == 1, (
+        "no estimated warning, though matched samples were extrapolated")
+    assert "no gimbal data" in page.locator(".gaze-est").inner_text()
+
+
+def test_no_estimated_badge_when_every_sample_is_real(serve_map, page):
+    """The mirror: a warning that always fires teaches users to ignore it."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 4,
+                    yaws=[90.0] * 4, pitches=[-90.0] * 4, focal=24.0,
+                    step=0.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _click_inside_ring(page, 2)
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    assert page.locator(".gaze-pass").count() >= 1   # the lookup really ran
+    assert page.locator(".gaze-est").count() == 0
+
+
 def test_clicking_the_track_still_opens_the_flight_popup(serve_map, page):
     """The flight line owns its own popup with View from here; the lookup must
     not fire a second popup on top of it."""

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -402,3 +402,142 @@ def test_beam_width_tracks_zoom(serve_map, page):
     # fails, just as a timeout instead of an immediate assertion.
     page.wait_for_function("() => window.__beamSets > 0", timeout=15000)
     assert _beam_width() > near_beam
+
+
+def _click_at(page, lng, lat):
+    """Click the map canvas at a geographic point."""
+    pt = page.evaluate("([lng, lat]) => { const p = map.project([lng, lat]);"
+                       " return [p.x, p.y]; }", [lng, lat])
+    page.mouse.click(pt[0], pt[1])
+
+
+def _click_inside_ring(page, sample: int):
+    """Click inside sample's footprint but clear of the flight line.
+
+    Two traps, both of which made these tests prove nothing:
+
+    A nadir footprint's centroid IS the track vertex. At pitch exactly -90
+    frustum_ground_ring has fwd_n == 0 and up_z == 0, so the four corners sit
+    at (+/-tan_h*agl, +/-tan_v*agl) and average back to the camera position --
+    clicking there hits the flight line, gazeLookup correctly bails, and the
+    flight's own popup answers instead. Blending halfway to a corner moves the
+    click off-axis.
+
+    And these fixtures are tiny on screen: a ~200 m track under the map's
+    fitBounds/maxZoom 15 spans ~40 px, so the whole 75 m footprint is ~16 px
+    wide and every point in it is within a few pixels of the line. Zooming in
+    is what actually buys the clearance; an off-nadir pitch alone would move
+    the axis ~2 px.
+
+    The precondition assertion is the point: it turns a silent bail into a
+    loud failure if this geometry ever drifts again.
+    """
+    pt = page.evaluate(
+        "(s) => { const r = gazeRing(flights[0], s).ring;"
+        " const c = r.slice(0, 4).reduce("
+        "   (a, p) => [a[0] + p[0] / 4, a[1] + p[1] / 4], [0, 0]);"
+        " return [c[0] + (r[0][0] - c[0]) * 0.5,"
+        "         c[1] + (r[0][1] - c[1]) * 0.5]; }", sample)
+    page.evaluate("(p) => map.jumpTo({center: p, zoom: 17})", pt)
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    px = page.evaluate(
+        "(p) => { const q = map.project(p); return [q.x, q.y]; }", pt)
+    on_line = page.evaluate(
+        "([x, y]) => map.queryRenderedFeatures([x, y],"
+        " {layers: flights.map(f => f.id).filter(id => map.getLayer(id))})"
+        ".length", px)
+    assert on_line == 0, (
+        "click point sits on the flight line, so gazeLookup would bail and "
+        "this test would prove nothing")
+    page.mouse.click(px[0], px[1])
+    return pt
+
+
+def test_clicking_inside_a_footprint_lists_the_passes(serve_map, page):
+    """The provenance question: which seconds filmed this ground?"""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _click_inside_ring(page, 2)
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    text = page.locator(".maplibregl-popup").inner_text()
+    assert "DJI_0001" in text
+    assert "in frame" in text
+    assert page.locator(".gaze-pass").count() >= 1
+    page.wait_for_function(
+        "() => map.querySourceFeatures('gaze-hits').length > 0", timeout=5000)
+
+
+def test_clicking_empty_ground_says_so(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    # Centre the map on the empty point rather than guessing an offset that
+    # stays on canvas: at the auto-fit zoom, 0.05 deg away projects to roughly
+    # (1420, -48) in a 1280x720 viewport, so the click never reached the map
+    # and the miss popup never appeared. ~330 m clears a ~75 m footprint.
+    # Offset in LATITUDE: the track runs east-west from lon 20.0000 to 20.0030
+    # in six 0.0006 steps, so a longitude offset of 0.003 lands exactly on the
+    # last sample. 0.003 deg north is ~330 m, well clear of footprints that
+    # reach ~0.00034 deg (37.5 m) across-track.
+    empty = [20.0015, 10.003]
+    page.evaluate("(p) => map.jumpTo({center: p, zoom: 17})", empty)
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    px = page.evaluate(
+        "(p) => { const q = map.project(p); return [q.x, q.y]; }", empty)
+    size = page.evaluate("() => [map.getCanvas().clientWidth,"
+                         " map.getCanvas().clientHeight]")
+    assert 0 <= px[0] <= size[0] and 0 <= px[1] <= size[1], (
+        f"click point {px} is outside the {size} viewport; no click would fire")
+    page.mouse.click(px[0], px[1])
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    assert "No recorded frame covered this spot" in \
+        page.locator(".maplibregl-popup").inner_text()
+    assert page.locator(".gaze-pass").count() == 0
+
+
+def test_a_pass_button_seeks_and_plays(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _click_inside_ring(page, 4)
+    page.wait_for_selector(".gaze-pass", timeout=5000)
+    page.locator(".gaze-pass").first.click()
+    assert page.evaluate("() => pb.t") >= 3.0
+    assert page.evaluate("() => pb.playing") is True
+
+
+def test_highlight_clears_when_the_popup_closes(serve_map, page):
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _click_inside_ring(page, 2)
+    page.wait_for_selector(".maplibregl-popup-close-button", timeout=5000)
+    # Assert the highlight is THERE before closing. Without this the test
+    # passed while gazeLookup was bailing on the flight-line guard and
+    # gaze-hits had been empty all along -- "empty at the end" proves nothing
+    # if it was never populated.
+    page.wait_for_function(
+        "() => map.querySourceFeatures('gaze-hits').length > 0", timeout=5000)
+    page.click(".maplibregl-popup-close-button")
+    page.wait_for_function(
+        "() => map.querySourceFeatures('gaze-hits').length === 0",
+        timeout=5000)
+
+
+def test_clicking_the_track_still_opens_the_flight_popup(serve_map, page):
+    """The flight line owns its own popup with View from here; the lookup must
+    not fire a second popup on top of it."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _click_at(page, *page.evaluate("() => flights[0].pts[3].slice(0, 2)"))
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    assert page.locator(".maplibregl-popup").count() == 1
+    assert page.locator(".ghost-open").count() == 1
+    assert page.locator(".gaze-pass").count() == 0

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -178,6 +178,9 @@ def test_patch_clears_without_altitude(serve_map, page):
                     yaws=[0.0] * 4, pitches=[-45.0] * 4, focal=24.0)
     serve_map(flights_to_3d_html([track], "trip"))
     _ready(page)
+    _wait_patch(page, True)      # present before the seek, or "cleared" is
+                                  # meaningless -- its sibling above asserts
+                                  # this too
     page.evaluate("() => { pb.t = 3; pbRender(); }")
     _wait_patch(page, False)
     assert page.evaluate("() => document.getElementById('pb-note')"
@@ -251,8 +254,12 @@ def test_beam_is_four_continuous_rays(serve_map, page):
 
 def test_beam_heights_survive_the_elevation_conversion(serve_map, page):
     """A constant-elevation DEM must give the SAME heights as no DEM at all.
-    Skipping the takeoff/local conversion, or interpolating it end to end,
-    breaks this."""
+    Skipping the takeoff/local conversion breaks this. (Interpolating the
+    local surface end to end, rather than sampling it per boundary, does
+    NOT break this: on a constant-elevation DEM the two formulas collapse to
+    the identical h(s) = (A - E_cam)(1 - s) -- see beamFor's own comment.
+    test_beam_stops_at_a_cliff is the test that would actually catch that
+    defect, on a DEM where the two formulas diverge.)"""
     track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 5,
                     yaws=[90.0] * 5, pitches=[-50.0] * 5, focal=24.0)
     html = flights_to_3d_html([track], "trip")
@@ -493,9 +500,13 @@ def test_clicking_empty_ground_says_so(serve_map, page):
         f"click point {px} is outside the {size} viewport; no click would fire")
     page.mouse.click(px[0], px[1])
     page.wait_for_selector(".maplibregl-popup", timeout=5000)
-    assert "No recorded frame covered this spot" in \
+    assert "No footprint on this map covers this spot" in \
         page.locator(".maplibregl-popup").inner_text()
     assert page.locator(".gaze-pass").count() == 0
+    # Nothing was skipped in this fixture (one flight, shown, with agl), so
+    # the honesty line must not appear -- it would be noise on the common
+    # case.
+    assert page.locator(".gaze-skip").count() == 0
 
 
 def test_a_pass_button_seeks_and_plays(serve_map, page):
@@ -508,6 +519,35 @@ def test_a_pass_button_seeks_and_plays(serve_map, page):
     page.locator(".gaze-pass").first.click()
     assert page.evaluate("() => pb.t") >= 3.0
     assert page.evaluate("() => pb.playing") is True
+
+
+def test_pass_list_caps_at_gaze_max_passes(serve_map, page):
+    """M2 (#378 whole-branch review): GAZE_MAX_PASSES and the "+N more" note
+    had no test at all -- an off-by-one in the slice or a broken note would
+    ship unseen.
+
+    A hover (step=0) with altitude alternating real/None gives more than 12
+    passes cheaply, and DISCONTIGUOUS ones at that: every real-altitude
+    sample sits between two None-altitude samples (no ring, so no hit), so
+    each real sample closes its own one-sample pass instead of merging into
+    a single long run.
+    """
+    n = 30
+    agls = [50.0 if i % 2 == 0 else None for i in range(n)]
+    real_hits = sum(1 for a in agls if a is not None)
+    track = _flight("DJI_0001", 10.0, 20.0, agls,
+                    yaws=[90.0] * n, pitches=[-90.0] * n, focal=24.0,
+                    step=0.0)                       # hover: all rings coincide
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    max_passes = page.evaluate("() => GAZE_MAX_PASSES")
+    assert max_passes == 12
+    assert real_hits > max_passes, "fixture must exceed the cap to test it"
+    _click_inside_ring(page, 0)
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    assert page.locator(".gaze-pass").count() == max_passes
+    text = page.locator(".maplibregl-popup").inner_text()
+    assert f"+{real_hits - max_passes} more" in text, text
 
 
 def test_highlight_clears_when_the_popup_closes(serve_map, page):
@@ -527,6 +567,48 @@ def test_highlight_clears_when_the_popup_closes(serve_map, page):
     page.wait_for_function(
         "() => map.querySourceFeatures('gaze-hits').length === 0",
         timeout=5000)
+
+
+def test_two_consecutive_lookups_leave_a_highlight(serve_map, page):
+    """This started as a coverage-gap test (#378 whole-branch review): the
+    review's theory was that MapLibre 5.24 closes the previous popup on a
+    'preclick' event that fires before our own 'click' handler, and that a
+    pinned-version bump could one day break that silently. Checking the
+    ACTUAL bundled bundle found no 'preclick' anywhere in it: closeOnClick
+    binds a plain (non-'once') 'click' listener when a popup opens. On a
+    second click both listeners are registered -- gazeLookup (bound once, at
+    mount, so first) and the FIRST popup's own close listener (bound after
+    it, when that popup opened) -- and they fire in THAT order, so the first
+    popup's belated close ran AFTER gazeLookup had already set the new
+    highlight and wiped it right back out. Not a future-bump risk: a live
+    bug, reproduced against the pinned version this repo actually ships.
+    gazeLookup now closes the previous lookup popup itself, synchronously,
+    before computing the new click's answer, which sidesteps the listener
+    order question entirely -- see gazePopup's own comment.
+
+    A wide step and far-apart samples: _click_inside_ring re-centres the
+    viewport on its own click point every time, so with the default tight
+    spacing the FIRST popup (still open, and repositioned by the recentre
+    like any other map-anchored popup) can visually sit on top of the
+    SECOND click's pixel and swallow the click itself -- proving nothing
+    about MapLibre's click ordering, only about DOM overlap in the test.
+    ~450 m between samples puts the two views (each a couple hundred
+    metres wide at zoom 17) nowhere near each other on screen.
+    """
+    n = 10
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * n,
+                    yaws=[90.0] * n, pitches=[-90.0] * n, focal=24.0,
+                    step=0.004)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _click_inside_ring(page, 1)
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    _click_inside_ring(page, 8)
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    assert page.locator(".maplibregl-popup").count() == 1, (
+        "the first popup did not close on the second click")
+    page.wait_for_function(
+        "() => map.querySourceFeatures('gaze-hits').length > 0", timeout=5000)
 
 
 def test_estimated_badge_covers_every_matched_sample(serve_map, page):
@@ -561,7 +643,14 @@ def test_estimated_badge_covers_every_matched_sample(serve_map, page):
     page.wait_for_selector(".maplibregl-popup", timeout=5000)
     assert page.locator(".gaze-est").count() == 1, (
         "no estimated warning, though matched samples were extrapolated")
-    assert "no gimbal data" in page.locator(".gaze-est").inner_text()
+    # Yaw is real throughout this fixture (only pitch is dropped), so the
+    # badge's reason must name pitch specifically -- not the old hardcoded
+    # "no gimbal data", which would be true here by coincidence and would
+    # stay wrong the moment yaw was the missing one instead.
+    text = page.locator(".gaze-est").inner_text()
+    assert "no gimbal pitch" in text
+    assert "no gimbal yaw" not in text
+    assert "assumed lens" not in text
 
 
 def test_no_estimated_badge_when_every_sample_is_real(serve_map, page):
@@ -627,3 +716,56 @@ def test_hiding_the_flight_hides_its_gaze(serve_map, page):
     assert page.evaluate(vis, "gaze-cursor-dot") == "none"
     page.locator("#flights-panel input[type=checkbox]").first.check()
     assert page.evaluate(vis, "gaze-fill") == "visible"
+
+
+def test_switching_the_picker_reapplies_gaze_visibility(serve_map, page):
+    """I2 (#378 whole-branch review): applyGazeVisibility derives visibility
+    from pb.run.shown but was never re-run when pb.run itself changes. Hide
+    flight A (the flight the picker starts on) -- every gaze layer goes
+    'none'. Switch the picker to flight B, which is still shown: without the
+    fix, pbRecolour() (called from the picker's own change handler) leaves
+    the layers exactly as hiding A set them, and B's gaze looks dead even
+    though B is visible."""
+    a = _flight("DJI_0001", 10.0, 20.0, [50.0] * 4,
+                yaws=[90.0] * 4, pitches=[-45.0] * 4, focal=24.0)
+    b = _flight("DJI_0002", 10.01, 20.0, [50.0] * 4,
+                yaws=[90.0] * 4, pitches=[-45.0] * 4, focal=24.0)
+    serve_map(flights_to_3d_html([a, b], "trip"))
+    _ready(page)
+    vis = "(id) => map.getLayoutProperty(id, 'visibility') || 'visible'"
+    assert page.evaluate("() => pb.run.name") == "DJI_0001"
+    page.locator("#flights-panel input[type=checkbox]").first.uncheck()
+    assert page.evaluate(vis, "gaze-fill") == "none"
+    page.evaluate("() => { const s = document.getElementById('pb-flight');"
+                 " s.value = '1'; s.dispatchEvent(new Event('change')); }")
+    assert page.evaluate("() => pb.run.name") == "DJI_0002"
+    assert page.evaluate(vis, "gaze-fill") == "visible", (
+        "gaze-fill stayed 'none' after switching to a shown flight")
+    assert page.evaluate(vis, "gaze-edge") == "visible"
+    assert page.evaluate(vis, "gaze-cursor-dot") == "visible"
+
+
+def test_hiding_any_flight_clears_an_onscreen_highlight(serve_map, page):
+    """M1 (#378 whole-branch review): gaze-hits-line has no single pb.run to
+    follow -- a lookup highlight can span several flights at once, so tying
+    its visibility to whichever flight is selected in the picker either
+    hides a highlight that still belongs to a visible flight, or leaves one
+    drawn for a flight the user just hid. This project's chosen fix is the
+    simple one the review explicitly sanctions: any panel toggle clears the
+    highlight outright rather than trying to work out which of its passes
+    still belong to a shown flight. It can always be reopened by clicking
+    the spot again."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    _click_inside_ring(page, 2)
+    page.wait_for_selector(".maplibregl-popup", timeout=5000)
+    page.wait_for_function(
+        "() => map.querySourceFeatures('gaze-hits').length > 0", timeout=5000)
+    page.locator("#flights-panel input[type=checkbox]").first.uncheck()
+    # GeoJSON source tiles build asynchronously (see _wait_patch above), so
+    # wait rather than sampling the instant after setData.
+    page.wait_for_function(
+        "() => map.querySourceFeatures('gaze-hits').length === 0",
+        timeout=5000)

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -395,6 +395,10 @@ def test_beam_width_tracks_zoom(serve_map, page):
     # renderGaze() hook in rebuildSculpture and __beamSets stays 0), and what
     # it hands the source must be rebuilt at the new width rather than the one
     # it had on load.
-    assert page.evaluate("() => window.__beamSets") > 0, (
-        "zoomend did not refresh the beam source")
+    # wait_for_function, not a synchronous read: 'zoomend' can be dispatched
+    # a tick after isMoving() itself flips false, and sampling the instant
+    # after a state change is a flake -- the same class _wait_patch guards
+    # against elsewhere in this file. If the hook is truly gone this still
+    # fails, just as a timeout instead of an immediate assertion.
+    page.wait_for_function("() => window.__beamSets > 0", timeout=15000)
     assert _beam_width() > near_beam

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -468,7 +468,7 @@ def test_geojson_pose_arrays_absent_without_data():
 
     fc = flights_to_geojson([_ghost_track()])
     props = fc["features"][0]["properties"]
-    for key in ("gyaw_deg", "gpitch_deg", "agl_m", "vfov_deg"):
+    for key in ("gyaw_deg", "gpitch_deg", "agl_m", "hfov_deg", "vfov_deg"):
         assert key not in props
 
 
@@ -479,7 +479,7 @@ def test_geojson_pose_arrays_not_on_single_fix_point():
     track.points = track.points[:1]
     fc = flights_to_geojson([track])
     assert fc["features"][0]["geometry"]["type"] == "Point"
-    for key in ("gyaw_deg", "gpitch_deg", "agl_m", "vfov_deg"):
+    for key in ("gyaw_deg", "gpitch_deg", "agl_m", "hfov_deg", "vfov_deg"):
         assert key not in fc["features"][0]["properties"]
 
 
@@ -489,6 +489,17 @@ def test_geojson_vfov_from_median_focal():
     fc = flights_to_geojson([_ghost_track(focal_len=24.0)])
     # DEFAULT_LENS aspect 4:3 -> full-frame height 27 mm;
     # vfov = 2*atan(27 / (2*24)) = 58.7 deg.
+    assert fc["features"][0]["properties"]["vfov_deg"] == 58.7
+
+
+def test_geojson_hfov_from_median_focal():
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    fc = flights_to_geojson([_ghost_track(focal_len=24.0)])
+    # Same median focal, full-frame width 36 mm:
+    # hfov = 2*atan(36 / (2*24)) = 73.7 deg. The 3D gaze sizes the camera
+    # footprint from it (#378).
+    assert fc["features"][0]["properties"]["hfov_deg"] == 73.7
     assert fc["features"][0]["properties"]["vfov_deg"] == 58.7
 
 

--- a/tests/test_geo_flightmap3d_html.py
+++ b/tests/test_geo_flightmap3d_html.py
@@ -105,6 +105,15 @@ def test_3d_html_carries_the_sculpture_layers():
     assert "sculpture-toggle" in html
 
 
+def test_template_carries_the_gaze_and_playback_app():
+    html = flights_to_3d_html([_track()], "trip")
+    for needle in ("function gazeRing(", "function beamFor(",
+                   "function gazeLookup(", "'gaze-fill'", "'beam-ray'",
+                   "'gaze-hits-line'", "id: 'gaze-cursor-dot'",
+                   "pb-play", "pb-slider", "GAZE_FALLBACK_HFOV"):
+        assert needle in html, needle
+
+
 def test_write_flights_3d_html(tmp_path):
     out = tmp_path / "flightmap-3d.html"
     result = write_flights_3d_html([_track()], out, "trip")


### PR DESCRIPTION
Closes #378. Stage 3 of the 3D arc, after Ghost Camera (#372) and the flight sculpture (#375).

The 3D map could already put you at the drone's altitude and show the shape of a flight in the air. It could not answer the question people actually ask of their own footage: **what was the camera looking at, and when did it film this spot?**

## What this adds

- **Playback** — the 3D map had none; the flat map has had it since #267. Play/pause, speed (1×/5×/20×/60×), scrubber, time readout, and a picker when more than one flight is playable. Semantics deliberately identical to the flat map's animator.
- **The gaze patch** — the camera's ground footprint for the current second, draped on the terrain, dashed and badged when it was drawn from estimated attitude.
- **The beam** — the four frustum corner rays from camera to patch, staircased into vertical prisms because MapLibre cannot slant geometry.
- **Riding the cockpit** — press play inside the ghost view and the camera flies the recorded path in real time instead of arrow-keying sample by sample. Arrow-stepping keeps its 150 ms glide and carries the clock with it, so the ground patch always matches what you are looking at.
- **Click a spot** — click any terrain and get back which seconds of recording covered it: `in frame 14 s over 3 passes`, each pass a button that seeks the clock there, with the matching stretches of flight line highlighted.

The footprint projection is a browser-side port of `geo/geometry.py:frustum_ground_ring`, pinned by a cross-language parity test that calls the Python and the JS on the same inputs and compares corner by corner to 1e-9°. Rings are not embedded: at ~115 bytes per second per flight a 20-clip folder map would carry hundreds of KB of derivable data.

**One new GeoJSON property**, `hfov_deg`, beside the existing `vfov_deg`. No new CLI flags, dependencies or pinned assets.

## Honesty posture

This tool exists so people can verify footage, so the feature is built to under-claim:

- **`--redact fuzz` switches the whole gaze off** — patch, beam and lookup — while playback keeps working and the panel says why. A footprint projected from a position deliberately moved ~100 m is a confident claim about ground the camera never saw. `--footprint` already refuses redacted exports for the same reason.
- **Missing gimbal attitude is estimated at −30°, the same tilt the cockpit assumes**, so the two views never disagree in one frame, and it is marked: dashed outline plus a badge naming what was guessed. Every Mini-series drone is in this case today (#374).
- **The estimate is tracked per sample**, so a clip that loses attitude partway through reports "some passes estimated" rather than silently answering with a mix.
- **A miss says only what was checked.** "No footprint on this map covers this spot", plus a count of flights that were not searched — hidden ones, and ones carrying no height data.
- **Footprints assume flat ground at the drone's height reference**, the same simplification the `--footprint` export makes. Documented, not hidden.

## Review

Eight tasks, each implemented and reviewed independently, then a whole-branch review on the most capable model. Notable things it caught:

- **The beam could aim above the camera.** It took the ray's far end from the DEM at the ring corner, but that corner comes from a flat-plane projection and was never a measured ground hit — so where terrain climbed into frame the ray pointed upward, 118 m of beam for a 50 m AGL frame. Terrain-off rendering would never have shown it.
- **The miss message asserted an absence the search never established** — flights that are drawn, listed and playable were silently excluded. For a provenance tool a false negative is the worst answer available.
- **The estimated badge named a cause that can be false.** `mp4_telemetry` sets `focal_len=None` while successfully reading gimbal attitude, so every sidecar-less MP4 clip was told its drone logged no gimbal data.
- **Gaze visibility was never re-applied when the playing flight changed**, so hiding one flight and switching to another left the feature looking dead for a visible flight.

Five tests were vacuous when first written — passing for reasons unrelated to their names — and each was caught by re-deriving what the assertion could distinguish rather than by running it. The ones that survived are documented with what would make them fail.

## Gate

`ruff` clean, `mypy` clean (37 files), `pytest` **773 passed / 3 skipped** (pre-existing environment gates: two need a DJI MP4 fixture and ExifTool ≥ 13.39, one needs network). The browser suite is included.

## Deferred, recorded for follow-up

Splitting `flightmap3d_html.py` (the gaze/playback block is a self-contained ~595-line seam); two pre-existing non-ASCII characters in the emitted JS; a height-convention kink on a partially warm DEM; the beam hiding during any ghost session rather than only its own flight's; and the unmeasured 60× terrain-query budget (~4.4k DEM lookups a second), which wants an eyeball on real footage rather than a stub.
