### PR TITLE
fix(3d): end the gaze pass label at the end of coverage

### DIFF
--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -1301,9 +1301,12 @@ function gazePasses(fl, lngLat) {
   // to name the weakest frame it is offering, not just the first one (the
   // same reasoning gazeRingsFor's own comment gives for keeping the flag per
   // sample -- see #378 whole-branch review, I1).
+  // t1e is where COVERAGE ends -- one interval past the last sample's
+  // timestamp -- so a label built from it reconciles with secs on screen: a
+  // single-sample pass reads t0-(t0+1s) next to "1 s", not t0-t0 (#389).
   const close = () => passes.push({
-    i0: start, i1: prev, t0: times[start], t1: times[prev], secs: secs,
-    est: est, estNotes: notes });
+    i0: start, i1: prev, t0: times[start], t1e: times[prev] + dt(prev),
+    secs: secs, est: est, estNotes: notes });
   hits.forEach(i => {
     if (i > prev + 1) {
       close();
@@ -1402,7 +1405,7 @@ function gazeLookup(ev) {
       b.type = 'button';
       b.className = 'gaze-pass';
       b.textContent = fmtDuration(Math.round(p.t0)) + '\\u2013'
-                    + fmtDuration(Math.round(p.t1));
+                    + fmtDuration(Math.round(p.t1e));
       b.addEventListener('click', () => gazeSeek(fl, p.t0));
       row.appendChild(b);
     });

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -1,6 +1,7 @@
 """Camera's Gaze (#378): footprint projection, patch, beam and lookup."""
 
 import math
+import re
 from datetime import datetime, timedelta
 
 import pytest
@@ -519,6 +520,68 @@ def test_a_pass_button_seeks_and_plays(serve_map, page):
     page.locator(".gaze-pass").first.click()
     assert page.evaluate("() => pb.t") >= 3.0
     assert page.evaluate("() => pb.playing") is True
+
+
+def _pass_label_reconciles(page):
+    """Parse the popup: assert the one pass's label spans the counted seconds.
+
+    The header sums each matched sample's forward interval (deliberate: a
+    single-sample hit must read ~1 s, not zero), so the label has to end where
+    coverage ends -- one interval after the last sample's timestamp -- or the
+    two figures in the same popup disagree on screen (#389).
+    """
+    text = page.locator(".maplibregl-popup").inner_text()
+    m = re.search(r"in frame (\d+) s over 1 pass\b", text)
+    assert m, f"expected exactly one pass in: {text!r}"
+    header_secs = int(m.group(1))
+    label = page.locator(".gaze-pass").first.inner_text()
+    lm = re.fullmatch(r"(\d+):(\d{2})–(\d+):(\d{2})", label)
+    assert lm, f"unexpected pass label format: {label!r}"
+    start = int(lm.group(1)) * 60 + int(lm.group(2))
+    end = int(lm.group(3)) * 60 + int(lm.group(4))
+    assert end - start == header_secs, (
+        f"label {label!r} spans {end - start} s but the header counts "
+        f"{header_secs} s -- the label ends at the last sample instead of "
+        f"the end of its interval")
+
+
+def test_pass_label_spans_the_counted_seconds(serve_map, page):
+    """#389: a multi-sample pass read '6 s' beside a five-second range."""
+    # Samples ~22 m apart so neighbouring footprints overlap the click point
+    # and the pass genuinely covers several samples.
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0,
+                    step=0.0002)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    pt = _click_inside_ring(page, 2)
+    page.wait_for_selector(".gaze-pass", timeout=5000)
+    # Loud precondition: prove this is the multi-sample case, or the test
+    # silently degrades into the single-sample one.
+    span = page.evaluate(
+        "(p) => { const ps = gazePasses(flights[0], {lng: p[0], lat: p[1]});"
+        " return ps.length === 1 ? ps[0].i1 - ps[0].i0 : -1; }", pt)
+    assert span >= 1, f"expected one multi-sample pass, got span {span}"
+    _pass_label_reconciles(page)
+
+
+def test_single_sample_pass_label_has_duration(serve_map, page):
+    """#389's most visible shape: '1 s' beside '2:35–2:35', which reads
+    as no duration at all."""
+    # A None gap isolates sample 0: its neighbour has no ring, and the later
+    # samples are too far east for their footprints to reach the click point.
+    track = _flight("DJI_0001", 10.0, 20.0,
+                    [50.0, None, 50.0, 50.0, 50.0, 50.0],
+                    yaws=[90.0] * 6, pitches=[-90.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    pt = _click_inside_ring(page, 0)
+    page.wait_for_selector(".gaze-pass", timeout=5000)
+    span = page.evaluate(
+        "(p) => { const ps = gazePasses(flights[0], {lng: p[0], lat: p[1]});"
+        " return ps.length === 1 ? ps[0].i1 - ps[0].i0 : -1; }", pt)
+    assert span == 0, f"expected one single-sample pass, got span {span}"
+    _pass_label_reconciles(page)
 
 
 def test_pass_list_caps_at_gaze_max_passes(serve_map, page):


### PR DESCRIPTION
Closes #389.

The gaze click-query popup showed two figures that disagreed: the header counted **6 s** while the pass label read `2:35–2:40`, a five-second range. Both were computed correctly; they measured different things. The header sums each matched sample's *forward* interval (deliberate, so a single-sample hit reads ~1 s rather than zero), while the label printed the first and last *sample timestamps* — ending one interval before coverage actually ends.

## Change

- `gazePasses` now returns `t1e = times[prev] + dt(prev)`, the end of the last sample's interval. The label prints `t0–t1e`, so a single-sample pass reads `2:35–2:36` beside its `1 s` instead of `2:35–2:35`.
- `t1` had no consumer other than the label and is replaced rather than left as a dead field.
- The seek is untouched: clicking a pass still lands the clock at the start of the pass.

## Tests

Two new browser tests, both watched failing first for exactly this defect:

- `test_pass_label_spans_the_counted_seconds` — a multi-sample pass (samples ~22 m apart so neighbouring footprints genuinely overlap the click point), asserting label end minus label start equals the header's count. Failed with `'0:02–0:03' spans 1 s but the header counts 2 s`.
- `test_single_sample_pass_label_has_duration` — the most visible shape of the bug, isolated via a `None`-AGL gap. Failed with `'0:00–0:00' spans 0 s but the header counts 1 s`.

Both carry a loud precondition on what the pass covers (span ≥ 1 / span == 0 via `gazePasses` directly), so geometry drift degrades into a named failure instead of a silently weaker test — the same trap `_click_inside_ring` already guards.

## Gates

Browser suite 109 passed (8m23s), unit 723 passed / 3 env skips, ruff clean, mypy clean.

Found during post-2.2.0 field verification; the quirk is visible in the screenshot currently on callmarcus.com's home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX