### PR TITLE
GUI macOS portability pass (#414 Stage B)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using DjiEmbed.Gui.ViewModels;
 
 namespace DjiEmbed.Gui.Tests;
@@ -19,6 +20,25 @@ public class CliDiscoveryViewModelTests : IDisposable
             Assert.StartsWith("dji-embed", c.Command);
             Assert.False(string.IsNullOrWhiteSpace(c.Description));
         });
+    }
+
+    [Fact]
+    public void Starter_command_sample_folders_match_the_platform()
+    {
+        // The examples are copy-paste bait — a D:\ drive path handed to a
+        // macOS user cannot work, so the sample folder follows the OS.
+        var windows = CliDiscoveryViewModel.StarterCommandsFor(
+            OSPlatform.Windows);
+        Assert.Contains(windows, c => c.Command.Contains(@"D:\Footage"));
+
+        foreach (var platform in new[] { OSPlatform.OSX, OSPlatform.Linux })
+        {
+            var commands = CliDiscoveryViewModel.StarterCommandsFor(platform);
+            Assert.DoesNotContain(commands, c => c.Command.Contains(@"D:\"));
+            Assert.Contains(commands, c => c.Command.Contains(
+                platform == OSPlatform.OSX
+                    ? "~/Movies/Footage" : "~/Videos/Footage"));
+        }
     }
 
     [Fact]

--- a/gui/DjiEmbed.Gui.Tests/RevealTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/RevealTests.cs
@@ -1,10 +1,12 @@
+using System.Runtime.InteropServices;
 using DjiEmbed.Gui.Services;
 
 namespace DjiEmbed.Gui.Tests;
 
 // Reveal.For is the pure seam behind "Show in folder" — like
-// TerminalLauncher.Candidates, tests assert the exact invocation
-// without spawning a file manager.
+// TerminalLauncher.Candidates, platform-parameterized so every
+// platform's exact invocation is asserted on any CI host, without
+// spawning file managers.
 public class RevealTests
 {
     [Fact]
@@ -17,11 +19,8 @@ public class RevealTests
     [Fact]
     public void Windows_reveal_asks_explorer_to_select_the_file()
     {
-        Assert.SkipWhen(!OperatingSystem.IsWindows(),
-            "Reveal.For only takes the explorer.exe branch on Windows");
-
         var full = Path.GetFullPath("C:\\a b\\map.html");
-        var psi = Reveal.For("C:\\a b\\map.html");
+        var psi = Reveal.For("C:\\a b\\map.html", OSPlatform.Windows);
         Assert.NotNull(psi);
         Assert.Equal("explorer.exe", psi.FileName);
         Assert.Equal(Reveal.SelectArgument(full), psi.Arguments);
@@ -29,14 +28,23 @@ public class RevealTests
     }
 
     [Fact]
-    public void Non_windows_reveal_opens_the_containing_directory()
+    public void Macos_reveal_asks_finder_to_select_the_file()
     {
-        Assert.SkipWhen(OperatingSystem.IsWindows(),
-            "Reveal.For only takes the containing-directory branch off Windows");
-
-        var psi = Reveal.For("/tmp/some dir/map.html");
+        var full = Path.GetFullPath("/tmp/some dir/map.html");
+        var psi = Reveal.For("/tmp/some dir/map.html", OSPlatform.OSX);
         Assert.NotNull(psi);
-        Assert.Equal("/tmp/some dir", psi.FileName);
+        Assert.Equal("open", psi.FileName);
+        Assert.Equal(["-R", full], psi.ArgumentList);
+        Assert.False(psi.UseShellExecute);
+    }
+
+    [Fact]
+    public void Elsewhere_reveal_opens_the_containing_directory()
+    {
+        var full = Path.GetFullPath("/tmp/some dir/map.html");
+        var psi = Reveal.For("/tmp/some dir/map.html", OSPlatform.Linux);
+        Assert.NotNull(psi);
+        Assert.Equal(Path.GetDirectoryName(full), psi.FileName);
         Assert.True(psi.UseShellExecute);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -182,9 +182,10 @@ public class ScreenshotCaptureTests
     }
 
     /// <summary>
-    /// Done step on a machine without a usable WebView2: the done card
-    /// with the WebView2-unavailable note visible instead of the inline
-    /// map, above the output row whose Open button the note points at.
+    /// Done step on a machine without a usable web view engine: the done
+    /// card with the preview-unavailable note visible instead of the
+    /// inline map, above the output row whose Open button the note
+    /// points at.
     /// </summary>
     [AvaloniaFact]
     public void Captures_degraded_done_state_to_dir_when_requested()

--- a/gui/DjiEmbed.Gui.Tests/TerminalLauncherTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/TerminalLauncherTests.cs
@@ -1,13 +1,18 @@
+using System.Runtime.InteropServices;
 using DjiEmbed.Gui.Services;
 
 namespace DjiEmbed.Gui.Tests;
 
+// Candidates is the pure seam behind "Open PowerShell/Terminal and try
+// it" — platform-parameterized so every platform's exact invocations are
+// asserted on any CI host, without spawning shells.
 public class TerminalLauncherTests
 {
     [Fact]
-    public void Prefers_windows_terminal_then_falls_back_to_powershell()
+    public void Windows_prefers_windows_terminal_then_falls_back_to_powershell()
     {
-        var candidates = TerminalLauncher.Candidates(@"C:\Users\demo");
+        var candidates = TerminalLauncher.Candidates(
+            @"C:\Users\demo", OSPlatform.Windows);
 
         Assert.Equal(2, candidates.Count);
         Assert.Equal("wt.exe", candidates[0].FileName);
@@ -15,9 +20,10 @@ public class TerminalLauncherTests
     }
 
     [Fact]
-    public void Every_candidate_stays_open_and_proves_the_cli_works()
+    public void Every_windows_candidate_stays_open_and_proves_the_cli_works()
     {
-        foreach (var psi in TerminalLauncher.Candidates(@"C:\Users\demo"))
+        foreach (var psi in TerminalLauncher.Candidates(
+                     @"C:\Users\demo", OSPlatform.Windows))
         {
             Assert.Contains("-NoExit", psi.ArgumentList);
             Assert.Contains("dji-embed --help", psi.ArgumentList);
@@ -28,9 +34,62 @@ public class TerminalLauncherTests
     [Fact]
     public void Windows_terminal_opens_in_the_requested_folder()
     {
-        var wt = TerminalLauncher.Candidates(@"C:\Users\demo")[0];
+        var wt = TerminalLauncher.Candidates(
+            @"C:\Users\demo", OSPlatform.Windows)[0];
         var args = wt.ArgumentList.ToList();
         var d = args.IndexOf("-d");
         Assert.True(d >= 0 && args[d + 1] == @"C:\Users\demo");
+    }
+
+    [Fact]
+    public void Macos_tells_terminal_to_prove_the_cli_then_come_to_front()
+    {
+        var candidates = TerminalLauncher.Candidates(
+            "/Users/demo", OSPlatform.OSX);
+
+        var osa = Assert.Single(candidates);
+        Assert.Equal("osascript", osa.FileName);
+
+        // Terminal windows stay open on their own; the do-script lands
+        // the user in the requested folder with proof the CLI works,
+        // and the activate brings Terminal in front of our window.
+        var args = osa.ArgumentList.ToList();
+        var doScript = Assert.Single(args, a => a.Contains("do script"));
+        Assert.Contains("dji-embed --help", doScript);
+        Assert.Contains("cd '/Users/demo'", doScript);
+        Assert.Contains(args, a => a.Contains(
+            "tell application \"Terminal\" to activate"));
+    }
+
+    [Fact]
+    public void Macos_do_script_survives_a_folder_with_a_single_quote()
+    {
+        var osa = Assert.Single(TerminalLauncher.Candidates(
+            "/Users/o'brien", OSPlatform.OSX));
+
+        // Two escaping layers stack: the shell sees cd '/Users/o'\''brien',
+        // and the AppleScript string literal wrapping it doubles the
+        // backslash on the way in.
+        var doScript = osa.ArgumentList.Single(a => a.Contains("do script"));
+        Assert.Contains(@"cd '/Users/o'\\''brien'", doScript);
+    }
+
+    [Fact]
+    public void Linux_has_no_candidates_yet()
+    {
+        // No dependable cross-distro terminal invocation (#360); Launch
+        // reports false and the view's copy already names any terminal.
+        Assert.Empty(TerminalLauncher.Candidates("/home/demo", OSPlatform.Linux));
+    }
+
+    [Fact]
+    public void The_button_label_names_the_shell_the_platform_will_open()
+    {
+        Assert.Equal("Open PowerShell and try it",
+            TerminalLauncher.ButtonLabelOn(OSPlatform.Windows));
+        Assert.Equal("Open Terminal and try it",
+            TerminalLauncher.ButtonLabelOn(OSPlatform.OSX));
+        Assert.Equal("Open a terminal and try it",
+            TerminalLauncher.ButtonLabelOn(OSPlatform.Linux));
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/WebViewSupportTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WebViewSupportTests.cs
@@ -1,19 +1,59 @@
+using System.Runtime.InteropServices;
 using DjiEmbed.Gui.Services;
 
 namespace DjiEmbed.Gui.Tests;
 
 // WebViewSupport is the real default probe behind the VM's
-// previewAvailable seam (every VM test pins its own fake) — off Windows
-// there is never a WebView2 runtime, so the probe must say no and send
-// the app down the done-card + note degradation path.
+// previewAvailable seam (every VM test pins its own fake). The
+// per-platform answers are asserted through the OSPlatform seam so the
+// macOS contract is proven on any CI host, not just a Mac: Windows
+// depends on the machine's WebView2 runtime, macOS ships WKWebView with
+// the OS so the preview is always worth attempting, and Linux (where
+// Avalonia's native WebView has no dependable engine) stays on the
+// done-card + note degradation path.
 public class WebViewSupportTests
 {
     [Fact]
-    public void Off_windows_the_preview_is_never_likely_available()
+    public void On_macos_the_preview_is_always_likely_available()
+    {
+        Assert.True(WebViewSupport.IsLikelyAvailableOn(OSPlatform.OSX));
+    }
+
+    [Fact]
+    public void On_linux_the_preview_is_never_likely_available()
+    {
+        Assert.False(WebViewSupport.IsLikelyAvailableOn(OSPlatform.Linux));
+    }
+
+    [Fact]
+    public void The_fallback_note_blames_webview2_only_on_windows()
+    {
+        var windows = WebViewSupport.FallbackNoteOn(OSPlatform.Windows);
+        Assert.StartsWith("The map couldn't be previewed inside the app",
+            windows);
+        Assert.Contains("WebView2", windows);
+
+        // Off Windows the WebView2 sentence would be a lie — macOS ships
+        // its engine with the OS, and Linux can't fix it by installing
+        // WebView2 either.
+        foreach (var platform in new[] { OSPlatform.OSX, OSPlatform.Linux })
+        {
+            var note = WebViewSupport.FallbackNoteOn(platform);
+            Assert.StartsWith("The map couldn't be previewed inside the app",
+                note);
+            Assert.DoesNotContain("WebView2", note);
+            Assert.DoesNotContain("Windows", note);
+        }
+    }
+
+    [Fact]
+    public void The_default_probe_follows_the_current_platform()
     {
         Assert.SkipWhen(OperatingSystem.IsWindows(),
             "On Windows the answer depends on the machine's WebView2 runtime");
 
-        Assert.False(WebViewSupport.IsLikelyAvailable);
+        Assert.Equal(
+            OperatingSystem.IsMacOS(),
+            WebViewSupport.IsLikelyAvailable);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -239,8 +239,10 @@ public class WorkspaceScreenTests
         vm.Step = FlowStep.Done;
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();
+        // The note's tail is platform-aware (WebView2 is only named on
+        // Windows), so locate it by its platform-stable first sentence.
         var tip = window.GetVisualDescendants().OfType<TextBlock>()
-            .Single(t => (t.Text ?? "").Contains("WebView2"));
+            .Single(t => (t.Text ?? "").Contains("couldn't be previewed"));
         Assert.True(tip.IsEffectivelyVisible);
 
         vm.PreviewUnavailable = false;   // a healthy Done never shows the tip

--- a/gui/DjiEmbed.Gui/App.axaml.cs
+++ b/gui/DjiEmbed.Gui/App.axaml.cs
@@ -19,7 +19,9 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             // The one persisted GUI state (workspace spec): MRU folders +
-            // window bounds in %APPDATA%/DjiEmbed/state.json.
+            // window bounds in DjiEmbed/state.json under the platform's
+            // app-data folder — %APPDATA% on Windows, ~/Library/Application
+            // Support on macOS (the .NET 8+ GetFolderPath mapping).
             var store = new GuiStateStore(GuiState.DefaultPath);
             desktop.MainWindow = new MainWindow(store)
             {

--- a/gui/DjiEmbed.Gui/Services/Platforms.cs
+++ b/gui/DjiEmbed.Gui/Services/Platforms.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>The running OS as an OSPlatform value — the shared seam the
+/// platform-branched services (WebViewSupport, TerminalLauncher, Reveal)
+/// default to, so tests can call their overloads with any platform.</summary>
+internal static class Platforms
+{
+    internal static OSPlatform Current =>
+        OperatingSystem.IsWindows() ? OSPlatform.Windows
+        : OperatingSystem.IsMacOS() ? OSPlatform.OSX
+        : OSPlatform.Linux;
+}

--- a/gui/DjiEmbed.Gui/Services/Reveal.cs
+++ b/gui/DjiEmbed.Gui/Services/Reveal.cs
@@ -1,16 +1,16 @@
-using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace DjiEmbed.Gui.Services;
 
-/// <summary>Opens the OS file manager with a file highlighted (Windows)
-/// or its folder shown (elsewhere).</summary>
+/// <summary>Opens the OS file manager with the file highlighted
+/// (Windows Explorer, macOS Finder) or its folder shown (elsewhere).</summary>
 public static class Reveal
 {
     public static void InFolder(string path)
     {
-        if (For(path) is { } psi)
+        if (For(path, Platforms.Current) is { } psi)
         {
             Process.Start(psi);
         }
@@ -18,16 +18,24 @@ public static class Reveal
 
     /// <summary>
     /// The launch a reveal would make, or null when the path has no
-    /// containing directory. Pure so tests can assert the exact
-    /// invocation without spawning file managers.
+    /// containing directory. Pure so tests can assert every platform's
+    /// exact invocation without spawning file managers.
     /// </summary>
-    internal static ProcessStartInfo? For(string path)
+    internal static ProcessStartInfo? For(string path, OSPlatform platform)
     {
         var full = Path.GetFullPath(path);
-        if (OperatingSystem.IsWindows())
+        if (platform == OSPlatform.Windows)
         {
             return new ProcessStartInfo("explorer.exe", SelectArgument(full))
             { UseShellExecute = false };
+        }
+        if (platform == OSPlatform.OSX)
+        {
+            // Finder's reveal: open -R highlights the file itself.
+            var open = new ProcessStartInfo("open") { UseShellExecute = false };
+            open.ArgumentList.Add("-R");
+            open.ArgumentList.Add(full);
+            return open;
         }
         return Path.GetDirectoryName(full) is { } dir
             ? new ProcessStartInfo(dir) { UseShellExecute = true }

--- a/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
+++ b/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
@@ -2,26 +2,72 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace DjiEmbed.Gui.Services;
 
 /// <summary>
 /// Launches an interactive shell that lands the user on proof the CLI
-/// works (#293): Windows Terminal when installed, classic PowerShell
-/// otherwise, pre-running "dji-embed --help" so the first thing they see
-/// is output, not a blank prompt.
+/// works (#293): on Windows, Windows Terminal when installed and classic
+/// PowerShell otherwise; on macOS, Terminal.app via osascript. Both
+/// pre-run "dji-embed --help" so the first thing the user sees is
+/// output, not a blank prompt.
 /// </summary>
 public static class TerminalLauncher
 {
     private const string ProofCommand = "dji-embed --help";
 
-    /// <summary>
-    /// Candidate launches, best first. Pure so tests can assert the exact
-    /// invocations without spawning shells.
-    /// </summary>
+    /// <summary>What the launch button should say — the shell it will
+    /// actually open on this platform.</summary>
+    public static string ButtonLabel => ButtonLabelOn(Platforms.Current);
+
+    internal static string ButtonLabelOn(OSPlatform platform) =>
+        platform == OSPlatform.Windows ? "Open PowerShell and try it"
+        : platform == OSPlatform.OSX ? "Open Terminal and try it"
+        : "Open a terminal and try it";
+
+    /// <summary>Candidate launches for this machine, best first.</summary>
     public static IReadOnlyList<ProcessStartInfo> Candidates(
-        string workingDirectory)
+        string workingDirectory) =>
+        Candidates(workingDirectory, Platforms.Current);
+
+    /// <summary>
+    /// Candidate launches for a platform, best first. Pure so tests can
+    /// assert every platform's exact invocations on any CI host without
+    /// spawning shells.
+    /// </summary>
+    internal static IReadOnlyList<ProcessStartInfo> Candidates(
+        string workingDirectory, OSPlatform platform)
     {
+        if (platform == OSPlatform.OSX)
+        {
+            // Terminal.app is always present and its windows stay open on
+            // their own; "do script" opens a fresh window running the
+            // proof command in the requested folder, and the second -e
+            // brings Terminal in front of our window.
+            var osa = new ProcessStartInfo("osascript")
+            {
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory,
+            };
+            osa.ArgumentList.Add("-e");
+            osa.ArgumentList.Add(
+                "tell application \"Terminal\" to do script "
+                + AppleScriptString(
+                    $"cd {ShellSingleQuote(workingDirectory)} && {ProofCommand}"));
+            osa.ArgumentList.Add("-e");
+            osa.ArgumentList.Add("tell application \"Terminal\" to activate");
+            return [osa];
+        }
+
+        if (platform != OSPlatform.Windows)
+        {
+            // No dependable cross-distro terminal invocation (#360);
+            // Launch reports false and the view's copy already names
+            // any terminal.
+            return [];
+        }
+
         // wt.exe resolves through the App Execution Alias when Windows
         // Terminal is installed; a missing alias throws at Start and the
         // loop falls through to powershell.exe.
@@ -69,4 +115,12 @@ public static class TerminalLauncher
         }
         return false;
     }
+
+    /// <summary>POSIX single-quoting: '…' with embedded ' as '\''.</summary>
+    private static string ShellSingleQuote(string s) =>
+        "'" + s.Replace("'", @"'\''") + "'";
+
+    /// <summary>An AppleScript string literal: "…" with \ and " escaped.</summary>
+    private static string AppleScriptString(string s) =>
+        "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
 }

--- a/gui/DjiEmbed.Gui/Services/WebViewSupport.cs
+++ b/gui/DjiEmbed.Gui/Services/WebViewSupport.cs
@@ -1,24 +1,52 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
 
 namespace DjiEmbed.Gui.Services;
 
 /// <summary>
-/// Whether the inline map preview is worth attempting on this machine:
-/// Windows with the WebView2 runtime actually installed. The app ships
-/// for Windows, where WebView2 is preinstalled from Windows 11 on — but
-/// on a runtime-less Windows 10 the control attaches silently and stays
-/// blank, so the OS check alone isn't enough; probing the runtime's
-/// registry footprint sends those machines down the done-card + note
-/// path instead, per the GUI 2.0 spec's degradation rule. A machine that
-/// passes this probe but still lacks a usable engine is caught by the
-/// try/catch around the control itself.
+/// Whether the inline map preview is worth attempting on this machine.
+/// Per platform: Windows needs the WebView2 runtime actually installed —
+/// it is preinstalled from Windows 11 on, but on a runtime-less Windows
+/// 10 the control attaches silently and stays blank, so the OS check
+/// alone isn't enough; probing the runtime's registry footprint sends
+/// those machines down the done-card + note path instead, per the GUI
+/// 2.0 spec's degradation rule. macOS ships WKWebView with the OS, so
+/// the preview is always worth attempting there. Linux has no dependable
+/// native WebView engine (#360), so it stays on the degraded path. A
+/// machine that passes this probe but still lacks a usable engine is
+/// caught by the try/catch around the control itself.
 /// </summary>
 public static class WebViewSupport
 {
     public static bool IsLikelyAvailable =>
-        OperatingSystem.IsWindows() && HasWebView2Runtime();
+        OperatingSystem.IsWindows()
+            ? HasWebView2Runtime()
+            : IsLikelyAvailableOn(Platforms.Current);
+
+    /// <summary>The done-card note shown when the preview pane stays
+    /// blank — Open still works, so stay calm and say so. Only Windows
+    /// gets the WebView2 sentence: macOS ships its engine with the OS,
+    /// and Linux can't fix it by installing WebView2 either.</summary>
+    public static string FallbackNote => FallbackNoteOn(Platforms.Current);
+
+    internal static string FallbackNoteOn(OSPlatform platform)
+    {
+        const string common = "The map couldn't be previewed inside the app"
+            + " — Open shows it in your browser instead.";
+        return platform == OSPlatform.Windows
+            ? common + " Inline preview needs Microsoft Edge WebView2,"
+                + " which comes preinstalled from Windows 11 on."
+            : common;
+    }
+
+    /// <summary>The per-platform answer, minus the Windows registry
+    /// probe (which only the public property runs, on Windows itself) —
+    /// a seam so the macOS and Linux contracts are testable on any CI
+    /// host.</summary>
+    internal static bool IsLikelyAvailableOn(OSPlatform platform) =>
+        platform == OSPlatform.OSX;
 
     // Documented runtime detection: the EdgeUpdate client key for the WebView2 runtime
     // ({F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}) with a plausible "pv" version value.

--- a/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -29,16 +30,28 @@ public partial class CliDiscoveryViewModel(string? cliPath, Action goHome)
     /// the live --help expander covers completeness.
     /// </summary>
     public IReadOnlyList<StarterCommand> StarterCommands { get; } =
-    [
-        new(@"dji-embed convert gpx flight.SRT",
-            "Turn one flight log into a GPX track any mapping tool can read"),
-        new(@"dji-embed embed D:\Footage --redact fuzz",
-            "Embed telemetry with the GPS positions fuzzed for privacy"),
-        new(@"dji-embed validate D:\Footage",
-            "Check every video/flight-log pair for telemetry drift"),
-        new("dji-embed doctor",
-            "Full system diagnostics, beyond the app's setup check"),
-    ];
+        StarterCommandsFor(Platforms.Current);
+
+    /// <summary>The examples are copy-paste bait, so the sample folder
+    /// follows the OS — a D:\ drive path is Windows-only truth.</summary>
+    internal static IReadOnlyList<StarterCommand> StarterCommandsFor(
+        OSPlatform platform)
+    {
+        var footage = platform == OSPlatform.Windows ? @"D:\Footage"
+            : platform == OSPlatform.OSX ? "~/Movies/Footage"
+            : "~/Videos/Footage";
+        return
+        [
+            new("dji-embed convert gpx flight.SRT",
+                "Turn one flight log into a GPX track any mapping tool can read"),
+            new($"dji-embed embed {footage} --redact fuzz",
+                "Embed telemetry with the GPS positions fuzzed for privacy"),
+            new($"dji-embed validate {footage}",
+                "Check every video/flight-log pair for telemetry drift"),
+            new("dji-embed doctor",
+                "Full system diagnostics, beyond the app's setup check"),
+        ];
+    }
 
     [ObservableProperty]
     public partial string? HelpText { get; set; }

--- a/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml
+++ b/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:DjiEmbed.Gui.ViewModels"
+             xmlns:services="using:DjiEmbed.Gui.Services"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="560" d:DesignHeight="520"
@@ -36,7 +37,7 @@
 
                 <Button HorizontalAlignment="Left"
                         Command="{Binding OpenTerminalCommand}">
-                    <TextBlock Text="Open PowerShell and try it" />
+                    <TextBlock Text="{x:Static services:TerminalLauncher.ButtonLabel}" />
                 </Button>
 
                 <TextBlock Text="A few things only the command line can do:"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -989,7 +989,7 @@
                     </ItemsControl>
                     <TextBlock IsVisible="{Binding PreviewUnavailable}"
                                Opacity="0.65" FontSize="12" TextWrapping="Wrap"
-                               Text="The map couldn't be previewed inside the app — Open shows it in your browser instead. Inline preview needs Microsoft Edge WebView2, which comes preinstalled from Windows 11 on." />
+                               Text="{x:Static svc:WebViewSupport.FallbackNote}" />
                     <StackPanel Spacing="10" IsVisible="{Binding !!SetupItems.Count}">
                         <TextBlock FontSize="16"
                                    IsVisible="{Binding AllGood}"


### PR DESCRIPTION
Stage B of the #414 macOS plan (roadmap: https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/414#issuecomment-5135907636): make the GUI's platform-branched services answer correctly on macOS, with every macOS contract asserted on today's Windows/Linux CI — no Mac needed until the Stage E E2E.

## What changed

- **WebViewSupport** — the preview gate is now per-platform: Windows keeps the WebView2 registry probe unchanged, macOS is always likely available (Avalonia's NativeWebView is WKWebView there, shipped with the OS), Linux stays on the done-card degradation path (#360).
- **TerminalLauncher** — macOS gets a Terminal.app candidate via `osascript` (`do script` runs `dji-embed --help` in the requested folder, then `activate` brings Terminal forward), matching the Windows path's land-on-proof behavior. Single quotes in folder names survive both escaping layers (shell + AppleScript literal). Linux explicitly has no candidates yet. The CLI-discovery button now labels itself with the shell it will actually open ("Open PowerShell…" / "Open Terminal…").
- **Reveal** — macOS highlights the file in Finder via `open -R` instead of just opening the containing folder.
- **Degraded-preview note** — only names WebView2 on Windows, where installing it is actually the fix; elsewhere the calm first sentence stands alone.
- **GuiState** — verified no change needed: .NET 8+ maps `SpecialFolder.ApplicationData` to `~/Library/Application Support` on macOS ([GetFolderPath Unix change](https://learn.microsoft.com/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix)), so `state.json` already lands in the right place. Comment updated.
- **CliLocator** — verified already portable (`dji-embed` vs `dji-embed.exe` per platform); the .app bundle layout is Stage D's concern.

## Test design

The existing tests proved platform branches via host-OS `Assert.SkipWhen`, which would leave every macOS branch unproven until a Mac exists in CI. The pure seams (`Candidates`, `For`, the gate, the notes) now take an explicit `OSPlatform` parameter (defaulting to the new shared `Platforms.Current`), so each platform's exact invocations are asserted deterministically on any host. TDD throughout; full GUI suite 488 passed / 0 failed / 0 warnings in Release.

Part of #414. No behavior change on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FLcETZggQHMhxrmAQUXFK

## Post-review addendum

An independent review pass confirmed the escaping (both osascript layers, traced adversarially), Windows byte-identity, and that no changed test will surprise a real-Mac host run. One in-scope gap it found is fixed in the follow-up commit: the CLI-discovery starter commands showed `D:\Footage` to every platform; the sample folder now follows the OS.

**Stage E (real-Mac E2E) must explicitly verify** — these are the things this PR asserts but cannot prove without hardware:

- [ ] Inline flightmap HTML actually renders in NativeWebView/WKWebView on macOS (top-level `file://` loads are historically picky there; if blank, the gate passed so no note shows — fallback plan is a WKWebView-specific load path or gating change)
- [ ] The "Open Terminal and try it" button, including the first-click TCC automation consent prompt and a TCC-deny run (osascript starts fine and fails async, so `Launch()` can return true with nothing visible)
- [ ] `open -R` reveal on a real output path
- [ ] `state.json` lands in `~/Library/Application Support/DjiEmbed/`

Stage D worklist addition: the discovery screen's "the app's installer put it on your PATH" sentence needs the macOS PATH story decided alongside CliLocator's bundle layout.
