### PR TITLE
docs: retire the two Experimental banners #393 missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,12 +412,6 @@ range, GPS points) and a layer toggle; the KML imports into Google Earth and
 Google My Maps as one line per flight. SRT files without GPS telemetry
 (e.g. ordinary subtitles) are skipped and counted in a summary; `-v` lists them.
 
-> **Experimental:** `flightmap` is new and its size-split joining heuristics
-> may still be tuned based on real-world feedback. If it joins flights it
-> shouldn't (or misses ones it should), please
-> [open an issue](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues)
-> with the SRT file names and timestamps.
-
 ```bash
 dji-embed flightmap /path/to/footage                        # -> footage/flightmap.html
 dji-embed flightmap /path/to/footage -f all                 # -> footage/flightmap.{html,kml,geojson}

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -157,11 +157,6 @@ dji-embed convert html DJI_0001.SRT --redact fuzz   # ~100 m coarsened coords
 
 ## Combined flight map (`flightmap`)
 
-> **Experimental:** `flightmap` is new and its size-split joining heuristics
-> may still be tuned based on real-world feedback. If it joins flights it
-> shouldn't (or misses ones it should), please open an issue with the SRT
-> file names and timestamps.
-
 ```bash
 dji-embed flightmap ./footage                    # -> footage/flightmap.html
 dji-embed flightmap ./footage -r                 # scan subdirectories too


### PR DESCRIPTION
PR #393 removed the "experimental" label from five places, but two blockquote banners still open with `flightmap` **is new** — README:415 and `docs/geospatial.md:160`. Same reasoning as #393: removed rather than softened; the size-split joining sections right beside them already explain the behaviour and how to report a misjoin.

**This PR is also the live proof of #405's early-exit**: it touches only `README.md` and `docs/geospatial.md`, so the required `browser` check should report green in seconds without installing anything. Compare its duration against the ~7m45 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpaNjdPAu8UJadY9k8QYYX