### PR TITLE
docs: give the 3D features their due in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,18 @@ it's a handful of copy-paste commands. For a guided tour see
 - **See every flight on one map** — point `dji-embed flightmap` at a folder of
   footage and get a single interactive map with each flight as its own
   coloured track *(experimental)*.
-- **Camera's gaze** in the 3D map: play a flight back, watch the camera's
-  ground footprint sweep the terrain, and click any spot to see which seconds
-  of recording covered it.
-- **Crossfade to the footage** — in the 3D map, blend the terrain
-  reconstruction into the real video frame and see whether the telemetry
-  lines up.
+- **Fly it back in 3D** — add `--3d` and the flights are drawn over real
+  terrain instead of a flat map. Each one rises as a translucent curtain from
+  the ground to the drone, so a 30 m hover and a 300 m transit stop looking
+  alike from above, and **View from here** moves the camera to the drone's
+  recorded position and gimbal direction. Press play and it rides the whole
+  flight.
+- **Camera's gaze** — watch the camera's ground footprint sweep the terrain
+  as the flight plays, then click any spot to see which seconds of recording
+  covered it.
+- **Crossfade to the footage** — blend the terrain reconstruction into your
+  real video frame for the second you're looking at, and see whether the
+  telemetry lines up.
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
   folder of stills on one clustered map, thumbnails included; 360° panoramas
   get their own marker color and toggle, and open in an interactive viewer.
@@ -483,7 +489,12 @@ Notes:
   deliberately, or use `--redact fuzz`.
 - `--3d` renders the flights over real 3D terrain (MapLibre + Mapterhorn/
   Copernicus, keyless) as a separate `flightmap-3d.html`, instead of the
-  flat basemap.
+  flat basemap. The 3D map adds altitude curtains, a cockpit view, playback,
+  the camera's ground footprint, and — with `--link-originals` — a crossfade
+  between the terrain and your footage. Each is documented in
+  [docs/geospatial.md](docs/geospatial.md#3d-terrain-view); note that
+  `--redact fuzz` withholds the footprint and the crossfade, because
+  coarsened coordinates cannot honestly say which ground was filmed.
 
 ### `dji-embed photomap` - Map Still Photos
 


### PR DESCRIPTION
Part of a documentation sweep asking a simple question: does a reader landing on our pages come away knowing this tool does 3D?

For the README the answer was "partly, and out of order".

**What was wrong**

- The "What can it do?" list named *Camera's gaze* and the *crossfade* as being "in the 3D map" — but never introduced the 3D map. It first appears ~460 lines later as a flag under `flightmap`. The reader meets the definite article before the noun.
- The **ghost camera** and the **flight sculpture** — the two most visual parts of the arc, and two of the four features in 2.2.0 — were absent entirely.
- The `--3d` flag entry described the *renderer* (MapLibre, Mapterhorn) rather than anything you can do with it.

**What changed**

A new "Fly it back in 3D" bullet introduces the 3D map and covers the sculpture and the cockpit view, so the gaze and crossfade bullets that follow no longer need to name a feature the reader hasn't met.

The `--3d` entry now lists what the 3D map offers, links `docs/geospatial.md`, and states the `--redact fuzz` gate — that fuzzing withholds the footprint and the crossfade, because coarsened coordinates cannot honestly say which ground was filmed.

**Not changed, flagged for a decision**

The flight map bullet still carries *(experimental)*. After two releases of investment that may no longer be the right label, but changing a maturity marker is a call for the maintainer, not a docs sweep.

Reference docs needed no work: `docs/geospatial.md` already gives all four features their own sections, ~180 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UHN2wJZNm8Bj8pFXgJsj7