### PR TITLE
release: prepare version 2.2.0 — the complete 3D arc

### DIFF
--- a/HOUSEKEEPING.md
+++ b/HOUSEKEEPING.md
@@ -1,7 +1,7 @@
 # Repository Housekeeping Recommendations
 
 **Last refreshed:** 2026-06-21
-**Current state:** v2.1.0, production-ready, root directory already slim
+**Current state:** v2.2.0, production-ready, root directory already slim
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release](https://img.shields.io/github/v/release/CallMarcus/dji-drone-metadata-embedder?logo=github)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
-[![Version](https://img.shields.io/badge/version-2.1.0-blue)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
+[![Version](https://img.shields.io/badge/version-2.2.0-blue)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
 [![PyPI](https://img.shields.io/pypi/v/dji-drone-metadata-embedder?logo=pypi)](https://pypi.org/project/dji-drone-metadata-embedder/)
 [![Winget](https://img.shields.io/winget/v/CallMarcus.DJIMetadataEmbedder?logo=windows&label=winget)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/CallMarcus/DJIMetadataEmbedder)
 

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -1,6 +1,6 @@
 # Development Roadmap
 
-_Last updated: 2026-07-23 · Current version: **v2.1.0** · Status: **Production Ready**_
+_Last updated: 2026-07-27 · Current version: **v2.2.0** · Status: **Production Ready**_
 
 This roadmap tracks the evolution of **DJI Drone Metadata Embedder**. The
 original Phase 1–6 plan (standalone Windows GUI, dependency bootstrap,

--- a/docs/external-tool-versions.md
+++ b/docs/external-tool-versions.md
@@ -81,10 +81,10 @@ The image installs ExifTool from apt with no version pin (`apt-get install ffmpe
 
 | dji-embed | FFmpeg | ExifTool | Status |
 |-----------|---------|----------|--------|
-| 2.1.0    | 6.1.1   | 13.59    | ✅ Recommended |
-| 2.1.0    | 6.0.x   | 12.70+   | ✅ Supported |
-| 2.1.0    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
-| 2.1.0    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
+| 2.2.0    | 6.1.1   | 13.59    | ✅ Recommended |
+| 2.2.0    | 6.0.x   | 12.70+   | ✅ Supported |
+| 2.2.0    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
+| 2.2.0    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
 
 ## Known Issues
 
@@ -101,7 +101,7 @@ The image installs ExifTool from apt with no version pin (`apt-get install ffmpe
 The `dji-embed --version` command now shows detected tool versions:
 
 ```
-dji-embed 2.1.0
+dji-embed 2.2.0
   python: python
   ffmpeg: 6.1.1
   exiftool: 13.59

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,6 +1,6 @@
 """DJI Drone Metadata Embedder."""
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 # Import check to ensure files were moved correctly
 try:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -196,7 +196,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "2.1.0"
+    $fallbackVersion = "2.2.0"
     
     try{
         LogInfo "Checking for latest version..."

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.1.0
+PackageVersion: 2.2.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -16,7 +16,7 @@ FileExtensions:
 - dat
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.1.0/dji-embed.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.2.0/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.1.0
+PackageVersion: 2.2.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus
@@ -37,7 +37,7 @@ Tags:
 - srt
 - ffmpeg
 - cli
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.1.0
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.2.0
 PurchaseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder
 InstallationNotes: |
   After installation, run 'dji-embed doctor' to verify dependencies are installed.

--- a/winget/CallMarcus.DJIMetadataEmbedder.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.1.0
+PackageVersion: 2.2.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.1.0
+PackageVersion: 2.2.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -14,7 +14,7 @@ AppsAndFeaturesEntries:
 - ProductCode: '{A0F2FECD-3BEB-4832-9BC6-4A57B20ED947}_is1'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.1.0/dji-metadata-embedder-setup-2.1.0.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.2.0/dji-metadata-embedder-setup-2.2.0.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.1.0
+PackageVersion: 2.2.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus
@@ -37,7 +37,7 @@ Tags:
 - map
 - panorama
 - gui
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.1.0
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.2.0
 InstallationNotes: |
   Start the app from the Start menu ("DJI Metadata Embedder"). The
   dji-embed command is also available in new terminals.

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.1.0
+PackageVersion: 2.2.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Version-string bump across the same 13 files as the 2.1.0 prep, plus the roadmap's "last updated" date. No behaviour changes — the diff is 21 insertions and 21 deletions, all version strings.

Minor bump: four new features since 2.1.0, nothing breaking. The GeoJSON gains properties (additive) and `flightmap` gains flags (additive).

## What 2.2.0 ships — the complete 3D arc

**Ghost Camera (#372)** — fly the map camera to the drone's recorded pose and look out from where it was.

**Flight sculpture (#375)** — altitude you can see from outside: a translucent curtain from the ground to the drone, capped by a ribbon at true flight altitude. MapLibre cannot draw lines at altitude, so this is `fill-extrusion` geometry converted through the terrain so the curtain's length is real ground clearance.

**Camera's Gaze (#378)** — playback on the 3D map (which had none), the camera's ground footprint drawn on the terrain as the clock sweeps, a staircased beam from camera to footprint, riding the flight from inside the cockpit, and **click any spot to get back which seconds of recording covered it**.

**Media crossfade (#380)** — a blend slider that fades the terrain reconstruction into the real video frame for the second you are looking at. Held halfway you see both: if the telemetry is right, they line up. Handles DJI's 4 GB split recordings, and `geo/serve.py` gained HTTP Range so seeking works over HTTP.

## Honesty posture across the arc

This tool exists so people can verify their own footage, so every stage was built to under-claim, and the reviews spent more effort here than on correctness:

- **Estimates are labelled.** Where telemetry carries no gimbal attitude — every Mini-series drone today, see #374 — the cockpit and the footprint are drawn from an assumed 30-degree down-tilt and say so, with a dashed outline and a badge naming exactly what was guessed.
- **Fuzzed positions withdraw the features that would lie about them.** `--redact fuzz` turns off the gaze and the crossfade blend, and the page says why. Linking originals stays permitted, matching `photomap`: fuzz corrupts *derived geometry*, but a file reference is not a derived claim.
- **A negative answer says only what was checked.** "No footprint on this map covers this spot" — plus a count of flights that were not searched, because hidden flights and flights without height data are excluded.
- **Approximations are stated.** Footprints assume flat ground at the drone's height reference; a crossfade mismatch is described as *consistent with* an attitude error but also with an estimated focal length, terrain approximation or lens distortion.

## Verification

Validated on real footage: 5 clips including two genuine 4 GB split pairs, both joining correctly with the video cue restarting at each boundary.

Gate at merge: `ruff` clean, `mypy` clean (39 files), `pytest` 830 passed / 3 pre-existing environment skips, browser suite included.

## Known limitations shipping with this release

- The gaze and cockpit are **estimates on every Mini-series drone** until #374 lands. They say so on screen.
- The crossfade needs the browser to decode the file. DJI's 4K is H.265, which **Firefox will not play at all** and Chrome only with a platform decoder.
- Follow-ups are tracked in #382–#386.
