### PR TITLE
release: prepare version 2.2.1

### DIFF
--- a/HOUSEKEEPING.md
+++ b/HOUSEKEEPING.md
@@ -1,7 +1,7 @@
 # Repository Housekeeping Recommendations
 
 **Last refreshed:** 2026-06-21
-**Current state:** v2.2.0, production-ready, root directory already slim
+**Current state:** v2.2.1, production-ready, root directory already slim
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release](https://img.shields.io/github/v/release/CallMarcus/dji-drone-metadata-embedder?logo=github)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
-[![Version](https://img.shields.io/badge/version-2.2.0-blue)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
+[![Version](https://img.shields.io/badge/version-2.2.1-blue)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
 [![PyPI](https://img.shields.io/pypi/v/dji-drone-metadata-embedder?logo=pypi)](https://pypi.org/project/dji-drone-metadata-embedder/)
 [![Winget](https://img.shields.io/winget/v/CallMarcus.DJIMetadataEmbedder?logo=windows&label=winget)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/CallMarcus/DJIMetadataEmbedder)
 

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -1,6 +1,6 @@
 # Development Roadmap
 
-_Last updated: 2026-07-27 · Current version: **v2.2.0** · Status: **Production Ready**_
+_Last updated: 2026-07-27 · Current version: **v2.2.1** · Status: **Production Ready**_
 
 This roadmap tracks the evolution of **DJI Drone Metadata Embedder**. The
 original Phase 1–6 plan (standalone Windows GUI, dependency bootstrap,

--- a/docs/external-tool-versions.md
+++ b/docs/external-tool-versions.md
@@ -81,10 +81,10 @@ The image installs ExifTool from apt with no version pin (`apt-get install ffmpe
 
 | dji-embed | FFmpeg | ExifTool | Status |
 |-----------|---------|----------|--------|
-| 2.2.0    | 6.1.1   | 13.59    | ✅ Recommended |
-| 2.2.0    | 6.0.x   | 12.70+   | ✅ Supported |
-| 2.2.0    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
-| 2.2.0    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
+| 2.2.1    | 6.1.1   | 13.59    | ✅ Recommended |
+| 2.2.1    | 6.0.x   | 12.70+   | ✅ Supported |
+| 2.2.1    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
+| 2.2.1    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
 
 ## Known Issues
 
@@ -101,7 +101,7 @@ The image installs ExifTool from apt with no version pin (`apt-get install ffmpe
 The `dji-embed --version` command now shows detected tool versions:
 
 ```
-dji-embed 2.2.0
+dji-embed 2.2.1
   python: python
   ffmpeg: 6.1.1
   exiftool: 13.59

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,6 +1,6 @@
 """DJI Drone Metadata Embedder."""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 # Import check to ensure files were moved correctly
 try:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -196,7 +196,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "2.2.0"
+    $fallbackVersion = "2.2.1"
     
     try{
         LogInfo "Checking for latest version..."

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.2.0
+PackageVersion: 2.2.1
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -16,7 +16,7 @@ FileExtensions:
 - dat
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.2.0/dji-embed.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.2.1/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.2.0
+PackageVersion: 2.2.1
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus
@@ -37,7 +37,7 @@ Tags:
 - srt
 - ffmpeg
 - cli
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.2.0
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.2.1
 PurchaseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder
 InstallationNotes: |
   After installation, run 'dji-embed doctor' to verify dependencies are installed.

--- a/winget/CallMarcus.DJIMetadataEmbedder.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.2.0
+PackageVersion: 2.2.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.2.0
+PackageVersion: 2.2.1
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -14,7 +14,7 @@ AppsAndFeaturesEntries:
 - ProductCode: '{A0F2FECD-3BEB-4832-9BC6-4A57B20ED947}_is1'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.2.0/dji-metadata-embedder-setup-2.2.0.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.2.1/dji-metadata-embedder-setup-2.2.1.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.2.0
+PackageVersion: 2.2.1
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus
@@ -37,7 +37,7 @@ Tags:
 - map
 - panorama
 - gui
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.2.0
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.2.1
 InstallationNotes: |
   Start the app from the Start menu ("DJI Metadata Embedder"). The
   dji-embed command is also available in new terminals.

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.2.0
+PackageVersion: 2.2.1
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Version bump via `tools/sync_version.py 2.2.1` (+ `--check` clean). 13 files, all pure version-string swaps — verified nothing but 2.2.0→2.2.1 changes in the diff.

Contents of v2.2.1 (all merged today): #394 (#389 gaze pass label), #395 (#385 serve robustness), #396 (#384 five silent-degradation fixes), #397 (#383 gaze JS split), #398 (#382 measured beam throttle), #399 (pymdown-extensions bump for Dependabot alert 3).

Tag `v2.2.1` follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX