### PR TITLE
polish: review follow-ups to #415 (over-request test pin + probe diagnostics)

### DIFF
--- a/src/dji_metadata_embedder/geo/flightlog.py
+++ b/src/dji_metadata_embedder/geo/flightlog.py
@@ -84,11 +84,14 @@ class MergeReport:
 # Columns that look like coordinates but are not the aircraft's position.
 _NOT_AIRCRAFT = ("home", "rc", "remote", "tablet")
 
+# One way of spelling a slot's column: (needles, exclude) for _find.
+_Alternative = tuple[tuple[str, ...], tuple[str, ...]]
+
 # Which export column fills each slot the merge consumes: per slot, the
 # (needles, exclude) alternatives tried in order, first hit winning.
 # Shared with logfetch.select_fields, so the API is asked for exactly the
 # columns parse_flight_log would choose from a hand-made export.
-_COLUMN_SPEC: dict[str, tuple[tuple[tuple[str, ...], tuple[str, ...]], ...]] = {
+_COLUMN_SPEC: dict[str, tuple[_Alternative, ...]] = {
     "pitch": ((("gimbal", "pitch"), ()),),
     # Signed yaw first, then heading, then the [0, 360) variant —
     # _normalize_yaw folds any of them into signed true-north degrees.

--- a/tests/test_geo_logfetch.py
+++ b/tests/test_geo_logfetch.py
@@ -73,6 +73,21 @@ def test_select_fields_skips_home_and_rc_coordinates():
     assert "RC.latitude" not in picked
 
 
+def test_select_fields_requests_every_alternative_not_just_the_first():
+    """The over-request hedge: when several columns could fill a slot,
+    all of them are asked for — the parser applies its own preference to
+    the fetched CSV, so a first-hit shortcut here would silently narrow
+    what the paid response can carry."""
+    fields = [
+        "GIMBAL.pitch", "GIMBAL.yaw", "GIMBAL.heading",
+        "CUSTOM.date [local]", "CUSTOM.updateTime [local]",
+    ]
+    picked = select_fields(fields)
+    assert picked is not None
+    assert "GIMBAL.yaw" in picked
+    assert "GIMBAL.heading" in picked
+
+
 def test_select_fields_finds_signed_yaw_behind_the_360_variant():
     fields = [
         "GIMBAL.yaw [360]", "GIMBAL.yaw", "GIMBAL.pitch",
@@ -145,6 +160,15 @@ def test_select_fields_stays_in_sync_with_the_parser(tmp_path, headers):
     )
     assert parse_flight_log(sub).rows == parse_flight_log(full).rows
     assert parse_flight_log(sub).time_base == parse_flight_log(full).time_base
+    # The API may return the picked columns in any order; the parse must
+    # not depend on the export's native ordering.
+    rev = tmp_path / "picked_reversed.csv"
+    rev.write_text(
+        _one_row_csv([h for h in reversed(headers) if h in picked]),
+        encoding="utf-8",
+    )
+    assert parse_flight_log(rev).rows == parse_flight_log(full).rows
+    assert parse_flight_log(rev).time_base == parse_flight_log(full).time_base
 
 
 def test_field_names_accepts_a_list_of_strings():

--- a/tools/mtp-copy.ps1
+++ b/tools/mtp-copy.ps1
@@ -29,17 +29,21 @@ $pc = $shell.NameSpace(17)  # "This PC", where portable devices appear
 # reliable across RC models, so probe contents instead.
 $records = @()
 $deviceName = $null
+$skipped = @()
 foreach ($dev in $pc.Items()) {
   if (-not $dev.IsFolder) { continue }
-  # Only portable (WPD) devices carry a shell-namespace path ("::{...");
-  # fixed drives (C:\) and network locations (\\server\share) have real
-  # paths. Skipping them keeps a local folder that happens to hold
-  # matching files - like a previous run's destination - from being
-  # mistaken for the RC and silently re-copied from.
-  if ($dev.Path -notlike '::{*') { continue }
   # A locked or half-attached device can still throw or return null from
-  # its COM folder calls - skip anything that will not enumerate cleanly.
+  # its COM calls - skip anything that will not enumerate cleanly.
   try {
+    # Only portable (WPD) devices carry a shell-namespace path ("::{...");
+    # fixed drives (C:\) and network locations (\\server\share) have real
+    # paths. Skipping them keeps a local folder that happens to hold
+    # matching files - like a previous run's destination - from being
+    # mistaken for the RC and silently re-copied from.
+    if ($dev.Path -notlike '::{*') {
+      $skipped += ('{0} ({1})' -f $dev.Name, $dev.Path)
+      continue
+    }
     $devFolder = $dev.GetFolder
     if ($null -eq $devFolder) { continue }
     $storages = @($devFolder.Items())
@@ -64,6 +68,11 @@ if (-not $deviceName) {
   Write-Output "No flight records matching '$Filter' found on any portable device."
   Write-Output 'Is the RC plugged in over USB, powered on, and unlocked?'
   Write-Output '(Records sit at the root of "Internal shared storage".)'
+  # Say what was ruled out, so "the filter skipped the RC" and "the RC
+  # was never there" do not produce the same silence.
+  if ($skipped.Count -gt 0) {
+    Write-Output ("Ignored {0} non-portable item(s): {1}" -f $skipped.Count, ($skipped -join ', '))
+  }
   exit 1
 }
 


### PR DESCRIPTION
Post-merge review findings on #415, verified and applied:

- **Test pin for the over-request hedge**: \`select_fields\` deliberately requests every alternative's hit (both \`GIMBAL.yaw\` and \`GIMBAL.heading\` when present) so the fetched CSV carries all candidates — but a \`break\` after the first hit passed the entire suite. Now pinned (mutation-checked). The sync test also parses a reversed-column subset, since the API may return fields in requested rather than native order.
- **\`_Alternative\` type alias** replaces the triple-nested tuple annotation on \`_COLUMN_SPEC\`.
- **mtp-copy.ps1 observability**: \`$dev.Path\` is read inside the guarded \`try\` (the script's own guard-the-COM-calls design), and the no-device failure now lists what the WPD filter ruled out — verified on real PowerShell 5.1 (\`Ignored 1 non-portable item(s): Windows (C:) (C:\)\`). This makes the pending real-RC E2E debuggable: a filtered-out RC and an absent RC no longer produce identical output, and the printed path doubles as the evidence to capture in #390.

Tests 54 passed on the touched suites; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtJXWDya9ZVfRK7n1CqnsT