### PR TITLE
perf(3d): wall-clock throttle on beam rebuilds while playing

### DIFF
--- a/src/dji_metadata_embedder/geo/flightmap3d_gaze_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_gaze_js.py
@@ -94,7 +94,9 @@ const GAZE_PATCH_OPACITY = 0.25;
 // continuous rather than a ladder.
 const GAZE_BEAM_STEPS = 16;
 const GAZE_BEAM_OPACITY = 0.5;
-const gaze = { dashed: false };
+const gaze = { dashed: false, beamAt: 0 };
+const BEAM_MIN_MS = 85;   // ~12 beam rebuilds/s while the clock free-runs
+                          // (#382: measured, not guessed -- see the issue)
 
 function addGazeLayers() {
   // Below the flight lines: a track must stay readable through its own patch.
@@ -147,8 +149,20 @@ function renderGaze() {
   }
   const bsrc = map.getSource('beam');
   if (bsrc) {
-    bsrc.setData({ type: 'FeatureCollection',
-                   features: beamFor(pb.run, pb.sample, g.ring) });
+    // Wall-clock throttle while the clock free-runs (#382): each staircase
+    // rebuild costs ~(GAZE_BEAM_STEPS + 1) * 4 terrain queries, measured at
+    // roughly a third of the frame budget at 60x on real hardware -- and
+    // nobody can track individual rays at that speed. Presentation only:
+    // the patch above stays per-sample (it costs no terrain queries), the
+    // click lookup is untouched, and every PAUSED render -- step, scrub,
+    // pbPause itself -- rebuilds exactly, so any resting state shows the
+    // true beam for the current sample.
+    const now = performance.now();
+    if (!pb.playing || now - gaze.beamAt >= BEAM_MIN_MS) {
+      gaze.beamAt = now;
+      bsrc.setData({ type: 'FeatureCollection',
+                     features: beamFor(pb.run, pb.sample, g.ring) });
+    }
   }
   if (g.estimated !== gaze.dashed) {
     gaze.dashed = g.estimated;
@@ -400,6 +414,9 @@ function pbPause() {
   if (b) b.textContent = '\\u25b6';
   if (pb.raf) cancelAnimationFrame(pb.raf);
   pb.raf = null;
+  // The free-running throttle above may have skipped the last rebuild;
+  // a resting map must show the true beam for the current sample (#382).
+  renderGaze();
 }
 
 function pbTick(now) {

--- a/tests/browser/test_flightmap_gaze.py
+++ b/tests/browser/test_flightmap_gaze.py
@@ -398,6 +398,47 @@ def test_render_reuses_the_ring_cache(serve_map, page):
     assert counts["second"] == 0, "renderGaze recomputed a memoised ring"
 
 
+def test_beam_rebuilds_are_throttled_while_playing(serve_map, page):
+    """#382, measured 2026-07-28: at 60x the beam's staircase costs ~3.1k
+    terrain queries/s on real hardware -- a third of the frame budget spent
+    on lookups alone. While the clock free-runs, beam rebuilds are
+    wall-clock throttled; every paused render (step, scrub, and pbPause
+    itself) rebuilds exactly, so any resting state shows the true beam."""
+    track = _flight("DJI_0001", 10.0, 20.0, [50.0] * 6,
+                    yaws=[90.0] * 6, pitches=[-45.0] * 6, focal=24.0)
+    serve_map(flights_to_3d_html([track], "trip"))
+    _ready(page)
+    counts = page.evaluate(
+        """() => {
+          const orig = beamFor;
+          let n = 0;
+          beamFor = (fl, i, ring) => { n += 1; return orig(fl, i, ring); };
+          pb.playing = true;
+          gaze.beamAt = 0;                  // stale stamp: first build runs
+          pb.sample = 0; renderGaze();
+          const first = n;
+          pb.sample = 1; renderGaze();      // microseconds later: throttled
+          const second = n - first;
+          pb.playing = false;
+          pb.sample = 2; renderGaze();      // paused: always exact
+          const third = n - first - second;
+          pb.playing = true;
+          gaze.beamAt = performance.now();  // fresh stamp: throttled
+          pb.sample = 3; renderGaze();
+          const fourth = n - first - second - third;
+          pbPause();                        // pausing rebuilds exactly
+          const fifth = n - first - second - third - fourth;
+          beamFor = orig;
+          return { first: first, second: second, third: third,
+                   fourth: fourth, fifth: fifth };
+        }""")
+    assert counts["first"] == 1
+    assert counts["second"] == 0, "a free-running rebuild dodged the throttle"
+    assert counts["third"] == 1, "a paused render must rebuild exactly"
+    assert counts["fourth"] == 0
+    assert counts["fifth"] == 1, "pausing must leave the true beam standing"
+
+
 def test_beam_survives_a_cold_mid_ray_dem_sample(serve_map, page):
     """#384: when the camera and corner elevations are known but one mid-ray
     terrainElevAt returns null on a partially warm DEM, that boundary used to


### PR DESCRIPTION
Closes #382. The issue's own order was followed: **measure first** — the paste-into-console harness and two runs on real hardware are on the issue (~3,100 DEM calls/s and ~320 ms/s of main thread during *active* 60× playback once the idle tail is factored out; ~1 in 10 playback frames over 33 ms).

## Change

Lever 2 from the issue body: while the clock free-runs, beam rebuilds are capped at ~12/s (`BEAM_MIN_MS = 85`) — an ~80% cut of the dominant measured cost, at a speed where nobody can track individual staircase rays anyway.

The issue's evidence/presentation boundary is kept explicitly:

- **The click-a-spot lookup is untouched** — which seconds filmed a spot never changes.
- **The patch stays per-sample** — it is the footprint itself and costs zero terrain queries (draped fill).
- **Every paused render rebuilds exactly** — stepping, scrubbing, and `pbPause` itself (which now forces a final rebuild), so no resting map ever shows a stale beam.

Lever 3 (`GAZE_BEAM_STEPS` scaling with speed) stays in the drawer unless a slower machine still stutters after this; the frame-budget controller stays rejected as over-engineering.

## Test

`test_beam_rebuilds_are_throttled_while_playing` (watched failing first): counts `beamFor` calls through five renders — first build runs, a free-running rebuild inside the window is skipped, a paused render rebuilds, a fresh-stamp playing render is skipped, and `pbPause` forces the final exact rebuild.

## Gates

Browser suite 84 + 34 (gaze file) passed, unit 734 passed / 3 env skips, ruff clean, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX