### PR TITLE
fix(serve): quiet aborted transfers, add Last-Modified/If-Range to 206

### DIFF
--- a/src/dji_metadata_embedder/geo/serve.py
+++ b/src/dji_metadata_embedder/geo/serve.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import re
+import socket
 import sys
 import threading
 import webbrowser
@@ -93,10 +94,20 @@ class _RangeHandler(SimpleHTTPRequestHandler):
         if not header or os.path.isdir(path):
             return super().send_head()
         try:
-            size = os.stat(path).st_size
+            fs = os.stat(path)
         except OSError:
             self.send_error(HTTPStatus.NOT_FOUND, "File not found")
             return None
+        size = fs.st_size
+        last_modified = self.date_time_string(int(fs.st_mtime))
+        # If-Range: serve the range only when the validator still matches the
+        # file, else fall back to the whole body -- a stale range spliced into
+        # a changed file is silent corruption. The only validator this server
+        # ever issues is Last-Modified (below), so an entity-tag can never
+        # match and the comparison is string equality with what we would send.
+        if_range = self.headers.get("If-Range")
+        if if_range is not None and if_range.strip() != last_modified:
+            return super().send_head()
         try:
             rng = _parse_range(header, size)
         except ValueError:
@@ -123,6 +134,9 @@ class _RangeHandler(SimpleHTTPRequestHandler):
             self.send_header("Content-Type", self.guess_type(path))
             self.send_header("Content-Range", f"bytes {first}-{last}/{size}")
             self.send_header("Content-Length", str(last - first + 1))
+            # The base handler sends this on every 200; a 206 needs it just as
+            # much or the client has no validator for its next If-Range.
+            self.send_header("Last-Modified", last_modified)
             self.end_headers()
             return f
         except Exception:
@@ -153,6 +167,25 @@ class _QuietHandler(_RangeHandler):
         pass
 
 
+class _MapServer(ThreadingHTTPServer):
+    """``ThreadingHTTPServer`` that treats a vanished client as normal.
+
+    Seeking media aborts in-flight range transfers as a matter of course, and
+    the stock ``handle_error`` prints a full traceback for each one — a
+    working server looks broken precisely when it is being used as intended.
+    Anything outside the connection-reset family keeps the stock report.
+    """
+
+    def handle_error(
+        self,
+        request: socket.socket | tuple[bytes, socket.socket],
+        client_address: object,
+    ) -> None:
+        if isinstance(sys.exc_info()[1], ConnectionError):
+            return
+        super().handle_error(request, client_address)
+
+
 def _make_server(directory: Path, *, log_requests: bool = False) -> ThreadingHTTPServer:
     """Build a threading HTTP server for *directory* on a free loopback port.
 
@@ -160,7 +193,7 @@ def _make_server(directory: Path, *, log_requests: bool = False) -> ThreadingHTT
     """
     handler_cls = _RangeHandler if log_requests else _QuietHandler
     handler = partial(handler_cls, directory=str(directory))
-    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server = _MapServer(("127.0.0.1", 0), handler)
     # Don't let an in-flight transfer keep the process alive after Ctrl+C.
     server.daemon_threads = True
     return server

--- a/tests/test_geo_serve_range.py
+++ b/tests/test_geo_serve_range.py
@@ -1,11 +1,14 @@
-"""HTTP Range support in the local map server (#380).
+"""HTTP Range support in the local map server (#380, #385).
 
 The video crossfade is a seek, and Python's stock SimpleHTTPRequestHandler
 ignores Range entirely: Chrome re-requests from byte zero on every seek and
 Safari refuses to play at all.
 """
 
+import socket
+import struct
 import threading
+import time
 import urllib.error
 import urllib.request
 
@@ -27,10 +30,12 @@ def server(tmp_path):
     thread.join(timeout=5)
 
 
-def _get(url, rng=None):
+def _get(url, rng=None, if_range=None):
     req = urllib.request.Request(url)
     if rng is not None:
         req.add_header("Range", rng)
+    if if_range is not None:
+        req.add_header("If-Range", if_range)
     with urllib.request.urlopen(req, timeout=10) as resp:
         return resp.status, dict(resp.headers), resp.read()
 
@@ -112,3 +117,103 @@ def test_parse_range(header, size, expected):
 def test_parse_range_rejects_start_past_end():
     with pytest.raises(ValueError):
         _parse_range("bytes=2048-", 2048)
+
+
+# ---------------------------------------------------------------------------
+# Validators on partial content (#385). A 206 without Last-Modified gives the
+# client nothing to revalidate against, and ignoring If-Range would splice a
+# stale byte range into a changed file. Files rarely change under this
+# loopback server, but "rarely" is not the standard the rest of the tool
+# holds itself to.
+
+def test_206_carries_the_same_last_modified_as_200(server):
+    _, whole, _ = _get(server)
+    status, partial, _ = _get(server, "bytes=0-99")
+    assert status == 206
+    assert "Last-Modified" in whole
+    assert partial.get("Last-Modified") == whole["Last-Modified"]
+
+
+def test_if_range_with_current_validator_gets_206(server):
+    _, whole, _ = _get(server)
+    status, _, body = _get(server, "bytes=0-99",
+                           if_range=whole["Last-Modified"])
+    assert status == 206
+    assert body == BODY[:100]
+
+
+def test_if_range_with_stale_validator_gets_the_whole_file(server):
+    """A changed file must not have an old range spliced into it: If-Range
+    that no longer matches downgrades to the full 200 by design."""
+    status, _, body = _get(server, "bytes=0-99",
+                           if_range="Wed, 21 Oct 2015 07:28:00 GMT")
+    assert status == 200
+    assert body == BODY
+
+
+def test_if_range_with_an_etag_gets_the_whole_file(server):
+    """This server never issues ETags, so an entity-tag validator can never
+    match anything we sent -- the safe answer is the whole file."""
+    status, _, body = _get(server, "bytes=0-99", if_range='"deadbeef"')
+    assert status == 200
+    assert body == BODY
+
+
+# ---------------------------------------------------------------------------
+# Aborted transfers (#385). Seeking media aborts in-flight range requests as
+# a matter of course; each one used to print a full traceback to the serve
+# console, making a working server look broken.
+
+def test_client_disconnect_is_not_reported(tmp_path, capsys):
+    """The connection-reset family is the normal end of an aborted seek."""
+    httpd = _make_server(tmp_path)
+    try:
+        raise ConnectionResetError(104, "peer reset")
+    except ConnectionResetError:
+        httpd.handle_error(None, ("127.0.0.1", 54321))
+    finally:
+        httpd.server_close()
+    assert capsys.readouterr().err == ""
+
+
+def test_genuine_errors_are_still_reported(tmp_path, capsys):
+    """Swallowing must be scoped: a real bug keeps its traceback."""
+    httpd = _make_server(tmp_path)
+    try:
+        raise ValueError("a real bug in the handler")
+    except ValueError:
+        httpd.handle_error(None, ("127.0.0.1", 54321))
+    finally:
+        httpd.server_close()
+    assert "ValueError" in capsys.readouterr().err
+
+
+def test_aborted_range_transfer_leaves_a_clean_console(tmp_path, capsys):
+    """End to end: abort a large range transfer mid-flight, then check the
+    server both survives and says nothing about it."""
+    (tmp_path / "big.bin").write_bytes(b"\0" * (8 * 1024 * 1024))
+    httpd = _make_server(tmp_path)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    port = httpd.server_address[1]
+    try:
+        s = socket.create_connection(("127.0.0.1", port), timeout=10)
+        s.sendall(b"GET /big.bin HTTP/1.1\r\nHost: t\r\n"
+                  b"Range: bytes=0-\r\n\r\n")
+        s.recv(1024)               # the transfer is genuinely under way
+        # SO_LINGER 0 turns close() into an RST, so the server's next write
+        # fails immediately instead of filling socket buffers into the void.
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER,
+                     struct.pack("ii", 1, 0))
+        s.close()
+        time.sleep(0.5)            # let the write loop hit the reset
+        # The server must shrug it off and keep serving.
+        with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/big.bin", timeout=10) as resp:
+            assert resp.status == 200
+            resp.read(1024)
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=5)
+        httpd.server_close()
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
Closes #385. Both robustness items deferred from #380's review, and the second is implemented rather than documented away — it turned out to be a dozen lines.

## Aborted transfers no longer print tracebacks

`_QuietHandler` silenced `log_message` only; `socketserver`'s `handle_error` still printed a full traceback per aborted transfer. Rapid seeking aborts range requests mid-flight constantly — now that seeking is the point of the feature, a working server looked broken precisely when it was being used as intended.

New `_MapServer` overrides `handle_error` to swallow the `ConnectionError` family only; a genuine bug in a handler keeps its stock traceback (pinned by a test).

## 206 responses carry `Last-Modified`, and `If-Range` is honoured

Previously a 206 gave the client no validator at all, and an `If-Range` was ignored — which risks splicing a stale byte range into a changed file. Now:

- 206 sends the same `Last-Modified` a 200 would (string-identical, pinned by a test).
- `If-Range` matching the current validator → 206 as before.
- A stale or entity-tag validator → whole-file 200. This server never issues ETags, so an entity tag can never match anything we sent; the safe answer is the full body.

## Tests

Seven new, each watched failing first (except the two scope guards, which pass by design and pin that the fix doesn't over-reach):

- direct `handle_error` calls: `ConnectionResetError` silent / `ValueError` still reported
- end-to-end: an 8 MB range transfer aborted mid-flight via SO_LINGER-0 RST leaves a clean stderr and the server keeps serving
- `Last-Modified` parity between 200 and 206
- `If-Range` current → 206, stale → 200, ETag → 200

## Gates

Unit 730 passed / 3 env skips, crossfade browser tests 16 passed (they run against the production `_RangeHandler`), ruff clean, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX