### PR TITLE
fetch-log follow-ups: shared column spec (#410) + WPD-only probe (#411)

### DIFF
--- a/src/dji_metadata_embedder/geo/flightlog.py
+++ b/src/dji_metadata_embedder/geo/flightlog.py
@@ -84,6 +84,31 @@ class MergeReport:
 # Columns that look like coordinates but are not the aircraft's position.
 _NOT_AIRCRAFT = ("home", "rc", "remote", "tablet")
 
+# Which export column fills each slot the merge consumes: per slot, the
+# (needles, exclude) alternatives tried in order, first hit winning.
+# Shared with logfetch.select_fields, so the API is asked for exactly the
+# columns parse_flight_log would choose from a hand-made export.
+_COLUMN_SPEC: dict[str, tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]] = {
+    "pitch": ((("gimbal", "pitch"), ()),),
+    # Signed yaw first, then heading, then the [0, 360) variant —
+    # _normalize_yaw folds any of them into signed true-north degrees.
+    "yaw": (
+        (("gimbal", "yaw"), ("360",)),
+        (("gimbal", "heading"), ()),
+        (("gimbal", "yaw"), ()),
+    ),
+    "utc": ((("utc",), ()),),
+    "datetime": ((("datetime",), ("utc",)),),
+    "date": ((("date",), ("datetime",)),),
+    # OSD.flyTime is a stopwatch, not a clock — hence the "fly" exclusion.
+    "time": (
+        (("time", "local"), ("date",)),
+        (("time",), ("date", "datetime", "fly")),
+    ),
+    "latitude": ((("latitude",), _NOT_AIRCRAFT),),
+    "longitude": ((("longitude",), _NOT_AIRCRAFT),),
+}
+
 _ADVICE = (
     "enable the UTC timestamp and the gimbal pitch/yaw fields in the "
     "decoder's export settings (in Flight Reader: GIMBAL.pitch and "
@@ -115,6 +140,14 @@ def _find(
             continue
         if all(n in toks for n in needles):
             return h
+    return None
+
+
+def _find_column(headers: Sequence[str], slot: str) -> str | None:
+    """The header filling *slot*, per _COLUMN_SPEC's preference order."""
+    for needles, exclude in _COLUMN_SPEC[slot]:
+        if hit := _find(headers, *needles, exclude=exclude):
+            return hit
     return None
 
 
@@ -220,25 +253,18 @@ def parse_flight_log(path: Path | str) -> FlightLog:
     reader = csv.DictReader(text.splitlines(), delimiter=delimiter)
     headers = reader.fieldnames or []
 
-    pitch_col = _find(headers, "gimbal", "pitch")
-    yaw_col = _find(headers, "gimbal", "yaw", exclude=("360",)) or _find(
-        headers, "gimbal", "heading"
-    )
-    yaw_360_col = None if yaw_col else _find(headers, "gimbal", "yaw")
-    if pitch_col is None or (yaw_col is None and yaw_360_col is None):
+    pitch_col = _find_column(headers, "pitch")
+    yaw_col = _find_column(headers, "yaw")
+    if pitch_col is None or yaw_col is None:
         raise FlightLogError(
             f"{src.name}: no gimbal pitch/yaw columns found — {_ADVICE}. "
             f"Columns present: {', '.join(headers) or '(none)'}"
         )
-    yaw_col = yaw_col or yaw_360_col
-    assert yaw_col is not None
 
-    utc_col = _find(headers, "utc")
-    datetime_col = _find(headers, "datetime", exclude=("utc",))
-    date_col = _find(headers, "date", exclude=("datetime",))
-    time_col = _find(headers, "time", "local", exclude=("date",)) or _find(
-        headers, "time", exclude=("date", "datetime", "fly")
-    )
+    utc_col = _find_column(headers, "utc")
+    datetime_col = _find_column(headers, "datetime")
+    date_col = _find_column(headers, "date")
+    time_col = _find_column(headers, "time")
     if utc_col is None and datetime_col is None and (
         date_col is None or time_col is None
     ):
@@ -247,8 +273,8 @@ def parse_flight_log(path: Path | str) -> FlightLog:
             f"by time, so {_ADVICE}. A UTC timestamp gives an exact join."
         )
 
-    lat_col = _find(headers, "latitude", exclude=_NOT_AIRCRAFT)
-    lon_col = _find(headers, "longitude", exclude=_NOT_AIRCRAFT)
+    lat_col = _find_column(headers, "latitude")
+    lon_col = _find_column(headers, "longitude")
 
     columns = {
         "pitch": pitch_col,

--- a/src/dji_metadata_embedder/geo/logfetch.py
+++ b/src/dji_metadata_embedder/geo/logfetch.py
@@ -15,31 +15,12 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from .flightlog import _NOT_AIRCRAFT, _find, FlightLogError, parse_flight_log
+from .flightlog import _COLUMN_SPEC, _find, FlightLogError, parse_flight_log
 
 logger = logging.getLogger(__name__)
 
 _BASE = "https://api.flightreader.com/v1"
 _TIMEOUT_S = 120
-
-# Each wanted column: (slot, needles, excludes) — mirroring the _find
-# calls in flightlog.parse_flight_log. Keep the two in sync, or the API
-# gets asked for a column the merge itself would reject (HOME.latitude,
-# OSD.flyTime as the clock). "time" appears twice: preferred form first,
-# parse_flight_log's fallback second.
-_WANTED: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
-    ("pitch", ("gimbal", "pitch"), ()),
-    ("yaw", ("gimbal", "yaw"), ("360",)),
-    ("yaw", ("gimbal", "heading"), ()),
-    ("yaw", ("gimbal", "yaw"), ()),  # the [360] fallback variant
-    ("utc", ("utc",), ()),
-    ("datetime", ("datetime",), ("utc",)),
-    ("date", ("date",), ("datetime",)),
-    ("time", ("time", "local"), ("date",)),
-    ("time", ("time",), ("date", "datetime", "fly")),
-    ("latitude", ("latitude",), _NOT_AIRCRAFT),
-    ("longitude", ("longitude",), _NOT_AIRCRAFT),
-)
 
 
 class LogFetchError(ValueError):
@@ -86,14 +67,18 @@ def select_fields(available: list[str]) -> list[str] | None:
     identified — the full CSV plus :func:`parse_flight_log`'s own
     detection then judges the result.
     """
+    # Unlike parse_flight_log's first-hit-per-slot, every alternative's
+    # hit is requested — the CSV then carries each candidate column and
+    # the parser applies its own preference order to the result.
     picked: list[str] = []
     hits: set[str] = set()
-    for slot, needles, excludes in _WANTED:
-        hit = _find(available, *needles, exclude=excludes)
-        if hit:
-            hits.add(slot)
-            if hit not in picked:
-                picked.append(hit)
+    for slot, alternatives in _COLUMN_SPEC.items():
+        for needles, exclude in alternatives:
+            hit = _find(available, *needles, exclude=exclude)
+            if hit:
+                hits.add(slot)
+                if hit not in picked:
+                    picked.append(hit)
     has_time = "utc" in hits or "datetime" in hits or (
         "date" in hits and "time" in hits
     )

--- a/tests/test_geo_logfetch.py
+++ b/tests/test_geo_logfetch.py
@@ -1,4 +1,5 @@
 """Unit tests for geo/logfetch.py — no network, ever."""
+import csv
 import io
 import json
 from pathlib import Path
@@ -6,6 +7,7 @@ from urllib.error import HTTPError, URLError
 
 import pytest
 
+from dji_metadata_embedder.geo.flightlog import parse_flight_log
 from dji_metadata_embedder.geo.logfetch import (
     LogFetchError,
     _field_names,
@@ -90,6 +92,59 @@ def test_select_fields_does_not_mistake_flytime_for_the_clock():
     assert picked is not None
     assert "CUSTOM.updateTime [local]" in picked
     assert "OSD.flyTime [s]" not in picked
+
+
+# One plausible value per known header, for building throwaway exports.
+_ROW_VALUES = {
+    "CUSTOM.date [local]": "2026-07-27",
+    "CUSTOM.updateTime [local]": "17:28:49.5",
+    "CUSTOM.updateTime [utc]": "2026-07-27 15:28:49.0",
+    "OSD.flyTime [s]": "12.3",
+    "OSD.latitude": "59.3",
+    "OSD.longitude": "18.1",
+    "HOME.latitude": "59.0",
+    "HOME.longitude": "18.0",
+    "GIMBAL.pitch": "-45.0",
+    "GIMBAL.yaw": "123.4",
+    "GIMBAL.yaw [360]": "303.4",
+    "GIMBAL.heading": "123.4",
+    "GIMBAL.roll": "0.0",
+}
+
+
+def _one_row_csv(headers: list[str]) -> str:
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(headers)
+    writer.writerow([_ROW_VALUES[h] for h in headers])
+    return buf.getvalue()
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        FR_FIELDS,
+        FR_FIELDS + ["CUSTOM.updateTime [utc]"],
+        ["GIMBAL.pitch", "GIMBAL.heading",
+         "CUSTOM.date [local]", "CUSTOM.updateTime [local]"],
+        ["GIMBAL.pitch", "GIMBAL.yaw [360]",
+         "CUSTOM.date [local]", "CUSTOM.updateTime [local]"],
+    ],
+)
+def test_select_fields_stays_in_sync_with_the_parser(tmp_path, headers):
+    """The contract with parse_flight_log: a CSV limited to the picked
+    fields must parse to exactly the rows the full export would give —
+    otherwise the API was asked for less than the merge consumes."""
+    picked = select_fields(headers)
+    assert picked is not None
+    full = tmp_path / "full.csv"
+    full.write_text(_one_row_csv(headers), encoding="utf-8")
+    sub = tmp_path / "picked.csv"
+    sub.write_text(
+        _one_row_csv([h for h in headers if h in picked]), encoding="utf-8"
+    )
+    assert parse_flight_log(sub).rows == parse_flight_log(full).rows
+    assert parse_flight_log(sub).time_base == parse_flight_log(full).time_base
 
 
 def test_field_names_accepts_a_list_of_strings():

--- a/tools/mtp-copy.ps1
+++ b/tools/mtp-copy.ps1
@@ -31,9 +31,14 @@ $records = @()
 $deviceName = $null
 foreach ($dev in $pc.Items()) {
   if (-not $dev.IsFolder) { continue }
-  # Fixed drives, empty card readers, and dropped network shares all live
-  # under "This PC" too, and their COM folder calls can throw or return
-  # null - skip anything that will not enumerate cleanly.
+  # Only portable (WPD) devices carry a shell-namespace path ("::{...");
+  # fixed drives (C:\) and network locations (\\server\share) have real
+  # paths. Skipping them keeps a local folder that happens to hold
+  # matching files - like a previous run's destination - from being
+  # mistaken for the RC and silently re-copied from.
+  if ($dev.Path -notlike '::{*') { continue }
+  # A locked or half-attached device can still throw or return null from
+  # its COM folder calls - skip anything that will not enumerate cleanly.
   try {
     $devFolder = $dev.GetFolder
     if ($null -eq $devFolder) { continue }


### PR DESCRIPTION
Two follow-ups from the #412 whole-branch review.

## #410 — one \`_COLUMN_SPEC\` feeds flightlog and logfetch

The comment-synced twin lists (\`parse_flight_log\`'s \`_find\` chain and logfetch's \`_WANTED\`) become a single spec in flightlog.py: per slot, the \`(needles, exclude)\` alternatives in preference order. The parser takes the first hit per slot — dissolving the \`yaw_360_col\` special case, since \`_normalize_yaw\` folds either range — while \`select_fields\` requests every alternative's hit so the fetched CSV carries all candidates.

- New parametrized test pins the actual contract: a CSV limited to the picked fields parses to exactly the rows of the full export (mutation-checked: dropping a spec entry fails it).
- Behavior preservation verified mechanically: old vs new trees compared over 900 header sets (all subsets ≤2 of a 15-header pool + 800 seeded random supersets), asserting \`select_fields\` output, chosen columns, parsed row values, time base, and refusal messages — byte-identical across all 900 (333 successful parses, 225 UTC-based, 567 refusal paths).

## #411 — mtp-copy.ps1 probes only WPD portable devices

The probe walked every This PC item, so a local folder holding matching files two levels deep (e.g. a previous run's destination) could be misidentified as the RC. Reproduced on real PowerShell 5.1: a decoy \`DJIFlightRecord_*.txt\` under \`C:\TEMP\` made the old script report *Found 1 record(s) on 'Windows (C:)'* and copy it. Portable devices are the only This PC items with a shell-namespace path (\`::{…\`), so anything else is now skipped before any COM folder call; with the decoy planted, the fixed script exits 1 with the no-device message. Positive identification of a real RC remains a #390 release-gate item for the hardware E2E.

Full suite: 912 passed, 3 expected skips; ruff and mypy clean.

Closes #410
Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtJXWDya9ZVfRK7n1CqnsT