### PR TITLE
feat: fetch-log — opt-in Flight Reader API decode + RC retrieval docs (#390 stage 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dji-embed fetch-log` — opt-in decode of TXT flight records through the
+  Flight Reader API with your own key (`FLIGHTREADER_API_KEY`); writes
+  `NAME.flightreader.csv` beside each record for `flightmap --flight-log`,
+  never uploads the same record twice, and states plainly that the whole
+  log is transmitted (#390).
+- `tools/mtp-copy.ps1` — bulk-copy flight records off a DJI RC over
+  USB/MTP, plus a how-to walkthrough for finding them by hand (#390).
+
 ### Changed
 
 - Photo map hover previews are now opt-in ([#345]): pins go straight to the

--- a/docs/PROGRESS_JSONL.md
+++ b/docs/PROGRESS_JSONL.md
@@ -1,7 +1,7 @@
 # `--progress jsonl` — machine-readable progress events
 
 `photomap`, `flightmap`, `embed`, `check`, `doctor`, `convert`, `validate`,
-and `verify-sun` accept `--progress jsonl`. In
+`verify-sun`, and `fetch-log` accept `--progress jsonl`. In
 this mode a command writes **one JSON object per line to stdout** and nothing
 else — human/informational output is suppressed, and warnings and log
 messages go to stderr. A non-zero exit code always means the run failed;
@@ -143,6 +143,27 @@ field, never by arrival order.
 - `outputs` is empty; `summary` is the sun summary dict (`file`, `points`,
   `sun_computed`, `utc_start`/`utc_end`, elevation/azimuth stats, `flags`).
 - `--format json` cannot be combined with `--progress jsonl`.
+
+### `fetch-log`
+- `--progress jsonl` requires `--yes`: the consent prompt cannot be answered
+  under jsonl (there is no stdin round-trip in the contract), so consent
+  must be obtained by the frontend before invoking the command; omitting
+  `--yes` is a usage error. It also requires `FLIGHTREADER_API_KEY` to
+  already be set in the environment — there is no key prompt under jsonl
+  either.
+- One `progress` event is not emitted per record; records that already have
+  a cached CSV are skipped silently and counted in `summary.cached`.
+- A successful run — including a run where every record was a cache hit and
+  nothing was uploaded — ends in `result` with `outputs` = absolute paths of
+  every available CSV (both previously cached and newly fetched) and
+  `summary`: `{"fetched": N, "cached": N, "failed": 0}`. `failed` is always
+  `0` in a `result` event: any per-record failure instead ends the run in
+  `error` (see next point), so a non-zero `failed` never reaches `result`.
+- A record that fails to fetch (e.g. the API rejects it) is reported as a
+  `warning` event (`item` = the record's file name) and the run continues
+  to the remaining records; if any record failed, the stream still
+  terminates with a single `error` event (not `result`) and a non-zero
+  exit code, per the terminal rule.
 
 ## Relation to `--log-json`
 

--- a/docs/how-to/flight-log-gimbal.md
+++ b/docs/how-to/flight-log-gimbal.md
@@ -52,8 +52,8 @@ a flight log requires an internet connection whichever tool you use** —
 the key comes from DJI. There is no offline decoder; that is a property of
 DJI's design, not of any particular product.
 
-1. Get the record onto your computer (see "Getting the TXT off your
-   controller" above).
+1. Get the record onto your computer (see [Getting the TXT off your
+   controller](#getting-the-txt-off-your-controller) above).
 2. Feed it to any decoder that exports CSV — Airdata, Flight Reader,
    PhantomHelp Log Viewer, and others all work. This tool is deliberately
    vendor-neutral: it recognises the *content* of the export, not one
@@ -71,7 +71,7 @@ DJI's design, not of any particular product.
 If you have a [Flight Reader API](https://www.flightreader.com/api/) key,
 `fetch-log` does the decode step for you:
 
-    set FLIGHTREADER_API_KEY=sk_...        # or export, on macOS/Linux
+    $env:FLIGHTREADER_API_KEY = "sk_..."   # PowerShell; use  export FLIGHTREADER_API_KEY=sk_...  on macOS/Linux
     dji-embed fetch-log DJIFlightRecord_2026-07-27_[17-28-49].txt
     dji-embed flightmap D:\Flights --3d --flight-log DJIFlightRecord_2026-07-27_[17-28-49].flightreader.csv
 

--- a/docs/how-to/flight-log-gimbal.md
+++ b/docs/how-to/flight-log-gimbal.md
@@ -32,8 +32,10 @@ the extension they are encrypted binary, not text.
    at the **root** of that storage, not in a folder.
 3. Copy the `DJIFlightRecord_*.txt` files anywhere on your computer.
 
-Or let the bundled helper do it (Windows; copies only records you do not
-already have):
+Or let the [helper script from the
+repository](https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/tools/mtp-copy.ps1)
+do it (Windows; copies only records you do not already have) — it is not
+shipped in the installed package, so grab it from the repo first:
 
     powershell -ExecutionPolicy Bypass -File tools\mtp-copy.ps1
 

--- a/docs/how-to/flight-log-gimbal.md
+++ b/docs/how-to/flight-log-gimbal.md
@@ -17,6 +17,34 @@ and the "estimated" badge disappears on its own. Where it doesn't, nothing
 changes — the estimate stays, honestly labelled. Repeat the flag for
 several flights.
 
+## Getting the TXT off your controller
+
+Flight records are small `.txt` files your DJI app or RC writes per
+flight — named like `DJIFlightRecord_2026-07-27_[17-28-49].txt`. Despite
+the extension they are encrypted binary, not text.
+
+**DJI RC (RC 2, RC Pro, ...):**
+
+1. Plug the RC into your computer over USB, with the RC **powered on and
+   unlocked**. It appears in Explorer as a portable (MTP) device — no
+   drive letter, which is why some copy tools cannot see it.
+2. Open the device › *Internal shared storage*. The flight records sit
+   at the **root** of that storage, not in a folder.
+3. Copy the `DJIFlightRecord_*.txt` files anywhere on your computer.
+
+Or let the bundled helper do it (Windows; copies only records you do not
+already have):
+
+    powershell -ExecutionPolicy Bypass -File tools\mtp-copy.ps1
+
+If the device does not appear: unlock the RC's screen, try another
+cable/port (some cables are charge-only), and accept any "allow access"
+prompt on the RC.
+
+**Phone as the controller:** use the DJI app itself — Profile › More ›
+Flight Data (wording varies by app version) offers a flight-record
+export/upload; the files it produces are the same `DJIFlightRecord_*.txt`.
+
 ## Getting the CSV
 
 DJI encrypts flight records and holds the decryption keys, so **decrypting
@@ -24,10 +52,8 @@ a flight log requires an internet connection whichever tool you use** —
 the key comes from DJI. There is no offline decoder; that is a property of
 DJI's design, not of any particular product.
 
-1. Copy the record from your device. On a DJI RC the files sit at the root
-   of *Internal shared storage* (plug in USB, open in your file manager):
-   `DJIFlightRecord_2026-07-27_[17-28-49].txt` and similar. On a phone,
-   use the DJI app's flight-record export.
+1. Get the record onto your computer (see "Getting the TXT off your
+   controller" above).
 2. Feed it to any decoder that exports CSV — Airdata, Flight Reader,
    PhantomHelp Log Viewer, and others all work. This tool is deliberately
    vendor-neutral: it recognises the *content* of the export, not one
@@ -39,6 +65,24 @@ DJI's design, not of any particular product.
       Logs/Reports; Airdata's `datetime(utc)` is there by default),
     - the aircraft's **latitude/longitude** if available — the merge uses
       them to verify the log really belongs to the flight.
+
+### Fetching the CSV via the API (optional)
+
+If you have a [Flight Reader API](https://www.flightreader.com/api/) key,
+`fetch-log` does the decode step for you:
+
+    set FLIGHTREADER_API_KEY=sk_...        # or export, on macOS/Linux
+    dji-embed fetch-log DJIFlightRecord_2026-07-27_[17-28-49].txt
+    dji-embed flightmap D:\Flights --3d --flight-log DJIFlightRecord_2026-07-27_[17-28-49].flightreader.csv
+
+Know what this does before you run it: **your entire flight log is
+uploaded to flightreader.com to decrypt it** — your exact coordinates,
+and everything else the log records, leave your computer (Flight Reader
+states uploads are deleted immediately after processing). The command
+asks for confirmation once per invocation before uploading new records,
+and each record's CSV is written beside it and reused on every later run
+— the same record is never uploaded twice. Delete the `.flightreader.csv`
+to refetch. You supply your own key; this tool never embeds or brokers one.
 
 ## How the merge behaves
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -1104,15 +1104,26 @@ def fetch_log_cmd(
     with _jsonl_terminal(progress, "fetch-log"):
         paths = [Path(r) for r in records]
         pending: list[Path] = []
+        outputs: list[Path] = []
+        cached = 0
         for p in paths:
-            if cache_path(p).exists():
-                click.echo(
-                    f"{cache_path(p).name} already exists — nothing "
-                    "uploaded (delete it to refetch)."
-                )
+            cached_csv = cache_path(p)
+            if cached_csv.exists():
+                outputs.append(cached_csv)
+                cached += 1
+                if not progress.active:
+                    click.echo(
+                        f"{cached_csv.name} already exists — nothing "
+                        "uploaded (delete it to refetch)."
+                    )
             else:
                 pending.append(p)
         if not pending:
+            progress.result(
+                ok=True,
+                outputs=[str(o.resolve()) for o in outputs],
+                summary={"fetched": 0, "cached": cached, "failed": 0},
+            )
             return
         if progress.active and not yes:
             raise click.UsageError(
@@ -1138,14 +1149,26 @@ def fetch_log_cmd(
                 out = fetch_log(p, key)
             except LogFetchError as e:
                 failures += 1
-                progress.warning(str(e))
-                click.echo(f"Error: {e}", err=True)
+                progress.warning(str(e), item=p.name)
+                if not progress.active:
+                    click.echo(f"Error: {e}", err=True)
             else:
-                click.echo(f"Wrote {out.name}")
+                outputs.append(out)
+                if not progress.active:
+                    click.echo(f"Wrote {out.name}")
         if failures:
             raise click.ClickException(
                 f"{failures} of {len(pending)} records failed"
             )
+        progress.result(
+            ok=True,
+            outputs=[str(o.resolve()) for o in outputs],
+            summary={
+                "fetched": len(pending),
+                "cached": cached,
+                "failed": failures,
+            },
+        )
 
 
 @main.command()

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -231,7 +231,7 @@ def _jsonl_terminal(
 
 
 # Shared by every progress-wired command (photomap/flightmap/embed/check/
-# doctor/convert/validate/verify-sun). Contract: docs/PROGRESS_JSONL.md.
+# doctor/convert/validate/verify-sun/fetch-log). Contract: docs/PROGRESS_JSONL.md.
 _progress_option = click.option(
     "--progress",
     "progress_mode",

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import webbrowser
 import click
@@ -44,6 +45,7 @@ from .geo import (
     write_photos_kml,
 )
 from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
+from .geo.logfetch import LogFetchError, cache_path, fetch_log
 from .geo.media import resolve_media
 from .mp4_telemetry import Mp4TelemetryError
 from .progress import NullProgress, make_progress
@@ -1055,6 +1057,95 @@ def flightmap(
                 "joined_files": files_joined,
             },
         )
+
+
+# Verbatim from the #390 spec — the fact, with the deletion claim
+# attributed. Do not reword without amending the spec.
+_FETCH_CONSENT = (
+    "This uploads your entire flight log to Flight Reader to decrypt it.\n"
+    "Your exact coordinates — and everything else the log records — leave\n"
+    "your computer (they state uploads are deleted immediately after\n"
+    "processing)."
+)
+
+
+@main.command(name="fetch-log")
+@click.argument(
+    "records", nargs=-1, required=True,
+    type=click.Path(exists=True, dir_okay=False),
+)
+@click.option(
+    "--yes", is_flag=True,
+    help="Skip the upload consent prompt (required with --progress jsonl; "
+         "the desktop app asks for consent in its own UI).",
+)
+@_progress_option
+@click.option("-v", "--verbose", is_flag=True, help="Verbose output")
+@click.option("-q", "--quiet", is_flag=True, help="Suppress info output")
+def fetch_log_cmd(
+    records: tuple[str, ...],
+    yes: bool,
+    progress_mode: str | None,
+    verbose: bool,
+    quiet: bool,
+) -> None:
+    """Decrypt TXT flight records via the Flight Reader API (opt-in).
+
+    Uploads each record to flightreader.com with YOUR OWN API key
+    (FLIGHTREADER_API_KEY) and writes the decoded CSV beside it as
+    NAME.flightreader.csv, ready for 'flightmap --flight-log'. A record
+    whose CSV already exists is never uploaded again — delete the CSV to
+    refetch. See the flight-log how-to for what is transmitted.
+    """
+    progress = make_progress(progress_mode)
+    if progress.active:
+        quiet = True
+    setup_logging(verbose, quiet)
+    with _jsonl_terminal(progress, "fetch-log"):
+        paths = [Path(r) for r in records]
+        pending: list[Path] = []
+        for p in paths:
+            if cache_path(p).exists():
+                click.echo(
+                    f"{cache_path(p).name} already exists — nothing "
+                    "uploaded (delete it to refetch)."
+                )
+            else:
+                pending.append(p)
+        if not pending:
+            return
+        if progress.active and not yes:
+            raise click.UsageError(
+                "--progress jsonl cannot answer the consent prompt; "
+                "pass --yes after obtaining consent in your own UI"
+            )
+        if not yes:
+            click.echo(_FETCH_CONSENT)
+            if not click.confirm("Proceed?", default=False):
+                click.echo("Nothing sent.")
+                return
+        key = os.environ.get("FLIGHTREADER_API_KEY")
+        if not key:
+            if progress.active:
+                raise click.ClickException(
+                    "FLIGHTREADER_API_KEY is not set — the jsonl contract "
+                    "has no key prompt; export the variable"
+                )
+            key = click.prompt("Flight Reader API key", hide_input=True)
+        failures = 0
+        for p in pending:
+            try:
+                out = fetch_log(p, key)
+            except LogFetchError as e:
+                failures += 1
+                progress.warning(str(e))
+                click.echo(f"Error: {e}", err=True)
+            else:
+                click.echo(f"Wrote {out.name}")
+        if failures:
+            raise click.ClickException(
+                f"{failures} of {len(pending)} records failed"
+            )
 
 
 @main.command()

--- a/src/dji_metadata_embedder/geo/logfetch.py
+++ b/src/dji_metadata_embedder/geo/logfetch.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import json
 import logging
+import secrets
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
-from .flightlog import _NOT_AIRCRAFT, _find
+from .flightlog import _NOT_AIRCRAFT, _find, FlightLogError, parse_flight_log
 
 logger = logging.getLogger(__name__)
 
@@ -97,3 +100,125 @@ def select_fields(available: list[str]) -> list[str] | None:
     if "pitch" not in hits or "yaw" not in hits or not has_time:
         return None
     return picked
+
+
+def _multipart(
+    filename: str, data: bytes, form: dict[str, str]
+) -> tuple[bytes, str]:
+    """A multipart/form-data body: *form* fields plus one file part."""
+    boundary = "----dji-embed-" + secrets.token_hex(12)
+    parts: list[bytes] = []
+    for name, value in form.items():
+        parts.append(
+            (
+                f"--{boundary}\r\n"
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'
+                f"{value}\r\n"
+            ).encode("utf-8")
+        )
+    parts.append(
+        (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="file"; '
+            f'filename="{filename}"\r\n'
+            f"Content-Type: application/octet-stream\r\n\r\n"
+        ).encode("utf-8")
+        + data
+        + b"\r\n"
+    )
+    parts.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+def _list_fields(key: str, transport) -> list[str]:
+    """Names from ``GET /v1/fields`` (free), or ``[]`` on soft failure.
+
+    A 401 raises — the very next call would bill against a bad key.
+    Everything else degrades to the full-CSV fallback.
+    """
+    req = Request(
+        f"{_BASE}/fields",
+        headers={"Authorization": f"Bearer {key}", "User-Agent": "dji-embed"},
+    )
+    try:
+        with transport(req, timeout=_TIMEOUT_S) as resp:
+            return _field_names(resp.read())
+    except HTTPError as exc:
+        if exc.code == 401:
+            raise LogFetchError(
+                "the API rejected the key (HTTP 401) — check "
+                "FLIGHTREADER_API_KEY"
+            ) from exc
+        logger.info("GET /v1/fields failed (%s); requesting the full CSV", exc)
+        return []
+    except (URLError, OSError) as exc:
+        logger.info("GET /v1/fields failed (%s); requesting the full CSV", exc)
+        return []
+
+
+def _post_log(
+    txt: Path, key: str, fields: list[str] | None, transport
+) -> bytes:
+    """``POST /v1/logs`` (billable): upload *txt*, return the CSV bytes."""
+    form = {"fields": ",".join(fields)} if fields else {}
+    body, content_type = _multipart(txt.name, txt.read_bytes(), form)
+    req = Request(
+        f"{_BASE}/logs",
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": content_type,
+            "User-Agent": "dji-embed",
+        },
+    )
+    try:
+        with transport(req, timeout=_TIMEOUT_S) as resp:
+            return resp.read()
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace").splitlines()
+        hint = " — check FLIGHTREADER_API_KEY" if exc.code == 401 else ""
+        raise LogFetchError(
+            f"{txt.name}: the API answered HTTP {exc.code}"
+            f"{': ' + detail[0] if detail and detail[0] else ''}{hint}"
+        ) from exc
+    except (URLError, OSError) as exc:
+        raise LogFetchError(
+            f"{txt.name}: network error ({exc}) — nothing was consumed; "
+            "re-running is safe"
+        ) from exc
+
+
+def _check_csv(body: bytes, txt: Path) -> None:
+    """Refuse to cache a body that is plainly not CSV."""
+    first = body.decode("utf-8-sig", errors="replace").split("\n", 1)[0].strip()
+    if not first or first[0] in "{<" or ("," not in first and ";" not in first):
+        raise LogFetchError(
+            f"{txt.name}: the API returned something other than CSV "
+            f"(first line: {first[:120]!r}); nothing was written"
+        )
+
+
+def fetch_log(txt: Path, key: str, *, transport=urlopen) -> Path:
+    """Decrypt *txt* through the API; return the cached CSV's path.
+
+    Cache hit = no network. One attempt per request, no retries. The
+    written CSV is verified with :func:`parse_flight_log` immediately —
+    a verification failure keeps the file (it cost money) and raises.
+    """
+    out = cache_path(txt)
+    if out.exists():
+        return out
+    names = _list_fields(key, transport)
+    fields = select_fields(names) if names else None
+    body = _post_log(txt, key, fields, transport)
+    _check_csv(body, txt)
+    out.write_bytes(body)
+    try:
+        parse_flight_log(out)
+    except FlightLogError as exc:
+        raise LogFetchError(
+            f"{out.name} was fetched and kept, but cannot drive the "
+            f"merge: {exc}"
+        ) from exc
+    return out

--- a/src/dji_metadata_embedder/geo/logfetch.py
+++ b/src/dji_metadata_embedder/geo/logfetch.py
@@ -1,0 +1,97 @@
+"""Fetch decrypted flight-log CSVs from the Flight Reader API (#390).
+
+A thin, polite client in front of :mod:`.flightlog`: the returned CSV is
+byte-for-byte what a hand-exported one would be, cached beside the TXT so
+the same record is never uploaded twice. Pure stdlib, matching the rest
+of :mod:`geo`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from .flightlog import _find
+
+logger = logging.getLogger(__name__)
+
+_BASE = "https://api.flightreader.com/v1"
+_TIMEOUT_S = 120
+
+# What the merge consumes (see flightlog.parse_flight_log), as _find
+# needle sets. Everything that matches gets requested; roll, battery,
+# and the rest stay on the server.
+_WANTED: tuple[tuple[str, ...], ...] = (
+    ("gimbal", "pitch"),
+    ("gimbal", "yaw"),
+    ("utc",),
+    ("datetime",),
+    ("date",),
+    ("time",),
+    ("latitude",),
+    ("longitude",),
+)
+
+
+class LogFetchError(ValueError):
+    """A fetch failed; the message states the concrete problem and fix."""
+
+
+def cache_path(txt: Path) -> Path:
+    """Where *txt*'s decoded CSV lives: beside it, provider-named."""
+    return txt.with_name(txt.stem + ".flightreader.csv")
+
+
+def _field_names(payload: bytes) -> list[str]:
+    """Field names from a ``/v1/fields`` response body.
+
+    Lenient by design: the exact schema is unverified until E2E, and a
+    wrong guess must degrade to the full-CSV fallback, never to a crash.
+    """
+    try:
+        data = json.loads(payload)
+    except ValueError:
+        return []
+    if isinstance(data, dict):
+        for key in ("fields", "data", "items"):
+            if isinstance(data.get(key), list):
+                data = data[key]
+                break
+        else:
+            return []
+    if not isinstance(data, list):
+        return []
+    names: list[str] = []
+    for item in data:
+        if isinstance(item, str):
+            names.append(item)
+        elif isinstance(item, dict) and isinstance(item.get("name"), str):
+            names.append(item["name"])
+    return names
+
+
+def select_fields(available: list[str]) -> list[str] | None:
+    """The subset of *available* the merge needs, or ``None`` for "all".
+
+    ``None`` (not an error) when gimbal or timestamp columns cannot be
+    identified — the full CSV plus :func:`parse_flight_log`'s own
+    detection then judges the result.
+    """
+    picked: list[str] = []
+    for needles in _WANTED:
+        hit = _find(available, *needles)
+        if hit and hit not in picked:
+            picked.append(hit)
+    have = set(picked)
+    has_gimbal = _find(sorted(have), "gimbal", "pitch") and _find(
+        sorted(have), "gimbal", "yaw"
+    )
+    has_time = (
+        _find(sorted(have), "utc")
+        or _find(sorted(have), "datetime")
+        or (_find(sorted(have), "date") and _find(sorted(have), "time"))
+    )
+    if not has_gimbal or not has_time:
+        return None
+    return picked

--- a/src/dji_metadata_embedder/geo/logfetch.py
+++ b/src/dji_metadata_embedder/geo/logfetch.py
@@ -12,25 +12,30 @@ import json
 import logging
 from pathlib import Path
 
-from .flightlog import _find
+from .flightlog import _NOT_AIRCRAFT, _find
 
 logger = logging.getLogger(__name__)
 
 _BASE = "https://api.flightreader.com/v1"
 _TIMEOUT_S = 120
 
-# What the merge consumes (see flightlog.parse_flight_log), as _find
-# needle sets. Everything that matches gets requested; roll, battery,
-# and the rest stay on the server.
-_WANTED: tuple[tuple[str, ...], ...] = (
-    ("gimbal", "pitch"),
-    ("gimbal", "yaw"),
-    ("utc",),
-    ("datetime",),
-    ("date",),
-    ("time",),
-    ("latitude",),
-    ("longitude",),
+# Each wanted column: (slot, needles, excludes) — mirroring the _find
+# calls in flightlog.parse_flight_log. Keep the two in sync, or the API
+# gets asked for a column the merge itself would reject (HOME.latitude,
+# OSD.flyTime as the clock). "time" appears twice: preferred form first,
+# parse_flight_log's fallback second.
+_WANTED: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
+    ("pitch", ("gimbal", "pitch"), ()),
+    ("yaw", ("gimbal", "yaw"), ("360",)),
+    ("yaw", ("gimbal", "heading"), ()),
+    ("yaw", ("gimbal", "yaw"), ()),  # the [360] fallback variant
+    ("utc", ("utc",), ()),
+    ("datetime", ("datetime",), ("utc",)),
+    ("date", ("date",), ("datetime",)),
+    ("time", ("time", "local"), ("date",)),
+    ("time", ("time",), ("date", "datetime", "fly")),
+    ("latitude", ("latitude",), _NOT_AIRCRAFT),
+    ("longitude", ("longitude",), _NOT_AIRCRAFT),
 )
 
 
@@ -79,19 +84,16 @@ def select_fields(available: list[str]) -> list[str] | None:
     detection then judges the result.
     """
     picked: list[str] = []
-    for needles in _WANTED:
-        hit = _find(available, *needles)
-        if hit and hit not in picked:
-            picked.append(hit)
-    have = set(picked)
-    has_gimbal = _find(sorted(have), "gimbal", "pitch") and _find(
-        sorted(have), "gimbal", "yaw"
+    hits: set[str] = set()
+    for slot, needles, excludes in _WANTED:
+        hit = _find(available, *needles, exclude=excludes)
+        if hit:
+            hits.add(slot)
+            if hit not in picked:
+                picked.append(hit)
+    has_time = "utc" in hits or "datetime" in hits or (
+        "date" in hits and "time" in hits
     )
-    has_time = (
-        _find(sorted(have), "utc")
-        or _find(sorted(have), "datetime")
-        or (_find(sorted(have), "date") and _find(sorted(have), "time"))
-    )
-    if not has_gimbal or not has_time:
+    if "pitch" not in hits or "yaw" not in hits or not has_time:
         return None
     return picked

--- a/tests/test_cli_fetch_log.py
+++ b/tests/test_cli_fetch_log.py
@@ -1,0 +1,132 @@
+"""CLI tests for fetch-log — fetch_log itself is always monkeypatched."""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import dji_metadata_embedder.cli as cli_mod
+from dji_metadata_embedder.cli import main
+from dji_metadata_embedder.geo.logfetch import LogFetchError, cache_path
+
+KEY_ENV = {"FLIGHTREADER_API_KEY": "sk_test"}
+
+
+def _record(tmp_path, name="DJIFlightRecord_2026-07-27_[17-28-49].txt"):
+    txt = tmp_path / name
+    txt.write_bytes(b"\x0a record")
+    return txt
+
+
+def _fake_ok(calls):
+    def fake(txt, key):
+        calls.append((Path(txt), key))
+        out = cache_path(Path(txt))
+        out.write_bytes(b"csv")
+        return out
+    return fake
+
+
+def test_consent_shown_then_fetches(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok(calls))
+    txt = _record(tmp_path)
+    res = CliRunner().invoke(
+        main, ["fetch-log", str(txt)], input="y\n", env=KEY_ENV
+    )
+    assert res.exit_code == 0, res.output
+    assert "uploads your entire flight log to Flight Reader" in res.output
+    assert "deleted immediately" in res.output
+    assert "Wrote DJIFlightRecord_2026-07-27_[17-28-49].flightreader.csv" \
+        in res.output
+    assert calls == [(txt, "sk_test")]
+
+
+def test_declining_consent_sends_nothing_and_exits_zero(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok(calls))
+    txt = _record(tmp_path)
+    res = CliRunner().invoke(
+        main, ["fetch-log", str(txt)], input="n\n", env=KEY_ENV
+    )
+    assert res.exit_code == 0, res.output
+    assert "Nothing sent." in res.output
+    assert calls == []
+
+
+def test_cache_hit_skips_consent_entirely(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok(calls))
+    txt = _record(tmp_path)
+    cache_path(txt).write_bytes(b"already here")
+    res = CliRunner().invoke(main, ["fetch-log", str(txt)], env=KEY_ENV)
+    assert res.exit_code == 0, res.output
+    assert "already exists" in res.output
+    assert "delete it to refetch" in res.output
+    assert "uploads your entire flight log" not in res.output
+    assert calls == []
+
+
+def test_yes_skips_the_prompt(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok(calls))
+    txt = _record(tmp_path)
+    res = CliRunner().invoke(
+        main, ["fetch-log", "--yes", str(txt)], env=KEY_ENV
+    )
+    assert res.exit_code == 0, res.output
+    assert calls and calls[0][0] == txt
+
+
+def test_jsonl_without_yes_is_a_usage_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok([]))
+    txt = _record(tmp_path)
+    res = CliRunner().invoke(
+        main, ["fetch-log", "--progress", "jsonl", str(txt)], env=KEY_ENV
+    )
+    assert res.exit_code == 2
+    assert "--yes" in res.output
+
+
+def test_jsonl_without_env_key_names_the_variable(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok([]))
+    monkeypatch.delenv("FLIGHTREADER_API_KEY", raising=False)
+    txt = _record(tmp_path)
+    res = CliRunner().invoke(
+        main, ["fetch-log", "--progress", "jsonl", "--yes", str(txt)]
+    )
+    assert res.exit_code != 0
+    assert "FLIGHTREADER_API_KEY" in res.output
+
+
+def test_missing_env_key_prompts_hidden(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok(calls))
+    monkeypatch.delenv("FLIGHTREADER_API_KEY", raising=False)
+    txt = _record(tmp_path)
+    res = CliRunner().invoke(
+        main, ["fetch-log", str(txt)], input="y\nsk_prompted\n"
+    )
+    assert res.exit_code == 0, res.output
+    assert calls == [(txt, "sk_prompted")]
+    assert "sk_prompted" not in res.output  # hidden input never echoes
+
+
+def test_one_failure_continues_and_exits_nonzero(tmp_path, monkeypatch):
+    good = _record(tmp_path, "DJIFlightRecord_A.txt")
+    bad = _record(tmp_path, "DJIFlightRecord_B.txt")
+
+    def fake(txt, key):
+        if Path(txt) == bad:
+            raise LogFetchError("DJIFlightRecord_B.txt: the API answered "
+                                "HTTP 402: insufficient balance")
+        out = cache_path(Path(txt))
+        out.write_bytes(b"csv")
+        return out
+
+    monkeypatch.setattr(cli_mod, "fetch_log", fake)
+    res = CliRunner().invoke(
+        main, ["fetch-log", "--yes", str(good), str(bad)], env=KEY_ENV
+    )
+    assert res.exit_code != 0
+    assert "Wrote DJIFlightRecord_A.flightreader.csv" in res.output
+    assert "HTTP 402" in res.output
+    assert "1 of 2 records failed" in res.output

--- a/tests/test_cli_fetch_log.py
+++ b/tests/test_cli_fetch_log.py
@@ -1,4 +1,5 @@
 """CLI tests for fetch-log — fetch_log itself is always monkeypatched."""
+import json
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -130,3 +131,33 @@ def test_one_failure_continues_and_exits_nonzero(tmp_path, monkeypatch):
     assert "Wrote DJIFlightRecord_A.flightreader.csv" in res.output
     assert "HTTP 402" in res.output
     assert "1 of 2 records failed" in res.output
+
+
+def test_jsonl_stdout_is_pure_json_and_ends_in_result(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok(calls))
+    fresh = _record(tmp_path, "DJIFlightRecord_A.txt")
+    cached = _record(tmp_path, "DJIFlightRecord_B.txt")
+    cache_path(cached).write_bytes(b"already here")
+    res = CliRunner().invoke(
+        main,
+        ["fetch-log", "--progress", "jsonl", "--yes", str(fresh), str(cached)],
+        env=KEY_ENV,
+    )
+    assert res.exit_code == 0, res.output
+    lines = [ln for ln in res.output.splitlines() if ln.strip()]
+    events = [json.loads(ln) for ln in lines]  # every line must parse
+    assert events[-1]["event"] == "result"
+
+
+def test_jsonl_cache_hit_only_run_still_ends_in_result(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_mod, "fetch_log", _fake_ok([]))
+    txt = _record(tmp_path)
+    cache_path(txt).write_bytes(b"already here")
+    res = CliRunner().invoke(
+        main, ["fetch-log", "--progress", "jsonl", "--yes", str(txt)],
+        env=KEY_ENV,
+    )
+    assert res.exit_code == 0, res.output
+    events = [json.loads(ln) for ln in res.output.splitlines() if ln.strip()]
+    assert events[-1]["event"] == "result"

--- a/tests/test_geo_logfetch.py
+++ b/tests/test_geo_logfetch.py
@@ -2,8 +2,12 @@
 import io
 import json
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import pytest
 
 from dji_metadata_embedder.geo.logfetch import (
+    LogFetchError,
     _field_names,
     cache_path,
     fetch_log,
@@ -168,3 +172,55 @@ def test_fetch_log_falls_back_to_full_csv_when_fields_are_odd(tmp_path):
     fetch_log(_txt(tmp_path), "sk_test", transport=transport)
     post_req = transport.requests[1]
     assert b'name="fields"' not in post_req.data  # no preselection sent
+
+
+def _http_error(code, reason, body=b""):
+    return HTTPError("https://api.flightreader.com/v1/x", code, reason,
+                     None, io.BytesIO(body))
+
+
+def test_401_on_fields_aborts_before_the_billable_call(tmp_path):
+    transport = FakeTransport([_http_error(401, "Unauthorized")])
+    with pytest.raises(LogFetchError, match="FLIGHTREADER_API_KEY"):
+        fetch_log(_txt(tmp_path), "sk_bad", transport=transport)
+    assert len(transport.requests) == 1  # POST /v1/logs never happened
+
+
+def test_post_http_error_carries_status_and_provider_message(tmp_path):
+    transport = FakeTransport(
+        [FIELDS_BODY, _http_error(402, "Payment Required",
+                                  b"insufficient balance")]
+    )
+    with pytest.raises(LogFetchError, match="HTTP 402.*insufficient balance"):
+        fetch_log(_txt(tmp_path), "sk_test", transport=transport)
+
+
+def test_network_error_says_rerunning_is_safe(tmp_path):
+    transport = FakeTransport([FIELDS_BODY, URLError("timed out")])
+    with pytest.raises(LogFetchError, match="re-running is safe"):
+        fetch_log(_txt(tmp_path), "sk_test", transport=transport)
+
+
+def test_non_csv_response_writes_nothing(tmp_path):
+    txt = _txt(tmp_path)
+    transport = FakeTransport([FIELDS_BODY, b'{"error": "oops"}'])
+    with pytest.raises(LogFetchError, match="other than CSV"):
+        fetch_log(txt, "sk_test", transport=transport)
+    assert not (txt.with_name(txt.stem + ".flightreader.csv")).exists()
+
+
+def test_verification_failure_keeps_the_paid_file(tmp_path):
+    txt = _txt(tmp_path)
+    no_gimbal = b'"OSD.latitude","OSD.longitude"\n"59,3","18,0"\n'
+    transport = FakeTransport([FIELDS_BODY, no_gimbal])
+    with pytest.raises(LogFetchError, match="fetched and kept"):
+        fetch_log(txt, "sk_test", transport=transport)
+    cache = txt.with_name(txt.stem + ".flightreader.csv")
+    assert cache.read_bytes() == no_gimbal  # kept — it cost money
+
+
+def test_requests_carry_the_dji_embed_user_agent(tmp_path):
+    transport = FakeTransport([FIELDS_BODY, CSV_BODY])
+    fetch_log(_txt(tmp_path), "sk_test", transport=transport)
+    for req in transport.requests:
+        assert req.get_header("User-agent") == "dji-embed"

--- a/tests/test_geo_logfetch.py
+++ b/tests/test_geo_logfetch.py
@@ -1,0 +1,65 @@
+"""Unit tests for geo/logfetch.py — no network, ever."""
+import json
+from pathlib import Path
+
+from dji_metadata_embedder.geo.logfetch import (
+    _field_names,
+    cache_path,
+    select_fields,
+)
+
+# The header set of a real Flight Reader export (mirrors the FLIGHT_READER
+# fixture in test_geo_flightlog.py).
+FR_FIELDS = [
+    "CUSTOM.date [local]", "CUSTOM.updateTime [local]", "OSD.flyTime [s]",
+    "OSD.latitude", "OSD.longitude", "HOME.latitude", "HOME.longitude",
+    "GIMBAL.pitch", "GIMBAL.yaw", "GIMBAL.yaw [360]", "GIMBAL.roll",
+]
+
+
+def test_cache_path_sits_beside_the_txt():
+    txt = Path("/x/DJIFlightRecord_2026-07-27_[17-28-49].txt")
+    assert cache_path(txt) == Path(
+        "/x/DJIFlightRecord_2026-07-27_[17-28-49].flightreader.csv"
+    )
+
+
+def test_select_fields_picks_the_merge_columns():
+    picked = select_fields(FR_FIELDS)
+    assert picked is not None
+    assert "GIMBAL.pitch" in picked
+    assert "GIMBAL.yaw" in picked
+    assert "CUSTOM.date [local]" in picked
+    assert "CUSTOM.updateTime [local]" in picked
+    assert "OSD.latitude" in picked and "OSD.longitude" in picked
+    # No duplicates, and nothing the merge does not use.
+    assert len(picked) == len(set(picked))
+    assert "GIMBAL.roll" not in picked
+
+
+def test_select_fields_prefers_utc_when_offered():
+    picked = select_fields(FR_FIELDS + ["CUSTOM.updateTime [utc]"])
+    assert picked is not None
+    assert "CUSTOM.updateTime [utc]" in picked
+
+
+def test_select_fields_returns_none_without_gimbal():
+    assert select_fields(["OSD.latitude", "CUSTOM.date [local]"]) is None
+
+
+def test_select_fields_returns_none_without_a_timestamp():
+    assert select_fields(["GIMBAL.pitch", "GIMBAL.yaw"]) is None
+
+
+def test_field_names_accepts_a_list_of_strings():
+    assert _field_names(json.dumps(FR_FIELDS).encode()) == FR_FIELDS
+
+
+def test_field_names_accepts_objects_with_a_name_key():
+    payload = json.dumps([{"name": "GIMBAL.pitch"}, {"name": "GIMBAL.yaw"}])
+    assert _field_names(payload.encode()) == ["GIMBAL.pitch", "GIMBAL.yaw"]
+
+
+def test_field_names_returns_empty_on_surprises():
+    assert _field_names(b"not json at all") == []
+    assert _field_names(json.dumps({"unexpected": 1}).encode()) == []

--- a/tests/test_geo_logfetch.py
+++ b/tests/test_geo_logfetch.py
@@ -51,6 +51,41 @@ def test_select_fields_returns_none_without_a_timestamp():
     assert select_fields(["GIMBAL.pitch", "GIMBAL.yaw"]) is None
 
 
+def test_select_fields_skips_home_and_rc_coordinates():
+    fields = [
+        "HOME.latitude", "HOME.longitude", "RC.latitude",
+        "OSD.latitude", "OSD.longitude",
+        "CUSTOM.date [local]", "CUSTOM.updateTime [local]",
+        "GIMBAL.pitch", "GIMBAL.yaw",
+    ]
+    picked = select_fields(fields)
+    assert picked is not None
+    assert "OSD.latitude" in picked and "OSD.longitude" in picked
+    assert "HOME.latitude" not in picked
+    assert "RC.latitude" not in picked
+
+
+def test_select_fields_finds_signed_yaw_behind_the_360_variant():
+    fields = [
+        "GIMBAL.yaw [360]", "GIMBAL.yaw", "GIMBAL.pitch",
+        "CUSTOM.date [local]", "CUSTOM.updateTime [local]",
+    ]
+    picked = select_fields(fields)
+    assert picked is not None
+    assert "GIMBAL.yaw" in picked  # signed yaw, despite [360] listed first
+
+
+def test_select_fields_does_not_mistake_flytime_for_the_clock():
+    fields = [
+        "OSD.flyTime [s]", "CUSTOM.date [local]",
+        "CUSTOM.updateTime [local]", "GIMBAL.pitch", "GIMBAL.yaw",
+    ]
+    picked = select_fields(fields)
+    assert picked is not None
+    assert "CUSTOM.updateTime [local]" in picked
+    assert "OSD.flyTime [s]" not in picked
+
+
 def test_field_names_accepts_a_list_of_strings():
     assert _field_names(json.dumps(FR_FIELDS).encode()) == FR_FIELDS
 

--- a/tests/test_geo_logfetch.py
+++ b/tests/test_geo_logfetch.py
@@ -1,10 +1,12 @@
 """Unit tests for geo/logfetch.py — no network, ever."""
+import io
 import json
 from pathlib import Path
 
 from dji_metadata_embedder.geo.logfetch import (
     _field_names,
     cache_path,
+    fetch_log,
     select_fields,
 )
 
@@ -98,3 +100,71 @@ def test_field_names_accepts_objects_with_a_name_key():
 def test_field_names_returns_empty_on_surprises():
     assert _field_names(b"not json at all") == []
     assert _field_names(json.dumps({"unexpected": 1}).encode()) == []
+
+
+# Flight Reader-shaped CSV (same shape test_geo_flightlog.py validates):
+# quoted decimal-comma values, 12-hour local clock.
+CSV_BODY = (
+    '"CUSTOM.date [local]","CUSTOM.updateTime [local]","OSD.latitude",'
+    '"OSD.longitude","GIMBAL.pitch","GIMBAL.yaw"\n'
+    '"2026-07-27","2:00:00,0 pm","59,33459","18,06324","-60,0","-10,0"\n'
+    '"2026-07-27","2:00:01,0 pm","59,33460","18,06325","-61,0","-9,0"\n'
+).encode()
+
+FIELDS_BODY = json.dumps([
+    "CUSTOM.date [local]", "CUSTOM.updateTime [local]",
+    "OSD.latitude", "OSD.longitude", "GIMBAL.pitch", "GIMBAL.yaw",
+]).encode()
+
+
+class FakeTransport:
+    """urlopen-shaped: records every Request, replays queued responses."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def __call__(self, req, *, timeout=None):
+        self.requests.append(req)
+        result = self.responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return io.BytesIO(result)
+
+
+def _txt(tmp_path):
+    txt = tmp_path / "DJIFlightRecord_2026-07-27_[17-28-49].txt"
+    txt.write_bytes(b"\x0a encrypted-record-bytes")
+    return txt
+
+
+def test_fetch_log_happy_path_writes_the_cache(tmp_path):
+    transport = FakeTransport([FIELDS_BODY, CSV_BODY])
+    out = fetch_log(_txt(tmp_path), "sk_test", transport=transport)
+    assert out.read_bytes() == CSV_BODY
+    assert out.name == "DJIFlightRecord_2026-07-27_[17-28-49].flightreader.csv"
+    fields_req, post_req = transport.requests
+    assert fields_req.full_url == "https://api.flightreader.com/v1/fields"
+    assert fields_req.get_header("Authorization") == "Bearer sk_test"
+    assert post_req.full_url == "https://api.flightreader.com/v1/logs"
+    assert post_req.get_method() == "POST"
+    assert b"GIMBAL.pitch" in post_req.data          # fields preselection
+    assert b"encrypted-record-bytes" in post_req.data  # the file itself
+    assert "sk_test" not in repr(post_req.data)
+
+
+def test_fetch_log_cache_hit_makes_no_network_calls(tmp_path):
+    txt = _txt(tmp_path)
+    cache = txt.with_name(txt.stem + ".flightreader.csv")
+    cache.write_bytes(CSV_BODY)
+    transport = FakeTransport([])
+    out = fetch_log(txt, "sk_test", transport=transport)
+    assert out == cache
+    assert transport.requests == []
+
+
+def test_fetch_log_falls_back_to_full_csv_when_fields_are_odd(tmp_path):
+    transport = FakeTransport([b"weird payload", CSV_BODY])
+    fetch_log(_txt(tmp_path), "sk_test", transport=transport)
+    post_req = transport.requests[1]
+    assert b'name="fields"' not in post_req.data  # no preselection sent

--- a/tests/test_progress_jsonl.py
+++ b/tests/test_progress_jsonl.py
@@ -733,6 +733,72 @@ def test_verify_sun_jsonl_rejects_format_json(tmp_path):
     assert "--format" in res.output and "--progress" in res.output
 
 
+def test_fetch_log_jsonl_happy_path(monkeypatch, tmp_path):
+    from dji_metadata_embedder import cli as cli_mod
+    from dji_metadata_embedder.geo.logfetch import cache_path
+
+    calls = []
+
+    def fake(txt, key):
+        calls.append((Path(txt), key))
+        out = cache_path(Path(txt))
+        out.write_bytes(b"csv")
+        return out
+
+    monkeypatch.setattr(cli_mod, "fetch_log", fake)
+    a = tmp_path / "DJIFlightRecord_A.txt"
+    b = tmp_path / "DJIFlightRecord_B.txt"
+    a.write_bytes(b"\x0a record")
+    b.write_bytes(b"\x0a record")
+    res = CliRunner().invoke(
+        main,
+        ["fetch-log", "--progress", "jsonl", "--yes", str(a), str(b)],
+        env={"FLIGHTREADER_API_KEY": "sk_test"},
+    )
+    assert res.exit_code == 0, res.output
+    events = _events(res.stdout)
+    assert events[0]["command"] == "fetch-log"
+    last = events[-1]
+    assert last["event"] == "result" and last["ok"] is True
+    assert sorted(last["outputs"]) == sorted(
+        str(p.resolve()) for p in (cache_path(a), cache_path(b))
+    )
+    assert last["summary"] == {"fetched": 2, "cached": 0, "failed": 0}
+    assert len(calls) == 2
+
+
+def test_fetch_log_jsonl_one_failure_ends_in_error(monkeypatch, tmp_path):
+    from dji_metadata_embedder import cli as cli_mod
+    from dji_metadata_embedder.geo.logfetch import LogFetchError, cache_path
+
+    good = tmp_path / "DJIFlightRecord_A.txt"
+    bad = tmp_path / "DJIFlightRecord_B.txt"
+    good.write_bytes(b"\x0a record")
+    bad.write_bytes(b"\x0a record")
+
+    def fake(txt, key):
+        if Path(txt) == bad:
+            raise LogFetchError(
+                "DJIFlightRecord_B.txt: the API answered HTTP 402: "
+                "insufficient balance"
+            )
+        out = cache_path(Path(txt))
+        out.write_bytes(b"csv")
+        return out
+
+    monkeypatch.setattr(cli_mod, "fetch_log", fake)
+    res = CliRunner().invoke(
+        main,
+        ["fetch-log", "--progress", "jsonl", "--yes", str(good), str(bad)],
+        env={"FLIGHTREADER_API_KEY": "sk_test"},
+    )
+    assert res.exit_code != 0
+    events = _events(res.stdout)
+    warnings = [e for e in events if e["event"] == "warning"]
+    assert len(warnings) == 1 and warnings[0]["item"] == "DJIFlightRecord_B.txt"
+    assert events[-1]["event"] == "error"
+
+
 def test_doctor_jsonl_never_runs_the_online_update_check(monkeypatch):
     # Consent for going online is interactive-only; a machine consumer of
     # the event stream must never trigger the network path.

--- a/tools/mtp-copy.ps1
+++ b/tools/mtp-copy.ps1
@@ -31,9 +31,21 @@ $records = @()
 $deviceName = $null
 foreach ($dev in $pc.Items()) {
   if (-not $dev.IsFolder) { continue }
-  foreach ($storage in $dev.GetFolder.Items()) {
+  # Fixed drives, empty card readers, and dropped network shares all live
+  # under "This PC" too, and their COM folder calls can throw or return
+  # null - skip anything that will not enumerate cleanly.
+  try {
+    $devFolder = $dev.GetFolder
+    if ($null -eq $devFolder) { continue }
+    $storages = @($devFolder.Items())
+  } catch { continue }
+  foreach ($storage in $storages) {
     if (-not $storage.IsFolder) { continue }
-    $found = @($storage.GetFolder.Items() | Where-Object { $_.Name -like $Filter })
+    try {
+      $storageFolder = $storage.GetFolder
+      if ($null -eq $storageFolder) { continue }
+      $found = @($storageFolder.Items() | Where-Object { $_.Name -like $Filter })
+    } catch { continue }
     if ($found.Count -gt 0) {
       $records = $found
       $deviceName = $dev.Name
@@ -57,7 +69,7 @@ if (-not (Test-Path $Destination)) {
 }
 $destFolder = $shell.NameSpace((Resolve-Path $Destination).Path)
 
-$existing = @(Get-ChildItem -Path $Destination -Filter '*.txt' -ErrorAction SilentlyContinue |
+$existing = @(Get-ChildItem -Path $Destination -Filter $Filter -ErrorAction SilentlyContinue |
               ForEach-Object { $_.Name })
 $want = @($records | Where-Object { $existing -notcontains $_.Name })
 Write-Output ("Copying {0} new record(s) to {1} ({2} already there)." -f
@@ -70,13 +82,19 @@ foreach ($r in $want) {
 
 # CopyHere is asynchronous over MTP; wait for the files to land.
 $target = $existing.Count + $want.Count
-for ($t = 0; $t -lt $TimeoutSeconds; $t++) {
-  Start-Sleep -Seconds 1
-  $have = @(Get-ChildItem -Path $Destination -Filter '*.txt' -ErrorAction SilentlyContinue)
-  if ($have.Count -ge $target) { break }
+if ($want.Count -gt 0) {
+  for ($t = 0; $t -lt $TimeoutSeconds; $t++) {
+    Start-Sleep -Seconds 1
+    $have = @(Get-ChildItem -Path $Destination -Filter $Filter -ErrorAction SilentlyContinue)
+    if ($have.Count -ge $target) { break }
+  }
+  $have = @(Get-ChildItem -Path $Destination -Filter $Filter -ErrorAction SilentlyContinue)
+  if ($have.Count -lt $target) {
+    Write-Output ("WARNING: timed out after {0}s with {1} of {2} files landed - MTP copies may still be in flight." -f $TimeoutSeconds, $have.Count, $target)
+  }
 }
 
-$landed = @(Get-ChildItem -Path $Destination -Filter '*.txt')
+$landed = @(Get-ChildItem -Path $Destination -Filter $Filter)
 Write-Output ''
 Write-Output ("{0} record(s) now in {1}:" -f $landed.Count, $Destination)
 $landed | Sort-Object Name | ForEach-Object {

--- a/tools/mtp-copy.ps1
+++ b/tools/mtp-copy.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+Copy DJI flight records off a remote controller over USB (MTP).
+
+.DESCRIPTION
+DJI RCs expose flight records at the root of "Internal shared storage"
+over MTP, which has no drive letter - plain Copy-Item cannot see it.
+This script walks the Shell.Application COM namespace instead, so it
+works on a stock Windows PowerShell 5.1 with the RC plugged in, powered
+on, and unlocked.
+
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File tools\mtp-copy.ps1
+.EXAMPLE
+powershell -ExecutionPolicy Bypass -File tools\mtp-copy.ps1 -Filter 'DJIFlightRecord_2026-07-*' -Destination D:\FlightRecords
+#>
+param(
+  [string]$Destination = (Join-Path $env:USERPROFILE 'Documents\FlightRecords'),
+  [string]$Filter = 'DJIFlightRecord_*.txt',
+  [int]$TimeoutSeconds = 120
+)
+
+$ErrorActionPreference = 'Stop'
+$shell = New-Object -ComObject Shell.Application
+$pc = $shell.NameSpace(17)  # "This PC", where portable devices appear
+
+# Find the portable device exposing flight records: any device whose
+# storage root contains a matching file. Name-matching ("*MTP*") is not
+# reliable across RC models, so probe contents instead.
+$records = @()
+$deviceName = $null
+foreach ($dev in $pc.Items()) {
+  if (-not $dev.IsFolder) { continue }
+  foreach ($storage in $dev.GetFolder.Items()) {
+    if (-not $storage.IsFolder) { continue }
+    $found = @($storage.GetFolder.Items() | Where-Object { $_.Name -like $Filter })
+    if ($found.Count -gt 0) {
+      $records = $found
+      $deviceName = $dev.Name
+      break
+    }
+  }
+  if ($deviceName) { break }
+}
+
+if (-not $deviceName) {
+  Write-Output "No flight records matching '$Filter' found on any portable device."
+  Write-Output 'Is the RC plugged in over USB, powered on, and unlocked?'
+  Write-Output '(Records sit at the root of "Internal shared storage".)'
+  exit 1
+}
+
+Write-Output ("Found {0} record(s) on '{1}'." -f $records.Count, $deviceName)
+
+if (-not (Test-Path $Destination)) {
+  New-Item -ItemType Directory -Path $Destination | Out-Null
+}
+$destFolder = $shell.NameSpace((Resolve-Path $Destination).Path)
+
+$existing = @(Get-ChildItem -Path $Destination -Filter '*.txt' -ErrorAction SilentlyContinue |
+              ForEach-Object { $_.Name })
+$want = @($records | Where-Object { $existing -notcontains $_.Name })
+Write-Output ("Copying {0} new record(s) to {1} ({2} already there)." -f
+              $want.Count, $Destination, ($records.Count - $want.Count))
+
+foreach ($r in $want) {
+  Write-Output ("  -> {0}" -f $r.Name)
+  $destFolder.CopyHere($r, 16)  # 16 = answer "yes to all" to dialogs
+}
+
+# CopyHere is asynchronous over MTP; wait for the files to land.
+$target = $existing.Count + $want.Count
+for ($t = 0; $t -lt $TimeoutSeconds; $t++) {
+  Start-Sleep -Seconds 1
+  $have = @(Get-ChildItem -Path $Destination -Filter '*.txt' -ErrorAction SilentlyContinue)
+  if ($have.Count -ge $target) { break }
+}
+
+$landed = @(Get-ChildItem -Path $Destination -Filter '*.txt')
+Write-Output ''
+Write-Output ("{0} record(s) now in {1}:" -f $landed.Count, $Destination)
+$landed | Sort-Object Name | ForEach-Object {
+  Write-Output ("  {0}  {1} bytes" -f $_.Name, $_.Length)
+}


### PR DESCRIPTION
Implements roadmap stage 1 per the (local) 2026-07-29 design spec: `geo/logfetch.py` API client behind a transport seam, the `fetch-log` subcommand with per-invocation consent (`--yes` required under `--progress jsonl`), `FLIGHTREADER_API_KEY` env/hidden-prompt key handling, `/v1/fields` token-matched preselection with full-CSV fallback, cache-as-politeness (a record is never uploaded twice; delete the CSV to refetch), fetch-time verification via `parse_flight_log`, `tools/mtp-copy.ps1`, and the RC-retrieval + API how-to sections. The jsonl contract (`PROGRESS_JSONL.md` + golden schema tests) covers the new command.

Every task passed an independent spec+quality review; the whole-branch review verdict is SHIP. Full local gate: 906 passed / 3 skipped, ruff clean, mypy clean, mkdocs strict clean.

**Pending outside CI** (release-gate items for v2.3.0, tracked on #390): live E2E against the real API (test key requested from the provider 2026-07-29; pay-as-you-go fallback) and a real-RC run of `mtp-copy.ps1`.

**Follow-ups filed:** #410 (extract the flightlog/logfetch shared column-spec), #411 (narrow the MTP probe to WPD devices, validate during the RC E2E).

Refs #390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FaYmng8yA7te6Nc25UDwF