### PR TITLE
feat(gui): flight map Link original videos option, 3D-only (#392)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -187,6 +187,45 @@ public class CommandBuilderTests
             CommandBuilder.FlightMap("/x", opts));
     }
 
+    // #392: --link-originals unlocks the 3D cockpit's video crossfade. On
+    // the flat map the CLI accepts it but warns it embeds dead weight, so
+    // the builder keeps every argv useful by construction: the flag rides
+    // only with --3d, directly after it (fixed position for these goldens).
+    [Fact]
+    public void Link_originals_with_three_d_follows_the_3d_flag()
+    {
+        var opts = FlightMapOptions.Defaults with
+        {
+            ThreeD = true,
+            LinkOriginals = true,
+        };
+        Assert.Equal(["flightmap", "/x", "-r", "--3d", "--link-originals"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Link_originals_without_three_d_is_suppressed()
+    {
+        var opts = FlightMapOptions.Defaults with { LinkOriginals = true };
+        Assert.Equal(["flightmap", "/x", "-r"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Link_originals_rides_along_with_fuzz_like_the_cli_permits()
+    {
+        var opts = FlightMapOptions.Defaults with
+        {
+            ThreeD = true,
+            LinkOriginals = true,
+            Privacy = MapPrivacy.Fuzz,
+        };
+        Assert.Equal(
+            ["flightmap", "/x", "-r", "--3d", "--link-originals",
+             "--redact", "fuzz"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
     [Fact]
     public void Three_d_passes_the_compatible_flags_through()
     {
@@ -234,7 +273,8 @@ public class CommandBuilderTests
     {
         var opts = new FlightMapOptions(
             Recursive: false, ThreeD: false, TileStyle: "cyclosm", Privacy: MapPrivacy.Fuzz,
-            JoinGap: 0, ExportAll: true, TzOffset: "-8", Title: "T", Output: "/o.html");
+            JoinGap: 0, LinkOriginals: false, ExportAll: true, TzOffset: "-8",
+            Title: "T", Output: "/o.html");
         Assert.Equal(
             ["flightmap", "/x", "--tile-style", "cyclosm", "--redact", "fuzz",
              "--join-gap", "0", "--format", "all", "--tz-offset", "-8",

--- a/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
@@ -20,6 +20,7 @@ public class FlightMapOptionsViewModelTests
         Assert.Equal("osm", vm.SelectedTileStyle.Key);
         Assert.Equal(MapPrivacy.Keep, vm.SelectedPrivacy.Value);
         Assert.Equal(15, vm.JoinGap);
+        Assert.False(vm.LinkOriginals);
         Assert.False(vm.ExportAll);
         Assert.Equal("auto", vm.TzOffset);
         Assert.Equal("", vm.Title);
@@ -44,6 +45,7 @@ public class FlightMapOptionsViewModelTests
             Recursive = false,
             ThreeD = true,
             JoinGap = 0,
+            LinkOriginals = true,
             ExportAll = true,
             TzOffset = "-8",
             Title = "Trip",
@@ -54,8 +56,49 @@ public class FlightMapOptionsViewModelTests
 
         Assert.Equal(
             new FlightMapOptions(false, true, "cyclosm", MapPrivacy.Fuzz, 0,
-                true, "-8", "Trip", "/out/map.html"),
+                true, true, "-8", "Trip", "/out/map.html"),
             vm.ToOptions());
+    }
+
+    // #392: the crossfade caveat mirrors the photo map's ShowsFuzzCaveat, but
+    // sharper — under fuzz the 3D map withholds the blend entirely, so the
+    // note must appear exactly when the emitted argv pairs --link-originals
+    // with --redact fuzz (i.e. only while the 3D toggle keeps the flag live).
+    [Fact]
+    public void Fuzz_caveat_needs_three_d_and_linking_and_fuzz()
+    {
+        var vm = new FlightMapOptionsViewModel();
+        Assert.False(vm.ShowsFuzzCaveat);      // defaults: nothing on
+
+        vm.ThreeD = true;
+        vm.LinkOriginals = true;
+        Assert.False(vm.ShowsFuzzCaveat);      // 3D + linked, Keep
+
+        vm.SelectedPrivacy = vm.PrivacyOptions.Single(
+            p => p.Value == MapPrivacy.Fuzz);
+        Assert.True(vm.ShowsFuzzCaveat);       // 3D + linked + Fuzz
+
+        vm.ThreeD = false;
+        Assert.False(vm.ShowsFuzzCaveat);      // flag suppressed without 3D
+    }
+
+    [Fact]
+    public void Fuzz_caveat_notifies_on_each_of_its_three_inputs()
+    {
+        var vm = new FlightMapOptionsViewModel();
+        var raised = 0;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(FlightMapOptionsViewModel.ShowsFuzzCaveat))
+            {
+                raised++;
+            }
+        };
+        vm.ThreeD = true;
+        vm.LinkOriginals = true;
+        vm.SelectedPrivacy = vm.PrivacyOptions.Single(
+            p => p.Value == MapPrivacy.Fuzz);
+        Assert.Equal(3, raised);
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -667,6 +667,50 @@ public class WorkspaceScreenTests
         Assert.False(note.IsVisible);
     }
 
+    // #392: the crossfade checkbox appears only while the 3D toggle is on —
+    // the flag does nothing on the flat map, and a control that silently
+    // does nothing is worse than no control. Its fuzz caveat surfaces only
+    // when the emitted argv will actually pair linking with fuzz.
+    [AvaloniaFact]
+    public void Flight_map_link_originals_appears_only_in_three_d()
+    {
+        var window = ShowWorkspace();   // default mode Flight map
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+
+        var link = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "FlightLinkOriginalsCheck");
+        Assert.False(link.IsEffectivelyVisible);
+
+        var toggle = window.GetVisualDescendants().OfType<ToggleSwitch>()
+            .Single(t => t.Name == "FlightThreeDToggle");
+        toggle.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(link.IsEffectivelyVisible);
+        Assert.False(link.IsChecked);
+
+        link.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.FlightOptions.LinkOriginals);
+        Assert.Contains("--link-originals", vm.CommandPreview);
+
+        var caveat = window.GetVisualDescendants().OfType<TextBlock>()
+            .Single(t => t.Name == "FlightFuzzCaveatNote");
+        Assert.False(caveat.IsVisible);
+        vm.FlightOptions.SelectedPrivacy = vm.FlightOptions.PrivacyOptions
+            .Single(p => p.Value == MapPrivacy.Fuzz);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(caveat.IsEffectivelyVisible);
+
+        toggle.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.False(link.IsEffectivelyVisible);
+        Assert.False(caveat.IsEffectivelyVisible);
+        Assert.DoesNotContain("--link-originals", vm.CommandPreview);
+    }
+
     [AvaloniaFact]
     public void Flight_map_clear_output_button_is_bound_to_its_command()
     {

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -53,6 +53,13 @@ public static class CommandBuilder
         {
             args.Add("--3d");
         }
+        if (opts.ThreeD && opts.LinkOriginals)
+        {
+            // 3D-only by construction: the crossfade the flag exists for
+            // lives in the 3D cockpit, and on the flat map the CLI warns
+            // the same media data is embedded with nothing that reads it.
+            args.Add("--link-originals");
+        }
         if (!opts.ThreeD && opts.TileStyle != FlightMapOptions.Defaults.TileStyle)
         {
             args.Add("--tile-style");

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
@@ -22,6 +22,11 @@ public enum MapPrivacy
 /// <c>osm-hot</c>, <c>opentopomap</c>, or <c>cyclosm</c>.</param>
 /// <param name="JoinGap">Seconds to chain size-split recordings; 15 = the CLI
 /// default, 0 = don't join.</param>
+/// <param name="LinkOriginals">Embed links to each flight's source videos
+/// (<c>--link-originals</c>), which the 3D cockpit's video crossfade needs.
+/// Only useful with <paramref name="ThreeD"/> — on the flat map the CLI
+/// warns it embeds dead weight — so the builder emits it only alongside
+/// <c>--3d</c> (#392).</param>
 /// <param name="ExportAll">Also write KML + GeoJSON (<c>--format all</c>); the
 /// CLI format is single-valued, so this is one honest toggle, not per-format.</param>
 /// <param name="TzOffset"><c>auto</c> (default) or an explicit UTC offset.</param>
@@ -31,6 +36,7 @@ public sealed record FlightMapOptions(
     string TileStyle,
     MapPrivacy Privacy,
     int JoinGap,
+    bool LinkOriginals,
     bool ExportAll,
     string TzOffset,
     string Title,
@@ -42,6 +48,7 @@ public sealed record FlightMapOptions(
         TileStyle: "osm",
         Privacy: MapPrivacy.Keep,
         JoinGap: 15,
+        LinkOriginals: false,
         ExportAll: false,
         TzOffset: "auto",
         Title: "",

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
@@ -39,6 +39,9 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
     public partial int JoinGap { get; set; } = 15;
 
     [ObservableProperty]
+    public partial bool LinkOriginals { get; set; }
+
+    [ObservableProperty]
     public partial bool ExportAll { get; set; }
 
     [ObservableProperty]
@@ -56,12 +59,35 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
         SelectedPrivacy = PrivacyOptions[0];
     }
 
+    /// <summary>
+    /// True when the emitted argv will pair <c>--link-originals</c> with
+    /// <c>--redact fuzz</c> — the 3D map keeps the links but withholds the
+    /// video blend, because coarsened coordinates cannot honestly be
+    /// compared against real footage. Mirrors the photo map's caveat
+    /// (which the CLI prints only to stderr, where the GUI discards it on
+    /// success); gated on ThreeD because without it the builder suppresses
+    /// the flag entirely (#392). A real property so it is assertable
+    /// headless.
+    /// </summary>
+    public bool ShowsFuzzCaveat =>
+        ThreeD && LinkOriginals && SelectedPrivacy.Value == MapPrivacy.Fuzz;
+
+    partial void OnThreeDChanged(bool value) =>
+        OnPropertyChanged(nameof(ShowsFuzzCaveat));
+
+    partial void OnLinkOriginalsChanged(bool value) =>
+        OnPropertyChanged(nameof(ShowsFuzzCaveat));
+
+    partial void OnSelectedPrivacyChanged(PrivacyChoice value) =>
+        OnPropertyChanged(nameof(ShowsFuzzCaveat));
+
     public FlightMapOptions ToOptions() => new(
         Recursive: Recursive,
         ThreeD: ThreeD,
         TileStyle: SelectedTileStyle.Key,
         Privacy: SelectedPrivacy.Value,
         JoinGap: JoinGap,
+        LinkOriginals: LinkOriginals,
         ExportAll: ExportAll,
         TzOffset: TzOffset,
         Title: Title,

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -269,6 +269,16 @@
                                                    IsVisible="{Binding FlightOptions.ThreeD}"
                                                    TextWrapping="Wrap"
                                                    Opacity="0.5" FontSize="11" />
+                                        <CheckBox Name="FlightLinkOriginalsCheck"
+                                                  IsVisible="{Binding FlightOptions.ThreeD}"
+                                                  IsChecked="{Binding FlightOptions.LinkOriginals}"
+                                                  Content="Link the original videos"
+                                                  ToolTip.Tip="Lets the cockpit view blend into the real footage. Needs the videos next to the map, in a format the browser can play (DJI 4K H.265 needs Edge or Chrome)." />
+                                        <TextBlock Name="FlightFuzzCaveatNote"
+                                                   Text="With fuzzed locations the video blend stays off — coarsened coordinates can't honestly be compared against real footage. The links still open the originals, which keep exact GPS in their own metadata."
+                                                   IsVisible="{Binding FlightOptions.ShowsFuzzCaveat}"
+                                                   TextWrapping="Wrap"
+                                                   Opacity="0.5" FontSize="11" />
                                     </StackPanel>
 
                                     <StackPanel Spacing="4">


### PR DESCRIPTION
## Summary

The video crossfade — the payoff of the 2.2.0 3D arc — required `--link-originals`, which the flight map's GUI options never exposed, so the app's no-CLI users couldn't reach it (#392).

This adopts the middle path proposed in the issue:

- **The checkbox appears only while the 3D toggle is on.** On the flat map the flag embeds media data nothing reads (the CLI itself warns about this), and a control that silently does nothing is worse than no control.
- **Legal-and-useful by construction:** `CommandBuilder.FlightMap` emits `--link-originals` only alongside `--3d`, following the same pattern that already suppresses `--tile-style`/`--format all` under 3D (#366).
- **Fuzz caveat:** a `ShowsFuzzCaveat` note mirrors the photo map's, with the sharper 3D wording — links stay, blend is withheld, because coarsened coordinates can't honestly be compared against real footage. The CLI prints this only to stderr, which the GUI discards on success, so the panel note is the only place a GUI user can learn it.
- `--link-base` deliberately not exposed (curated options; the issue flagged it as likely a step too far).

## Tests

TDD: watched the suite fail on the missing members first. New coverage:
- 3 CommandBuilder goldens (emitted after `--3d`, suppressed without 3D, composes with `--redact fuzz`)
- 2 view-model tests (caveat truth table over its three inputs, property-change notifications)
- 1 headless screen test (checkbox invisible until 3D, binds to the VM and the command strip, caveat appears under fuzz, everything hides again when 3D is off)

479 passed / 0 failed locally.

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX