### PR TITLE
feat(geo): --flight-log CSV ingestion — true gimbal attitude for SRT-only drones (#374)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -194,6 +194,13 @@ reuse DJI's restarting file numbering stay distinct. Sidecar-less models whose
 telemetry lives inside the MP4 (Air 3S, Mini 5 Pro, …) are not scanned — map
 those per clip with `dji-embed convert html VIDEO.MP4`.
 
+Drones whose SRT carries no gimbal attitude (the Mini series) can borrow it
+from a decoded flight log: `--flight-log my-flight.csv` merges per-sample
+gimbal pitch/yaw into the matching flight by timestamp, upgrading the 3D
+map's estimated camera footprints to measurements. See
+[Gimbal from a flight log](how-to/flight-log-gimbal.md) for the export
+settings that make the join exact.
+
 Popup start times are converted to UTC by auto-detecting the recording
 timezone from each file's mtime. On archives whose mtimes were rewritten by
 zip/cloud transfers the auto-detection fails; `flightmap` then warns once

--- a/docs/how-to/flight-log-gimbal.md
+++ b/docs/how-to/flight-log-gimbal.md
@@ -1,0 +1,58 @@
+# True gimbal attitude from a flight log
+
+Mini-series drones (Mini 3 Pro, Mini 4 Pro without an embedded telemetry
+track, and similar) record **no gimbal attitude anywhere on the SD card**.
+Their SRT sidecars carry position but not where the camera pointed, so the
+3D map draws the camera footprint as a labelled *estimate*.
+
+The attitude does exist — inside the flight record your DJI app or RC
+keeps. `--flight-log` merges it into the map:
+
+```bash
+dji-embed flightmap ./flights --3d --flight-log my-flight.csv
+```
+
+Where a log matches a flight, the camera footprint becomes a measurement
+and the "estimated" badge disappears on its own. Where it doesn't, nothing
+changes — the estimate stays, honestly labelled. Repeat the flag for
+several flights.
+
+## Getting the CSV
+
+DJI encrypts flight records and holds the decryption keys, so **decrypting
+a flight log requires an internet connection whichever tool you use** —
+the key comes from DJI. There is no offline decoder; that is a property of
+DJI's design, not of any particular product.
+
+1. Copy the record from your device. On a DJI RC the files sit at the root
+   of *Internal shared storage* (plug in USB, open in your file manager):
+   `DJIFlightRecord_2026-07-27_[17-28-49].txt` and similar. On a phone,
+   use the DJI app's flight-record export.
+2. Feed it to any decoder that exports CSV — Airdata, Flight Reader,
+   PhantomHelp Log Viewer, and others all work. This tool is deliberately
+   vendor-neutral: it recognises the *content* of the export, not one
+   product's schema.
+3. In the decoder's export settings, make sure these are included:
+    - **gimbal pitch and yaw** (in Flight Reader: `GIMBAL.pitch` and
+      `GIMBAL.yaw`),
+    - **a UTC timestamp** (in Flight Reader: the UTC option under
+      Logs/Reports; Airdata's `datetime(utc)` is there by default),
+    - the aircraft's **latitude/longitude** if available — the merge uses
+      them to verify the log really belongs to the flight.
+
+## How the merge behaves
+
+- **With a UTC column** the join is exact: each track point takes the
+  nearest log sample within one second.
+- **Without one** the UTC offset is inferred from the start times (snapped
+  to 15-minute steps) and the output says so — inference assumes the
+  recording started within a few minutes of the log, so prefer the UTC
+  export option.
+- A log whose GPS track sits far from the flight is refused even when the
+  clocks line up.
+- Gimbal data already present in the SRT always wins; a log fills gaps,
+  it never overwrites.
+- Numbers in the export follow the decimal separator of the machine that
+  produced it (comma or dot) — both parse. A value that parses as neither
+  stops the run with the column and line named, rather than being silently
+  dropped.

--- a/docs/superpowers/specs/2026-07-28-flight-log-ingestion-design.md
+++ b/docs/superpowers/specs/2026-07-28-flight-log-ingestion-design.md
@@ -1,0 +1,86 @@
+# Flight-log CSV ingestion — true gimbal attitude for SRT-only drones (#374)
+
+**Date:** 2026-07-28
+**Issue:** #374 (research trail in its comments is the full evidence base)
+
+## Problem
+
+Mini-series drones write no gimbal attitude anywhere on the SD card, so the
+3D map's gaze footprint and ghost view honestly fall back to labelled
+estimates. The attitude exists — in the encrypted phone/RC flight record —
+and every decoder that can read it (Flight Reader, Airdata, PhantomHelp)
+exports CSV. Decryption requires a network round-trip to DJI's key service
+whichever tool is used; there is no offline path, for anyone.
+
+## Decision: ingest CSV, not a vendor
+
+`dji-embed flightmap … --flight-log LOG.csv` (repeatable). A mapping layer
+recognises what the CSV contains and merges per-sample gimbal pitch/yaw into
+the matching flight's track points. Everything downstream already keys off
+whether gimbal attitude is present, so a filled field upgrades an estimate
+to a measurement and the "estimated" badge retires itself.
+
+Vendor-neutral by design (issue comment "Decoder landscape"): we cannot
+vouch for any decoder's privacy, the column set is user-configurable in at
+least one producer (confirmed by its developer — no stable schema exists),
+and a documented mapping outlives any vendor. Known producers are
+documented, not special-cased.
+
+## The mapping layer (`geo/flightlog.py`)
+
+**Column detection is semantic, never positional or exact-string:**
+
+| Semantic | Match rule (case-insensitive) | Known producers |
+| --- | --- | --- |
+| gimbal pitch | contains `gimbal` + `pitch` | `GIMBAL.pitch` (Flight Reader), `gimbal_pitch(degrees)` (Airdata) |
+| gimbal yaw | contains `gimbal` + (`yaw` or `heading`); the signed column preferred over a `[360]` variant | `GIMBAL.yaw`, `GIMBAL.yaw [360]`, `gimbal_heading(degrees)` |
+| UTC time | contains `utc` | `datetime(utc)` (Airdata); Flight Reader's UTC option (Logs/Reports settings) |
+| local date / time | contains `date` / `time` + `local` (or a combined `datetime` column) | `CUSTOM.date [local]` + `CUSTOM.updateTime [local]` |
+| aircraft GPS (validation only) | contains `latitude`/`longitude`, excluding `home`/`rc`/`remote`/`tablet` | `OSD.latitude`, `latitude` |
+
+Yaw is normalised to [-180, 180] true-north (DJI's own frame docs and the
+Follow-Yaw cross-check in the spike prove the export is world-referenced).
+
+**Locale rules (both confirmed permanent by the vendor):**
+
+- Numbers accept `.` or `,` as the decimal separator; a value with both is
+  an error. Clocks may be 12-hour with a locale-decimal seconds fraction
+  (`5:28:49,2 pm`).
+- **Fail loudly on an unparseable value; never treat it as missing.** A
+  skip-on-error parser silently degrades a complete dataset into a
+  plausible-looking sparse one (this exact failure happened during the
+  spike). Empty cells are missing; garbage raises with column and row.
+- Errors about missing columns say exactly which fields to enable in the
+  export, because the column set is user-configurable.
+- UTF-8 BOM and `;` delimiters tolerated (Windows exports).
+
+## The join
+
+1. **UTC column present → exact join.** Rows carry absolute UTC; match each
+   track point to the nearest row within 1.0 s.
+2. **Local-only → derived offset, said plainly.** The local→UTC offset is
+   derived by rounding (log start − flight start) to the nearest 15 min
+   (covers :30/:45 timezones). The report states the join was inferred and
+   recommends enabling the UTC export option.
+3. **GPS cross-validation when the log carries aircraft coordinates:**
+   median distance between matched positions must stay under 500 m
+   (tolerates `--redact fuzz`'s ~100 m). A log whose track is elsewhere is
+   refused even if its clock overlaps.
+4. Each log merges into the flight with the longest time overlap; SRT-borne
+   gimbal values always win (merge fills only `None`).
+
+## Non-goals (v1)
+
+- No DAT parsing, no TXT decryption, no network anything (see the issue:
+  the SDK door is closed for good, and this boundary is the point).
+- No GUI exposure yet — CLI + docs first; GUI integration is a separate
+  decision under the anti-bloat rules.
+- No new dependencies: stdlib `csv` + `datetime` only.
+
+## Documentation
+
+`docs/how-to/flight-log-gimbal.md`: recommended export settings (enable the UTC
+timestamp; include gimbal pitch/yaw), known-working producers, and the one
+honest sentence about the ecosystem: *decrypting a DJI flight log requires
+an internet connection whichever tool you use, because the decryption key
+comes from DJI.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - Embed GPS: how-to/embed-gps.md
       - Strip serial number: how-to/strip-serial-number.md
       - Generate GPX: how-to/generate-gpx.md
+      - Gimbal from a flight log: how-to/flight-log-gimbal.md
       - Windows Quick Setup: how-to/windows-bundle.md
   - Reference:
       - API Reference: api.md

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -43,6 +43,7 @@ from .geo import (
     write_photos_html,
     write_photos_kml,
 )
+from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
 from .geo.media import resolve_media
 from .mp4_telemetry import Mp4TelemetryError
 from .progress import NullProgress, make_progress
@@ -855,6 +856,16 @@ def photomap(
     help="Folder or URL prefix for --link-originals hrefs, for when the "
          "videos do not sit beside the map.",
 )
+@click.option(
+    "--flight-log", "flight_logs", multiple=True,
+    type=click.Path(exists=True, dir_okay=False), metavar="CSV",
+    help="Flight-log CSV export (Airdata, Flight Reader, ...) whose gimbal "
+         "pitch/yaw is merged into the matching flight by timestamp — for "
+         "drones whose SRT carries no gimbal data, this upgrades the 3D "
+         "map's estimated camera footprints to measurements. Repeat for "
+         "several flights. Enable the UTC timestamp and the gimbal "
+         "pitch/yaw fields in the decoder's export settings.",
+)
 @_tile_style_option
 @_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
@@ -871,6 +882,7 @@ def flightmap(
     three_d: bool,
     link_originals: bool,
     link_base: str | None,
+    flight_logs: tuple[str, ...],
     tile_style: str,
     progress_mode: str | None,
     verbose: bool,
@@ -951,6 +963,40 @@ def flightmap(
             progress.warning("No GPS telemetry", item=name)
             if verbose:
                 click.echo(f"Skipped (no GPS telemetry): {name}", err=True)
+        for log_path in flight_logs:
+            try:
+                log = parse_flight_log(log_path)
+            except FlightLogError as e:
+                raise click.ClickException(str(e))
+            report, matched = merge_into_flights(tracks, log)
+            if report.merged and matched is not None:
+                if report.mode == "utc":
+                    join = "exact UTC join"
+                else:
+                    assert report.offset is not None
+                    total_min = int(report.offset.total_seconds() // 60)
+                    join = (
+                        f"derived UTC offset {total_min // 60:+03d}:"
+                        f"{abs(total_min) % 60:02d} — enable the UTC "
+                        "timestamp in the export for an exact join"
+                    )
+                if not quiet:
+                    click.echo(
+                        f"Flight log {log.name}: gimbal attitude for "
+                        f"{report.matched} of {len(matched.points)} points "
+                        f"on {matched.name} ({join})"
+                    )
+            else:
+                reason = report.reason or "no alignment found"
+                progress.warning(
+                    f"Flight log {log.name} did not match any flight: "
+                    f"{reason}"
+                )
+                click.echo(
+                    f"Note: flight log {log.name} did not match any "
+                    f"flight: {reason}",
+                    err=True,
+                )
         joined = [t for t in tracks if t.segments]
         files_joined = sum(len(t.segments or []) for t in joined)
         if not quiet:

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -1,6 +1,14 @@
 """Geospatial track/photo models and exporters (GeoJSON, KML, HTML, CoT)."""
 
 from .cot import convert_to_cot, track_to_cot
+from .flightlog import (
+    FlightLog,
+    FlightLogError,
+    MergeReport,
+    merge_gimbal,
+    merge_into_flights,
+    parse_flight_log,
+)
 from .flightmap import (
     flights_to_geojson,
     flights_to_kml,
@@ -63,6 +71,12 @@ __all__ = [
     "DEFAULT_TILE_STYLE",
     "TILE_STYLES",
     "TileStyle",
+    "FlightLog",
+    "FlightLogError",
+    "MergeReport",
+    "parse_flight_log",
+    "merge_gimbal",
+    "merge_into_flights",
     "scan_flights",
     "flights_to_geojson",
     "write_flights_geojson",

--- a/src/dji_metadata_embedder/geo/flightlog.py
+++ b/src/dji_metadata_embedder/geo/flightlog.py
@@ -1,0 +1,451 @@
+"""Flight-log CSV ingestion: true gimbal attitude for SRT-only drones (#374).
+
+Mini-series drones write no gimbal attitude anywhere on the SD card; it
+lives in the encrypted phone/RC flight record, which every decoder
+(Flight Reader, Airdata, PhantomHelp, ...) can export as CSV. This module
+ingests that CSV and merges per-sample gimbal pitch/yaw into a flight's
+track points, upgrading the 3D map's labelled estimates to measurements.
+
+Vendor-neutral by design — no decoder is endorsed or special-cased:
+
+* Columns are matched **by semantics, never by position or exact header**:
+  at least one producer lets users rename and reorder every field, and its
+  own developer advises against relying on a stable schema.
+* Numbers are **locale-aware** (decimal comma or dot): exports use the
+  Windows locale of whoever produced them, permanently.
+* Unparseable values **fail loudly, never silently as missing** — the #374
+  spike proved a skip-on-error parser degrades a complete dataset into a
+  plausible-looking sparse one with no exception raised anywhere.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from bisect import bisect_left
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from statistics import median
+
+from .geometry import haversine_m
+from .track import Track
+
+__all__ = [
+    "FlightLog",
+    "FlightLogError",
+    "LogRow",
+    "MergeReport",
+    "merge_gimbal",
+    "merge_into_flights",
+    "parse_flight_log",
+]
+
+
+class FlightLogError(ValueError):
+    """A flight-log CSV that cannot be used, with the reason said plainly."""
+
+
+@dataclass
+class LogRow:
+    """One flight-log sample: a clock plus whatever attitude it carried."""
+
+    utc: datetime | None
+    local: datetime | None
+    pitch: float | None
+    yaw: float | None
+    lat: float | None
+    lon: float | None
+
+
+@dataclass
+class FlightLog:
+    """A parsed flight-log export: rows on one declared time base."""
+
+    name: str
+    time_base: str  # "utc" (exact join) or "local" (offset must be derived)
+    rows: list[LogRow]
+    columns: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class MergeReport:
+    """What :func:`merge_gimbal` did, for the CLI to say out loud."""
+
+    merged: bool
+    matched: int = 0
+    mode: str | None = None  # "utc" | "derived"
+    offset: timedelta | None = None
+    gps_median_m: float | None = None
+    reason: str | None = None
+
+
+# Columns that look like coordinates but are not the aircraft's position.
+_NOT_AIRCRAFT = ("home", "rc", "remote", "tablet")
+
+_ADVICE = (
+    "enable the UTC timestamp and the gimbal pitch/yaw fields in the "
+    "decoder's export settings (in Flight Reader: GIMBAL.pitch and "
+    "GIMBAL.yaw, plus the UTC option under Logs/Reports)"
+)
+
+
+def _tokens(header: str) -> set[str]:
+    """A header's semantic word set: ``CUSTOM.updateTime [local]`` ->
+    ``{custom, update, time, local}``.
+
+    Tokenised (camelCase and punctuation split) rather than substring-
+    matched, because substrings lie: ``updateTime`` *contains* both
+    ``date`` and ``datetime`` yet is neither.
+    """
+    spaced = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", header)
+    return {t.lower() for t in re.split(r"[^A-Za-z0-9]+", spaced) if t}
+
+
+def _find(
+    headers: Sequence[str],
+    *needles: str,
+    exclude: tuple[str, ...] = (),
+) -> str | None:
+    """First header whose tokens carry every needle and no exclusion."""
+    for h in headers:
+        toks = _tokens(h)
+        if any(x in toks for x in exclude):
+            continue
+        if all(n in toks for n in needles):
+            return h
+    return None
+
+
+def _number(raw: str, column: str, line: int) -> float | None:
+    """Locale-aware float: empty is missing, garbage is an error.
+
+    Accepts ``.`` or ``,`` as the decimal separator (the export follows the
+    producing machine's Windows locale). A value carrying both separators
+    is refused rather than guessed at.
+    """
+    s = raw.strip()
+    if not s:
+        return None
+    if "," in s and "." in s:
+        raise FlightLogError(
+            f"column {column!r}, line {line}: {raw!r} mixes '.' and ',' — "
+            "cannot tell the decimal separator apart"
+        )
+    try:
+        return float(s.replace(",", "."))
+    except ValueError:
+        raise FlightLogError(
+            f"column {column!r}, line {line}: {raw!r} is not a number. "
+            "Values are never skipped silently — fix the export or remove "
+            "the broken row."
+        ) from None
+
+
+_TIME_RE = re.compile(
+    r"^(\d{1,2}):(\d{2}):(\d{2})(?:[.,](\d+))?\s*([ap]m)?$", re.IGNORECASE
+)
+
+
+def _parse_clock(raw: str, column: str, line: int) -> tuple[int, int, int, int]:
+    """A wall-clock time, 24-hour or 12-hour, locale-decimal fraction OK."""
+    m = _TIME_RE.match(raw.strip())
+    if not m:
+        raise FlightLogError(
+            f"column {column!r}, line {line}: {raw!r} is not a time of day"
+        )
+    hour, minute, sec = int(m.group(1)), int(m.group(2)), int(m.group(3))
+    frac = m.group(4) or ""
+    micro = int(frac.ljust(6, "0")[:6]) if frac else 0
+    half = (m.group(5) or "").lower()
+    if half == "pm" and hour != 12:
+        hour += 12
+    elif half == "am" and hour == 12:
+        hour = 0
+    return hour, minute, sec, micro
+
+
+def _parse_date(raw: str, column: str, line: int) -> tuple[int, int, int]:
+    """A calendar date; ambiguous day/month orders are refused, not guessed."""
+    s = raw.strip()
+    if m := re.match(r"^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$", s):
+        return int(m.group(1)), int(m.group(2)), int(m.group(3))
+    if m := re.match(r"^(\d{1,2})[/.](\d{1,2})[/.](\d{4})$", s):
+        a, b, year = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        if a > 12 and b <= 12:
+            return year, b, a  # unambiguously D/M/Y
+        if b > 12 and a <= 12:
+            return year, a, b  # unambiguously M/D/Y
+        if a == b:
+            return year, a, b
+        raise FlightLogError(
+            f"column {column!r}, line {line}: {raw!r} is ambiguous (day and "
+            f"month cannot be told apart); {_ADVICE} for an exact join"
+        )
+    raise FlightLogError(
+        f"column {column!r}, line {line}: {raw!r} is not a date"
+    )
+
+
+def _parse_datetime(raw: str, column: str, line: int) -> datetime:
+    """A combined date + wall-clock value (``2026-07-27 12:00:00.0``)."""
+    s = raw.strip().removesuffix("Z").replace("T", " ")
+    date_part, _, time_part = s.partition(" ")
+    if not time_part:
+        raise FlightLogError(
+            f"column {column!r}, line {line}: {raw!r} has no time of day"
+        )
+    year, month, day = _parse_date(date_part, column, line)
+    hour, minute, sec, micro = _parse_clock(time_part, column, line)
+    return datetime(year, month, day, hour, minute, sec, micro)
+
+
+def _normalize_yaw(deg: float) -> float:
+    """Fold any yaw/heading into signed [-180, 180] true-north degrees."""
+    return (deg + 180.0) % 360.0 - 180.0
+
+
+def parse_flight_log(path: Path | str) -> FlightLog:
+    """Parse a flight-log CSV export into a :class:`FlightLog`.
+
+    Raises :class:`FlightLogError` — always with the concrete fix spelled
+    out — when the export lacks the columns this feature needs or carries
+    a value that cannot be parsed.
+    """
+    src = Path(path)
+    # utf-8-sig eats the BOM Windows exporters prepend.
+    text = src.read_text(encoding="utf-8-sig")
+    delimiter = ";" if text.split("\n", 1)[0].count(";") >= 2 else ","
+    reader = csv.DictReader(text.splitlines(), delimiter=delimiter)
+    headers = reader.fieldnames or []
+
+    pitch_col = _find(headers, "gimbal", "pitch")
+    yaw_col = _find(headers, "gimbal", "yaw", exclude=("360",)) or _find(
+        headers, "gimbal", "heading"
+    )
+    yaw_360_col = None if yaw_col else _find(headers, "gimbal", "yaw")
+    if pitch_col is None or (yaw_col is None and yaw_360_col is None):
+        raise FlightLogError(
+            f"{src.name}: no gimbal pitch/yaw columns found — {_ADVICE}. "
+            f"Columns present: {', '.join(headers) or '(none)'}"
+        )
+    yaw_col = yaw_col or yaw_360_col
+    assert yaw_col is not None
+
+    utc_col = _find(headers, "utc")
+    datetime_col = _find(headers, "datetime", exclude=("utc",))
+    date_col = _find(headers, "date", exclude=("datetime",))
+    time_col = _find(headers, "time", "local", exclude=("date",)) or _find(
+        headers, "time", exclude=("date", "datetime", "fly")
+    )
+    if utc_col is None and datetime_col is None and (
+        date_col is None or time_col is None
+    ):
+        raise FlightLogError(
+            f"{src.name}: no timestamp columns found — the merge is aligned "
+            f"by time, so {_ADVICE}. A UTC timestamp gives an exact join."
+        )
+
+    lat_col = _find(headers, "latitude", exclude=_NOT_AIRCRAFT)
+    lon_col = _find(headers, "longitude", exclude=_NOT_AIRCRAFT)
+
+    columns = {
+        "pitch": pitch_col,
+        "yaw": yaw_col,
+        **({"utc": utc_col} if utc_col else {}),
+        **({"latitude": lat_col} if lat_col else {}),
+    }
+
+    rows: list[LogRow] = []
+    for line_no, rec in enumerate(reader, start=2):
+        if all(not (v or "").strip() for v in rec.values()):
+            continue  # a structurally blank line, not data
+        utc = local = None
+        if utc_col:
+            utc = _parse_datetime(rec[utc_col], utc_col, line_no)
+        elif datetime_col:
+            local = _parse_datetime(rec[datetime_col], datetime_col, line_no)
+        else:
+            assert date_col is not None and time_col is not None
+            year, month, day = _parse_date(rec[date_col], date_col, line_no)
+            hour, minute, sec, micro = _parse_clock(
+                rec[time_col], time_col, line_no
+            )
+            local = datetime(year, month, day, hour, minute, sec, micro)
+        yaw = _number(rec[yaw_col], yaw_col, line_no)
+        rows.append(
+            LogRow(
+                utc=utc,
+                local=local,
+                pitch=_number(rec[pitch_col], pitch_col, line_no),
+                yaw=None if yaw is None else _normalize_yaw(yaw),
+                lat=_number(rec[lat_col], lat_col, line_no) if lat_col else None,
+                lon=_number(rec[lon_col], lon_col, line_no) if lon_col else None,
+            )
+        )
+    if not rows:
+        raise FlightLogError(f"{src.name}: the export contains no data rows")
+    time_base = "utc" if utc_col else "local"
+    rows.sort(key=lambda r: (r.utc or r.local or datetime.min))
+    return FlightLog(name=src.name, time_base=time_base, rows=rows,
+                     columns=columns)
+
+
+# A track point pairs with the nearest log row inside this window. Flight
+# logs sample at ~5 Hz and display tracks at ~1 Hz, so a second of slack
+# tolerates both cadences without ever bridging distinct flights.
+_TOLERANCE_S = 1.0
+
+# The derived-offset join snaps to 15-minute steps (covers :30/:45 zones);
+# it therefore assumes recording started within ~7 minutes of the log.
+_OFFSET_STEP_S = 900
+
+# Wider than --redact fuzz's ~100 m coarsening, far tighter than "a
+# different flight": a log whose GPS track sits beyond this is refused.
+_GPS_LIMIT_M = 500.0
+
+
+def merge_gimbal(track: Track, log: FlightLog) -> MergeReport:
+    """Merge *log*'s gimbal attitude into *track*, aligned by time.
+
+    SRT-borne gimbal values always win — only ``None`` fields are filled,
+    so a log can upgrade an estimate but never overwrite a measurement.
+    The report says which join was used: ``utc`` (exact) or ``derived``
+    (offset inferred by snapping the start difference to 15 minutes).
+    """
+    pts = [p for p in track.points if p.utc is not None]
+    if not pts:
+        return MergeReport(
+            merged=False,
+            reason="the flight has no resolved UTC to align by",
+        )
+    if log.time_base == "utc":
+        mode, offset = "utc", timedelta(0)
+        stamped = [(r.utc, r) for r in log.rows if r.utc is not None]
+    else:
+        first_local = next(
+            (r.local for r in log.rows if r.local is not None), None
+        )
+        if first_local is None:
+            return MergeReport(merged=False, reason="the log has no timestamps")
+        raw = (first_local - pts[0].utc).total_seconds()  # type: ignore[operator]
+        offset = timedelta(
+            seconds=round(raw / _OFFSET_STEP_S) * _OFFSET_STEP_S
+        )
+        mode = "derived"
+        stamped = [
+            (r.local - offset, r) for r in log.rows if r.local is not None
+        ]
+    if not stamped:
+        return MergeReport(merged=False, reason="the log has no timestamps")
+    stamped.sort(key=lambda tr: tr[0])
+    times = [t for t, _ in stamped]
+
+    t0, t1 = pts[0].utc, pts[-1].utc
+    assert t0 is not None and t1 is not None
+    if times[-1] < t0 - timedelta(seconds=_TOLERANCE_S) or times[0] > (
+        t1 + timedelta(seconds=_TOLERANCE_S)
+    ):
+        return MergeReport(
+            merged=False,
+            mode=mode,
+            offset=offset,
+            reason="the log covers a different time window than this flight",
+        )
+
+    pairs: list[tuple[int, LogRow]] = []
+    dists: list[float] = []
+    for i, p in enumerate(track.points):
+        if p.utc is None:
+            continue
+        k = bisect_left(times, p.utc)
+        best: tuple[float, LogRow] | None = None
+        for j in (k - 1, k):
+            if 0 <= j < len(times):
+                dt = abs((times[j] - p.utc).total_seconds())
+                if best is None or dt < best[0]:
+                    best = (dt, stamped[j][1])
+        if best is None or best[0] > _TOLERANCE_S:
+            continue
+        row = best[1]
+        pairs.append((i, row))
+        if row.lat is not None and row.lon is not None:
+            dists.append(haversine_m(p.lat, p.lon, row.lat, row.lon))
+
+    if not pairs:
+        return MergeReport(
+            merged=False,
+            mode=mode,
+            offset=offset,
+            reason="no log samples land within a second of the flight's points",
+        )
+    gps_median = round(median(dists), 1) if dists else None
+    if gps_median is not None and gps_median > _GPS_LIMIT_M:
+        return MergeReport(
+            merged=False,
+            mode=mode,
+            offset=offset,
+            gps_median_m=gps_median,
+            reason=(
+                f"GPS mismatch: the log's track sits a median {gps_median:.0f} m "
+                "from this flight — it looks like a different flight"
+            ),
+        )
+    for i, row in pairs:
+        p = track.points[i]
+        if p.gimbal_yaw is None and row.yaw is not None:
+            p.gimbal_yaw = row.yaw
+        if p.gimbal_pitch is None and row.pitch is not None:
+            p.gimbal_pitch = row.pitch
+    return MergeReport(
+        merged=True,
+        matched=len(pairs),
+        mode=mode,
+        offset=offset,
+        gps_median_m=gps_median,
+    )
+
+
+def merge_into_flights(
+    tracks: list[Track], log: FlightLog
+) -> tuple[MergeReport, Track | None]:
+    """Merge *log* into the closest-aligned flight of *tracks*.
+
+    Candidates are tried nearest-clock-first, so when a local-only log's
+    snapped offset would let it align with more than one same-day flight,
+    the one whose start actually agrees wins; :func:`merge_gimbal`'s
+    overlap and GPS refusals still apply to each attempt. Returns the
+    winning report and track, or the last refusal and ``None``.
+    """
+    candidates = [
+        t for t in tracks if any(p.utc is not None for p in t.points)
+    ]
+    if not candidates:
+        return (
+            MergeReport(
+                merged=False,
+                reason="no flight has a resolved clock to align by",
+            ),
+            None,
+        )
+    first = log.rows[0]
+    log_start = first.utc or first.local
+    assert log_start is not None  # parse_flight_log guarantees a time base
+
+    def closeness(t: Track) -> float:
+        t0 = next(p.utc for p in t.points if p.utc is not None)
+        assert t0 is not None
+        raw = (log_start - t0).total_seconds()
+        if log.time_base == "utc":
+            return abs(raw)
+        return abs(raw - round(raw / _OFFSET_STEP_S) * _OFFSET_STEP_S)
+
+    last: MergeReport | None = None
+    for t in sorted(candidates, key=closeness):
+        report = merge_gimbal(t, log)
+        if report.merged:
+            return report, t
+        last = report
+    assert last is not None
+    return last, None

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -1,4 +1,6 @@
 import json
+import os
+from datetime import datetime, timedelta, timezone
 
 from click.testing import CliRunner
 
@@ -340,3 +342,88 @@ def test_link_originals_geojson_alone_does_not_warn_dead_weight(tmp_path):
     )
     assert res.exit_code == 0, res.output
     assert "only benefits the 3D map" not in res.output
+
+
+# --- #374: --flight-log merges gimbal attitude from a decoder CSV export ---
+
+
+def _dt_srt(start, coords):
+    """Datetime-carrying bracket SRT, one block per second."""
+    blocks = []
+    for i, (lat, lon, alt) in enumerate(coords):
+        stamp = (start + timedelta(seconds=i)).strftime("%Y-%m-%d %H:%M:%S.000")
+        blocks.append(
+            f"{i + 1}\n00:00:{i:02d},000 --> 00:00:{i + 1:02d},000\n"
+            f'<font size="28">FrameCnt: {i + 1}, DiffTime: 1000ms\n'
+            f"{stamp}\n"
+            f"[iso: 100] [shutter: 1/500.0] [fnum: 1.8] [ev: 0] "
+            f"[focal_len: 24.00] [latitude: {lat}] [longitude: {lon}] "
+            f"[rel_alt: 10.000 abs_alt: {alt}] [ct: 5000] </font>\n"
+        )
+    return "\n".join(blocks)
+
+
+T0 = datetime(2026, 7, 27, 12, 0, 0)
+GIMBAL_LOG = """\
+time(millisecond),datetime(utc),latitude,longitude,gimbal_heading(degrees),gimbal_pitch(degrees)
+0,2026-07-27 12:00:00.0,59.33459,18.06324,350.0,-60.0
+1000,2026-07-27 12:00:01.0,59.33460,18.06325,351.0,-61.0
+2000,2026-07-27 12:00:02.0,59.33461,18.06326,352.0,-62.0
+"""
+
+
+def _gimbal_folder(tmp_path):
+    srt = _dt_srt(T0, [(59.33459, 18.06324, 100.0),
+                       (59.33460, 18.06325, 101.0),
+                       (59.33461, 18.06326, 102.0)])
+    folder = _folder(tmp_path, {"DJI_0001.SRT": srt})
+    # mtime at the recording end so tz auto-detection resolves offset 0
+    # (SRT wall-clock == UTC), matching the log's UTC column exactly.
+    end = (T0 + timedelta(seconds=3)).replace(tzinfo=timezone.utc).timestamp()
+    os.utime(folder / "DJI_0001.SRT", (end, end))
+    log = folder / "log.csv"
+    log.write_text(GIMBAL_LOG, encoding="utf-8")
+    return folder, log
+
+
+def test_flightmap_flight_log_merges_gimbal_into_the_geojson(tmp_path):
+    folder, log = _gimbal_folder(tmp_path)
+    out = folder / "out.geojson"
+    res = CliRunner().invoke(main, [
+        "flightmap", str(folder), "-f", "geojson", "-o", str(out),
+        "--flight-log", str(log),
+    ])
+    assert res.exit_code == 0, res.output
+    assert "DJI_0001" in res.output and "gimbal" in res.output.lower()
+    assert "exact UTC join" in res.output
+    props = json.loads(out.read_text(encoding="utf-8"))[
+        "features"][0]["properties"]
+    assert props["gyaw_deg"] == [-10.0, -9.0, -8.0]
+    assert props["gpitch_deg"] == [-60.0, -61.0, -62.0]
+
+
+def test_flightmap_flight_log_unmatched_notes_and_still_maps(tmp_path):
+    folder, log = _gimbal_folder(tmp_path)
+    log.write_text(GIMBAL_LOG.replace("2026-07-27", "2026-01-01"),
+                   encoding="utf-8")
+    out = folder / "out.geojson"
+    res = CliRunner().invoke(main, [
+        "flightmap", str(folder), "-f", "geojson", "-o", str(out),
+        "--flight-log", str(log),
+    ])
+    assert res.exit_code == 0, res.output
+    assert "did not match any flight" in res.output
+    props = json.loads(out.read_text(encoding="utf-8"))[
+        "features"][0]["properties"]
+    assert "gyaw_deg" not in props
+
+
+def test_flightmap_flight_log_bad_export_fails_loudly(tmp_path):
+    folder, log = _gimbal_folder(tmp_path)
+    log.write_text("datetime(utc),latitude\n2026-07-27 12:00:00.0,59.0\n",
+                   encoding="utf-8")
+    res = CliRunner().invoke(main, [
+        "flightmap", str(folder), "--flight-log", str(log),
+    ])
+    assert res.exit_code != 0
+    assert "gimbal" in res.output.lower()

--- a/tests/test_geo_flightlog.py
+++ b/tests/test_geo_flightlog.py
@@ -1,0 +1,242 @@
+"""Flight-log CSV ingestion (#374): parsing, alignment, and gimbal merge.
+
+The mapping layer is vendor-neutral by design — columns are matched by
+semantics, numbers are locale-aware, and unparseable values fail loudly
+(the spike proved a skip-on-error parser silently degrades a complete
+dataset into a plausible-looking sparse one). Fixtures mirror the two
+known producers: a Flight Reader-shaped export in a decimal-comma locale
+and an Airdata-shaped export with a UTC column.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from dji_metadata_embedder.geo.flightlog import (
+    FlightLogError,
+    merge_gimbal,
+    parse_flight_log,
+)
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+
+def _write(tmp_path, name, content, encoding="utf-8"):
+    path = tmp_path / name
+    path.write_text(content, encoding=encoding)
+    return path
+
+
+# Airdata-shaped: dot decimals, combined UTC datetime column, 0-360 heading.
+AIRDATA = """\
+time(millisecond),datetime(utc),latitude,longitude,gimbal_heading(degrees),gimbal_pitch(degrees)
+0,2026-07-27 12:00:00.0,59.33459,18.06324,350.0,-60.0
+1000,2026-07-27 12:00:01.0,59.33460,18.06325,351.0,-61.0
+2000,2026-07-27 12:00:02.0,59.33461,18.06326,352.0,-62.0
+3000,2026-07-27 12:00:03.0,59.33462,18.06327,353.0,-63.0
+4000,2026-07-27 12:00:04.0,59.33463,18.06328,354.0,-64.0
+"""
+
+# Flight Reader-shaped: quoted decimal-comma values, 12-hour local clock
+# with a comma seconds-fraction, both yaw variants, HOME columns present.
+FLIGHT_READER = """\
+"CUSTOM.date [local]","CUSTOM.updateTime [local]","OSD.flyTime [s]","OSD.latitude","OSD.longitude","HOME.latitude","HOME.longitude","GIMBAL.pitch","GIMBAL.yaw","GIMBAL.yaw [360]","GIMBAL.roll"
+"2026-07-27","2:00:00,0 pm","0,2","59,33459","18,06324","59,33459","18,06324","-60,0","-10,0","350,0","0,0"
+"2026-07-27","2:00:01,0 pm","1,2","59,33460","18,06325","59,33459","18,06324","-61,0","-9,0","351,0","0,0"
+"2026-07-27","2:00:02,0 pm","2,2","59,33461","18,06326","59,33459","18,06324","-62,0","-8,0","352,0","0,0"
+"2026-07-27","2:00:03,0 pm","3,2","59,33462","18,06327","59,33459","18,06324","-63,0","-7,0","353,0","0,0"
+"2026-07-27","2:00:04,0 pm","4,2","59,33463","18,06328","59,33459","18,06324","-64,0","-6,0","354,0","0,0"
+"""
+
+
+def test_parses_an_airdata_shaped_export_with_utc(tmp_path):
+    log = parse_flight_log(_write(tmp_path, "log.csv", AIRDATA))
+    assert log.time_base == "utc"
+    assert len(log.rows) == 5
+    first = log.rows[0]
+    assert first.utc == datetime(2026, 7, 27, 12, 0, 0)
+    assert first.pitch == -60.0
+    assert first.yaw == -10.0  # 350 in the 0-360 frame, normalised signed
+    assert first.lat == 59.33459
+    assert first.lon == 18.06324
+
+
+def test_parses_a_flight_reader_shaped_export_with_comma_decimals(tmp_path):
+    log = parse_flight_log(_write(tmp_path, "log.csv", FLIGHT_READER))
+    assert log.time_base == "local"
+    first = log.rows[0]
+    assert first.local == datetime(2026, 7, 27, 14, 0, 0)
+    assert first.utc is None
+    assert first.pitch == -60.0
+    assert first.yaw == -10.0  # the signed GIMBAL.yaw column, verbatim
+    assert first.lat == 59.33459
+
+
+def test_prefers_the_signed_yaw_column_over_the_360_variant(tmp_path):
+    # FLIGHT_READER carries both; the signed one must win (no reprojection).
+    log = parse_flight_log(_write(tmp_path, "log.csv", FLIGHT_READER))
+    assert [r.yaw for r in log.rows] == [-10.0, -9.0, -8.0, -7.0, -6.0]
+
+
+def test_normalises_a_360_only_yaw_column(tmp_path):
+    csv = (
+        '"CUSTOM.date [local]","CUSTOM.updateTime [local]",'
+        '"GIMBAL.pitch","GIMBAL.yaw [360]"\n'
+        '"2026-07-27","2:00:00,0 pm","-60,0","182,5"\n'
+    )
+    log = parse_flight_log(_write(tmp_path, "log.csv", csv))
+    assert log.rows[0].yaw == -177.5
+
+
+def test_home_coordinates_are_not_the_aircraft(tmp_path):
+    csv = (
+        '"CUSTOM.date [local]","CUSTOM.updateTime [local]",'
+        '"HOME.latitude","HOME.longitude","GIMBAL.pitch","GIMBAL.yaw"\n'
+        '"2026-07-27","2:00:00,0 pm","59,0","18,0","-60,0","-10,0"\n'
+    )
+    log = parse_flight_log(_write(tmp_path, "log.csv", csv))
+    assert log.rows[0].lat is None
+    assert log.rows[0].lon is None
+
+
+def test_missing_gimbal_columns_error_names_what_to_enable(tmp_path):
+    csv = "datetime(utc),latitude\n2026-07-27 12:00:00.0,59.0\n"
+    with pytest.raises(FlightLogError) as e:
+        parse_flight_log(_write(tmp_path, "log.csv", csv))
+    msg = str(e.value)
+    assert "gimbal" in msg.lower()
+    assert "pitch" in msg.lower() and "yaw" in msg.lower()
+
+
+def test_no_time_columns_error_recommends_the_utc_option(tmp_path):
+    csv = "GIMBAL.pitch,GIMBAL.yaw\n-60.0,-10.0\n"
+    with pytest.raises(FlightLogError) as e:
+        parse_flight_log(_write(tmp_path, "log.csv", csv))
+    assert "UTC" in str(e.value)
+
+
+def test_unparseable_number_fails_loudly_with_its_location(tmp_path):
+    bad = AIRDATA.replace("352.0", "three-five-two")
+    with pytest.raises(FlightLogError) as e:
+        parse_flight_log(_write(tmp_path, "log.csv", bad))
+    msg = str(e.value)
+    assert "gimbal_heading(degrees)" in msg
+    assert "three-five-two" in msg
+
+
+def test_empty_cells_are_missing_not_errors(tmp_path):
+    sparse = AIRDATA.replace("352.0", "")
+    log = parse_flight_log(_write(tmp_path, "log.csv", sparse))
+    assert log.rows[2].yaw is None
+    assert log.rows[1].yaw == -9.0
+
+
+def test_a_value_with_both_separators_is_an_error(tmp_path):
+    bad = AIRDATA.replace("350.0", '"1.234,5"')
+    with pytest.raises(FlightLogError):
+        parse_flight_log(_write(tmp_path, "log.csv", bad))
+
+
+def test_bom_and_semicolon_delimiters_are_tolerated(tmp_path):
+    semi = (
+        "datetime(utc);GIMBAL.pitch;GIMBAL.yaw\n"
+        "2026-07-27 12:00:00.0;-60.0;-10.0\n"
+    )
+    log = parse_flight_log(
+        _write(tmp_path, "log.csv", semi, encoding="utf-8-sig"))
+    assert log.rows[0].pitch == -60.0
+
+
+def test_an_ambiguous_local_date_is_refused(tmp_path):
+    csv = (
+        '"CUSTOM.date [local]","CUSTOM.updateTime [local]",'
+        '"GIMBAL.pitch","GIMBAL.yaw"\n'
+        '"07/06/2026","2:00:00,0 pm","-60,0","-10,0"\n'
+    )
+    with pytest.raises(FlightLogError) as e:
+        parse_flight_log(_write(tmp_path, "log.csv", csv))
+    assert "UTC" in str(e.value)  # points at the unambiguous fix
+
+
+def test_an_unambiguous_slash_date_is_accepted(tmp_path):
+    csv = (
+        '"CUSTOM.date [local]","CUSTOM.updateTime [local]",'
+        '"GIMBAL.pitch","GIMBAL.yaw"\n'
+        '"7/27/2026","2:00:00,0 pm","-60,0","-10,0"\n'
+    )
+    log = parse_flight_log(_write(tmp_path, "log.csv", csv))
+    assert log.rows[0].local == datetime(2026, 7, 27, 14, 0, 0)
+
+
+def _track(start: datetime, n: int = 5) -> Track:
+    return Track(name="DJI_0001", points=[
+        TrackPoint(lat=59.33459 + i * 1e-5, lon=18.06324 + i * 1e-5,
+                   alt=100.0 + i, timestamp=f"00:00:0{i},000",
+                   utc=start + timedelta(seconds=i))
+        for i in range(n)
+    ])
+
+
+def test_exact_utc_join_fills_gimbal_and_reports(tmp_path):
+    log = parse_flight_log(_write(tmp_path, "log.csv", AIRDATA))
+    track = _track(datetime(2026, 7, 27, 12, 0, 0))
+    report = merge_gimbal(track, log)
+    assert report.merged
+    assert report.mode == "utc"
+    assert report.matched == 5
+    assert [p.gimbal_yaw for p in track.points] == [
+        -10.0, -9.0, -8.0, -7.0, -6.0]
+    assert [p.gimbal_pitch for p in track.points] == [
+        -60.0, -61.0, -62.0, -63.0, -64.0]
+    assert report.gps_median_m is not None and report.gps_median_m < 50
+
+
+def test_srt_borne_gimbal_wins(tmp_path):
+    log = parse_flight_log(_write(tmp_path, "log.csv", AIRDATA))
+    track = _track(datetime(2026, 7, 27, 12, 0, 0))
+    track.points[0].gimbal_yaw = 42.0
+    track.points[0].gimbal_pitch = -5.0
+    merge_gimbal(track, log)
+    assert track.points[0].gimbal_yaw == 42.0
+    assert track.points[0].gimbal_pitch == -5.0
+    assert track.points[1].gimbal_yaw == -9.0
+
+
+def test_local_log_derives_the_offset_and_says_so(tmp_path):
+    log = parse_flight_log(_write(tmp_path, "log.csv", FLIGHT_READER))
+    track = _track(datetime(2026, 7, 27, 12, 0, 0))  # local is UTC+2
+    report = merge_gimbal(track, log)
+    assert report.merged
+    assert report.mode == "derived"
+    assert report.offset == timedelta(hours=2)
+    assert track.points[2].gimbal_pitch == -62.0
+
+
+def test_gps_mismatch_refuses_even_with_a_matching_clock(tmp_path):
+    elsewhere = AIRDATA.replace("59.334", "40.712")  # different city
+    log = parse_flight_log(_write(tmp_path, "log.csv", elsewhere))
+    track = _track(datetime(2026, 7, 27, 12, 0, 0))
+    report = merge_gimbal(track, log)
+    assert not report.merged
+    assert report.matched == 0
+    assert "GPS" in report.reason
+    assert all(p.gimbal_yaw is None for p in track.points)
+
+
+def test_no_time_overlap_is_refused(tmp_path):
+    log = parse_flight_log(_write(tmp_path, "log.csv", AIRDATA))
+    track = _track(datetime(2026, 7, 28, 9, 0, 0))  # next day
+    report = merge_gimbal(track, log)
+    assert not report.merged
+    assert all(p.gimbal_yaw is None for p in track.points)
+
+
+def test_points_beyond_the_tolerance_are_not_filled(tmp_path):
+    log = parse_flight_log(_write(tmp_path, "log.csv", AIRDATA))
+    track = _track(datetime(2026, 7, 27, 12, 0, 0), n=5)
+    track.points.append(TrackPoint(
+        lat=59.335, lon=18.064, alt=110.0, timestamp="00:00:30,000",
+        utc=datetime(2026, 7, 27, 12, 0, 30)))  # log ends at 12:00:04
+    report = merge_gimbal(track, log)
+    assert report.merged
+    assert report.matched == 5
+    assert track.points[-1].gimbal_yaw is None


### PR DESCRIPTION
## Summary

Implements the v1 agreed in #374's research trail: **bring-your-own-CSV flight-log ingestion**, vendor-neutral, offline, pure stdlib.

```bash
dji-embed flightmap ./flights --3d --flight-log my-flight.csv
```

Merges per-sample gimbal pitch/yaw from a decoded flight log (Flight Reader, Airdata, PhantomHelp, …) into the matching flight by timestamp. Everything downstream already keys off attitude presence, so the 3D map's estimated camera footprints upgrade to measurements and the *estimated* badge retires itself; with no log, nothing changes.

## Design (per the issue's settled decisions + spec committed in this PR)

- **Semantic column matching**, never positional or exact-header — one producer's own developer says not to rely on a stable schema. Matching is by header *tokens* (camelCase/punctuation split), because substrings lie: `updateTime` contains both `date` and `datetime`. `HOME.`/RC coordinates are excluded from the aircraft-GPS match.
- **Locale-aware numbers** (decimal comma or dot — permanent per the vendor), 12-hour clocks with locale fractions, BOM and `;` delimiters tolerated.
- **Fail loudly, never silently-missing**: an unparseable value stops the run naming column and line — the spike proved skip-on-error degrades a complete dataset into a plausible-looking sparse one. Empty cells are missing; garbage is an error. Ambiguous day/month dates are refused with the fix named (enable the UTC export).
- **Join**: UTC column → exact join (1 s tolerance). Local-only → offset derived by snapping the start difference to 15-minute steps, said plainly in the output with the recommendation to enable UTC. Logs are tried against the closest-clock flight first.
- **GPS cross-validation**: a log whose track sits a median >500 m from the flight is refused even when clocks align (threshold tolerates `--redact fuzz`).
- **SRT-borne gimbal always wins** — the merge fills only `None`.
- Yaw normalised to signed true-north degrees (handles `GIMBAL.yaw [360]` and Airdata's 0–360 `gimbal_heading`).

## Docs

- `docs/how-to/flight-log-gimbal.md`: retrieval (RC internal storage), recommended export settings, and the honest ecosystem sentence: *decrypting a DJI flight log requires an internet connection whichever tool you use, because the key comes from DJI.*
- Pointer from the flightmap section of `geospatial.md`; design spec under `docs/superpowers/specs/`.

## Tests

TDD throughout (watched each stage fail first): 19 parser/merge tests over Flight Reader-shaped (decimal-comma, 12-hour, both yaw variants, HOME columns) and Airdata-shaped fixtures, plus 3 CLI tests (merge reported with join mode, unmatched log notes and still maps, bad export fails loudly). 756 passed / ruff / mypy clean locally.

Follow-ups deliberately out of scope: GUI exposure (anti-bloat decision), #390 online mode, second-aircraft/US-locale format confirmation when real exports arrive.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX