### PR TITLE
fix(3d): five silent-degradation and rendering follow-ups

### DIFF
--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -317,8 +317,8 @@ def _relative_times(points: list[TrackPoint]) -> list[float]:
         assert base is not None
         raw = [(p.utc - base).total_seconds() for p in points if p.utc is not None]
     else:
-        base_cue = _cue_seconds(points[0].timestamp)
-        raw = [_cue_seconds(p.timestamp) - base_cue for p in points]
+        base_cue = _cue_seconds(points[0].timestamp) or 0.0
+        raw = [(_cue_seconds(p.timestamp) or 0.0) - base_cue for p in points]
     times: list[float] = []
     for t in raw:
         t = round(t, 1)
@@ -365,9 +365,10 @@ def _add_media_props(properties: dict, track: Track) -> None:
     if not track.media:
         return
     properties["media"] = list(track.media)
-    properties["cue_s"] = [
-        round(_cue_seconds(p.timestamp), 3) for p in track.points
-    ]
+    # null, not 0.0, for a corrupt cue: the viewer states "no timecode"
+    # instead of silently seeking the overlay to frame zero (#384).
+    cues = [_cue_seconds(p.timestamp) for p in track.points]
+    properties["cue_s"] = [None if c is None else round(c, 3) for c in cues]
     segs = [p.segment for p in track.points]
     if any(segs):
         properties["seg_i"] = segs

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -413,7 +413,20 @@ function ghostKeys(ev) {
   else if (ev.key === 'ArrowLeft') { ghostStep(-1); ev.preventDefault(); }
   else if (ev.key === 'ArrowRight') { ghostStep(1); ev.preventDefault(); }
   else if (ev.key === 'v' || ev.key === 'V') {
-    setBlend(cross.blend > 0.5 ? 0 : 1);
+    const slider = document.getElementById('ghost-blend');
+    if (cross.el && slider && !slider.disabled) {
+      setBlend(cross.blend > 0.5 ? 0 : 1);
+    } else if (!slider) {
+      // No crossfade mounted at all (redacted positions, or no linked
+      // video): say why the key does nothing instead of mutating a blend
+      // nothing displays (#384).
+      crossBadgeOnce(REDACTED !== 'none'
+        ? 'blend unavailable \\u2014 positions are redacted'
+        : 'blend unavailable \\u2014 no video linked for this flight');
+    }
+    // A DISABLED slider needs no badge from here: whatever disabled it
+    // (broken file, no frame for this second) already posted the reason,
+    // and the key must not mutate state underneath it.
     ev.preventDefault();
   }
 }
@@ -932,6 +945,31 @@ function renderGaze() {
   }
 }
 
+function beamFillLocals(locals, tElev, farElev) {
+  // Estimate cold DEM boundaries from their known neighbours (linear
+  // between the nearest known samples; constant extension at the ends).
+  // With NOTHING known, assume the flat plane gazeRing itself projects
+  // onto -- which reproduces the pre-#384 clearance exactly, so a wholly
+  // cold ray degrades no further than it always did.
+  const n = locals.length;
+  if (!locals.some(v => v != null)) {
+    for (let k = 0; k < n; k++) {
+      locals[k] = tElev + (farElev - tElev) * (k / (n - 1));
+    }
+    return;
+  }
+  for (let k = 0; k < n; k++) {
+    if (locals[k] != null) continue;
+    let p = k - 1;                        // already filled, so never null
+    let q = k + 1;
+    while (q < n && locals[q] == null) q++;
+    const a = p >= 0 ? locals[p] : null;
+    const b = q < n ? locals[q] : null;
+    locals[k] = a == null ? b
+      : (b == null ? a : a + (b - a) * ((k - p) / (q - p)));
+  }
+}
+
 function beamFor(fl, i, ring) {
   const feats = [];
   if (!ring) return feats;
@@ -958,17 +996,26 @@ function beamFor(fl, i, ring) {
     // -- and the ray would follow the ground contour instead of flying
     // straight over the ridges and valleys it crosses.
     const hs = [];
-    for (let k = 0; k <= GAZE_BEAM_STEPS; k++) {
-      const s = k / GAZE_BEAM_STEPS;
-      if (camTrue == null || cornerElev == null) {
+    if (camTrue == null || cornerElev == null) {
+      for (let k = 0; k <= GAZE_BEAM_STEPS; k++) {
         // Terrain off: the extrusion measures from sea level, so raw AGL is
         // already the right clearance.
-        hs.push(agl * (1 - s));
-        continue;
+        hs.push(agl * (1 - k / GAZE_BEAM_STEPS));
       }
-      const local = terrainElevAt(at(s));
-      const alt = camTrue + (farElev - camTrue) * s;
-      hs.push(local == null ? agl * (1 - s) : alt - local);
+    } else {
+      // Sample the surface first, then fill cold boundaries from their known
+      // neighbours: a null mid-ray sample must not switch height datums --
+      // the old agl*(1-s) fallback among terrain-relative neighbours kinked
+      // the ray upward at exactly that boundary (#384).
+      const locals = [];
+      for (let k = 0; k <= GAZE_BEAM_STEPS; k++) {
+        locals.push(terrainElevAt(at(k / GAZE_BEAM_STEPS)));
+      }
+      beamFillLocals(locals, tElev, farElev);
+      for (let k = 0; k <= GAZE_BEAM_STEPS; k++) {
+        const s = k / GAZE_BEAM_STEPS;
+        hs.push(camTrue + (farElev - camTrue) * s - locals[k]);
+      }
     }
     for (let k = 0; k < GAZE_BEAM_STEPS; k++) {
       const hgt = Math.max(hs[k], hs[k + 1]);
@@ -1114,8 +1161,11 @@ function pbDriveGhost() {
 function applyGazeVisibility() {
   const v = (pb.run && pb.run.shown) ? 'visible' : 'none';
   // The beam originates at the camera, so it hides in the cockpit for the
-  // same reason the sculpture does; the patch is what you came to see.
-  const beam = (v === 'visible' && !ghost.active) ? 'visible' : 'none';
+  // same reason the sculpture does; the patch is what you came to see. But
+  // only when the cockpit rides the SAME flight the clock is playing --
+  // another flight's beam is nowhere near your eye (#384).
+  const beam = (v === 'visible' && !(ghost.active && ghost.flight === pb.run))
+    ? 'visible' : 'none';
   // gaze-hits-line is NOT here: a lookup highlight can span several flights
   // at once, so it has no single pb.run to follow. It stays laid out
   // 'visible' always; its own source data (emptied by gazeHighlight([]) on
@@ -1514,6 +1564,18 @@ function crossBadge(text) {
   badges.appendChild(s);
 }
 
+function crossBadgeOnce(text) {
+  // For badges posted outside the updateHud -> render cycle (the 'v' key):
+  // nothing clears #ghost-badges between two presses, so an unconditional
+  // append would stack duplicates.
+  const badges = ghost.hud && ghost.hud.querySelector('#ghost-badges');
+  if (!badges) return;
+  for (const el of badges.children) {
+    if (el.textContent === text) return;
+  }
+  crossBadge(text);
+}
+
 function mountCrossfade() {
   // Fuzzed positions are deliberately ~100 m out, so overlaying real footage
   // would invite a comparison against geometry we know is wrong. Linking is
@@ -1536,6 +1598,11 @@ function mountCrossfade() {
       cross.pending = null;
       seekCrossfade(t);
     }
+    // The duration is only known from here on: re-render so a timecode past
+    // the video's end posts its badge even while the user sits still, not
+    // one step later (#384). updateHud first -- it clears #ghost-badges, so
+    // rendering without it would stack a duplicate of every badge.
+    if (ghost.active) { updateHud(); renderCrossfade(); }
   });
   v.addEventListener('error', () => {
     // A blank overlay reads as "the camera saw nothing here". Name the file
@@ -1611,6 +1678,16 @@ function renderCrossfade() {
     syncCrossfadePlayback();
     return;
   }
+  if (m.t == null) {
+    // A corrupt SRT cue reaches the viewer as a null timecode: refusing to
+    // guess beats silently seeking the overlay to frame zero under a HUD
+    // that reports a later second (#384).
+    cross.el.style.display = 'none';
+    if (slider) slider.disabled = true;
+    crossBadge('no video timecode for this second');
+    syncCrossfadePlayback();
+    return;
+  }
   if (m.seg !== cross.seg) {
     cross.seg = m.seg;
     cross.pending = m.t;
@@ -1635,6 +1712,19 @@ function renderCrossfade() {
     cross.el.style.display = 'none';
     if (slider) slider.disabled = true;
     crossBadge('could not load: ' + cross.broken);
+    syncCrossfadePlayback();
+    return;
+  }
+  if (cross.el.readyState >= 1 && Number.isFinite(cross.el.duration)
+      && m.t > cross.el.duration + 0.05) {
+    // Telemetry can outlast its own recording. The browser clamps the seek
+    // to the last frame, which would freeze the overlay under an advancing
+    // clock -- say what happened instead of standing on a stale frame (#384).
+    cross.el.style.display = 'none';
+    if (slider) slider.disabled = true;
+    crossBadge('video ends at '
+               + fmtDuration(Math.round(cross.el.duration))
+               + ' \\u2014 no frame for this second');
     syncCrossfadePlayback();
     return;
   }

--- a/src/dji_metadata_embedder/geo/track.py
+++ b/src/dji_metadata_embedder/geo/track.py
@@ -59,11 +59,18 @@ class Track:
     media: list[str | None] | None = None
 
 
-def _cue_seconds(cue: str) -> float:
-    """Convert an SRT cue ``HH:MM:SS,mmm`` into total seconds (0.0 if unparseable)."""
+def _cue_seconds(cue: str) -> float | None:
+    """Convert an SRT cue ``HH:MM:SS,mmm`` into total seconds.
+
+    ``None`` for an unparseable cue: 0.0 would masquerade as the video's
+    first frame, and the 3D map's crossfade would silently show frame zero
+    while its HUD reports a later second (#384). Callers that only need a
+    clock offset fall back to 0.0 themselves — a degraded clock is clamped
+    downstream, but a fabricated media timecode is not recoverable.
+    """
     m = re.match(r"(\d{2}):(\d{2}):(\d{2}),(\d{3})", cue)
     if not m:
-        return 0.0
+        return None
     h, mnt, s, ms = (int(g) for g in m.groups())
     return h * 3600 + mnt * 60 + s + ms / 1000.0
 
@@ -114,7 +121,7 @@ def build_track_from_samples(
         abs_times = [s.dt for s in samples if s.dt is not None]
         assert mtime_utc is not None, "mtime_utc is required when assume_utc is False"
         offset = resolve_utc_offset(abs_times, tz_offset, mtime_utc)
-    base_cue = _cue_seconds(samples[0].cue) if samples else 0.0
+    base_cue = (_cue_seconds(samples[0].cue) or 0.0) if samples else 0.0
 
     coords = redact_coords([(s.lat, s.lon) for s in samples], redact)
     if redact == "drop":
@@ -129,7 +136,8 @@ def build_track_from_samples(
         if s.dt is not None and offset is not None:
             utc = s.dt - offset
         elif mtime_utc is not None:
-            utc = mtime_utc + timedelta(seconds=_cue_seconds(s.cue) - base_cue)
+            utc = mtime_utc + timedelta(
+                seconds=(_cue_seconds(s.cue) or 0.0) - base_cue)
         else:
             utc = None
         points.append(

--- a/tests/browser/test_flightmap_3d_playback.py
+++ b/tests/browser/test_flightmap_3d_playback.py
@@ -250,6 +250,23 @@ def test_beam_hides_in_the_cockpit(serve_map, page):
     assert page.evaluate(vis, "beam-ray") == "visible"
 
 
+def test_beam_stays_up_when_riding_a_different_flight(serve_map, page):
+    """#384: the beam used to hide during ANY ghost session. Riding flight B
+    while the clock plays flight A hid A's beam, which is nowhere near your
+    eye -- only the ridden flight's own beam can fill the frame."""
+    serve_map(flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, 6),
+         _flight("DJI_0002", 10.05, 20.05, 6)], "trip"))
+    _ready(page)
+    vis = "(id) => map.getLayoutProperty(id, 'visibility') || 'visible'"
+    assert page.evaluate("() => pb.run === flights[0]") is True
+    page.evaluate("() => ghostEnter(1, 0)")      # ride the OTHER flight
+    assert page.evaluate(vis, "beam-ray") == "visible"
+    page.evaluate("() => ghostExit()")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    assert page.evaluate(vis, "beam-ray") == "visible"
+
+
 def test_bearing_scrub_takes_the_short_way_round(serve_map, page):
     """posePlayback's wraparound arithmetic is the only non-obvious math in
     this task, and every other fixture in this file uses a constant yaw

--- a/tests/browser/test_flightmap_crossfade.py
+++ b/tests/browser/test_flightmap_crossfade.py
@@ -188,6 +188,46 @@ def test_a_segment_without_video_disables_the_blend(serve_map, page,
     assert "no video for this part of the flight" in note
 
 
+def test_a_sample_without_a_timecode_hides_the_video_and_says_why(
+        serve_map, page, recorded_webm):
+    """#384: a corrupt SRT cue used to seek the overlay to frame zero with no
+    indication -- the HUD reported a later second over the wrong frame."""
+    track = _flight("DJI_0001", media=[VIDEO_NAME])
+    track.points[1].timestamp = "garbled"
+    _serve_with_video(serve_map, recorded_webm, track)
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 1)")
+    page.wait_for_function(
+        "() => document.getElementById('ghost-badges')"
+        ".textContent.includes('timecode')", timeout=5000)
+    assert page.evaluate(
+        "() => document.getElementById('ghost-video').style.display"
+    ) == "none"
+    assert page.evaluate(
+        "() => document.getElementById('ghost-blend').disabled") is True
+
+
+def test_a_timecode_past_the_video_end_says_so(serve_map, page,
+                                               recorded_webm):
+    """#384: telemetry can outlast its own recording. The browser clamps the
+    seek to the last frame, which used to freeze the overlay under an
+    advancing clock with no explanation."""
+    track = _flight("DJI_0001", media=[VIDEO_NAME])
+    for p in track.points:
+        p.timestamp = "01:00:00,000"      # an hour into a seconds-long clip
+    _serve_with_video(serve_map, recorded_webm, track)
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function(
+        "() => document.getElementById('ghost-badges')"
+        ".textContent.includes('video ends')", timeout=10000)
+    assert page.evaluate(
+        "() => document.getElementById('ghost-video').style.display"
+    ) == "none"
+    assert page.evaluate(
+        "() => document.getElementById('ghost-blend').disabled") is True
+
+
 def test_plays_in_sync_at_normal_speed(serve_map, page, recorded_webm):
     _serve_with_video(serve_map, recorded_webm,
                       _flight("DJI_0001", media=[VIDEO_NAME]))
@@ -232,6 +272,43 @@ def test_5x_playback_seeks_instead_of_playing(serve_map, page, recorded_webm):
     page.wait_for_function("() => pb.t > 2", timeout=10000)
     assert page.evaluate(
         "() => document.getElementById('ghost-video').paused") is True
+
+
+def test_v_key_under_fuzz_says_why_instead_of_mutating(serve_map, page,
+                                                       recorded_webm):
+    """#384: 'v' used to flip cross.blend invisibly when no crossfade was
+    mounted -- the key appeared to do nothing rather than saying why."""
+    _serve_with_video(serve_map, recorded_webm,
+                      _flight("DJI_0001", media=[VIDEO_NAME]), redact="fuzz")
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.keyboard.press("v")
+    assert page.evaluate("() => cross.blend") == 0
+    assert "redacted" in page.locator("#ghost-badges").inner_text()
+
+
+def test_v_key_without_media_says_why(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001")], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.keyboard.press("v")
+    assert page.evaluate("() => cross.blend") == 0
+    assert "no video" in page.locator("#ghost-badges").inner_text()
+
+
+def test_v_key_on_a_disabled_blend_leaves_state_alone(serve_map, page):
+    """The disabled slider's badge already names the reason; 'v' must not
+    mutate the blend underneath it or wipe that badge (#384)."""
+    serve_map(flights_to_3d_html(
+        [_flight("DJI_0001", media=["gone.webm"])], "trip"))
+    _ready(page)
+    page.evaluate("() => ghostEnter(0, 0)")
+    page.wait_for_function(
+        "() => document.getElementById('ghost-blend').disabled === true",
+        timeout=10000)
+    page.keyboard.press("v")
+    assert page.evaluate("() => cross.blend") == 0
+    assert "gone.webm" in page.locator("#ghost-badges").inner_text()
 
 
 def test_a_broken_video_disables_the_blend_and_names_the_file(serve_map, page):

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -372,6 +372,43 @@ _BEAM_SPY_JS = """
 """
 
 
+def test_beam_survives_a_cold_mid_ray_dem_sample(serve_map, page):
+    """#384: when the camera and corner elevations are known but one mid-ray
+    terrainElevAt returns null on a partially warm DEM, that boundary used to
+    fall back to takeoff-relative agl*(1-s) among terrain-relative
+    neighbours -- kinking the ray upward at exactly that boundary. The
+    missing surface sample must be estimated from its known neighbours."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 3,
+                    yaws=[90.0] * 3, pitches=[-45.0] * 3, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    steps = page.evaluate("() => GAZE_BEAM_STEPS")
+    assert steps % 2 == 0, "test geometry needs a boundary at s=0.5"
+    hgts = page.evaluate(
+        """(steps) => {
+          const fl = flights[0];
+          const c = fl.pts[0];
+          const corner = [c[0] + 0.001, c[1]];
+          // Camera and corner warm (100 m), a 115 m ridge under the middle
+          // of the ray, and exactly one cold sample at the s=0.5 boundary.
+          terrainElevAt = (ll) => {
+            const s = (ll[0] - c[0]) / 0.001;
+            if (Math.abs(s - 0.5) < 1 / (4 * steps)) return null;
+            if (s > 0.34 && s < 0.66) return 115.0;
+            return 100.0;
+          };
+          const ring = [corner, corner, corner, corner, corner];
+          return beamFor(fl, 0, ring).map(f => f.properties.hgt);
+        }""", steps)
+    assert len(hgts) == steps * 4          # no prism skipped, four rays
+    # The two prisms sharing the cold boundary. With agl=50 the ray runs
+    # 150 m down to 100 m; over the ridge its true clearance is ~13.1 m and
+    # ~10 m here. The old fallback put the shared boundary at agl*(1-s)=25 m.
+    a, b = steps // 2 - 1, steps // 2
+    assert hgts[a] < 15, f"prism {a} spiked to {hgts[a]}"
+    assert hgts[b] < 15, f"prism {b} spiked to {hgts[b]}"
+
+
 def test_beam_width_tracks_zoom(serve_map, page):
     track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 5,
                     yaws=[90.0] * 5, pitches=[-50.0] * 5, focal=24.0)

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -601,6 +601,29 @@ def test_geojson_cue_s_is_the_in_file_offset():
     assert "seg_i" not in props          # single segment: omitted
 
 
+def test_cue_seconds_refuses_an_unparseable_cue():
+    """0.0 would masquerade as the video's first frame; None says plainly
+    that there is no timecode (#384)."""
+    from dji_metadata_embedder.geo.track import _cue_seconds
+
+    assert _cue_seconds("00:01:02,500") == 62.5
+    assert _cue_seconds("garbled") is None
+
+
+def test_geojson_cue_s_is_null_for_an_unparseable_cue():
+    """A corrupt cue must not claim second zero: the crossfade would silently
+    show the first frame while the HUD reports a later second (#384)."""
+    from dji_metadata_embedder.geo.flightmap import flights_to_geojson
+
+    track = _ghost_track()
+    track.media = ["DJI_0001.MP4"]
+    track.points[1].timestamp = "garbled"
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert props["cue_s"][1] is None
+    assert props["cue_s"][0] == 0.0
+    assert len(props["cue_s"]) == len(track.points)
+
+
 def test_geojson_seg_i_emitted_only_when_split():
     from dji_metadata_embedder.geo.flightmap import flights_to_geojson
 


### PR DESCRIPTION
Closes #384. All five items, each built test-first with the failing test watched before the fix.

## Silent degradations

**1. Unparseable SRT cue → stated, not frame zero.** `_cue_seconds` now returns `None` instead of `0.0`, `cue_s` carries `null` for that point, and the cockpit posts *"no video timecode for this second"* with the video hidden and the slider disabled. Clock callers (`times_s` fallback, mtime-based UTC inference) keep their old `0.0` fallback with the reasoning stated in the docstring: a degraded clock is clamped downstream, but a fabricated media timecode is not recoverable.

**2. Timecode past the video's end → badge.** Telemetry that outlasts its own recording used to freeze the overlay on the last frame under an advancing clock. Now: *"video ends at M:SS — no frame for this second"*, video hidden, slider disabled. `loadedmetadata` re-renders (after `updateHud`, which owns badge clearing) so the badge appears while the user sits still rather than one step later.

**3. The `v` key explains itself.** It used to call `setBlend` unconditionally — mutating `cross.blend` invisibly under `--redact fuzz`, with no media, and over a disabled slider. Now: toggles only when the slider is live; with no crossfade mounted it posts why (*positions are redacted* / *no video linked for this flight*, deduped via a `crossBadgeOnce` helper since nothing clears badges between presses); over a disabled slider it does nothing and leaves the existing reason badge standing.

## Rendering correctness

**4. `beamFor` no longer switches height datums at a cold mid-ray DEM sample.** A null `terrainElevAt` between known camera/corner elevations used to fall back to takeoff-relative `agl*(1-s)` among terrain-relative neighbours, kinking the ray upward at exactly that boundary (the test pins the old spike at 25 m where the true clearance is ~10 m). The missing surface sample is now estimated from its known neighbours; a wholly cold ray reproduces the pre-fix clearance exactly, so nothing degrades further than it already did.

**5. The beam hides only for its own flight's cockpit.** Riding flight B while the clock plays flight A used to hide A's beam, which is nowhere near your eye. `applyGazeVisibility` now uses the same flight-identity check `pbDriveGhost` already had; the existing same-flight hide test still passes.

## Gates

Browser suite 114 passed (8m33s), unit 725 passed / 3 env skips, ruff clean, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX