### PR TITLE
feat(geo): flightmap --airspace zone overlay (#413, PR 2 of 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ it's a handful of copy-paste commands. For a guided tour see
   real video frame for the second you're looking at, and see whether the
   telemetry lines up.
 - **Flight records** — `dji-embed flightmap -f record` writes a printable
-  logbook with airspace facts (FAA / ED-269) and honestly-labelled heights.
+  logbook with airspace facts (FAA / ED-269) and honestly-labelled heights,
+  and `--airspace` overlays the same zones on the interactive map.
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
   folder of stills on one clustered map, thumbnails included; 360° panoramas
   get their own marker color and toggle, and open in an interactive viewer.

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -425,6 +425,25 @@ where a clip carries no focal length, the map's own field of view is an
 estimate, so the alignment is approximate — the same caveat the gaze badge
 already reports.
 
+### Airspace overlay (`--airspace`)
+
+`dji-embed flightmap FLIGHTS --airspace` overlays the official airspace zones
+for the flight area on the 2D HTML map — FAA UAS Facility Maps in the US,
+ED-269 UAS geographical zones where a national feed is available (currently
+Luxembourg and Finland). Zones draw in one neutral style; clicking one shows
+the published facts: restriction class, vertical limits (or "not stated"),
+applicability windows, and the feed, license and fetch time. Zones the
+flight entered get a slightly stronger outline plus the entry/exit times and
+maximum heights in the popup. The map states facts and makes no
+determination.
+
+Like `-f record`, the flag is the opt-in for network access: every fetch is
+announced before it happens, responses are cached in `airspace-cache/`
+beside the output (`--airspace-refresh` refetches), and areas without a
+supported feed get an honest "no data available" note on the map itself.
+`--airspace` needs exact coordinates, so it refuses `--redact`; the 3D map
+does not support the overlay yet.
+
 ## Photo map (`photomap`)
 
 ```bash

--- a/docs/how-to/flight-record.md
+++ b/docs/how-to/flight-record.md
@@ -115,3 +115,7 @@ flight complied with any regulation. Both the FAA's Part 107 rules and the
 EU's Open Category rules carry exceptions — structures, obstacles, and
 others — that telemetry alone cannot evaluate. Read every airspace
 zone and height figure as a measurement, not a verdict.
+
+The same zones can be drawn on the interactive map: `dji-embed flightmap
+FLIGHTS --airspace` overlays them on the 2D HTML map, sharing this
+command's cache and consent model.

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -44,6 +44,8 @@ from .geo import (
     write_photos_html,
     write_photos_kml,
 )
+from .geo.airspace import fetch as airspace_fetch
+from .geo.airspace.overlay import zones_to_overlay_json
 from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
 from .geo.logfetch import LogFetchError, cache_path, fetch_log
 from .geo.media import resolve_media
@@ -814,15 +816,21 @@ def photomap(
         ["html", "kml", "geojson", "record", "all"], case_sensitive=False
     ),
     default="html", show_default=True,
-    help="Map output format. 'record' (also written by 'all') writes a "
-         "printable flight record and fetches airspace data from official "
-         "feeds (FAA / ED-269) and terrain tiles from Mapterhorn — the "
-         "only network access in this command; data is cached beside the "
-         "output.",
+    help="Map output format. 'record' (also written by 'all') writes a printable "
+         "flight record and fetches airspace data from official feeds (FAA / "
+         "ED-269) and terrain tiles from Mapterhorn — with --airspace, the only "
+         "network access in this command; data is cached beside the output.",
 )
 @click.option(
     "--airspace-refresh", is_flag=True,
-    help="Refetch airspace data past the cache (record output only).",
+    help="Refetch airspace data past the cache (-f record or --airspace).",
+)
+@click.option(
+    "--airspace", is_flag=True,
+    help="Overlay official airspace zones (FAA UAS Facility Maps / ED-269) "
+         "on the 2D HTML map — announced, cached network fetches, exactly "
+         "like -f record. Zones draw in one neutral style; the map states "
+         "facts and makes no determination.",
 )
 @click.option("-r", "--recursive", is_flag=True, help="Scan subdirectories too")
 @click.option("--title", default=None, help="Map title (default: directory name)")
@@ -890,6 +898,7 @@ def flightmap(
     output: str | None,
     fmt: str,
     airspace_refresh: bool,
+    airspace: bool,
     recursive: bool,
     title: str | None,
     redact: str,
@@ -963,9 +972,28 @@ def flightmap(
                 "coordinates; drop --redact or choose another format"
             )
         skip_record_for_redact = fmt.lower() == "all" and redact.lower() != "none"
-        if airspace_refresh and (not wants_record or skip_record_for_redact):
+        if airspace:
+            if redact.lower() != "none":
+                raise click.UsageError(
+                    "airspace features need exact coordinates; drop --redact "
+                    "or --airspace"
+                )
+            if three_d:
+                raise click.UsageError(
+                    "--airspace draws on the flat 2D map; a 3D zone overlay is "
+                    "a planned follow-up — drop --3d"
+                )
+            if fmt.lower() not in ("html", "all"):
+                raise click.UsageError(
+                    "--airspace overlays the 2D HTML map (use -f html or all); "
+                    "the flight record already includes airspace"
+                )
+        if airspace_refresh and not (
+            airspace or (wants_record and not skip_record_for_redact)
+        ):
             click.echo(
-                "Note: --airspace-refresh does nothing without -f record",
+                "Note: --airspace-refresh does nothing without -f record "
+                "or --airspace",
                 err=True,
             )
         src = Path(directory)
@@ -1067,6 +1095,26 @@ def flightmap(
             targets = [(f, out)]
         if link_originals:
             resolve_media(tracks, src, link_base)
+        overlay_json = None
+        if airspace:
+            html_out = next(o for f2, o in targets if f2 == "html")
+            # transport is read off the module at call time (fetch_zones's own
+            # default binds urlopen at def time, which would dodge monkeypatching
+            # — same trap record.build_records documents).
+            per_track = [
+                airspace_fetch.fetch_zones(
+                    t,
+                    html_out.parent / "airspace-cache",
+                    refresh=airspace_refresh,
+                    transport=airspace_fetch.urlopen,
+                    announce=lambda m: click.echo(m, err=True),
+                )
+                for t in tracks
+            ]
+            overlay_json = zones_to_overlay_json(tracks, per_track)
+            for t, d in zip(tracks, per_track):
+                if d.gap_reason:
+                    click.echo(f"Note: {t.name}: {d.gap_reason}", err=True)
         for f, out in targets:
             try:
                 if f == "html":
@@ -1079,6 +1127,7 @@ def flightmap(
                             tracks, out, map_title,
                             tile_style=tile_style.lower(),
                             redact=redact.lower(),
+                            airspace_json=overlay_json,
                         )
                 elif f == "kml":
                     write_flights_kml(tracks, out, map_title)

--- a/src/dji_metadata_embedder/geo/airspace/overlay.py
+++ b/src/dji_metadata_embedder/geo/airspace/overlay.py
@@ -1,0 +1,108 @@
+"""Overlay content for the --airspace flightmap layer (#413 PR 2).
+
+Pure: no I/O, no network. Dedupes each track's fetched zones, runs the
+shipped evaluator, and emits one JSON-able dict the 2D map embeds.
+Restriction classes and limits are published data for the popups — never
+verdicts. All fetched zones are included (the map shows the area's
+published picture); time-window relevance lives in each zone's
+``applicability`` text, and entered-facts only ever come from the
+evaluator's findings.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ..track import Track
+from .evaluate import evaluate
+from .fetch import AirspaceData
+from .model import Applicability, VerticalLimit
+
+_MTIME_NOTE = (
+    "times derived from file modification times, not telemetry datetimes"
+)
+_PARTIAL_NOTE = "point timestamps are incomplete"
+
+
+def _fmt_utc(dt: datetime | None) -> str | None:
+    return dt.strftime("%Y-%m-%d %H:%M:%S UTC") if dt else None
+
+
+def _fmt_limit(limit: VerticalLimit | None) -> str | None:
+    return limit.label() if limit is not None else None
+
+
+def _fmt_window(win: Applicability) -> str:
+    if win.start and win.end:
+        return f"{_fmt_utc(win.start)} – {_fmt_utc(win.end)}"
+    if win.start:
+        return f"from {_fmt_utc(win.start)}"
+    if win.end:
+        return f"until {_fmt_utc(win.end)}"
+    return "open-ended"
+
+
+def _time_note(track: Track) -> str | None:
+    times = [p.utc for p in track.points if p.utc is not None]
+    if len(times) != len(track.points) or not times:
+        return _PARTIAL_NOTE
+    return _MTIME_NOTE if track.utc_source == "mtime" else None
+
+
+def zones_to_overlay_json(
+    tracks: list[Track], airspace_per_track: list[AirspaceData]
+) -> dict:
+    """One embeddable dict: deduped zones + entered-facts + corner notes."""
+    zone_dicts: dict[tuple[str, str], dict] = {}
+    notes: list[str] = []
+    covered = False
+    for track, data in zip(tracks, airspace_per_track):
+        if data.gap_reason is not None:
+            line = f"Airspace, {track.name}: {data.gap_reason}"
+            if line not in notes:
+                notes.append(line)
+            continue
+        covered = True
+        if data.source is not None:
+            line = f"Airspace: {data.source.feed}, fetched {data.source.fetched}"
+            if line not in notes:
+                notes.append(line)
+        report = evaluate(track, data.zones)
+        for zone in data.zones:
+            key = (zone.source.feed, zone.identifier)
+            if key not in zone_dicts:
+                zone_dicts[key] = {
+                    "id": zone.identifier,
+                    "name": zone.name,
+                    "restriction": zone.restriction,
+                    "lower": _fmt_limit(zone.lower),
+                    "upper": _fmt_limit(zone.upper),
+                    "applicability": [
+                        _fmt_window(w) for w in zone.applicability
+                    ],
+                    "polygons": zone.polygons,
+                    "source": {
+                        "feed": zone.source.feed,
+                        "license": zone.source.license,
+                        "fetched": zone.source.fetched,
+                    },
+                    "entered": [],
+                }
+        note = _time_note(track)
+        for finding in report.findings:
+            if not finding.entered:
+                continue
+            key = (finding.zone.source.feed, finding.zone.identifier)
+            zone_dicts[key]["entered"].append({
+                "flight": track.name,
+                "entry_utc": _fmt_utc(finding.entry_utc),
+                "exit_utc": _fmt_utc(finding.exit_utc),
+                "max_rel_alt_m": finding.max_rel_alt_m,
+                "max_amsl_m": finding.max_amsl_m,
+                "time_note": note,
+            })
+    return {
+        "zones": list(zone_dicts.values()),
+        "notes": notes,
+        "covered": covered,
+    }

--- a/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
@@ -1,0 +1,71 @@
+"""JS for the --airspace zone overlay on the 2D flightmap (#413 PR 2).
+
+Same contract as :mod:`.flightmap_js`: plain browser JS embedded by string
+substitution. This snippet is injected into the 2D app BETWEEN the flight
+loop and the fitBounds/layer-control block, so it can rely on ``map``,
+``overlays`` and ``esc`` existing, zones registered here appear in the
+same layer control, and ``bringToBack()`` puts them under the tracks that
+were just added. One neutral style for every zone — the published
+restriction class is popup data, not a color: this map states facts and
+makes no determination.
+"""
+
+from __future__ import annotations
+
+AIRSPACE_OVERLAY_JS = """\
+const airspace = JSON.parse(document.getElementById('airspace-data').textContent);
+
+function zonePopupHtml(z) {
+  let html = `<div class="flight-popup"><b>${esc(z.name)}</b>`;
+  if (z.id && z.id !== z.name) html += `<br>${esc(z.id)}`;
+  html += `<br>${esc(z.restriction)}`;
+  html += `<br>upper limit: ${z.upper ? esc(z.upper) : 'not stated'}`;
+  html += `<br>lower limit: ${z.lower ? esc(z.lower) : 'not stated'}`;
+  html += z.applicability.length
+    ? `<br>applies: ${z.applicability.map(esc).join('; ')}`
+    : '<br>applies: permanently';
+  for (const e of z.entered) {
+    html += `<hr><b>${esc(e.flight)}</b> was inside this zone`;
+    html += e.entry_utc
+      ? `<br>${esc(e.entry_utc)} – ${esc(e.exit_utc)}`
+      : '<br>(times not stated)';
+    if (e.max_rel_alt_m != null)
+      html += `<br>max height in zone: ${e.max_rel_alt_m} m above takeoff`;
+    if (e.max_amsl_m != null)
+      html += `<br>max altitude in zone: ${e.max_amsl_m} m (as logged)`;
+    if (e.time_note) html += `<br><i>${esc(e.time_note)}</i>`;
+  }
+  html += `<hr>${esc(z.source.feed)} — ${esc(z.source.license)}` +
+          `<br>fetched ${esc(z.source.fetched)}`;
+  html += '</div>';
+  return html;
+}
+
+const zoneGroup = L.layerGroup();
+airspace.zones.forEach(z => {
+  const entered = z.entered.length > 0;
+  const style = { color: '#4a6a8a', weight: entered ? 3 : 1.5,
+                  fillColor: '#4a6a8a', fillOpacity: entered ? 0.15 : 0.08 };
+  z.polygons.forEach(ring => {
+    L.polygon(ring.map(c => [c[1], c[0]]), style)
+      .bindPopup(zonePopupHtml(z)).addTo(zoneGroup);
+  });
+});
+if (airspace.covered) {
+  // Registered even when empty: "fetched and empty" must stay
+  // distinguishable from "never fetched".
+  zoneGroup.addTo(map);
+  zoneGroup.eachLayer(l => l.bringToBack());
+  overlays['<span style="color:#4a6a8a">&#9632;</span> Airspace zones'] = zoneGroup;
+}
+if (airspace.notes.length) {
+  const note = L.control({ position: 'bottomright' });
+  note.onAdd = () => {
+    const div = L.DomUtil.create('div', 'airspace-note');
+    div.innerHTML = airspace.notes.map(esc).join('<br>');
+    L.DomEvent.disableClickPropagation(div);
+    return div;
+  };
+  note.addTo(map);
+}
+"""

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -16,6 +16,7 @@ from html import escape
 from pathlib import Path
 
 from .flightmap import flights_to_geojson
+from .flightmap_airspace_js import AIRSPACE_OVERLAY_JS
 from .flightmap_js import FLIGHT_POPUP_JS
 from .tiles import DEFAULT_TILE_STYLE, tile_layer_js
 from .track import Track
@@ -54,13 +55,13 @@ _TEMPLATE = """<!DOCTYPE html>
   .playback span {{ font-variant-numeric: tabular-nums; }}
   .playback label {{ opacity: .7; }}
   .playback select {{ font: inherit; max-width: 160px; }}
-</style>
+{airspace_css}</style>
 </head>
 <body>
 <div id="map"></div>
 <script type="application/json" id="flight-data">
 {data}
-</script>
+</script>{airspace_block}
 <script src="https://unpkg.com/leaflet@{leaflet}/dist/leaflet.js"
         integrity="{js_sri}" crossorigin=""></script>
 <script>
@@ -108,7 +109,7 @@ const runs = [];   // playback (#267): flights with usable per-point times
   overlays[label] = group;
   allLatLngs.push(...latlngs);
 });
-
+__AIRSPACE_JS__
 if (allLatLngs.length > 1) {
   map.fitBounds(L.latLngBounds(allLatLngs).pad(0.1), { maxZoom: 17 });
 } else if (allLatLngs.length === 1) {
@@ -236,27 +237,49 @@ if (runs.length && maxT > 0) {
 """
 
 
+_AIRSPACE_CSS = """  .airspace-note { background: rgba(255,255,255,.85);
+                   border-radius: 4px; padding: 4px 8px;
+                   font: 12px/1.5 sans-serif; max-width: 320px; }
+"""
+
+
 def flights_to_html(
     tracks: list[Track], title: str, *, tile_style: str = DEFAULT_TILE_STYLE,
-    redact: str = "none"
+    redact: str = "none", airspace_json: dict | None = None
 ) -> str:
     """Return a complete self-contained HTML flight map.
 
     ``tile_style`` (issue #311): a :data:`~.tiles.TILE_STYLES` key selecting
     the basemap drawn under the tracks.
+
+    ``airspace_json`` (#413): the overlay dict from
+    :func:`~.airspace.overlay.zones_to_overlay_json`; None renders the map
+    exactly as before.
     """
     geojson = flights_to_geojson(tracks, redact=redact)
     # Escape "<" to "\\u003c" (a JSON Unicode escape) so JSON.parse round-trips
     # it while no literal "</script>" can break out of the data block.
     data = json.dumps(geojson).replace("<", "\\u003c")
+    airspace_block = airspace_css = airspace_js = ""
+    if airspace_json is not None:
+        adata = json.dumps(airspace_json).replace("<", "\\u003c")
+        airspace_block = (
+            '\n<script type="application/json" id="airspace-data">\n'
+            f"{adata}\n</script>"
+        )
+        airspace_css = _AIRSPACE_CSS
+        airspace_js = AIRSPACE_OVERLAY_JS
     return _TEMPLATE.format(
         title=escape(title),
         leaflet=_LEAFLET_VERSION,
         css_sri=_LEAFLET_CSS_SRI,
         js_sri=_LEAFLET_JS_SRI,
         data=data,
+        airspace_block=airspace_block,
+        airspace_css=airspace_css,
         app_js=_APP_JS.replace("__TILE_LAYER__", tile_layer_js(tile_style))
-        .replace("__SHARED_JS__", FLIGHT_POPUP_JS),
+        .replace("__SHARED_JS__", FLIGHT_POPUP_JS)
+        .replace("__AIRSPACE_JS__", airspace_js),
     )
 
 
@@ -266,11 +289,15 @@ def write_flights_html(
     title: str,
     *,
     tile_style: str = DEFAULT_TILE_STYLE,
-    redact: str = "none"
+    redact: str = "none",
+    airspace_json: dict | None = None,
 ) -> Path:
     """Write *tracks* as an HTML map to *output_path* and return it."""
     output_path.write_text(
-        flights_to_html(tracks, title, tile_style=tile_style, redact=redact), encoding="utf-8"
+        flights_to_html(
+            tracks, title, tile_style=tile_style, redact=redact, airspace_json=airspace_json
+        ),
+        encoding="utf-8",
     )
     logger.info("HTML flight map created: %s", output_path)
     return output_path

--- a/tests/test_airspace_overlay.py
+++ b/tests/test_airspace_overlay.py
@@ -142,5 +142,5 @@ def test_no_verdict_vocabulary_in_output():
         [_track_inside(zones[0])], [AirspaceData(zones=zones, source=source)]
     )
     blob = _json.dumps(out).lower()
-    for banned in ("illegal", "compliant", "violation"):
+    for banned in ("legal", "compliant", "violation"):  # "legal" subsumes "illegal"
         assert banned not in blob

--- a/tests/test_airspace_overlay.py
+++ b/tests/test_airspace_overlay.py
@@ -1,0 +1,146 @@
+"""Unit tests for the pure --airspace overlay builder (#413 PR 2)."""
+from datetime import datetime
+from pathlib import Path
+
+from dji_metadata_embedder.geo.airspace.ed269 import ED269_FEEDS, parse_ed269
+from dji_metadata_embedder.geo.airspace.fetch import AirspaceData
+from dji_metadata_embedder.geo.airspace.model import SourceInfo
+from dji_metadata_embedder.geo.airspace.overlay import zones_to_overlay_json
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+SAMPLES = Path(__file__).parent.parent / "samples" / "airspace"
+
+
+def _lu_zones():
+    feed = ED269_FEEDS["LU"]
+    source = SourceInfo(
+        feed=feed.feed_name, url=feed.url, fetched="2026-07-30T10:00:00Z",
+        license=feed.license, caveat=feed.caveat, note=feed.note,
+    )
+    return parse_ed269((SAMPLES / "ed269-lu.json").read_bytes(), source), source
+
+
+def _point(lat, lon, second, rel_alt=50.0):
+    return TrackPoint(
+        lat=lat, lon=lon, alt=300.0, timestamp=f"00:00:{second:02d}",
+        utc=datetime(2026, 7, 30, 12, 0, second),
+        rel_alt=rel_alt,
+    )
+
+
+def _track_inside(zone, name="LUX0001"):
+    """A 3-point track sitting on the vertex-mean of the zone's first ring.
+    Self-validating: asserts the point really is inside (guards against a
+    concave fixture ring making the whole test vacuous)."""
+    from dji_metadata_embedder.geo.airspace.evaluate import point_in_ring
+
+    ring = zone.polygons[0]
+    lon = sum(c[0] for c in ring[:-1]) / (len(ring) - 1)
+    lat = sum(c[1] for c in ring[:-1]) / (len(ring) - 1)
+    assert point_in_ring(lon, lat, ring), "fixture ring is concave; pick a point inside"
+    return Track(name=name, points=[
+        _point(lat, lon, 0), _point(lat, lon, 1, rel_alt=80.0), _point(lat, lon, 2),
+    ])
+
+
+def _track_far(name="FAR0001"):
+    return Track(name=name, points=[_point(49.99, 6.05, s) for s in range(3)])
+
+
+def test_entered_zone_carries_facts_and_dedupe_merges_tracks():
+    zones, source = _lu_zones()
+    target = zones[0]
+    t1 = _track_inside(target, "LUX0001")
+    t2 = _track_inside(target, "LUX0002")
+    data = [
+        AirspaceData(zones=zones, source=source),
+        AirspaceData(zones=list(zones), source=source),  # second fetch, same zones
+    ]
+    out = zones_to_overlay_json([t1, t2], data)
+    assert out["covered"] is True
+    # dedupe: each zone appears once even though both tracks fetched it
+    ids = [z["id"] for z in out["zones"]]
+    assert len(ids) == len(set(ids)) == len(zones)
+    entered = [z for z in out["zones"] if z["entered"]]
+    hit = next(z for z in entered if z["id"] == target.identifier)
+    flights = [e["flight"] for e in hit["entered"]]
+    assert flights == ["LUX0001", "LUX0002"]
+    e = hit["entered"][0]
+    assert e["entry_utc"] == "2026-07-30 12:00:00 UTC"
+    assert e["exit_utc"] == "2026-07-30 12:00:02 UTC"
+    assert e["max_rel_alt_m"] == 80.0
+    assert e["max_amsl_m"] == 300.0
+    assert e["time_note"] is None
+
+
+def test_zone_dict_shape_and_source_footer():
+    zones, source = _lu_zones()
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(zones=zones, source=source)]
+    )
+    z = out["zones"][0]
+    assert set(z) == {
+        "id", "name", "restriction", "lower", "upper", "applicability",
+        "polygons", "source", "entered",
+    }
+    assert z["source"] == {
+        "feed": source.feed, "license": source.license, "fetched": source.fetched,
+    }
+
+
+def test_missing_limits_stay_none():
+    # the FI fixture (verified) carries a zone without a published limit:
+    # it must surface as None — the JS renders "not stated", never 0
+    feed = ED269_FEEDS["FI"]
+    source = SourceInfo(
+        feed=feed.feed_name, url=feed.url, fetched="2026-07-30T10:00:00Z",
+        license=feed.license, caveat=feed.caveat, note=feed.note,
+    )
+    zones = parse_ed269((SAMPLES / "ed269-fi.json").read_bytes(), source)
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(zones=zones, source=source)]
+    )
+    assert any(z["upper"] is None or z["lower"] is None for z in out["zones"])
+
+
+def test_notes_provenance_line_once_and_gap_lines():
+    zones, source = _lu_zones()
+    data = [
+        AirspaceData(zones=zones, source=source),
+        AirspaceData(gap_reason="no airspace data available for this location"),
+    ]
+    out = zones_to_overlay_json([_track_far("A"), _track_far("B")], data)
+    assert out["covered"] is True
+    provenance = [n for n in out["notes"] if source.feed in n]
+    assert provenance == [f"Airspace: {source.feed}, fetched {source.fetched}"]
+    assert any(n.startswith("Airspace, B:") for n in out["notes"])
+
+
+def test_all_gapped_is_not_covered_but_notes_survive():
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(gap_reason="reason text")]
+    )
+    assert out["covered"] is False
+    assert out["zones"] == []
+    assert out["notes"] == ["Airspace, FAR0001: reason text"]
+
+
+def test_mtime_time_note_reaches_entered_entries():
+    zones, source = _lu_zones()
+    target = zones[0]
+    t = _track_inside(target)
+    t.utc_source = "mtime"
+    out = zones_to_overlay_json([t], [AirspaceData(zones=zones, source=source)])
+    hit = next(z for z in out["zones"] if z["id"] == target.identifier)
+    assert "modification times" in hit["entered"][0]["time_note"]
+
+
+def test_no_verdict_vocabulary_in_output():
+    import json as _json
+    zones, source = _lu_zones()
+    out = zones_to_overlay_json(
+        [_track_inside(zones[0])], [AirspaceData(zones=zones, source=source)]
+    )
+    blob = _json.dumps(out).lower()
+    for banned in ("illegal", "compliant", "violation"):
+        assert banned not in blob

--- a/tests/test_cli_airspace.py
+++ b/tests/test_cli_airspace.py
@@ -1,0 +1,138 @@
+"""CLI tests for flightmap --airspace (#413 PR 2)."""
+import io
+from datetime import datetime, timedelta
+from pathlib import Path
+from urllib.error import URLError
+
+from click.testing import CliRunner
+
+from dji_metadata_embedder.cli import main
+from dji_metadata_embedder.geo.airspace import fetch as airspace_fetch
+
+SAMPLES = Path(__file__).parent.parent / "samples"
+
+
+def _dt_srt(start, coords):
+    blocks = []
+    for i, (lat, lon, alt) in enumerate(coords):
+        stamp = (start + timedelta(seconds=i)).strftime("%Y-%m-%d %H:%M:%S.000")
+        blocks.append(
+            f"{i + 1}\n00:00:{i:02d},000 --> 00:00:{i + 1:02d},000\n"
+            f'<font size="28">FrameCnt: {i + 1}, DiffTime: 1000ms\n'
+            f"{stamp}\n"
+            f"[iso: 100] [shutter: 1/500.0] [fnum: 1.8] [ev: 0] "
+            f"[focal_len: 24.00] [latitude: {lat}] [longitude: {lon}] "
+            f"[rel_alt: 10.000 abs_alt: {alt}] [ct: 5000] </font>\n"
+        )
+    return "\n".join(blocks)
+
+
+T0 = datetime(2026, 7, 30, 12, 0, 0)
+
+
+def _srt_dir(tmp_path):
+    d = tmp_path / "flights"
+    d.mkdir()
+    coords = [(49.615 + i * 0.001, 6.19, 300.0 + i) for i in range(4)]
+    (d / "LUX0001.SRT").write_text(_dt_srt(T0, coords), encoding="utf-8")
+    return d
+
+
+class FakeTransport:
+    def __init__(self, bodies):
+        self.bodies = list(bodies)
+        self.calls = 0
+
+    def __call__(self, req, timeout=None):
+        self.calls += 1
+        if not self.bodies:
+            raise URLError("no more fake responses queued")
+        resp = io.BytesIO(self.bodies.pop(0))
+        resp.__enter__ = lambda *a: resp  # type: ignore[method-assign]
+        resp.__exit__ = lambda *a: False  # type: ignore[method-assign]
+        return resp
+
+
+def _lux_body():
+    return (SAMPLES / "airspace" / "ed269-lu.json").read_bytes()
+
+
+def test_airspace_overlays_the_html_map(tmp_path, monkeypatch):
+    fake = FakeTransport([_lux_body()])
+    monkeypatch.setattr(airspace_fetch, "urlopen", fake)
+    d = _srt_dir(tmp_path)
+    result = CliRunner().invoke(main, ["flightmap", str(d), "--airspace"])
+    assert result.exit_code == 0, result.output
+    html = (d / "flightmap.html").read_text(encoding="utf-8")
+    assert 'id="airspace-data"' in html
+    assert "Airspace zones" in html
+    assert (d / "airspace-cache").is_dir()
+    assert fake.calls == 1
+
+
+def test_all_plus_airspace_fetches_once_record_hits_cache(tmp_path, monkeypatch):
+    from dji_metadata_embedder.geo import record as record_mod
+
+    fake = FakeTransport([_lux_body()])          # exactly ONE network body
+    monkeypatch.setattr(airspace_fetch, "urlopen", fake)
+    # the record path resolves record.urlopen; terrain outruns the empty
+    # queue and degrades to a stated note, airspace must hit the cache
+    monkeypatch.setattr(record_mod, "urlopen", FakeTransport([]))
+    d = _srt_dir(tmp_path)
+    result = CliRunner().invoke(
+        main, ["flightmap", str(d), "-f", "all", "--airspace"]
+    )
+    assert result.exit_code == 0, result.output
+    assert (d / "flightmap.html").exists()
+    assert (d / "flight-record.html").exists()
+    assert fake.calls == 1
+    assert "cached" in result.output.lower()
+
+
+def test_airspace_refuses_redact(tmp_path):
+    d = _srt_dir(tmp_path)
+    result = CliRunner().invoke(
+        main, ["flightmap", str(d), "--airspace", "--redact", "fuzz"]
+    )
+    assert result.exit_code != 0
+    assert "exact coordinates" in result.output
+
+
+def test_airspace_refuses_3d(tmp_path):
+    d = _srt_dir(tmp_path)
+    result = CliRunner().invoke(main, ["flightmap", str(d), "--airspace", "--3d"])
+    assert result.exit_code != 0
+
+
+def test_airspace_refuses_non_map_formats(tmp_path):
+    d = _srt_dir(tmp_path)
+    for fmt in ("kml", "geojson", "record"):
+        result = CliRunner().invoke(
+            main, ["flightmap", str(d), "--airspace", "-f", fmt]
+        )
+        assert result.exit_code != 0, fmt
+
+
+def test_refresh_note_not_shown_with_airspace(tmp_path, monkeypatch):
+    fake = FakeTransport([_lux_body()])
+    monkeypatch.setattr(airspace_fetch, "urlopen", fake)
+    d = _srt_dir(tmp_path)
+    result = CliRunner().invoke(
+        main, ["flightmap", str(d), "--airspace", "--airspace-refresh"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "does nothing" not in result.output
+
+
+def test_gap_track_still_renders_map_with_note(tmp_path, monkeypatch):
+    monkeypatch.setattr(airspace_fetch, "urlopen", FakeTransport([]))
+    d = tmp_path / "flights"
+    d.mkdir()
+    coords = [(0.0 + i * 0.001, -160.0, 300.0 + i) for i in range(4)]
+    (d / "PAC0001.SRT").write_text(_dt_srt(T0, coords), encoding="utf-8")
+    result = CliRunner().invoke(main, ["flightmap", str(d), "--airspace"])
+    assert result.exit_code == 0, result.output
+    assert "Note: PAC0001:" in result.output
+    html = (d / "flightmap.html").read_text(encoding="utf-8")
+    assert 'id="airspace-data"' in html      # gap note embedded in the map
+    assert "airspace-note" in html

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -193,3 +193,58 @@ def test_html_alternate_tile_style_swaps_provider():
     assert "maxZoom: 17" in html
     assert "tile.openstreetmap.org" not in html
     assert "__TILE_LAYER__" not in html
+
+
+# Airspace overlay (#413, PR 2): flights_to_html/write_flights_html gain an
+# airspace_json param that embeds the Task 1 overlay dict as a second data
+# block plus the zone-drawing JS. None (the default) must leave the map
+# byte-identical to before this feature existed.
+
+
+def _mini_track(name="F1"):
+    from dji_metadata_embedder.geo.track import Track, TrackPoint
+    return Track(name=name, points=[
+        TrackPoint(lat=49.6, lon=6.1, alt=300.0, timestamp="00:00:00"),
+        TrackPoint(lat=49.61, lon=6.11, alt=310.0, timestamp="00:00:01"),
+    ])
+
+
+_OVERLAY = {
+    "zones": [{
+        "id": "LU-1", "name": "Test zone", "restriction": "PROHIBITED",
+        "lower": None, "upper": "120 m AGL", "applicability": [],
+        "polygons": [[(6.0, 49.5), (6.2, 49.5), (6.2, 49.7), (6.0, 49.5)]],
+        "source": {"feed": "Feed", "license": "CC0", "fetched": "2026-07-30T10:00:00Z"},
+        "entered": [{"flight": "F1", "entry_utc": "2026-07-30 12:00:00 UTC",
+                     "exit_utc": "2026-07-30 12:00:02 UTC",
+                     "max_rel_alt_m": 80.0, "max_amsl_m": 300.0,
+                     "time_note": None}],
+    }],
+    "notes": ["Airspace: Feed, fetched 2026-07-30T10:00:00Z"],
+    "covered": True,
+}
+
+
+def test_no_airspace_json_means_no_airspace_bytes():
+    from dji_metadata_embedder.geo.flightmap_html import flights_to_html
+    html = flights_to_html([_mini_track()], "t")
+    assert "airspace" not in html.lower()
+
+
+def test_airspace_json_embeds_block_layer_and_note():
+    from dji_metadata_embedder.geo.flightmap_html import flights_to_html
+    html = flights_to_html([_mini_track()], "t", airspace_json=_OVERLAY)
+    assert 'id="airspace-data"' in html
+    assert "Airspace zones" in html
+    assert "airspace-note" in html
+    assert "zonePopupHtml" in html
+
+
+def test_airspace_json_escapes_script_breakout():
+    from dji_metadata_embedder.geo.flightmap_html import flights_to_html
+    evil = dict(_OVERLAY)
+    evil["notes"] = ["</script><script>alert(1)</script>"]
+    html = flights_to_html([_mini_track()], "t", airspace_json=evil)
+    start = html.index('id="airspace-data"')
+    end = html.index("</script>", start)
+    assert "<script" not in html[start:end]


### PR DESCRIPTION
Second half of #413: \`dji-embed flightmap FLIGHTS --airspace\` overlays official airspace zones on the 2D HTML flight map, consuming the PR 1 core (#421).

## What it does

- **Zones on the map**: FAA UAS Facility Maps (US) and ED-269 UAS geographical zones (Luxembourg, Finland) draw as a toggleable Leaflet layer under the flight tracks — one neutral style, no verdict color-coding. The map states facts and makes no determination.
- **Popups carry the published facts**: restriction class verbatim, vertical limits (or "not stated"), applicability windows, feed + license + fetch time.
- **Entered zones marked subtly**: slightly stronger outline plus entry/exit UTC and max heights (above takeoff / AMSL) in the popup — same factual framing as the flight record.
- **On-map provenance/gap note**: a corner box lists the data source(s) or an honest "no supported airspace data source for this location", so the shareable artifact itself carries the caveat, not just stderr.
- **Same consent model as \`-f record\`**: the flag is the opt-in, every fetch is announced before it happens, responses cache in \`airspace-cache/\` beside the output, \`--airspace-refresh\` refetches. \`-f all --airspace\` fetches once — record and overlay share the cache. The overlay never fetches terrain.
- **Refusals**: \`--redact\` (airspace features need exact coordinates), \`--3d\` (follow-up), and non-map formats are UsageErrors.
- With \`airspace_json=None\` the 2D map output is byte-identical to master — no impact when the flag is off.

## Verification

- 913 tests passing (17 new across overlay builder / HTML embedding / CLI), ruff, mypy, mkdocs --strict.
- Live E2E: real Swedish footage (honest gap in-map), live LU fetch (47 zones, entered-zone facts), live US FAA (325 grid cells, announce→cache→refresh cycle), single-fetch \`-f all --airspace\`.

Closes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9mBAKfKxdYJCerfoKamtq