### PR TITLE
Media crossfade: blend the cockpit view into the real footage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ it's a handful of copy-paste commands. For a guided tour see
 - **Camera's gaze** in the 3D map: play a flight back, watch the camera's
   ground footprint sweep the terrain, and click any spot to see which seconds
   of recording covered it.
+- **Crossfade to the footage** — in the 3D map, blend the terrain
+  reconstruction into the real video frame and see whether the telemetry
+  lines up.
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
   folder of stills on one clustered map, thumbnails included; 360° panoramas
   get their own marker color and toggle, and open in an interactive viewer.

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -364,6 +364,50 @@ reference, the same simplification the `--footprint` KML/GeoJSON export
 makes, so on terrain that rises into the frame the drawn patch is an
 approximation rather than the true footprint.
 
+### Crossfade to the footage
+
+Point `flightmap` at a folder with `--link-originals` and the 3D map learns
+where each flight's video sits:
+
+```bash
+dji-embed flightmap ./footage --3d --link-originals
+```
+
+In the ghost view a slider then appears in the HUD. Slide it and the terrain
+reconstruction fades into the real video frame for the second you are looking
+at; **v** swaps straight between the two extremes. Held half-way you see both
+at once, which is the point: if the telemetry is right, the horizon and the
+landmarks line up. If they do not, something in the recorded attitude is
+off — which is the most direct check this tool offers.
+
+The video follows the clock, but only the slowest speed keeps pace with it:
+at 1× it plays alongside the flight, and at 5× and above it steps frame to
+frame instead, because no browser decodes reliably that fast. A flight
+that DJI split across several files at the 4 GB container limit switches
+source automatically as the clock crosses each boundary, seeking into the
+new file at that sample's own offset rather than the flight's elapsed time.
+A file that fails to load disables the slider and names the file in a badge,
+and stays that way — not just for the frame it broke on — until the clock
+reaches a segment backed by a different file.
+
+Linking is opt-in because the map only works alongside the videos: share the
+HTML on its own and the links have nothing to point at. `--link-base` gives
+the hrefs a different prefix when the footage does not sit beside the map.
+`flightmap` itself has no `--serve` flag, but the standalone `serve` command
+(below, under `photomap`) serves a flightmap page just as well — do that
+rather than opening the file straight from disk, and scrubbing the slider or
+stepping through the flight seeks the video cleanly instead of restarting
+it, because the server answers HTTP Range requests.
+
+Two limits, not one. `--link-originals` is still permitted with `--redact
+fuzz` — originals still carry exact GPS in their own metadata, so linking
+warns rather than refusing — but the crossfade itself is switched off:
+coarsened positions are deliberately ~100 m out, so overlaying real footage
+would invite a comparison against geometry that is knowingly wrong. And
+where a clip carries no focal length, the map's own field of view is an
+estimate, so the alignment is approximate — the same caveat the gaze badge
+already reports.
+
 ## Photo map (`photomap`)
 
 ```bash
@@ -467,6 +511,13 @@ screen are served automatically, so the 360° viewer just works there.)
 Wrapper flags for that kind of integration: `--no-browser`, `--url-only`
 (print the bare URL as the first line), and `--exit-with-stdin` (stop when
 stdin closes, tying the server to the app that started it).
+
+Both the `--serve` flag and the standalone `serve` command answer HTTP Range
+requests (`206 Partial Content`), not just whole-file downloads — Python's
+stock file server does not, and without it a browser scrubbing a served
+video has to re-fetch from the start instead of jumping straight to the
+requested second. This is what makes seeking smooth in the flightmap
+crossfade above, on video files that can run well past the size of a photo.
 
 Notes:
 

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -376,28 +376,43 @@ dji-embed flightmap ./footage --3d --link-originals
 In the ghost view a slider then appears in the HUD. Slide it and the terrain
 reconstruction fades into the real video frame for the second you are looking
 at; **v** swaps straight between the two extremes. Held half-way you see both
-at once, which is the point: if the telemetry is right, the horizon and the
-landmarks line up. If they do not, something in the recorded attitude is
-off — which is the most direct check this tool offers.
+at once, which is the point: a horizon and landmarks that line up are
+consistent with the recorded attitude being right. A mismatch is not proof it
+is wrong — the same picture follows from an estimated or median field of view
+(see below), a terrain model that includes canopy or rooftops, the flat
+ground-plane approximation, or lens distortion the map does not model. Read it
+as the most direct sanity check this tool offers, not a verdict.
 
 The video follows the clock, but only the slowest speed keeps pace with it:
-at 1× it plays alongside the flight, and at 5× and above it steps frame to
-frame instead, because no browser decodes reliably that fast. A flight
-that DJI split across several files at the 4 GB container limit switches
-source automatically as the clock crosses each boundary, seeking into the
-new file at that sample's own offset rather than the flight's elapsed time.
-A file that fails to load disables the slider and names the file in a badge,
-and stays that way — not just for the frame it broke on — until the clock
-reaches a segment backed by a different file.
+at 1× it plays alongside the flight, and at 5× and above it steps sample to
+sample instead — roughly a second at a time — because no browser decodes
+reliably that fast. A flight that DJI split across several files at the 4 GB
+container limit switches source automatically as the clock crosses each
+boundary, seeking into the new file at that sample's own offset rather than
+the flight's elapsed time. A file that fails to load disables the slider and
+names the file in a badge, and stays that way — not just for the frame it
+broke on — until the clock moves into a different segment, even one backed
+by the same file.
+
+That badge only knows the browser refused to load the file, not why: a moved
+file, a wrong link base and an undecodable codec all look identical to it.
+DJI's 4K footage is commonly H.265/HEVC, which Firefox does not decode inside
+MP4 at all and Chrome only where a platform decoder is present — an intact,
+correctly-linked clip can still show as failed on those browsers.
 
 Linking is opt-in because the map only works alongside the videos: share the
 HTML on its own and the links have nothing to point at. `--link-base` gives
 the hrefs a different prefix when the footage does not sit beside the map.
+
+Opening the written file straight from disk (`file://`) works out of the box:
+the video seeks natively with no server involved, and that is the common path.
 `flightmap` itself has no `--serve` flag, but the standalone `serve` command
-(below, under `photomap`) serves a flightmap page just as well — do that
-rather than opening the file straight from disk, and scrubbing the slider or
-stepping through the flight seeks the video cleanly instead of restarting
-it, because the server answers HTTP Range requests.
+(below, under `photomap`) is what makes seeking work when the map is served
+over HTTP instead — the path the desktop app and any hosted copy of the map
+take, and the reason `geo/serve.py` answers HTTP Range requests. Either way,
+it is the *playback* slider (or stepping through the flight) that seeks the
+video; the blend slider only fades between the two layers at whatever second
+the clock is already on.
 
 Two limits, not one. `--link-originals` is still permitted with `--redact
 fuzz` — originals still carry exact GPS in their own metadata, so linking

--- a/docs/superpowers/specs/2026-07-27-media-crossfade-design.md
+++ b/docs/superpowers/specs/2026-07-27-media-crossfade-design.md
@@ -1,0 +1,214 @@
+# Media crossfade — design
+
+**Date:** 2026-07-27
+**Issue:** [#380](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/380)
+**Status:** Approved
+
+## Problem
+
+The 3D map can put you at the drone's altitude (Ghost Camera, #372), show the
+shape of the flight in the air (#375), sweep the camera's ground footprint
+along it and tell you which seconds covered any spot you click (#378). All of
+it is a reconstruction from telemetry. It cannot show the footage, and — more
+importantly — it offers no way to check that the reconstruction and the footage
+agree.
+
+The **media crossfade** puts the real video frame over the cockpit view on a
+blend slider. Held half-way, the terrain reconstruction and the recorded frame
+are overlaid: if the telemetry is right, they line up. That is the payoff of
+the arc and the most direct verification the tool offers — the map's claim
+about where the camera pointed, checked against what the camera saw.
+
+This is stage 4, the last of the 3D arc.
+
+## Scope
+
+- **Video only.** Photos are a separate source and would pull in the MapLibre
+  half of #322.
+- **Opt-in** via `--link-originals` / `--link-base` on `flightmap`, mirroring
+  `photomap`'s existing flags.
+- **Split recordings handled.** DJI closes the container at 4 GB; an Air 3 at
+  4K/100 Mbps reaches that in about five minutes, so single-file-only would
+  miss the flights most worth reviewing.
+- **`geo/serve.py` gains HTTP Range support**, because the crossfade is
+  fundamentally a seek.
+
+Out of scope: photos and panoramas; drawing video pixels into WebGL (the blend
+is CSS compositing only, so no CORS/canvas-taint concerns); audio; any change
+to the flat map.
+
+## Design
+
+### 1. Media resolution (Python)
+
+`flightmap` gains `--link-originals` and `--link-base`, matching `photomap`'s
+semantics — the second requires the first, as it already does there.
+
+A new helper fills `Track.media: list[str] | None`, one href per segment in
+segment order, called by the CLI after scanning:
+
+- For each segment name, resolve the **actual sibling file on disk** rather
+  than guessing a stem: DJI writes `.MP4`, some tools write `.mp4`, and the
+  container can be `.MOV`. Only files that exist are linked; a segment with no
+  resolvable video contributes `null`.
+- Hrefs are relative to the map's output directory, or prefixed with
+  `--link-base` when given.
+- **Allowed under `--redact fuzz`**, matching `photomap`, which already permits
+  the same combination and warns rather than refusing ("Linked/attached
+  original files still carry exact GPS in their EXIF"). Two commands behaving
+  differently on the same flag pair would be a usability trap, and there is a
+  principled line: fuzz corrupts *derived geometry*, so deriving geometry from
+  it is refused — the gaze draws a footprint at a knowingly-wrong place — but a
+  file reference is not a derived claim. The *blend* is disabled instead
+  (see §8).
+
+Keeping resolution in the CLI leaves the writers pure: `flights_to_geojson`
+emits whatever `Track.media` holds and never touches the filesystem.
+
+### 2. Segment identity must travel on the point
+
+`join_split_flights` (`geo/flightmap.py:87`) merges segments with
+`prev.track.points.extend(entry.track.points)` at line 129, so the boundary is
+`len(prev.track.points)` immediately before that call. **Recording boundary
+indices there would be wrong**: `_decimate_points` runs *after* joining and
+thins the track to roughly one point per second, keeping first and last, which
+invalidates any index captured earlier.
+
+So `TrackPoint` gains `segment: int = 0`, set during the join for each appended
+segment. Decimation then carries it for free, and every later consumer sees the
+right value without bookkeeping. The field is defaulted, so every existing
+construction site — including tests — is unaffected.
+
+### 3. Time to (file, offset)
+
+**The in-file offset is already in the data.** Each point's `timestamp` is its
+raw SRT cue, which is video-relative, and `join_split_flights` rebases only
+`utc` — it never touches `timestamp`. So `_cue_seconds(p.timestamp)` is exactly
+the offset within that point's own video file, for joined and single-file
+flights alike.
+
+New per-flight GeoJSON properties, emitted only when `Track.media` is present:
+
+| Property | Shape | Meaning |
+| --- | --- | --- |
+| `media` | list, one per segment | href per segment, `null` where unresolved |
+| `cue_s` | per-point array | offset within that point's own video file |
+| `seg_i` | per-point array | segment index; omitted when every point is 0 |
+
+`cue_s` follows the `times_s` contract: parallel to `coordinates`, same length.
+`seg_i` is omitted for the common single-file case, and its absence means "all
+zero" — a folder of single-file flights pays nothing.
+
+At sample `i` the viewer needs `media[seg_i[i]]` and `cue_s[i]`. Nothing else.
+
+### 4. HTTP Range in `geo/serve.py`
+
+`_QuietHandler` extends `SimpleHTTPRequestHandler`, which does not implement
+Range. Without it Safari refuses to play at all and Chrome re-requests from
+byte zero on every seek.
+
+Add a `send_head` override that:
+
+- advertises `Accept-Ranges: bytes` on every file response;
+- parses a single `Range: bytes=start-end` (open-ended on either side) and
+  answers `206 Partial Content` with `Content-Range` and the exact byte slice;
+- answers `416 Range Not Satisfiable` with a `Content-Range: bytes */<size>`
+  when the range falls outside the file;
+- falls back to a plain `200` for multi-range requests, which no browser needs
+  for media playback.
+
+This is unit-testable without a browser and benefits the existing 360° pano
+viewer too.
+
+### 5. The overlay and the blend control
+
+One `<video>` element over the map canvas: `position: absolute`, covering the
+map, `pointer-events: none` so it never eats a click meant for the terrain,
+`muted` and `playsinline`. Its `opacity` is the blend.
+
+- **A blend slider in the ghost HUD** (`#ghost-blend`), 0-100. This is the
+  control that matters: held mid-way you see both layers at once, which is the
+  whole point.
+- **`V` toggles the extremes** (0 ↔ 100) with a short CSS opacity transition,
+  for when you just want to swap. It joins `Escape`, `ArrowLeft` and
+  `ArrowRight` in the existing `ghostKeys` handler
+  (`geo/flightmap3d_html.py:398`) and, like them, calls `preventDefault`.
+- The element is created only when the current flight has a resolvable video,
+  and removed when it does not, so a flight without media has no dead control.
+
+`src` is swapped when the current sample crosses into a different segment;
+`currentTime` is set from `cue_s`. A `src` swap resets playback state, so the
+swap sets `currentTime` again once `loadedmetadata` fires.
+
+### 6. Playback sync
+
+Two regimes, because browsers cannot decode reliably at 20× or 60×:
+
+- **Speed ≤ 4×:** `video.playbackRate = pb.speed` and `play()`, re-seeking
+  whenever `|video.currentTime − cue_s[sample]|` exceeds 0.25 s. Small drift is
+  expected and correcting it every frame would thrash the decoder.
+- **Above 4×, or paused, or scrubbing:** the video stays paused and seeks on
+  each sample change. At those speeds it is a slideshow, which is honest — the
+  alternative is a decoder that silently falls behind and shows the wrong
+  second.
+
+### 7. Framing alignment
+
+Ghost mode already calls `setVerticalFieldOfView(fl.vfov)`, so the map's
+vertical field of view is the camera's. `object-fit: contain` then scales the
+video to fit height, which keeps vertical framing matched and leaves the
+reconstruction visible either side of the frame — a good look at 50% blend, and
+the alignment the demo depends on.
+
+Horizontal framing matches only when the window's aspect ratio matches the
+video's; otherwise the video is letterboxed within the map. That is the correct
+compromise: distorting either layer to force a match would make the comparison
+meaningless.
+
+### 8. Failure posture and edge cases
+
+| Condition | Behaviour |
+| --- | --- |
+| `--redact fuzz` | Linking is allowed (see §1), but **the crossfade blend is disabled**, and the HUD says why: positions are deliberately coarsened by ~100 m, so overlaying real footage on that reconstruction would invite a comparison against geometry we know is wrong. The premise of the feature, not just its privacy posture, is what fuzz breaks. Same shape as the gaze gate — feature off, reason stated — without diverging from `photomap` on the CLI. |
+| `--redact drop` | The track is removed upstream, so there is no flight to link media to and nothing to render. |
+| No `--link-originals` | No `media` property, no video element, no slider. The 3D map is exactly what it is today. |
+| Segment with no resolvable file | `media[s]` is `null`; the crossfade is unavailable while the clock is inside that segment, and the HUD says which file is missing. |
+| Flight has no `vfov_deg` | The map's own FOV is an estimate, so the alignment is approximate. Reuse the existing estimated badge wording rather than inventing a second vocabulary. |
+| Video fails to load (moved, unsupported codec) | The slider disables itself and the HUD names the file. No silent blank overlay. |
+| Not in the cockpit | The slider lives in the ghost HUD, so the crossfade is a cockpit feature. Third-person playback is unchanged. |
+| `file://` | Works with no server: relative `<video src>` seeks natively. This is the common path and needs no Range. |
+
+## Testing
+
+**Range support** is unit-tested in Python with no browser: a served file
+fetched whole; `bytes=0-99`, `bytes=100-`, `bytes=-100`; a `416` for a range
+past the end; `Accept-Ranges` present; and a multi-range request falling back
+to `200` with the whole body.
+
+**Browser tests get a real, seekable video without ffmpeg, a committed binary,
+or fabricated bytes.** Chromium records its own canvas via `MediaRecorder` and
+the result is served as a blob URL. This was verified empirically before the
+spec was written: VP9 WebM, ~38 KB for two seconds, **finite** duration
+(1.9656 s), and a seek to 1.0 s landed exactly at 1.0. The honest limit is that
+it is WebM rather than MP4, so these tests prove our seek logic, segment
+mapping and blend wiring — not MP4 decoding, which is the browser's job.
+
+Covered: the video element appears only when media resolves and is absent
+otherwise; the blend slider drives opacity; the key toggles the extremes;
+`currentTime` tracks `cue_s` as the clock moves; crossing a segment boundary
+swaps `src` and re-seeks; a `null` segment disables the control and names the
+file; the speed regimes (`playbackRate` at 1×, paused-and-seeking at 60×); and
+`--link-originals` refused under `--redact fuzz`.
+
+Python-side: `TrackPoint.segment` set correctly across a join and **preserved
+through decimation** — the trap §2 exists to avoid; `cue_s` equal to the raw
+cue time for both joined and single-file flights; `media` emitted only when
+resolved; href resolution across `.MP4`/`.mp4`/`.MOV` and a missing sibling.
+
+## Docs
+
+`docs/geospatial.md` gains a crossfade subsection after the Camera's gaze one,
+covering the slider, the key, what `--link-originals` does and why it is
+opt-in, that the videos must travel with a shared map, and the two honesty
+limits (refused under redaction; approximate alignment without a focal length).
+The `--serve` note gains a line that seeking now works. README gains one line.

--- a/docs/superpowers/specs/2026-07-27-media-crossfade-design.md
+++ b/docs/superpowers/specs/2026-07-27-media-crossfade-design.md
@@ -51,8 +51,13 @@ segment order, called by the CLI after scanning:
   than guessing a stem: DJI writes `.MP4`, some tools write `.mp4`, and the
   container can be `.MOV`. Only files that exist are linked; a segment with no
   resolvable video contributes `null`.
-- Hrefs are relative to the map's output directory, or prefixed with
-  `--link-base` when given.
+- Hrefs are relative to **the scanned folder**, not to the map's output path —
+  `resolve_media(tracks, src, link_base)` resolves against the directory that
+  was scanned, matching `photomap`. That is the same folder the map is written
+  into by default, so relative hrefs resolve; when `-o` puts the map somewhere
+  else, `--link-base` is the escape. Stated explicitly because getting it
+  backwards makes every href dead while every file is present, and the viewer
+  would then report the user's intact footage as unloadable.
 - **Allowed under `--redact fuzz`**, matching `photomap`, which already permits
   the same combination and warns rather than refusing ("Linked/attached
   original files still carry exact GPS in their EXIF"). Two commands behaving

--- a/docs/superpowers/specs/2026-07-27-media-crossfade-design.md
+++ b/docs/superpowers/specs/2026-07-27-media-crossfade-design.md
@@ -155,15 +155,22 @@ Two regimes, because browsers cannot decode reliably at 20× or 60×:
 ### 7. Framing alignment
 
 Ghost mode already calls `setVerticalFieldOfView(fl.vfov)`, so the map's
-vertical field of view is the camera's. `object-fit: contain` then scales the
-video to fit height, which keeps vertical framing matched and leaves the
-reconstruction visible either side of the frame — a good look at 50% blend, and
-the alignment the demo depends on.
+vertical field of view is the camera's. The video is sized to the container's
+full height directly (`height: 100%; width: auto`, centred with
+`left: 50%; transform: translateX(-50%)`) rather than `object-fit: contain`.
+`contain` only fits by height when the container is *wider* in aspect than the
+video; on a narrower one — a tall window, a tablet, a portrait phone — it fits
+by width instead, and the vertical framing silently shrinks (whole-branch
+review C1: ~16% for 16:9 footage in a 1200×800 window). Sizing to height keeps
+the vertical match true by construction, in every container shape, which is
+what the alignment claim actually rests on.
 
-Horizontal framing matches only when the window's aspect ratio matches the
-video's; otherwise the video is letterboxed within the map. That is the correct
-compromise: distorting either layer to force a match would make the comparison
-meaningless.
+Horizontal framing crops instead, in both directions depending on which is
+wider: the video overflows past the map's sides, or the map shows either side
+of the video, and the map container's own `overflow: hidden` clips whichever
+overflows. That is the correct compromise — distorting either layer to force a
+horizontal match would make the comparison meaningless, and only the vertical
+axis is load-bearing for the alignment check.
 
 ### 8. Failure posture and edge cases
 
@@ -172,9 +179,9 @@ meaningless.
 | `--redact fuzz` | Linking is allowed (see §1), but **the crossfade blend is disabled**, and the HUD says why: positions are deliberately coarsened by ~100 m, so overlaying real footage on that reconstruction would invite a comparison against geometry we know is wrong. The premise of the feature, not just its privacy posture, is what fuzz breaks. Same shape as the gaze gate — feature off, reason stated — without diverging from `photomap` on the CLI. |
 | `--redact drop` | The track is removed upstream, so there is no flight to link media to and nothing to render. |
 | No `--link-originals` | No `media` property, no video element, no slider. The 3D map is exactly what it is today. |
-| Segment with no resolvable file | `media[s]` is `null`; the crossfade is unavailable while the clock is inside that segment, and the HUD says which file is missing. |
+| Segment with no resolvable file | `media[s]` is `null`; the crossfade is unavailable while the clock is inside that segment. `media[s]` being `null` is exactly the fact that there is no filename left to name (whole-branch review I2) — the HUD says "no video for this part of the flight" rather than asserting one it does not have. |
 | Flight has no `vfov_deg` | The map's own FOV is an estimate, so the alignment is approximate. Reuse the existing estimated badge wording rather than inventing a second vocabulary. |
-| Video fails to load (moved, unsupported codec) | The slider disables itself and the HUD names the file. No silent blank overlay. |
+| Video fails to load (moved, unsupported codec) | The slider disables itself and the HUD names the file, worded as what the `<video>` `error` event actually tells us — "could not load: `<file>`" — since the same event fires for a moved file, a wrong href base, a transport failure and an undecodable codec alike (whole-branch review I3). No silent blank overlay. |
 | Not in the cockpit | The slider lives in the ghost HUD, so the crossfade is a cockpit feature. Third-person playback is unchanged. |
 | `file://` | Works with no server: relative `<video src>` seeks natively. This is the common path and needs no Range. |
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -911,6 +911,23 @@ def flightmap(
                 "metadata; the map's crossfade is disabled under --redact.",
                 err=True,
             )
+        if link_originals and (
+            fmt.lower() == "all" or (fmt.lower() == "html" and not three_d)
+        ):
+            # The crossfade that --link-originals exists for is 3D-only, but
+            # flights_to_geojson (shared with GeoJSON output, where the same
+            # arrays are the intended deliverable) has no way to know which
+            # HTML it is embedding into -- the flat 2D map gets the same
+            # media/cue_s/seg_i arrays with nothing that reads them, dead
+            # weight in a template this codebase otherwise guards the size
+            # of. photomap warns in the analogous case; match it (#380
+            # whole-branch review M2).
+            click.echo(
+                "Note: --link-originals only benefits the 3D map (--3d); "
+                "the flat HTML map embeds the same media data with nothing "
+                "that reads it.",
+                err=True,
+            )
         src = Path(directory)
         tracks, skipped = scan_flights(
             src,

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -43,6 +43,7 @@ from .geo import (
     write_photos_html,
     write_photos_kml,
 )
+from .geo.media import resolve_media
 from .mp4_telemetry import Mp4TelemetryError
 from .progress import NullProgress, make_progress
 from .utilities import check_dependencies, setup_logging, get_tool_versions
@@ -843,6 +844,17 @@ def photomap(
     "the flat map. HTML only; defaults to flightmap-3d.html so the 2D "
     "map is never overwritten.",
 )
+@click.option(
+    "--link-originals", is_flag=True,
+    help="Embed a link to each flight's source video, enabling the 3D map's "
+         "video crossfade. Originals still carry exact GPS in their own "
+         "metadata even when --redact fuzz coarsens the map.",
+)
+@click.option(
+    "--link-base", default=None,
+    help="Folder or URL prefix for --link-originals hrefs, for when the "
+         "videos do not sit beside the map.",
+)
 @_tile_style_option
 @_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
@@ -857,6 +869,8 @@ def flightmap(
     join_gap: float,
     tz_offset: str,
     three_d: bool,
+    link_originals: bool,
+    link_base: str | None,
     tile_style: str,
     progress_mode: str | None,
     verbose: bool,
@@ -887,6 +901,16 @@ def flightmap(
         if three_d and tile_style.lower() != DEFAULT_TILE_STYLE:
             progress.warning("--tile-style is ignored with --3d")
             click.echo("Note: --tile-style is ignored with --3d", err=True)
+        if link_base is not None and not link_originals:
+            raise click.UsageError("--link-base requires --link-originals")
+        if link_originals and redact != "none":
+            # photomap permits this pair and warns; flightmap matches it rather
+            # than diverging on the same flag. The viewer disables the blend.
+            click.echo(
+                "Note: linked originals still carry exact GPS in their own "
+                "metadata; the map's crossfade is disabled under --redact.",
+                err=True,
+            )
         src = Path(directory)
         tracks, skipped = scan_flights(
             src,
@@ -938,6 +962,8 @@ def flightmap(
             default_name = "flightmap-3d.html" if three_d else f"flightmap.{f}"
             out = Path(output) if output else src / default_name
             targets = [(f, out)]
+        if link_originals:
+            resolve_media(tracks, src, link_base)
         for f, out in targets:
             try:
                 if f == "html":

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -851,7 +851,7 @@ def photomap(
          "metadata even when --redact fuzz coarsens the map.",
 )
 @click.option(
-    "--link-base", default=None,
+    "--link-base", default=None, metavar="PREFIX",
     help="Folder or URL prefix for --link-originals hrefs, for when the "
          "videos do not sit beside the map.",
 )

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -126,6 +126,11 @@ def join_split_flights(
                     for p in entry.track.points:
                         if p.utc is not None:
                             p.utc += shift
+            # Stamp before extending: segments was appended just above, so the
+            # index of the segment being added is len(segments) - 1.
+            seg_index = len(prev.track.segments) - 1
+            for p in entry.track.points:
+                p.segment = seg_index
             prev.track.points.extend(entry.track.points)
             prev.last_dt = entry.last_dt
         else:

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -353,6 +353,26 @@ def _add_ghost_props(properties: dict, points: list[TrackPoint]) -> None:
         properties["vfov_deg"] = round(vfov, 1)
 
 
+def _add_media_props(properties: dict, track: Track) -> None:
+    """Per-point video coordinates for the crossfade (#380).
+
+    ``cue_s`` is each point's offset within *its own* video file, straight
+    from the raw SRT cue — cues are video-relative and ``join_split_flights``
+    rebases only ``utc``, never ``timestamp``, so this stays correct across a
+    join. ``seg_i`` is omitted when every point is in segment 0, which is the
+    common single-file case; its absence means "all zero".
+    """
+    if not track.media:
+        return
+    properties["media"] = list(track.media)
+    properties["cue_s"] = [
+        round(_cue_seconds(p.timestamp), 3) for p in track.points
+    ]
+    segs = [p.segment for p in track.points]
+    if any(segs):
+        properties["seg_i"] = segs
+
+
 def flights_to_geojson(tracks: list[Track], redact: str = "none") -> dict:
     """Return a GeoJSON ``FeatureCollection`` with one feature per flight.
 
@@ -360,6 +380,9 @@ def flights_to_geojson(tracks: list[Track], redact: str = "none") -> dict:
     summary properties plus ``times_s`` — per-point seconds relative to the
     flight start — which drives the HTML viewer's playback animation (#267).
     LineStrings also carry per-point ghost-camera pose arrays (``gyaw_deg``/``gpitch_deg``/``agl_m``) and per-flight ``hfov_deg``/``vfov_deg`` when the telemetry has them (#372).
+    They also carry ``media`` (per-segment video hrefs), ``cue_s`` (each
+    point's in-file video offset), and ``seg_i`` (each point's segment
+    index) once :func:`..media.resolve_media` has linked originals (#380).
     A single-fix clip degrades to a ``Point`` (RFC 7946 §3.1.4 requires two
     or more positions in a LineString) and carries no times. Unlike the
     single-track exporter no per-sample Point features are emitted — at
@@ -374,6 +397,7 @@ def flights_to_geojson(tracks: list[Track], redact: str = "none") -> dict:
             geometry: dict = {"type": "LineString", "coordinates": coords}
             properties["times_s"] = _relative_times(track.points)
             _add_ghost_props(properties, track.points)
+            _add_media_props(properties, track)
         else:
             geometry = {"type": "Point", "coordinates": coords[0]}
         features.append(

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -1207,6 +1207,10 @@ function mountPlayback() {
   speed.addEventListener('click', () => {
     pb.speed = PB_SPEEDS[(PB_SPEEDS.indexOf(pb.speed) + 1) % PB_SPEEDS.length];
     speed.textContent = pb.speed + '\\u00d7';
+    // The riding/stepping boundary is speed-dependent, not just
+    // playing-dependent -- without this a speed change across
+    // CROSSFADE_MAX_RATE would not take effect until the next sample.
+    syncCrossfadePlayback();
   });
   slider.addEventListener('input', () => {
     pb.t = Number(slider.value);
@@ -1460,9 +1464,13 @@ function gazeLookup(ev) {
 // --- Media crossfade (#380): blend the reconstruction into the footage ---
 // The video is composited by CSS opacity only -- never drawn into a canvas,
 // which would taint it and buy nothing.
-const CROSSFADE_MAX_RATE = 4;     // browsers cannot decode reliably above this
+const CROSSFADE_MAX_RATE = 4;     // browsers cannot decode reliably above
+                                   // this; PB_SPEEDS has no value in (1, 4],
+                                   // so in the shipped UI this is effectively
+                                   // "riding only at 1x"
 const CROSSFADE_DRIFT_S = 0.25;   // re-seek only when playback slips this far
-const cross = { el: null, blend: 0, seg: -1, pending: null };
+const cross = { el: null, blend: 0, seg: -1, pending: null, href: null,
+                 broken: null };
 
 function mediaFor(fl, i) {
   // Which file, and how far into it. The offset is the point's own SRT cue:
@@ -1474,6 +1482,8 @@ function mediaFor(fl, i) {
   return { href: href, seg: seg, t: fl.cue[i] };
 }
 
+// Answers "may we offer the crossfade?", not "does this flight have
+// footage?" -- both call sites want the redaction answer, not the raw one.
 function hasMedia(fl) {
   return REDACTED === 'none'
     && !!(fl && fl.media && fl.cue && fl.media.some(h => h));
@@ -1522,12 +1532,14 @@ function mountCrossfade() {
   });
   v.addEventListener('error', () => {
     // A blank overlay reads as "the camera saw nothing here". Name the file
-    // instead and take the control away.
+    // instead and take the control away -- and record it in cross.broken, so
+    // the next renderCrossfade (one arrow key or one sample tick away) does
+    // not straight-line undo all three the way this used to.
+    cross.broken = cross.href;
     const slider = document.getElementById('ghost-blend');
     if (slider) slider.disabled = true;
     v.style.display = 'none';
-    crossBadge('video unavailable: ' + (cross.el ? cross.el.src.split('/')
-      .pop() : ''));
+    crossBadge('video unavailable: ' + (cross.broken || ''));
   });
   document.getElementById('map').appendChild(v);
   cross.el = v;
@@ -1572,13 +1584,14 @@ function renderCrossfade() {
     // previous file's frame standing over a different part of the flight.
     cross.el.style.display = 'none';
     if (slider) slider.disabled = true;
+    syncCrossfadePlayback();
     return;
   }
-  cross.el.style.display = '';
-  if (slider) slider.disabled = false;
   if (m.seg !== cross.seg) {
     cross.seg = m.seg;
     cross.pending = m.t;
+    cross.broken = null;      // a different file may load fine
+    cross.href = m.href;
     // A src swap resets playback state, so the seek is re-applied from the
     // loadedmetadata handler below rather than now.
     cross.el.src = m.href;
@@ -1589,6 +1602,20 @@ function renderCrossfade() {
       || Math.abs(v.currentTime - m.t) > CROSSFADE_DRIFT_S;
     if (drifted) seekCrossfade(m.t);
   }
+  if (cross.broken) {
+    // The error handler already hid the element, disabled the slider and
+    // posted the badge once. Without this the next render (one arrow key or
+    // one sample tick away) would straight-line undo all three, leaving a
+    // LIVE blend slider over a video that will never show a frame -- the
+    // "camera saw nothing here" reading this posture exists to prevent.
+    cross.el.style.display = 'none';
+    if (slider) slider.disabled = true;
+    crossBadge('video unavailable: ' + cross.broken);
+    syncCrossfadePlayback();
+    return;
+  }
+  cross.el.style.display = '';
+  if (slider) slider.disabled = false;
   syncCrossfadePlayback();
 }
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -85,6 +85,10 @@ _TEMPLATE = """<!DOCTYPE html>
                       padding: 2px 9px; }}
   .ghost-badge {{ background: #b58900; color: #fff; border-radius: 3px;
                  padding: 0 6px; font-size: 11px; }}
+  .ghost-video {{ position: absolute; inset: 0; width: 100%; height: 100%;
+                 object-fit: contain; pointer-events: none; z-index: 4;
+                 transition: opacity .18s linear; }}
+  .playback #ghost-blend {{ width: 110px; }}
   .playback {{ position: absolute; bottom: 14px; left: 10px; z-index: 6;
               background: #fff; border-radius: 4px; padding: 6px 10px;
               box-shadow: 0 1px 5px rgba(0,0,0,.4); display: flex;
@@ -145,6 +149,9 @@ const allCoords = [];
     entry.agl = p.agl_m || null;
     entry.vfov = p.vfov_deg || null;
     entry.hfov = p.hfov_deg || null;
+    entry.media = p.media || null;
+    entry.cue = p.cue_s || null;
+    entry.segi = p.seg_i || null;
   } else {                                             // single-fix clip
     const c = f.geometry.coordinates;
     entry.geometry = { type: 'Point', coordinates: [c[0], c[1]] };
@@ -398,6 +405,10 @@ function ghostKeys(ev) {
   if (ev.key === 'Escape') { ghostExit(); ev.preventDefault(); }
   else if (ev.key === 'ArrowLeft') { ghostStep(-1); ev.preventDefault(); }
   else if (ev.key === 'ArrowRight') { ghostStep(1); ev.preventDefault(); }
+  else if (ev.key === 'v' || ev.key === 'V') {
+    setBlend(cross.blend > 0.5 ? 0 : 1);
+    ev.preventDefault();
+  }
 }
 
 function terrainElevAt(lngLat) {
@@ -474,6 +485,7 @@ function ghostEnter(flightIdx, sampleIdx) {
   }
   applyPose(samplePose(fl, ghost.idx), riding ? 0 : GHOST_ENTER_MS);
   mountHud();
+  mountCrossfade();
 }
 
 function ghostStep(d) {
@@ -527,6 +539,7 @@ function ghostExit() {
     applyGazeVisibility();
   });
   unmountHud();
+  unmountCrossfade();
   ghost.flight = null;
   ghost.takeoffElev = null;
 }
@@ -549,8 +562,20 @@ function mountHud() {
   exit.setAttribute('aria-label', 'Exit ghost view');
   hud.append(mk('ghost-prev', '\\u2039', () => ghostStep(-1)),
              info, badges,
-             mk('ghost-next', '\\u203a', () => ghostStep(1)),
-             exit);
+             mk('ghost-next', '\\u203a', () => ghostStep(1)));
+  if (hasMedia(ghost.flight)) {
+    const blend = document.createElement('input');
+    blend.type = 'range';
+    blend.id = 'ghost-blend';
+    blend.min = '0';
+    blend.max = '100';
+    blend.value = '0';
+    blend.title = 'Blend the map into the footage';
+    blend.addEventListener('input',
+                           () => setBlend(Number(blend.value) / 100));
+    hud.appendChild(blend);
+  }
+  hud.appendChild(exit);
   document.body.appendChild(hud);
   ghost.hud = hud;
   updateHud();
@@ -1426,6 +1451,75 @@ function gazeLookup(ev) {
   gazePopup = new maplibregl.Popup({ maxWidth: '320px' })
     .setLngLat(ev.lngLat).setDOMContent(el).addTo(map);
   gazePopup.on('close', () => { gazeHighlight([]); gazePopup = null; });
+}
+
+// --- Media crossfade (#380): blend the reconstruction into the footage ---
+// The video is composited by CSS opacity only -- never drawn into a canvas,
+// which would taint it and buy nothing.
+const CROSSFADE_MAX_RATE = 4;     // browsers cannot decode reliably above this
+const CROSSFADE_DRIFT_S = 0.25;   // re-seek only when playback slips this far
+const cross = { el: null, blend: 0, seg: -1, pending: null };
+
+function mediaFor(fl, i) {
+  // Which file, and how far into it. The offset is the point's own SRT cue:
+  // cues are video-relative and the split-join never rewrites them.
+  if (!fl || !fl.media || !fl.cue) return null;
+  const seg = fl.segi ? fl.segi[i] : 0;
+  const href = fl.media[seg];
+  if (!href) return { href: null, seg: seg, t: null };
+  return { href: href, seg: seg, t: fl.cue[i] };
+}
+
+function hasMedia(fl) {
+  return !!(fl && fl.media && fl.cue && fl.media.some(h => h));
+}
+
+function setBlend(x) {
+  cross.blend = Math.max(0, Math.min(1, x));
+  if (cross.el) cross.el.style.opacity = String(cross.blend);
+  const s = document.getElementById('ghost-blend');
+  if (s && Number(s.value) / 100 !== cross.blend) {
+    s.value = String(Math.round(cross.blend * 100));
+  }
+}
+
+function mountCrossfade() {
+  // Cockpit-only: the slider lives in the ghost HUD, and outside the cockpit
+  // there is no pose for the footage to be compared against.
+  if (cross.el || !hasMedia(ghost.flight)) return;
+  const v = document.createElement('video');
+  v.id = 'ghost-video';
+  v.className = 'ghost-video';
+  v.muted = true;
+  v.playsInline = true;
+  v.preload = 'auto';
+  v.style.opacity = '0';
+  document.getElementById('map').appendChild(v);
+  cross.el = v;
+  cross.seg = -1;
+  cross.pending = null;
+  setBlend(0);
+  renderCrossfade();
+}
+
+function unmountCrossfade() {
+  if (!cross.el) return;
+  cross.el.pause();
+  cross.el.remove();
+  cross.el = null;
+  cross.seg = -1;
+  cross.pending = null;
+  cross.blend = 0;
+}
+
+function renderCrossfade() {
+  if (!cross.el || !ghost.active) return;
+  const m = mediaFor(ghost.flight, ghost.idx);
+  if (!m || !m.href) return;
+  if (m.seg !== cross.seg) {
+    cross.seg = m.seg;
+    cross.el.src = m.href;
+  }
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -1124,6 +1124,7 @@ function applyGazeVisibility() {
 
 function pbPause() {
   pb.playing = false;
+  syncCrossfadePlayback();
   const b = document.getElementById('pb-play');
   if (b) b.textContent = '\\u25b6';
   if (pb.raf) cancelAnimationFrame(pb.raf);
@@ -1143,6 +1144,7 @@ function pbPlay() {
   if (!pb.run) return;
   if (pb.t >= pbMax()) { pb.t = 0; pb.cursor = 0; }
   pb.playing = true;
+  syncCrossfadePlayback();
   const b = document.getElementById('pb-play');
   if (b) b.textContent = '\\u275a\\u275a';
   pb.last = performance.now();
@@ -1473,7 +1475,8 @@ function mediaFor(fl, i) {
 }
 
 function hasMedia(fl) {
-  return !!(fl && fl.media && fl.cue && fl.media.some(h => h));
+  return REDACTED === 'none'
+    && !!(fl && fl.media && fl.cue && fl.media.some(h => h));
 }
 
 function setBlend(x) {
@@ -1485,7 +1488,21 @@ function setBlend(x) {
   }
 }
 
+function crossBadge(text) {
+  const badges = ghost.hud && ghost.hud.querySelector('#ghost-badges');
+  if (!badges) return;
+  const s = document.createElement('span');
+  s.className = 'ghost-badge';
+  s.textContent = text;
+  badges.appendChild(s);
+}
+
 function mountCrossfade() {
+  // Fuzzed positions are deliberately ~100 m out, so overlaying real footage
+  // would invite a comparison against geometry we know is wrong. Linking is
+  // still permitted (photomap allows the same pair) -- it is the blend that
+  // is withheld.
+  if (REDACTED !== 'none') return;
   // Cockpit-only: the slider lives in the ghost HUD, and outside the cockpit
   // there is no pose for the footage to be compared against.
   if (cross.el || !hasMedia(ghost.flight)) return;
@@ -1502,6 +1519,15 @@ function mountCrossfade() {
       cross.pending = null;
       seekCrossfade(t);
     }
+  });
+  v.addEventListener('error', () => {
+    // A blank overlay reads as "the camera saw nothing here". Name the file
+    // instead and take the control away.
+    const slider = document.getElementById('ghost-blend');
+    if (slider) slider.disabled = true;
+    v.style.display = 'none';
+    crossBadge('video unavailable: ' + (cross.el ? cross.el.src.split('/')
+      .pop() : ''));
   });
   document.getElementById('map').appendChild(v);
   cross.el = v;
@@ -1532,6 +1558,13 @@ function seekCrossfade(t) {
 
 function renderCrossfade() {
   if (!cross.el || !ghost.active) return;
+  if (!ghost.flight.vfov) {
+    // Without a focal length the map's own field of view is a guess, so a
+    // mismatch is not evidence the telemetry is wrong. updateHud() clears
+    // #ghost-badges on every call, so this is re-added here (rather than
+    // once at mount) to survive every step, not just the first frame.
+    crossBadge('alignment approximate \\u2014 no focal length');
+  }
   const slider = document.getElementById('ghost-blend');
   const m = mediaFor(ghost.flight, ghost.idx);
   if (!m || !m.href) {
@@ -1551,8 +1584,26 @@ function renderCrossfade() {
     cross.el.src = m.href;
     cross.el.load();
   } else {
-    seekCrossfade(m.t);
+    const v = cross.el;
+    const drifted = v.paused
+      || Math.abs(v.currentTime - m.t) > CROSSFADE_DRIFT_S;
+    if (drifted) seekCrossfade(m.t);
   }
+  syncCrossfadePlayback();
+}
+
+function syncCrossfadePlayback() {
+  const v = cross.el;
+  if (!v || !ghost.active) return;
+  const riding = pb.playing && pb.run === ghost.flight;
+  if (riding && pb.speed <= CROSSFADE_MAX_RATE) {
+    v.playbackRate = pb.speed;
+    if (v.paused) v.play().catch(() => {});    // autoplay policy: muted, so
+    return;                                    // this should not reject
+  }
+  // Paused, scrubbing, or faster than the decoder can follow: step instead.
+  // A slideshow is honest; a decoder falling silently behind is not.
+  if (!v.paused) v.pause();
 }
 """
 

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -85,8 +85,9 @@ _TEMPLATE = """<!DOCTYPE html>
                       padding: 2px 9px; }}
   .ghost-badge {{ background: #b58900; color: #fff; border-radius: 3px;
                  padding: 0 6px; font-size: 11px; }}
-  .ghost-video {{ position: absolute; inset: 0; width: 100%; height: 100%;
-                 object-fit: contain; pointer-events: none; z-index: 4;
+  .ghost-video {{ position: absolute; top: 0; left: 50%; height: 100%;
+                 width: auto; transform: translateX(-50%);
+                 pointer-events: none; z-index: 1;
                  transition: opacity .18s linear; }}
   #ghost-hud #ghost-blend {{ width: 110px; }}
   .playback {{ position: absolute; bottom: 14px; left: 10px; z-index: 6;
@@ -311,7 +312,13 @@ function buildPanel() {
   if (REDACTED !== 'none' && runs.length) {
     const note = document.createElement('div');
     note.className = 'panel-note';
-    note.textContent = 'Camera gaze off \\u2014 positions fuzzed';
+    // The crossfade gate (mountCrossfade) withholds the same way the gaze
+    // gate does, but has no HUD of its own to say so while the cockpit is
+    // closed -- state it here too, same shape as the gaze note (#380
+    // whole-branch review I1).
+    note.textContent = flights.some(f => f.media)
+      ? 'Camera gaze and video crossfade off \\u2014 positions fuzzed'
+      : 'Camera gaze off \\u2014 positions fuzzed';
     panel.appendChild(note);
   }
   if (flights.some(f => f.sculptSrc)) {
@@ -1534,12 +1541,18 @@ function mountCrossfade() {
     // A blank overlay reads as "the camera saw nothing here". Name the file
     // instead and take the control away -- and record it in cross.broken, so
     // the next renderCrossfade (one arrow key or one sample tick away) does
-    // not straight-line undo all three the way this used to.
+    // not straight-line undo all three the way this used to. Worded as what
+    // the <video> error event actually tells us: it fires the same way for
+    // a moved file, a wrong href base, a transport failure and a codec the
+    // browser cannot decode -- DJI's own 4K default, H.265/HEVC, is exactly
+    // that case in Firefox and on Chrome without a platform decoder -- so
+    // "unavailable" would assert a cause the code cannot know (#380
+    // whole-branch review I3).
     cross.broken = cross.href;
     const slider = document.getElementById('ghost-blend');
     if (slider) slider.disabled = true;
     v.style.display = 'none';
-    crossBadge('video unavailable: ' + (cross.broken || ''));
+    crossBadge('could not load: ' + (cross.broken || ''));
   });
   document.getElementById('map').appendChild(v);
   cross.el = v;
@@ -1553,10 +1566,17 @@ function unmountCrossfade() {
   cross.blend = 0;
   if (!cross.el) return;
   cross.el.pause();
+  // Clear the source and let the element re-check itself before removal --
+  // otherwise a multi-GB MP4 the browser was mid-fetch on keeps downloading
+  // after the cockpit closes (#380 whole-branch review M3).
+  cross.el.removeAttribute('src');
+  cross.el.load();
   cross.el.remove();
   cross.el = null;
   cross.seg = -1;
   cross.pending = null;
+  cross.broken = null;
+  cross.href = null;
 }
 
 function seekCrossfade(t) {
@@ -1581,9 +1601,13 @@ function renderCrossfade() {
   const m = mediaFor(ghost.flight, ghost.idx);
   if (!m || !m.href) {
     // A segment whose file was never resolved: hide rather than leave the
-    // previous file's frame standing over a different part of the flight.
+    // previous file's frame standing over a different part of the flight,
+    // and say so. media[seg] is null here, so there is no filename left to
+    // name -- this is the honest version of what spec #380 section 8 asks
+    // for (#380 whole-branch review I2).
     cross.el.style.display = 'none';
     if (slider) slider.disabled = true;
+    crossBadge('no video for this part of the flight');
     syncCrossfadePlayback();
     return;
   }
@@ -1610,7 +1634,7 @@ function renderCrossfade() {
     // "camera saw nothing here" reading this posture exists to prevent.
     cross.el.style.display = 'none';
     if (slider) slider.disabled = true;
-    crossBadge('video unavailable: ' + cross.broken);
+    crossBadge('could not load: ' + cross.broken);
     syncCrossfadePlayback();
     return;
   }

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -88,7 +88,7 @@ _TEMPLATE = """<!DOCTYPE html>
   .ghost-video {{ position: absolute; inset: 0; width: 100%; height: 100%;
                  object-fit: contain; pointer-events: none; z-index: 4;
                  transition: opacity .18s linear; }}
-  .playback #ghost-blend {{ width: 110px; }}
+  #ghost-hud #ghost-blend {{ width: 110px; }}
   .playback {{ position: absolute; bottom: 14px; left: 10px; z-index: 6;
               background: #fff; border-radius: 4px; padding: 6px 10px;
               box-shadow: 0 1px 5px rgba(0,0,0,.4); display: flex;
@@ -510,6 +510,7 @@ function ghostStep(d) {
   }
   applyPose(samplePose(ghost.flight, next), GHOST_STEP_MS);
   updateHud();
+  renderCrossfade();
 }
 
 function ghostExit() {
@@ -1099,6 +1100,7 @@ function pbDriveGhost() {
   if (pb.sample !== ghost.idx) {
     ghost.idx = pb.sample;
     updateHud();
+    renderCrossfade();
   }
 }
 
@@ -1494,6 +1496,13 @@ function mountCrossfade() {
   v.playsInline = true;
   v.preload = 'auto';
   v.style.opacity = '0';
+  v.addEventListener('loadedmetadata', () => {
+    if (cross.pending != null) {
+      const t = cross.pending;
+      cross.pending = null;
+      seekCrossfade(t);
+    }
+  });
   document.getElementById('map').appendChild(v);
   cross.el = v;
   cross.seg = -1;
@@ -1503,22 +1512,46 @@ function mountCrossfade() {
 }
 
 function unmountCrossfade() {
+  cross.blend = 0;
   if (!cross.el) return;
   cross.el.pause();
   cross.el.remove();
   cross.el = null;
   cross.seg = -1;
   cross.pending = null;
-  cross.blend = 0;
+}
+
+function seekCrossfade(t) {
+  const v = cross.el;
+  if (!v || t == null) return;
+  // currentTime does not stick before metadata arrives; hold it and apply
+  // once the browser knows the duration.
+  if (v.readyState < 1) { cross.pending = t; return; }
+  if (Math.abs(v.currentTime - t) > 0.05) v.currentTime = t;
 }
 
 function renderCrossfade() {
   if (!cross.el || !ghost.active) return;
+  const slider = document.getElementById('ghost-blend');
   const m = mediaFor(ghost.flight, ghost.idx);
-  if (!m || !m.href) return;
+  if (!m || !m.href) {
+    // A segment whose file was never resolved: hide rather than leave the
+    // previous file's frame standing over a different part of the flight.
+    cross.el.style.display = 'none';
+    if (slider) slider.disabled = true;
+    return;
+  }
+  cross.el.style.display = '';
+  if (slider) slider.disabled = false;
   if (m.seg !== cross.seg) {
     cross.seg = m.seg;
+    cross.pending = m.t;
+    // A src swap resets playback state, so the seek is re-applied from the
+    // loadedmetadata handler below rather than now.
     cross.el.src = m.href;
+    cross.el.load();
+  } else {
+    seekCrossfade(m.t);
   }
 }
 """

--- a/src/dji_metadata_embedder/geo/links.py
+++ b/src/dji_metadata_embedder/geo/links.py
@@ -1,0 +1,19 @@
+"""Hrefs from a generated map to the original media beside it."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+
+def link_href(name: str, base: str) -> str:
+    """Href to an original file: percent-encoded *name* under *base*.
+
+    Each ``/``-separated segment of *name* is fully percent-encoded (spaces,
+    ``#``, quotes) while the separators survive, so relative subdirectory
+    links from recursive scans still resolve. *base* is taken as-is apart
+    from separator normalisation — it may be a relative folder or an absolute
+    URL, and encoding it would corrupt ``https://``.
+    """
+    encoded = "/".join(quote(seg, safe="") for seg in name.split("/"))
+    base = base.replace("\\", "/").rstrip("/")
+    return f"{base}/{encoded}" if base else encoded

--- a/src/dji_metadata_embedder/geo/media.py
+++ b/src/dji_metadata_embedder/geo/media.py
@@ -21,12 +21,28 @@ _VIDEO_SUFFIXES = (".MP4", ".mp4", ".MOV", ".mov")
 
 
 def _find_video(root: Path, name: str) -> str | None:
-    """Relative POSIX path of the video for segment *name*, or ``None``."""
-    for suffix in _VIDEO_SUFFIXES:
-        candidate = root / f"{name}{suffix}"
-        if candidate.is_file():
-            return candidate.relative_to(root).as_posix()
-    return None
+    """Relative POSIX path of the video for segment *name*, or ``None``.
+
+    Scans the real directory entries rather than probing guessed filenames.
+    Probing (``(root / f"{name}{suffix}").is_file()``) is wrong on a
+    case-insensitive filesystem (Windows, default macOS): a real
+    ``flight.mov`` also answers ``is_file()`` for the guessed ``flight.MOV``,
+    so the href would carry a case the directory entry does not actually
+    have -- working locally, and 404ing the moment the folder is served from
+    a case-sensitive host (#380 whole-branch review M1).
+    """
+    target = root / name
+    parent, stem = target.parent, target.name
+    if not parent.is_dir():
+        return None
+    rank = {suffix.lower(): i for i, suffix in enumerate(_VIDEO_SUFFIXES)}
+    best: tuple[int, Path] | None = None
+    for entry in parent.iterdir():
+        if entry.is_file() and entry.stem == stem:
+            r = rank.get(entry.suffix.lower())
+            if r is not None and (best is None or r < best[0]):
+                best = (r, entry)
+    return best[1].relative_to(root).as_posix() if best else None
 
 
 def resolve_media(

--- a/src/dji_metadata_embedder/geo/media.py
+++ b/src/dji_metadata_embedder/geo/media.py
@@ -1,0 +1,48 @@
+"""Resolve the video file that belongs to each flight segment (#380).
+
+A flight's ``name`` is its SRT stem, path-qualified on recursive scans, and a
+size-split flight lists every source in ``segments``. The video sits beside
+the SRT under the same stem — but DJI writes ``.MP4`` while other tools write
+``.mp4`` or ``.MOV``, so the file is *looked up*, never guessed: an href to a
+file that is not there is indistinguishable from a codec failure once it
+reaches a ``<video>`` element.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .links import link_href
+from .track import Track
+
+# Ordered by how DJI writes them. Low-res ``.LRF`` proxies are deliberately
+# excluded: they sit beside the real footage and would silently win.
+_VIDEO_SUFFIXES = (".MP4", ".mp4", ".MOV", ".mov")
+
+
+def _find_video(root: Path, name: str) -> str | None:
+    """Relative POSIX path of the video for segment *name*, or ``None``."""
+    for suffix in _VIDEO_SUFFIXES:
+        candidate = root / f"{name}{suffix}"
+        if candidate.is_file():
+            return candidate.relative_to(root).as_posix()
+    return None
+
+
+def resolve_media(
+    tracks: list[Track], root: Path, base: str | None = None
+) -> None:
+    """Fill ``Track.media`` with one href per segment, in segment order.
+
+    A segment whose video is missing contributes ``None`` and **keeps its
+    slot**, because the per-point ``seg_i`` array indexes into this list. A
+    track with no resolvable video at all gets ``None``, so nothing downstream
+    offers a crossfade it cannot deliver.
+    """
+    for track in tracks:
+        names = track.segments or [track.name]
+        hrefs: list[str | None] = []
+        for name in names:
+            found = _find_video(root, name)
+            hrefs.append(link_href(found, base or "") if found else None)
+        track.media = hrefs if any(hrefs) else None

--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -14,11 +14,11 @@ import re
 import subprocess
 from dataclasses import dataclass, replace
 from pathlib import Path
-from urllib.parse import quote
 from xml.sax.saxutils import escape
 
 from ..utilities import is_gps_fix, redact_coords
 from ..utils.exiftool import exiftool_exe
+from .links import link_href
 
 logger = logging.getLogger(__name__)
 
@@ -368,20 +368,6 @@ def redact_photo_points(points: list[PhotoPoint], mode: str) -> list[PhotoPoint]
     return [replace(p, lat=lat, lon=lon) for p, (lat, lon) in zip(points, coords)]
 
 
-def _link_href(name: str, base: str) -> str:
-    """Href to the original photo: percent-encoded *name* under *base*.
-
-    Each ``/``-separated segment of *name* is fully percent-encoded (spaces,
-    ``#``, quotes) while the separators survive, so relative subdirectory
-    links from recursive scans still resolve. *base* is taken as-is apart
-    from separator normalisation — it may be a relative folder or an absolute
-    URL, and encoding it would corrupt ``https://``.
-    """
-    encoded = "/".join(quote(seg, safe="") for seg in name.split("/"))
-    base = base.replace("\\", "/").rstrip("/")
-    return f"{base}/{encoded}" if base else encoded
-
-
 def photos_to_geojson(
     points: list[PhotoPoint],
     *,
@@ -415,7 +401,7 @@ def photos_to_geojson(
             if p.pano_hfov is not None:
                 props["hfov"] = round(p.pano_hfov, 2)
         if link_base is not None:
-            props["link"] = _link_href(p.name, link_base)
+            props["link"] = link_href(p.name, link_base)
         if p.timestamp:
             props["timestamp"] = p.timestamp
         # Missing altitude is omitted entirely (no property, 2D coordinate)

--- a/src/dji_metadata_embedder/geo/serve.py
+++ b/src/dji_metadata_embedder/geo/serve.py
@@ -43,12 +43,31 @@ def _parse_range(header: str, size: int) -> tuple[int, int] | None:
         n = int(last_s)
         if n == 0:
             raise ValueError("zero-length suffix range")
+        if size == 0:
+            # A suffix range has nothing to select from an empty file. This
+            # is unsatisfiable *because of the file's size* -- the same
+            # category as `first >= size` below -- not a malformed header,
+            # so it gets 416 rather than the "ignore" treatment below.
+            # (Left uncaught, max(0, size - n) would compute (0, -1): a
+            # reversed pair, but for a different reason than the
+            # explicit-range case, so it doesn't belong under that guard.)
+            raise ValueError("empty file has no satisfiable range")
         return (max(0, size - n), size - 1)
     first = int(first_s)
     if first >= size:
         raise ValueError("range starts at or past end of file")
     last = int(last_s) if last_s else size - 1
-    return (first, min(last, size - 1))
+    last = min(last, size - 1)
+    if last < first:
+        # A reversed range ("bytes=100-50") is syntactically valid but
+        # semantically backwards. RFC 9110 has a server ignore a
+        # ranges-specifier it can't use rather than reject it -- 416 means
+        # "outside the file," which a reversed-but-in-bounds range isn't.
+        # Treating it as "not a shape we understand" (-> None, whole file)
+        # matches how a foreign unit or a multi-range request is already
+        # handled above: one rule for "this header is not usable," not two.
+        return None
+    return (first, last)
 
 
 class _RangeHandler(SimpleHTTPRequestHandler):
@@ -74,25 +93,30 @@ class _RangeHandler(SimpleHTTPRequestHandler):
         if not header or os.path.isdir(path):
             return super().send_head()
         try:
+            size = os.stat(path).st_size
+        except OSError:
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
+        try:
+            rng = _parse_range(header, size)
+        except ValueError:
+            self.send_response(HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+            self.send_header("Content-Range", f"bytes */{size}")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return None
+        if rng is None:
+            # Whole-file response: let the base handler open and serve it.
+            # Opening it ourselves here too would mean two file opens for
+            # one request.
+            return super().send_head()
+        first, last = rng
+        try:
             f = open(path, "rb")
         except OSError:
             self.send_error(HTTPStatus.NOT_FOUND, "File not found")
             return None
         try:
-            size = os.fstat(f.fileno()).st_size
-            try:
-                rng = _parse_range(header, size)
-            except ValueError:
-                f.close()
-                self.send_response(HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
-                self.send_header("Content-Range", f"bytes */{size}")
-                self.send_header("Content-Length", "0")
-                self.end_headers()
-                return None
-            if rng is None:
-                f.close()
-                return super().send_head()
-            first, last = rng
             self._range = rng
             f.seek(first)
             self.send_response(HTTPStatus.PARTIAL_CONTENT)

--- a/src/dji_metadata_embedder/geo/serve.py
+++ b/src/dji_metadata_embedder/geo/serve.py
@@ -2,23 +2,128 @@
 
 Browsers refuse WebGL pixel access to images on ``file://`` pages, so the
 photomap 360-degree viewer only works when the map is served over HTTP.
-This module is the loopback-only server behind ``dji-embed photomap --serve``.
+Media seeking needs HTTP Range (``206 Partial Content``), which Python's
+stock handler does not implement, so this module supplies it.
 """
 
 from __future__ import annotations
 
+import os
+import re
 import sys
 import threading
 import webbrowser
 from functools import partial
+from http import HTTPStatus
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import BinaryIO
 
 import click
 
+_RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
 
-class _QuietHandler(SimpleHTTPRequestHandler):
-    """SimpleHTTPRequestHandler without per-request stderr logging."""
+
+def _parse_range(header: str, size: int) -> tuple[int, int] | None:
+    """Return an inclusive ``(first, last)`` byte range for *header*.
+
+    ``None`` means "serve the whole file": a unit other than bytes, a
+    multi-range request (which no browser needs for media playback and which
+    would cost a multipart body), or anything unparseable. Raises
+    :class:`ValueError` when the syntax is fine but the range cannot be
+    satisfied, so the caller can answer 416 rather than guessing.
+    """
+    m = _RANGE_RE.match(header.strip())
+    if m is None:
+        return None
+    first_s, last_s = m.group(1), m.group(2)
+    if not first_s and not last_s:
+        return None
+    if not first_s:                       # bytes=-N : the final N bytes
+        n = int(last_s)
+        if n == 0:
+            raise ValueError("zero-length suffix range")
+        return (max(0, size - n), size - 1)
+    first = int(first_s)
+    if first >= size:
+        raise ValueError("range starts at or past end of file")
+    last = int(last_s) if last_s else size - 1
+    return (first, min(last, size - 1))
+
+
+class _RangeHandler(SimpleHTTPRequestHandler):
+    """``SimpleHTTPRequestHandler`` with single-range GET support.
+
+    The stock handler ignores ``Range`` completely. The 3D map's video
+    crossfade is a seek, so without this Chrome re-downloads from byte zero
+    every time the clock moves and Safari refuses to play at all.
+    """
+
+    _range: tuple[int, int] | None = None
+
+    def end_headers(self) -> None:
+        # Advertised on every response: a media element checks for it before
+        # it will attempt a seek at all.
+        self.send_header("Accept-Ranges", "bytes")
+        super().end_headers()
+
+    def send_head(self) -> BinaryIO | None:
+        self._range = None
+        header = self.headers.get("Range")
+        path = self.translate_path(self.path)
+        if not header or os.path.isdir(path):
+            return super().send_head()
+        try:
+            f = open(path, "rb")
+        except OSError:
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
+        try:
+            size = os.fstat(f.fileno()).st_size
+            try:
+                rng = _parse_range(header, size)
+            except ValueError:
+                f.close()
+                self.send_response(HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+                self.send_header("Content-Range", f"bytes */{size}")
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return None
+            if rng is None:
+                f.close()
+                return super().send_head()
+            first, last = rng
+            self._range = rng
+            f.seek(first)
+            self.send_response(HTTPStatus.PARTIAL_CONTENT)
+            self.send_header("Content-Type", self.guess_type(path))
+            self.send_header("Content-Range", f"bytes {first}-{last}/{size}")
+            self.send_header("Content-Length", str(last - first + 1))
+            self.end_headers()
+            return f
+        except Exception:
+            f.close()
+            raise
+
+    # mypy sees the base `copyfile` as generic over AnyStr (str or bytes);
+    # this handler only ever deals in bytes, which mypy's LSP check can't
+    # express as a narrowing override.
+    def copyfile(self, source: BinaryIO, outputfile: BinaryIO) -> None:  # type: ignore[override]
+        if self._range is None:
+            super().copyfile(source, outputfile)
+            return
+        first, last = self._range
+        remaining = last - first + 1
+        while remaining > 0:
+            chunk = source.read(min(64 * 1024, remaining))
+            if not chunk:
+                break
+            outputfile.write(chunk)
+            remaining -= len(chunk)
+
+
+class _QuietHandler(_RangeHandler):
+    """Range-capable handler without per-request stderr logging."""
 
     def log_message(self, format: str, *args: object) -> None:
         pass
@@ -29,7 +134,7 @@ def _make_server(directory: Path, *, log_requests: bool = False) -> ThreadingHTT
 
     Binds 127.0.0.1 only — the map must never be exposed beyond this machine.
     """
-    handler_cls = SimpleHTTPRequestHandler if log_requests else _QuietHandler
+    handler_cls = _RangeHandler if log_requests else _QuietHandler
     handler = partial(handler_cls, directory=str(directory))
     server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
     # Don't let an in-flight transfer keep the process alive after Ctrl+C.

--- a/src/dji_metadata_embedder/geo/track.py
+++ b/src/dji_metadata_embedder/geo/track.py
@@ -47,11 +47,16 @@ class Track:
     ``segments`` lists the source file names when the track was stitched from
     size-split recordings (see :func:`..flightmap.join_split_flights`); it is
     ``None`` for a track built from a single file.
+
+    ``media`` holds one href per entry of ``segments`` (or a single-element
+    list for an unsplit flight) once :func:`..media.resolve_media` has run;
+    ``None`` means no video was linked or none was found.
     """
 
     name: str
     points: list[TrackPoint]
     segments: list[str] | None = None
+    media: list[str | None] | None = None
 
 
 def _cue_seconds(cue: str) -> float:

--- a/src/dji_metadata_embedder/geo/track.py
+++ b/src/dji_metadata_embedder/geo/track.py
@@ -20,7 +20,13 @@ from ..mp4_telemetry import is_video
 class TrackPoint:
     """One GPS-fixed sample: WGS84 lat/lon, absolute altitude (m), raw cue time,
     best-effort UTC datetime, and optional footprint inputs (AGL via rel_alt,
-    35mm-equivalent focal length, gimbal yaw/pitch) when the format carries them."""
+    35mm-equivalent focal length, gimbal yaw/pitch) when the format carries them.
+
+    ``segment`` is the index of the source recording a point came from: DJI
+    closes the container at 4 GB and keeps recording, so one flight can span
+    several files. It rides on the point because :func:`_decimate_points` thins
+    the track after joining, which would invalidate any boundary index.
+    """
 
     lat: float
     lon: float
@@ -31,6 +37,7 @@ class TrackPoint:
     focal_len: float | None = None
     gimbal_yaw: float | None = None
     gimbal_pitch: float | None = None
+    segment: int = 0
 
 
 @dataclass

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -27,6 +27,8 @@ import pytest
 
 pytest.importorskip("playwright")
 
+from dji_metadata_embedder.geo.serve import _QuietHandler  # noqa: E402
+
 
 # A valid 1x1 transparent PNG: the stand-in for every tile and sprite
 # request, so the map lays out normally with zero external traffic.
@@ -134,11 +136,6 @@ _STRIP_HILLSHADE_JS = """
   });
 })();
 """
-
-
-class _QuietHandler(http.server.SimpleHTTPRequestHandler):
-    def log_message(self, *args):  # noqa: ARG002 - silence per-request stderr
-        pass
 
 
 _RECORD_JS = """

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -141,6 +141,55 @@ class _QuietHandler(http.server.SimpleHTTPRequestHandler):
         pass
 
 
+_RECORD_JS = """
+async () => {
+  const c = document.createElement('canvas');
+  c.width = 320; c.height = 180;
+  const ctx = c.getContext('2d');
+  const stream = c.captureStream(30);
+  const types = ['video/webm;codecs=vp9', 'video/webm;codecs=vp8',
+                 'video/webm'];
+  const type = types.find(t => MediaRecorder.isTypeSupported(t));
+  if (!type) throw new Error('no recordable mime type');
+  const rec = new MediaRecorder(stream, {mimeType: type});
+  const chunks = [];
+  rec.ondataavailable = e => chunks.push(e.data);
+  rec.start();
+  for (let i = 0; i < 60; i++) {            // ~2 s of visibly changing frames
+    ctx.fillStyle = `rgb(${i * 4}, 0, 0)`;
+    ctx.fillRect(0, 0, 320, 180);
+    await new Promise(r => setTimeout(r, 33));
+  }
+  await new Promise(r => { rec.onstop = r; rec.stop(); });
+  const buf = await new Blob(chunks, {type}).arrayBuffer();
+  let s = '';
+  const bytes = new Uint8Array(buf);
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+"""
+
+
+@pytest.fixture(scope="session")
+def recorded_webm(browser) -> bytes:
+    """A small, real, seekable video, recorded by Chromium itself.
+
+    There is no ffmpeg in this environment and hand-built container bytes are
+    a trap, so the browser makes its own: ~38 KB of VP9 WebM with a finite
+    duration that seeks exactly. It is WebM rather than MP4, so these tests
+    prove our seek logic and segment mapping -- MP4 decoding is the browser's
+    job, not ours.
+    """
+    import base64
+
+    page = browser.new_page()
+    try:
+        page.goto("about:blank")
+        return base64.b64decode(page.evaluate(_RECORD_JS))
+    finally:
+        page.close()
+
+
 @pytest.fixture(scope="session")
 def map_server(tmp_path_factory):
     """(directory, base_url) of a localhost server the tests write maps into."""
@@ -174,17 +223,24 @@ def serve_map(map_server, page):
     strip the ``hillshade`` source/layer before the map constructs: headless
     SwiftShader hangs rendering it against real DEM data under pitch, and it
     is presentation-only, so these runs never see it (see
-    ``_STRIP_HILLSHADE_JS``).
+    ``_STRIP_HILLSHADE_JS``). ``extra_files`` writes additional files
+    (e.g. a recorded video clip) beside the served HTML, keyed by the
+    relative href the map references them with.
     """
     root, base_url = map_server
 
     def _serve(html: str, *, on=None, terrain_stub: float | None = None,
-               terrain_steps: tuple[float, float] | None = None) -> str:
+               terrain_steps: tuple[float, float] | None = None,
+               extra_files: dict[str, bytes] | None = None) -> str:
         import uuid
 
         target = on if on is not None else page
         name = f"map-{uuid.uuid4().hex[:12]}.html"
         (root / name).write_text(html, encoding="utf-8")
+        for rel, data in (extra_files or {}).items():
+            target_path = root / rel
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            target_path.write_bytes(data)
         assets = {
             url: _fetch_asset(url, integrity)
             for url, integrity in _ASSET_RE.findall(html)

--- a/tests/browser/test_flightmap_crossfade.py
+++ b/tests/browser/test_flightmap_crossfade.py
@@ -181,6 +181,11 @@ def test_a_segment_without_video_disables_the_blend(serve_map, page,
     assert page.evaluate(
         "() => getComputedStyle(document.getElementById('ghost-video'))"
         ".display") == "none"
+    # Review I2 (#380): a null media[seg] must not grey out the control with
+    # no explanation -- assert the message itself, not just that a badge
+    # element exists.
+    note = page.locator("#ghost-badges").inner_text()
+    assert "no video for this part of the flight" in note
 
 
 def test_plays_in_sync_at_normal_speed(serve_map, page, recorded_webm):
@@ -291,3 +296,7 @@ def test_no_crossfade_under_fuzz(serve_map, page, recorded_webm):
     assert page.evaluate("() => flights[0].media")[0] == VIDEO_NAME
     # And the cockpit itself still works.
     assert page.evaluate("() => ghost.active") is True
+    # Review I1 (#380): a shared HTML must say the crossfade was withheld,
+    # not just omit the slider silently -- same shape as the gaze note.
+    note = page.locator(".panel-note").inner_text()
+    assert "video crossfade off" in note

--- a/tests/browser/test_flightmap_crossfade.py
+++ b/tests/browser/test_flightmap_crossfade.py
@@ -214,6 +214,21 @@ def test_fast_playback_seeks_instead_of_playing(serve_map, page,
         "() => document.getElementById('ghost-video').paused") is True
 
 
+def test_5x_playback_seeks_instead_of_playing(serve_map, page, recorded_webm):
+    """Review M2 (#380): 5x is the first speed a user can actually click that
+    is above CROSSFADE_MAX_RATE (4) -- PB_SPEEDS has no value in (1, 4], so
+    the 1x/60x pair alone never exercises the boundary itself."""
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    _wait_video_ready(page)
+    page.evaluate("() => { pb.speed = 5; pbPlay(); }")
+    page.wait_for_function("() => pb.t > 2", timeout=10000)
+    assert page.evaluate(
+        "() => document.getElementById('ghost-video').paused") is True
+
+
 def test_a_broken_video_disables_the_blend_and_names_the_file(serve_map, page):
     """Spec section 8: a moved or undecodable file must not leave a blank
     overlay that reads as 'the camera saw nothing here'."""
@@ -224,6 +239,25 @@ def test_a_broken_video_disables_the_blend_and_names_the_file(serve_map, page):
     page.wait_for_function(
         "() => document.getElementById('ghost-blend').disabled === true",
         timeout=10000)
+    note = page.locator("#ghost-badges").inner_text()
+    assert "gone.webm" in note
+
+
+def test_a_broken_video_stays_disabled_after_a_step(serve_map, page):
+    """Review I1 (#380): the error handler's disable/hide/badge must survive
+    the next render, not just the one that follows ghostEnter -- otherwise
+    one arrow key (or the first sample tick of playback) undoes all three and
+    leaves a LIVE blend slider over a video that will never show a frame."""
+    serve_map(flights_to_3d_html(
+        [_flight("DJI_0001", media=["gone.webm"])], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function(
+        "() => document.getElementById('ghost-blend').disabled === true",
+        timeout=10000)
+    page.evaluate("() => ghostStep(1)")
+    assert page.evaluate(
+        "() => document.getElementById('ghost-blend').disabled") is True
     note = page.locator("#ghost-badges").inner_text()
     assert "gone.webm" in note
 

--- a/tests/browser/test_flightmap_crossfade.py
+++ b/tests/browser/test_flightmap_crossfade.py
@@ -181,3 +181,79 @@ def test_a_segment_without_video_disables_the_blend(serve_map, page,
     assert page.evaluate(
         "() => getComputedStyle(document.getElementById('ghost-video'))"
         ".display") == "none"
+
+
+def test_plays_in_sync_at_normal_speed(serve_map, page, recorded_webm):
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    _wait_video_ready(page)
+    page.evaluate("() => { pb.speed = 1; pbPlay(); }")
+    page.wait_for_function(
+        "() => !document.getElementById('ghost-video').paused", timeout=10000)
+    assert page.evaluate(
+        "() => document.getElementById('ghost-video').playbackRate") == 1
+    page.evaluate("() => pbPause()")
+    page.wait_for_function(
+        "() => document.getElementById('ghost-video').paused", timeout=10000)
+
+
+def test_fast_playback_seeks_instead_of_playing(serve_map, page,
+                                                recorded_webm):
+    """Above CROSSFADE_MAX_RATE a decoder silently falls behind and shows the
+    wrong second, so the video stays paused and steps instead."""
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    _wait_video_ready(page)
+    page.evaluate("() => { pb.speed = 60; pbPlay(); }")
+    page.wait_for_function("() => pb.t > 2", timeout=10000)
+    assert page.evaluate(
+        "() => document.getElementById('ghost-video').paused") is True
+
+
+def test_a_broken_video_disables_the_blend_and_names_the_file(serve_map, page):
+    """Spec section 8: a moved or undecodable file must not leave a blank
+    overlay that reads as 'the camera saw nothing here'."""
+    serve_map(flights_to_3d_html(
+        [_flight("DJI_0001", media=["gone.webm"])], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function(
+        "() => document.getElementById('ghost-blend').disabled === true",
+        timeout=10000)
+    note = page.locator("#ghost-badges").inner_text()
+    assert "gone.webm" in note
+
+
+def test_missing_focal_length_marks_the_alignment_approximate(serve_map, page,
+                                                              recorded_webm):
+    """Spec section 8: without a focal length the map's own field of view is
+    an estimate, so a mismatch is not evidence the telemetry is wrong."""
+    track = _flight("DJI_0001", media=[VIDEO_NAME])
+    for p in track.points:
+        p.focal_len = None
+    _serve_with_video(serve_map, recorded_webm, track)
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    assert page.evaluate("() => flights[0].vfov") is None
+    assert "alignment approximate" in page.locator("#ghost-badges").inner_text()
+
+
+def test_no_crossfade_under_fuzz(serve_map, page, recorded_webm):
+    """Positions are coarsened ~100 m, so an overlay would invite a
+    comparison against geometry we know is wrong. Linking is still allowed --
+    photomap permits the same pair -- so the media property is present and it
+    is the blend that is withheld."""
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]), redact="fuzz")
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    assert page.locator("#ghost-video").count() == 0
+    assert page.locator("#ghost-blend").count() == 0
+    # The data is still there; only the feature is gated.
+    assert page.evaluate("() => flights[0].media")[0] == VIDEO_NAME
+    # And the cockpit itself still works.
+    assert page.evaluate("() => ghost.active") is True

--- a/tests/browser/test_flightmap_crossfade.py
+++ b/tests/browser/test_flightmap_crossfade.py
@@ -1,0 +1,112 @@
+"""Media crossfade (#380): blend the reconstruction into the footage."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+VIDEO_NAME = "clip.webm"
+
+
+def _flight(name: str, points: int = 6, *, media=None, segments=None,
+            seg_of=None) -> Track:
+    """Synthetic flight, one sample a second, gimbal and lens present."""
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    track = Track(name=name, points=[
+        TrackPoint(lat=10.0, lon=20.0 + i * 0.0006, alt=150.0,
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i), rel_alt=50.0,
+                   focal_len=24.0, gimbal_yaw=90.0, gimbal_pitch=-45.0,
+                   segment=0 if seg_of is None else seg_of[i])
+        for i in range(points)
+    ])
+    track.segments = segments
+    track.media = media
+    return track
+
+
+def _ready(page):
+    page.wait_for_selector("#flights-panel", timeout=15000)
+
+
+def _serve_with_video(serve_map, recorded_webm, track, **kw):
+    return serve_map(flights_to_3d_html([track], "trip", **kw),
+                     extra_files={VIDEO_NAME: recorded_webm})
+
+
+def test_no_video_element_without_linked_media(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001")], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    assert page.locator("#ghost-video").count() == 0
+    assert page.locator("#ghost-blend").count() == 0
+
+
+def test_video_and_slider_appear_in_the_cockpit(serve_map, page,
+                                                recorded_webm):
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    assert page.locator("#ghost-video").count() == 0   # cockpit only
+    page.evaluate("() => ghostEnter(0, 0)")
+    assert page.locator("#ghost-video").count() == 1
+    assert page.locator("#ghost-blend").count() == 1
+    # Starts fully on the reconstruction: the video is opt-in, not a surprise.
+    assert page.evaluate(
+        "() => Number(document.getElementById('ghost-video').style.opacity)"
+    ) == 0
+
+
+def test_slider_drives_opacity(serve_map, page, recorded_webm):
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.evaluate("() => { const s = document.getElementById('ghost-blend');"
+                  " s.value = '60'; s.dispatchEvent(new Event('input')); }")
+    assert abs(page.evaluate(
+        "() => Number(document.getElementById('ghost-video').style.opacity)")
+        - 0.6) < 1e-6
+
+
+def test_v_key_toggles_the_extremes(serve_map, page, recorded_webm):
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    op = "() => Number(document.getElementById('ghost-video').style.opacity)"
+    assert page.evaluate(op) == 0
+    page.keyboard.press("v")
+    assert page.evaluate(op) == 1
+    page.keyboard.press("v")
+    assert page.evaluate(op) == 0
+
+
+def test_video_is_removed_on_exit(serve_map, page, recorded_webm):
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    assert page.locator("#ghost-video").count() == 1
+    page.evaluate("() => ghostExit()")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    assert page.locator("#ghost-video").count() == 0
+
+
+def test_video_never_swallows_a_map_click(serve_map, page, recorded_webm):
+    """pointer-events: none -- a click at full blend must still reach the
+    terrain, or the gaze lookup dies whenever the video is up."""
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.keyboard.press("v")
+    assert page.evaluate(
+        "() => getComputedStyle(document.getElementById('ghost-video'))"
+        ".pointerEvents") == "none"

--- a/tests/browser/test_flightmap_crossfade.py
+++ b/tests/browser/test_flightmap_crossfade.py
@@ -110,3 +110,71 @@ def test_video_never_swallows_a_map_click(serve_map, page, recorded_webm):
     assert page.evaluate(
         "() => getComputedStyle(document.getElementById('ghost-video'))"
         ".pointerEvents") == "none"
+
+
+def _wait_video_ready(page):
+    page.wait_for_function(
+        "() => { const v = document.getElementById('ghost-video');"
+        " return v && v.readyState >= 1 && Number.isFinite(v.duration); }",
+        timeout=15000)
+
+
+def test_seeks_to_the_sample_cue_time(serve_map, page, recorded_webm):
+    """currentTime must track the point's own cue, which is what makes the
+    overlay show the second the camera is at."""
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    _wait_video_ready(page)
+    page.evaluate("() => ghostStep(1)")
+    page.wait_for_function(
+        "() => Math.abs(document.getElementById('ghost-video').currentTime"
+        " - 1.0) < 0.2", timeout=10000)
+
+
+def test_crossing_a_segment_boundary_swaps_the_source(serve_map, page,
+                                                      recorded_webm):
+    """A split flight's second half plays from the second file, and the cue
+    restarts near zero rather than continuing the flight clock."""
+    track = _flight("DJI_0001", points=6,
+                    media=["a/" + VIDEO_NAME, "b/" + VIDEO_NAME],
+                    segments=["a/clip", "b/clip"],
+                    seg_of=[0, 0, 0, 1, 1, 1])
+    # The second segment's cues restart: rewrite them as its own file's clock.
+    for i, p in enumerate(track.points):
+        if p.segment == 1:
+            p.timestamp = f"00:00:{i - 3:02d},000"
+    serve_map(flights_to_3d_html([track], "trip"),
+              extra_files={"a/" + VIDEO_NAME: recorded_webm,
+                           "b/" + VIDEO_NAME: recorded_webm})
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    _wait_video_ready(page)
+    assert page.evaluate(
+        "() => document.getElementById('ghost-video').src").endswith(
+            "a/" + VIDEO_NAME)
+    page.evaluate("() => { ghost.idx = 4; renderCrossfade(); }")
+    page.wait_for_function(
+        "() => document.getElementById('ghost-video').src.endsWith('b/"
+        + VIDEO_NAME + "')", timeout=10000)
+    _wait_video_ready(page)
+    page.wait_for_function(
+        "() => document.getElementById('ghost-video').currentTime < 2.0",
+        timeout=10000)
+
+
+def test_a_segment_without_video_disables_the_blend(serve_map, page,
+                                                    recorded_webm):
+    track = _flight("DJI_0001", points=6, media=[VIDEO_NAME, None],
+                    segments=["clip", "missing"], seg_of=[0, 0, 0, 1, 1, 1])
+    _serve_with_video(serve_map, recorded_webm, track)
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    _wait_video_ready(page)
+    page.evaluate("() => { ghost.idx = 4; renderCrossfade(); }")
+    assert page.evaluate(
+        "() => document.getElementById('ghost-blend').disabled") is True
+    assert page.evaluate(
+        "() => getComputedStyle(document.getElementById('ghost-video'))"
+        ".display") == "none"

--- a/tests/browser/test_flightmap_crossfade.py
+++ b/tests/browser/test_flightmap_crossfade.py
@@ -159,9 +159,12 @@ def test_crossing_a_segment_boundary_swaps_the_source(serve_map, page,
         "() => document.getElementById('ghost-video').src.endsWith('b/"
         + VIDEO_NAME + "')", timeout=10000)
     _wait_video_ready(page)
+    # The restart, not just "small": sample 4's own cue in file b (~1s) --
+    # a flight-relative clock would land minutes past this clip's end.
+    cue = page.evaluate("() => flights[0].cue[4]")
     page.wait_for_function(
-        "() => document.getElementById('ghost-video').currentTime < 2.0",
-        timeout=10000)
+        "() => Math.abs(document.getElementById('ghost-video').currentTime"
+        f" - {cue}) < 0.3", timeout=10000)
 
 
 def test_a_segment_without_video_disables_the_blend(serve_map, page,

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -263,3 +263,24 @@ def test_flightmap_3d_jsonl_reports_output(tmp_path):
     events = [json.loads(line) for line in res.output.splitlines() if line]
     result = next(e for e in events if e["event"] == "result")
     assert result["outputs"][0].endswith("flightmap-3d.html")
+
+
+def test_link_base_requires_link_originals(tmp_path):
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "--link-base", "../footage"]
+    )
+    assert res.exit_code != 0
+    assert "--link-base requires --link-originals" in res.output
+
+
+def test_link_originals_allowed_with_fuzz_but_warns(tmp_path):
+    """photomap permits the same pair and warns; flightmap matches it. The
+    blend is disabled in the viewer instead."""
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    res = CliRunner().invoke(
+        main,
+        ["flightmap", str(tmp_path), "--3d", "--link-originals", "--redact", "fuzz"],
+    )
+    assert res.exit_code == 0
+    assert "still carry exact GPS" in res.output

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -284,3 +284,59 @@ def test_link_originals_allowed_with_fuzz_but_warns(tmp_path):
     )
     assert res.exit_code == 0
     assert "still carry exact GPS" in res.output
+
+
+def test_link_originals_reaches_the_geojson_media_property(tmp_path):
+    """Review I5 (#380): the only place --link-originals connects to the
+    written output is `if link_originals: resolve_media(tracks, src,
+    link_base)` in cli.py -- deleting it, or moving it below the write loop,
+    left every other test in the suite green. This is the guard for that
+    seam specifically."""
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"fake video bytes")
+    res = CliRunner().invoke(
+        main,
+        ["flightmap", str(tmp_path), "--format", "geojson", "--link-originals"],
+    )
+    assert res.exit_code == 0, res.output
+    data = json.loads((tmp_path / "flightmap.geojson").read_text(encoding="utf-8"))
+    assert data["features"][0]["properties"]["media"] == ["DJI_0001.MP4"]
+
+
+def test_link_originals_with_flat_html_warns_dead_weight(tmp_path):
+    """Review M2 (#380): the flat 2D map embeds the same media/cue_s/seg_i
+    arrays the 3D crossfade needs, but nothing in the 2D viewer reads them --
+    warn the way photomap does for its analogous case."""
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"fake video bytes")
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "--link-originals"]
+    )
+    assert res.exit_code == 0, res.output
+    assert "only benefits the 3D map" in res.output
+
+
+def test_link_originals_3d_does_not_warn_dead_weight(tmp_path):
+    """The 3D map is exactly the case --link-originals exists for -- no
+    'dead weight' note should fire alongside it."""
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"fake video bytes")
+    res = CliRunner().invoke(
+        main, ["flightmap", str(tmp_path), "--3d", "--link-originals"]
+    )
+    assert res.exit_code == 0, res.output
+    assert "only benefits the 3D map" not in res.output
+
+
+def test_link_originals_geojson_alone_does_not_warn_dead_weight(tmp_path):
+    """GeoJSON is the intended --link-originals target (the media/cue_s/
+    seg_i arrays are the deliverable there), so it must not be told they are
+    dead weight."""
+    _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"fake video bytes")
+    res = CliRunner().invoke(
+        main,
+        ["flightmap", str(tmp_path), "--format", "geojson", "--link-originals"],
+    )
+    assert res.exit_code == 0, res.output
+    assert "only benefits the 3D map" not in res.output

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from dji_metadata_embedder.geo.flightmap import (
     flights_to_geojson,
@@ -518,58 +518,59 @@ def test_write_flights_geojson_threads_redact(tmp_path):
 
 
 def _joined_pair(tmp_path):
-    """Two real, densely-sampled SRTs that join into one flight.
+    """Two real, densely-sampled (30 Hz) SRTs that join into one flight.
 
-    Reuses the exact 30 Hz join-fixture shape already proven to join in
-    ``test_decimation_does_not_break_split_joining``. Built and joined
-    through the same real functions ``scan_flights`` uses internally
-    (``load_samples`` -> ``build_track_from_samples`` -> ``_ScanEntry`` ->
-    ``join_split_flights``), but stops short of ``scan_flights``' own
-    decimate/redact/sort epilogue -- callers need the genuinely undecimated,
-    joined points so ``test_segment_survives_decimation`` can exercise
-    ``_decimate_points`` on real data instead of on an already-thinned (and
-    therefore un-thinnable-further) result.
+    Same fixture shape already proven to join in
+    ``test_decimation_does_not_break_split_joining``, exercised end to end
+    through the real ``scan_flights`` -- no internals duplicated. Dense
+    enough (2 x 60 raw points) that ``scan_flights``' internal decimation
+    genuinely thins the result rather than passing every point through
+    untouched, so the join-stamping test below also proves the stamp
+    survives real thinning, not just a no-op pass.
     """
-    from dji_metadata_embedder.geo.flightmap import _ScanEntry, join_split_flights
-    from dji_metadata_embedder.geo.track import build_track_from_samples
-    from dji_metadata_embedder.utilities import load_samples
-
-    path_a = _write(tmp_path, "DJI_0001.SRT", _hz30_srt(T0, 2.0))
-    path_b = _write(
+    _write(tmp_path, "DJI_0001.SRT", _hz30_srt(T0, 2.0))
+    _write(
         tmp_path,
         "DJI_0002.SRT",
         _hz30_srt(T0 + timedelta(seconds=2), 2.0, lat0=34.0 + 60 * 1e-6),
     )
-    entries = []
-    for path in (path_a, path_b):
-        samples = load_samples(path)
-        mtime_utc = datetime.fromtimestamp(
-            path.stat().st_mtime, tz=timezone.utc
-        ).replace(tzinfo=None)
-        track = build_track_from_samples(path.stem, samples, mtime_utc=mtime_utc)
-        entries.append(_ScanEntry(track, samples[0].dt, samples[-1].dt))
-    return join_split_flights(entries)
+    tracks, _ = scan_flights(tmp_path)
+    return tracks
 
 
 def test_join_stamps_each_point_with_its_segment(tmp_path):
     tracks = _joined_pair(tmp_path)
     assert len(tracks) == 1
-    segs = {p.segment for p in tracks[0].points}
-    assert segs == {0, 1}
+    segs = [p.segment for p in tracks[0].points]
+    # scan_flights has already decimated by this point, so this single
+    # assertion proves both that the join stamps segments and that the
+    # stamp survives thinning through the real pipeline a user hits.
+    assert set(segs) == {0, 1}
     # Segment 0 must come first and never interleave.
-    seq = [p.segment for p in tracks[0].points]
-    assert seq == sorted(seq)
+    assert segs == sorted(segs)
 
 
-def test_segment_survives_decimation(tmp_path):
-    """_decimate_points runs AFTER the join and keeps ~1 point/s, so a
-    boundary index captured at join time would be wrong. The stamp rides on
-    the point instead."""
+def test_decimation_preserves_the_segment_stamp():
+    """Unit test for the property in isolation: _decimate_points must
+    genuinely thin the points (not a no-op) while keeping each surviving
+    point's segment stamp intact. No SRT files or join involved -- a
+    hand-built dense (30 Hz) list is enough to exercise this on its own."""
     from dji_metadata_embedder.geo.flightmap import _decimate_points
 
-    tracks = _joined_pair(tmp_path)
-    thinned = _decimate_points(tracks[0].points)
-    assert len(thinned) < len(tracks[0].points)
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    points = [
+        TrackPoint(
+            lat=10.0,
+            lon=20.0 + i * 1e-6,
+            alt=100.0,
+            timestamp=f"00:00:{i // 30:02d},{(i % 30) * 33:03d}",
+            utc=t0 + timedelta(seconds=i / 30),
+            segment=0 if i < 45 else 1,
+        )
+        for i in range(90)
+    ]
+    thinned = _decimate_points(points)
+    assert len(thinned) < len(points)
     assert {p.segment for p in thinned} == {0, 1}
 
 

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -611,3 +611,36 @@ def test_geojson_seg_i_emitted_only_when_split():
     props = flights_to_geojson([track])["features"][0]["properties"]
     assert set(props["seg_i"]) == {0, 1}
     assert len(props["seg_i"]) == len(track.points)
+
+
+def test_geojson_media_props_absent_on_single_fix_point():
+    """Mirrors test_geojson_pose_arrays_not_on_single_fix_point: the Point
+    degenerate case skips times_s and the ghost props, and media/cue_s/seg_i
+    must be skipped the same way (#380)."""
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    track = _ghost_track()
+    track.media = ["DJI_0001.MP4"]
+    track.points = track.points[:1]
+    fc = flights_to_geojson([track])
+    assert fc["features"][0]["geometry"]["type"] == "Point"
+    for key in ("media", "cue_s", "seg_i"):
+        assert key not in fc["features"][0]["properties"]
+
+
+def test_cue_s_restarts_at_a_segment_boundary(tmp_path):
+    """The property task-4-review verified only by reading source: cue_s is
+    each point's offset within its own video file, not a flight-relative
+    clock. If it climbed across a join instead of restarting, a split
+    flight's second video would seek minutes past its own end (#380)."""
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    tracks = _joined_pair(tmp_path)
+    track = tracks[0]
+    track.media = ["a.MP4", "b.MP4"]
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    seg_i = props["seg_i"]
+    assert 0 in seg_i and 1 in seg_i
+    last_seg0 = max(i for i, s in enumerate(seg_i) if s == 0)
+    first_seg1 = min(i for i, s in enumerate(seg_i) if s == 1)
+    assert props["cue_s"][first_seg1] < props["cue_s"][last_seg0]

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -577,3 +577,37 @@ def test_decimation_preserves_the_segment_stamp():
 def test_single_file_flight_is_all_segment_zero():
     track = _ghost_track()
     assert {p.segment for p in track.points} == {0}
+
+
+def test_geojson_media_props_absent_without_linking():
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    props = flights_to_geojson([_ghost_track()])["features"][0]["properties"]
+    for key in ("media", "cue_s", "seg_i"):
+        assert key not in props
+
+
+def test_geojson_cue_s_is_the_in_file_offset():
+    """Not flight-relative time: cue_s is what video.currentTime wants, and
+    for a joined flight the second file's cues restart near zero."""
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    track = _ghost_track()
+    track.media = ["DJI_0001.MP4"]
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert props["media"] == ["DJI_0001.MP4"]
+    assert len(props["cue_s"]) == len(track.points)
+    assert props["cue_s"][0] == 0.0
+    assert "seg_i" not in props          # single segment: omitted
+
+
+def test_geojson_seg_i_emitted_only_when_split():
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    track = _ghost_track()
+    track.media = ["a.MP4", "b.MP4"]
+    for p in track.points[len(track.points) // 2:]:
+        p.segment = 1
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert set(props["seg_i"]) == {0, 1}
+    assert len(props["seg_i"]) == len(track.points)

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from dji_metadata_embedder.geo.flightmap import (
     flights_to_geojson,
@@ -515,3 +515,64 @@ def test_write_flights_geojson_threads_redact(tmp_path):
     out = tmp_path / "flights.geojson"
     write_flights_geojson([_ghost_track()], out, redact="fuzz")
     assert json.loads(out.read_text(encoding="utf-8"))["redacted"] == "fuzz"
+
+
+def _joined_pair(tmp_path):
+    """Two real, densely-sampled SRTs that join into one flight.
+
+    Reuses the exact 30 Hz join-fixture shape already proven to join in
+    ``test_decimation_does_not_break_split_joining``. Built and joined
+    through the same real functions ``scan_flights`` uses internally
+    (``load_samples`` -> ``build_track_from_samples`` -> ``_ScanEntry`` ->
+    ``join_split_flights``), but stops short of ``scan_flights``' own
+    decimate/redact/sort epilogue -- callers need the genuinely undecimated,
+    joined points so ``test_segment_survives_decimation`` can exercise
+    ``_decimate_points`` on real data instead of on an already-thinned (and
+    therefore un-thinnable-further) result.
+    """
+    from dji_metadata_embedder.geo.flightmap import _ScanEntry, join_split_flights
+    from dji_metadata_embedder.geo.track import build_track_from_samples
+    from dji_metadata_embedder.utilities import load_samples
+
+    path_a = _write(tmp_path, "DJI_0001.SRT", _hz30_srt(T0, 2.0))
+    path_b = _write(
+        tmp_path,
+        "DJI_0002.SRT",
+        _hz30_srt(T0 + timedelta(seconds=2), 2.0, lat0=34.0 + 60 * 1e-6),
+    )
+    entries = []
+    for path in (path_a, path_b):
+        samples = load_samples(path)
+        mtime_utc = datetime.fromtimestamp(
+            path.stat().st_mtime, tz=timezone.utc
+        ).replace(tzinfo=None)
+        track = build_track_from_samples(path.stem, samples, mtime_utc=mtime_utc)
+        entries.append(_ScanEntry(track, samples[0].dt, samples[-1].dt))
+    return join_split_flights(entries)
+
+
+def test_join_stamps_each_point_with_its_segment(tmp_path):
+    tracks = _joined_pair(tmp_path)
+    assert len(tracks) == 1
+    segs = {p.segment for p in tracks[0].points}
+    assert segs == {0, 1}
+    # Segment 0 must come first and never interleave.
+    seq = [p.segment for p in tracks[0].points]
+    assert seq == sorted(seq)
+
+
+def test_segment_survives_decimation(tmp_path):
+    """_decimate_points runs AFTER the join and keeps ~1 point/s, so a
+    boundary index captured at join time would be wrong. The stamp rides on
+    the point instead."""
+    from dji_metadata_embedder.geo.flightmap import _decimate_points
+
+    tracks = _joined_pair(tmp_path)
+    thinned = _decimate_points(tracks[0].points)
+    assert len(thinned) < len(tracks[0].points)
+    assert {p.segment for p in thinned} == {0, 1}
+
+
+def test_single_file_flight_is_all_segment_zero():
+    track = _ghost_track()
+    assert {p.segment for p in track.points} == {0}

--- a/tests/test_geo_flightmap3d_html.py
+++ b/tests/test_geo_flightmap3d_html.py
@@ -114,6 +114,14 @@ def test_template_carries_the_gaze_and_playback_app():
         assert needle in html, needle
 
 
+def test_template_carries_the_crossfade_app():
+    html = flights_to_3d_html([_track()], "trip")
+    for needle in ("function mountCrossfade(", "function renderCrossfade(",
+                   "function syncCrossfadePlayback(", "v.id = 'ghost-video'",
+                   "ghost-blend", "CROSSFADE_MAX_RATE"):
+        assert needle in html, needle
+
+
 def test_write_flights_3d_html(tmp_path):
     out = tmp_path / "flightmap-3d.html"
     result = write_flights_3d_html([_track()], out, "trip")

--- a/tests/test_geo_media.py
+++ b/tests/test_geo_media.py
@@ -1,0 +1,74 @@
+"""Resolving the video file behind each flight segment (#380)."""
+
+from dji_metadata_embedder.geo.links import link_href
+from dji_metadata_embedder.geo.media import resolve_media
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+
+def _track(name: str, segments: list[str] | None = None) -> Track:
+    t = Track(name=name, points=[
+        TrackPoint(lat=10.0, lon=20.0, alt=100.0, timestamp="00:00:00,000")])
+    t.segments = segments
+    return t
+
+
+def test_resolves_uppercase_mp4(tmp_path):
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"x")
+    track = _track("DJI_0001")
+    resolve_media([track], tmp_path)
+    assert track.media == ["DJI_0001.MP4"]
+
+
+def test_resolves_lowercase_and_mov(tmp_path):
+    (tmp_path / "a.mp4").write_bytes(b"x")
+    (tmp_path / "b.MOV").write_bytes(b"x")
+    ta, tb = _track("a"), _track("b")
+    resolve_media([ta, tb], tmp_path)
+    assert ta.media == ["a.mp4"]
+    assert tb.media == ["b.MOV"]
+
+
+def test_missing_video_is_none_not_a_guess(tmp_path):
+    """Never emit an href for a file that is not there -- a dead <video> src
+    is indistinguishable from a codec failure to the user."""
+    track = _track("DJI_0001")
+    resolve_media([track], tmp_path)
+    assert track.media is None
+
+
+def test_one_href_per_segment_in_order(tmp_path):
+    for n in ("DJI_0001", "DJI_0002", "DJI_0003"):
+        (tmp_path / f"{n}.MP4").write_bytes(b"x")
+    track = _track("DJI_0001", segments=["DJI_0001", "DJI_0002", "DJI_0003"])
+    resolve_media([track], tmp_path)
+    assert track.media == ["DJI_0001.MP4", "DJI_0002.MP4", "DJI_0003.MP4"]
+
+
+def test_partial_segments_keep_their_slots(tmp_path):
+    """A gap must not shift the others: seg_i indexes into this list."""
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"x")
+    (tmp_path / "DJI_0003.MP4").write_bytes(b"x")
+    track = _track("DJI_0001", segments=["DJI_0001", "DJI_0002", "DJI_0003"])
+    resolve_media([track], tmp_path)
+    assert track.media == ["DJI_0001.MP4", None, "DJI_0003.MP4"]
+
+
+def test_recursive_names_keep_their_subdirectory(tmp_path):
+    (tmp_path / "session1").mkdir()
+    (tmp_path / "session1" / "DJI_0001.MP4").write_bytes(b"x")
+    track = _track("session1/DJI_0001")
+    resolve_media([track], tmp_path)
+    assert track.media == ["session1/DJI_0001.MP4"]
+
+
+def test_link_base_prefixes_every_href(tmp_path):
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"x")
+    track = _track("DJI_0001")
+    resolve_media([track], tmp_path, base="../footage")
+    assert track.media == ["../footage/DJI_0001.MP4"]
+
+
+def test_link_href_percent_encodes_segments_but_not_separators():
+    assert link_href("a b/c#d.MP4", "") == "a%20b/c%23d.MP4"
+    assert link_href("x.MP4", "https://example.test/v") == \
+        "https://example.test/v/x.MP4"

--- a/tests/test_geo_serve_range.py
+++ b/tests/test_geo_serve_range.py
@@ -86,6 +86,14 @@ def test_garbage_range_is_ignored(server):
     assert body == BODY
 
 
+def test_reversed_range_falls_back_to_whole_file(server):
+    """`bytes=100-50` is syntactically valid but backwards. A reversed range
+    is ignored rather than rejected -- see the comment in _parse_range."""
+    status, _, body = _get(server, "bytes=100-50")
+    assert status == 200
+    assert body == BODY
+
+
 @pytest.mark.parametrize("header,size,expected", [
     ("bytes=0-99", 2048, (0, 99)),
     ("bytes=100-", 2048, (100, 2047)),
@@ -95,6 +103,7 @@ def test_garbage_range_is_ignored(server):
     ("bytes=0-99,200-299", 2048, None),      # multi-range -> whole file
     ("furlongs=0-9", 2048, None),
     ("bytes=-", 2048, None),
+    ("bytes=100-50", 2048, None),            # reversed -> ignored, not 416
 ])
 def test_parse_range(header, size, expected):
     assert _parse_range(header, size) == expected

--- a/tests/test_geo_serve_range.py
+++ b/tests/test_geo_serve_range.py
@@ -1,0 +1,105 @@
+"""HTTP Range support in the local map server (#380).
+
+The video crossfade is a seek, and Python's stock SimpleHTTPRequestHandler
+ignores Range entirely: Chrome re-requests from byte zero on every seek and
+Safari refuses to play at all.
+"""
+
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+from dji_metadata_embedder.geo.serve import _make_server, _parse_range
+
+BODY = bytes(range(256)) * 8       # 2048 bytes, every value distinguishable
+
+
+@pytest.fixture
+def server(tmp_path):
+    (tmp_path / "clip.bin").write_bytes(BODY)
+    httpd = _make_server(tmp_path)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{httpd.server_address[1]}/clip.bin"
+    httpd.shutdown()
+    thread.join(timeout=5)
+
+
+def _get(url, rng=None):
+    req = urllib.request.Request(url)
+    if rng is not None:
+        req.add_header("Range", rng)
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return resp.status, dict(resp.headers), resp.read()
+
+
+def test_whole_file_advertises_range_support(server):
+    status, headers, body = _get(server)
+    assert status == 200
+    assert headers["Accept-Ranges"] == "bytes"
+    assert body == BODY
+
+
+def test_leading_range(server):
+    status, headers, body = _get(server, "bytes=0-99")
+    assert status == 206
+    assert headers["Content-Range"] == f"bytes 0-99/{len(BODY)}"
+    assert headers["Content-Length"] == "100"
+    assert body == BODY[:100]
+
+
+def test_open_ended_range(server):
+    status, headers, body = _get(server, "bytes=2000-")
+    assert status == 206
+    assert headers["Content-Range"] == f"bytes 2000-2047/{len(BODY)}"
+    assert body == BODY[2000:]
+
+
+def test_suffix_range(server):
+    """`bytes=-100` means the LAST 100 bytes, not the first 100."""
+    status, headers, body = _get(server, "bytes=-100")
+    assert status == 206
+    assert headers["Content-Range"] == f"bytes 1948-2047/{len(BODY)}"
+    assert body == BODY[-100:]
+
+
+def test_range_past_end_is_416(server):
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _get(server, "bytes=9000-9100")
+    assert exc.value.code == 416
+    assert exc.value.headers["Content-Range"] == f"bytes */{len(BODY)}"
+
+
+def test_multi_range_falls_back_to_whole_file(server):
+    """No browser needs multipart ranges for media; serving the whole file is
+    a legal and much simpler answer than building a multipart body."""
+    status, _, body = _get(server, "bytes=0-99,200-299")
+    assert status == 200
+    assert body == BODY
+
+
+def test_garbage_range_is_ignored(server):
+    status, _, body = _get(server, "furlongs=0-99")
+    assert status == 200
+    assert body == BODY
+
+
+@pytest.mark.parametrize("header,size,expected", [
+    ("bytes=0-99", 2048, (0, 99)),
+    ("bytes=100-", 2048, (100, 2047)),
+    ("bytes=-100", 2048, (1948, 2047)),
+    ("bytes=0-99999", 2048, (0, 2047)),      # clamped to the file
+    ("bytes=-99999", 2048, (0, 2047)),       # suffix longer than the file
+    ("bytes=0-99,200-299", 2048, None),      # multi-range -> whole file
+    ("furlongs=0-9", 2048, None),
+    ("bytes=-", 2048, None),
+])
+def test_parse_range(header, size, expected):
+    assert _parse_range(header, size) == expected
+
+
+def test_parse_range_rejects_start_past_end():
+    with pytest.raises(ValueError):
+        _parse_range("bytes=2048-", 2048)


### PR DESCRIPTION
Closes #380. Stage 4, the last of the 3D arc, after Ghost Camera (#372), the flight sculpture (#375) and Camera's Gaze (#378).

The 3D map could put you at the drone's altitude, show the shape of the flight in the air, sweep the camera's footprint along the ground and tell you which seconds filmed any spot you click. All of it is a *reconstruction from telemetry*. Nothing let you check it against the footage itself.

## What this adds

**A blend slider in the cockpit.** Slide it and the terrain reconstruction fades into the real video frame for the second you are looking at; **v** swaps straight between them. Held halfway you see both at once — if the telemetry is right, the horizon and the landmarks line up.

- **`--link-originals` / `--link-base` on `flightmap`**, mirroring `photomap`. Opt-in, because the map only works alongside the videos.
- **Split recordings handled.** DJI closes the container at 4 GB — an Air 3 at 4K/100 Mbps hits that in about five minutes — so a flight often spans several files. The video switches source as the clock crosses each boundary.
- **HTTP Range in the local server**, so seeking works when the map is served over HTTP rather than opened from disk. The existing 360° panorama viewer benefits too.
- **Three new GeoJSON properties**, emitted only when media is linked: `media` (href per segment), `cue_s` (each point's offset within its *own* file) and `seg_i` (per-point segment index, omitted when all zero).

The in-file offset came almost free: each point's SRT cue is already video-relative, and `join_split_flights` rebases `utc` but never `timestamp`. Segment identity had to ride *on the point* rather than as a boundary index, because `_decimate_points` runs after the join and thins the track to ~1 point/second.

## Honesty posture

The tool exists so people can verify footage, so the feature is built to under-claim — and the whole-branch review spent most of its effort here rather than on correctness:

- **The alignment claim is now true by construction.** The video is sized to the container's full height rather than `object-fit: contain`, which only fits by height when the window is wider in aspect than the video — on a 1200×800 window with 16:9 footage it fitted by width instead, compressing the frame ~16% vertically with no indication.
- **A mismatch is not stated as proof of bad telemetry.** The docs now say a mismatch is *consistent with* an attitude error, but also with an estimated or median focal length, terrain and ground-plane approximation, and lens distortion.
- **"Could not load", not "video unavailable"** — the `error` event cannot distinguish a missing file from a codec the browser refuses. DJI's 4K is H.265, which Firefox will not decode at all, so the old wording told users their intact footage was missing. The docs now name that case.
- **Every withheld feature states its reason on the page.** Under `--redact fuzz` the blend is withheld (coarsened positions would invite comparison against geometry we know is wrong) and the panel says so; a segment with no resolvable file says so; a video that fails to load stays disabled with the file named, until the clock reaches another segment.
- **`--link-originals` remains permitted with `--redact fuzz`**, matching `photomap` and warning rather than refusing. Fuzz corrupts *derived geometry*, so deriving geometry from it is refused elsewhere — but a file reference is not a derived claim.
- **The map attribution is no longer coverable** by the overlay at high blend, which is a licence condition rather than a preference.

## Review

Eight tasks, each independently implemented and reviewed, then a whole-branch review on the most capable model. What it caught:

- The alignment claim above — the payoff claim of the entire four-stage arc, conditionally false, carried from spec through implementation into the docs because nobody tested a non-widescreen viewport.
- **Deleting the two lines that call `resolve_media` left all 826 tests green.** The one seam with no coverage was the one a refactor would most easily break silently; it now has a test, proven by deletion.
- The docs contradicted this branch's own spec on whether `file://` needs a server. The spec was right.

Implementers found eight further bugs in the plan's own briefs by stopping to ask rather than guessing — including a variable shadowing that would have broken every test using the new fixture, and a fixture whose decimation assertion could never hold because `_decimate_points` is idempotent.

Test-integrity work continued from the previous arc: a weak `currentTime < 2.0` assertion was replaced with one comparing against the sample's own cue and proven by mutation; the `cue_s` restart is now pinned on both the Python and browser sides.

## Gate

`ruff` clean, `mypy` clean (39 files), `pytest` **830 passed / 3 skipped** (pre-existing environment gates: two need a DJI MP4 fixture and ExifTool ≥ 13.39, one needs network). The browser suite is included, and its harness now runs against the production HTTP handler, so Range is covered end to end by a real media element rather than only by unit tests.

## Deferred, recorded for follow-up

The `v` key firing when there is nothing to blend; an unparseable SRT cue degrading to 0.0 silently; a cue past the video's duration clamping silently; `socketserver` tracebacks on aborted range requests; `Last-Modified`/`If-Range` on 206 responses; and a pre-existing `_relative_times` plateau on a joined flight whose points lack UTC — orthogonal to the crossfade, which uses `cue_s`, but this branch is what made it nameable.
