### PR TITLE
docs: retire the "experimental" label on flightmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ it's a handful of copy-paste commands. For a guided tour see
 
 - **See every flight on one map** — point `dji-embed flightmap` at a folder of
   footage and get a single interactive map with each flight as its own
-  coloured track *(experimental)*.
+  coloured track.
 - **Fly it back in 3D** — add `--3d` and the flights are drawn over real
   terrain instead of a flat map. Each one rises as a translucent curtain from
   the ground to the drone, so a 30 m hover and a 300 m transit stop looking
@@ -402,7 +402,7 @@ dji-embed convert geojson DJI_0001.SRT --footprint --model air3
 dji-embed convert kml DJI_0001.SRT --footprint --footprint-interval 5
 ```
 
-### `dji-embed flightmap` - Combined Flight Map (experimental)
+### `dji-embed flightmap` - Combined Flight Map
 
 Map every flight in a folder of DJI `.SRT` logs on one combined map. Reads
 only the `.SRT` telemetry sidecars — the videos are never opened and no

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -14,7 +14,7 @@ This guide helps you choose the right command and approach for your specific use
 | **Validate file quality** | `dji-embed validate` | Check for timing drift or file issues |
 | **System diagnostics** | `dji-embed doctor` | Troubleshoot installation or dependencies |
 | **Point and click instead of typing** | the desktop app (Windows installer) | Folder in, map/telemetry out — no terminal. |
-| **Map a whole folder of flights** | `dji-embed flightmap` | You want every flight's track on one combined map (experimental) |
+| **Map a whole folder of flights** | `dji-embed flightmap` | You want every flight's track on one combined map |
 | **Map your still photos** | `dji-embed photomap` | You shot geotagged photos and want them on a map |
 | **No terminal at all** | drag the folder onto `dji-embed.exe` | Maps the folder's flight logs and photos, then opens the result in your browser (same as `dji-embed <folder>`) |
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -196,7 +196,7 @@ def main(ctx: click.Context, log_json: bool) -> None:
       embed     Embed telemetry from SRT files into MP4 videos
       validate  Validate SRT/MP4/MOV pairs and report drift
       convert   Convert SRT telemetry to GPX or CSV formats
-      flightmap Map every flight in a folder of SRT logs on one combined map (experimental)
+      flightmap Map every flight in a folder of SRT logs on one combined map
       photomap  Map GPS-tagged still photos to an HTML/KML/GeoJSON map
       check     Analyze video files for embedded metadata
       doctor    Check system dependencies and configuration
@@ -876,7 +876,7 @@ def flightmap(
     verbose: bool,
     quiet: bool,
 ) -> None:
-    """Map every flight in a folder of DJI .SRT logs on one combined map (experimental).
+    """Map every flight in a folder of DJI .SRT logs on one combined map.
 
     Reads only the .SRT telemetry sidecars (fast — the videos are never
     opened) and draws each flight as its own coloured track with a summary


### PR DESCRIPTION
Follow-up from #391, where the docs sweep flagged this but left it as a maintainer call. Marcus's steer: remove it or replace it with "evolving".

**Removed, not softened.**

`flightmap` has shipped since 1.16.0. It is the flagship feature, the [site's](https://callmarcus.com/demo/) primary demo, the mode the desktop app suggests by default, and the foundation the entire 3D arc was built on across 2.1.0 and 2.2.0. "Experimental" implies it might not work or might be withdrawn — neither is true, and a reader deciding whether to rely on it would be misled.

"Evolving" is more accurate but carries no information: every feature in an actively developed tool is evolving, so a label that applies to everything tells the reader nothing they can act on. Where a real caveat exists it should name itself — and 2.2.0's changes to the GeoJSON properties and the flag set were additive, so there isn't one to name.

**All five occurrences**, so the CLI help stops contradicting the docs:

- `README.md` — the "What can it do?" bullet and the `dji-embed flightmap` section heading
- `docs/decision-table.md` — the flight-map row
- `src/dji_metadata_embedder/cli.py` — the command list in the top-level help, and the `flightmap` docstring

No test asserted on the string, so nothing was pinning it.

**Gate:** `ruff` clean, `mypy` clean (39 files), `pytest` 723 passed / 3 pre-existing environment skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UHN2wJZNm8Bj8pFXgJsj7