### PR TITLE
fix(geo): rebuild a flight-global clock from per-segment cues (#386)

### DIFF
--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -317,13 +317,42 @@ def _relative_times(points: list[TrackPoint]) -> list[float]:
         assert base is not None
         raw = [(p.utc - base).total_seconds() for p in points if p.utc is not None]
     else:
-        base_cue = _cue_seconds(points[0].timestamp) or 0.0
-        raw = [(_cue_seconds(p.timestamp) or 0.0) - base_cue for p in points]
+        raw = _cue_clock(points)
     times: list[float] = []
     for t in raw:
         t = round(t, 1)
         times.append(max(t, times[-1]) if times else t)
     return times
+
+
+def _cue_clock(points: list[TrackPoint]) -> list[float]:
+    """A flight-global clock rebuilt from video-relative cues (#386).
+
+    Cues restart near zero with every source file, so on a joined flight a
+    single ``cue - first_cue`` sequence runs backwards at each boundary and
+    the monotonic clamp would flatten everything after it into a plateau.
+    Instead each segment's own cue span is accumulated: a new segment
+    resumes one sample interval after the previous one ended, the interval
+    being the last spacing observed (the real gap is unknowable without
+    UTC, and size-split recordings resume near-instantly). Single-segment
+    tracks reproduce the old ``cue - first_cue`` behaviour exactly.
+    """
+    clock: list[float] = []
+    offset = 0.0  # flight-global seconds at the current segment's base cue
+    step = 1.0  # last observed sample spacing, the boundary filler
+    base = _cue_seconds(points[0].timestamp) or 0.0
+    seg = points[0].segment
+    for p in points:
+        if p.segment != seg:
+            seg = p.segment
+            base = _cue_seconds(p.timestamp) or 0.0
+            offset = (clock[-1] if clock else 0.0) + step
+        cue = _cue_seconds(p.timestamp)
+        t = offset + ((cue if cue is not None else base) - base)
+        if clock and t > clock[-1]:
+            step = t - clock[-1]
+        clock.append(t)
+    return clock
 
 
 def _add_ghost_props(properties: dict, points: list[TrackPoint]) -> None:

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -128,6 +128,43 @@ def test_times_use_cues_when_any_utc_missing():
     assert props["times_s"] == [0.0, 2.0]
 
 
+def test_times_survive_a_segment_boundary_without_utc():
+    # #386: cues are video-relative — each source file restarts near zero.
+    # The cue fallback must rebuild a flight-global clock from the per-point
+    # segment stamps instead of clamping the whole second file into a
+    # plateau that stalls playback at the boundary. (scan_flights cannot
+    # currently produce this track — SRT points always get a synthesized
+    # UTC — but flights_to_geojson is public API and video-built points
+    # carry utc=None, so the contract must hold here.)
+    def pt(cue: str, seg: int) -> TrackPoint:
+        return TrackPoint(lat=1.0, lon=2.0, alt=3.0, timestamp=cue,
+                          segment=seg)
+
+    track = Track(name="f", segments=["DJI_0001", "DJI_0002"], points=[
+        pt("00:00:00,000", 0), pt("00:00:01,000", 0),
+        pt("00:00:02,000", 0), pt("00:00:03,000", 0),
+        pt("00:00:00,000", 1), pt("00:00:01,000", 1),
+        pt("00:00:02,000", 1),
+    ])
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert props["times_s"] == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+def test_segment_boundary_advances_by_the_observed_cadence():
+    # The gap between the files is unknowable without UTC; the honest filler
+    # is the flight's own sample spacing, not a hardcoded second.
+    def pt(cue: str, seg: int) -> TrackPoint:
+        return TrackPoint(lat=1.0, lon=2.0, alt=3.0, timestamp=cue,
+                          segment=seg)
+
+    track = Track(name="f", segments=["DJI_0001", "DJI_0002"], points=[
+        pt("00:00:00,000", 0), pt("00:00:00,500", 0), pt("00:00:01,000", 0),
+        pt("00:00:00,000", 1), pt("00:00:00,500", 1),
+    ])
+    props = flights_to_geojson([track])["features"][0]["properties"]
+    assert props["times_s"] == [0.0, 0.5, 1.0, 1.5, 2.0]
+
+
 def test_times_clamped_monotonic():
     # A cue that jumps backwards (corrupt SRT) must not run the animation
     # backwards; the offending sample pins to the previous time.


### PR DESCRIPTION
## Summary

`_relative_times`'s cue fallback treated raw SRT cues as a flight-global clock. Cues are video-relative (the very fact #380 established for `cue_s`), so on a multi-segment track the second file's cues restart near zero and the monotonic clamp flattened `times_s` into a plateau — playback would stall at the segment boundary on both the flat and 3D maps.

**Fix:** a new `_cue_clock` helper accumulates each segment's own cue span using the per-point `segment` stamps from #380. A new segment resumes one sample interval after the previous one ended (the last observed spacing — the real gap is unknowable without UTC, and size-split recordings resume near-instantly). Single-segment tracks reproduce the old `cue - first_cue` behaviour exactly.

## Empirical scoping (changes the issue's threat model slightly)

Before writing the test I verified the issue's suggested repro: **two joined SRTs with deliberately unresolvable UTC do *not* trigger the bug** — SRT points always receive a synthesized UTC (mtime fallback in `build_track_from_samples`) and `join_split_flights` rebases it, so the UTC branch stays live and times_s comes out continuous. The defect is real but latent: it is reachable through the public `flights_to_geojson` API with video-built points (which carry `utc=None`), and would have gone live the moment any joined track lacked per-point UTC. The regression tests pin the contract at that public-API level and say so in a comment.

## Tests

TDD — watched both fail with the exact plateau (`[0.0, 0.5, 1.0, 1.0, 1.0]`) first:
- `test_times_survive_a_segment_boundary_without_utc` — 2 segments, cues restarting, expects a continuous clock
- `test_segment_boundary_advances_by_the_observed_cadence` — boundary filler is the flight's own sample spacing, not a hardcoded second

736 passed / ruff / mypy clean locally.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX