### PR TITLE
feat(release): notarized macOS arm64 CLI binary (#414 Stage C)

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -62,11 +62,12 @@ jobs:
     runs-on: macos-14
     # Notarization budget: a routine submission takes single-digit minutes,
     # but this young account gets extended vetting — 2026-07-31 observed
-    # 30m, ~40m, then 2h+ on successive submissions, with the Apple status
-    # page green throughout. The generous allowance costs nothing on a
-    # healthy day (the poll exits on Accepted) and saves the run on a slow
-    # one; it shrinks to minutes once Apple trusts the account.
-    timeout-minutes: 300
+    # 30m, ~40m, 2h20m, then >3h on successive submissions, with the Apple
+    # status page green throughout. The poll deadline sits at the ceiling
+    # GitHub's 360-minute job cap allows; it costs nothing on a healthy day
+    # (the poll exits on Accepted) and shrinks to minutes once Apple trusts
+    # the account.
+    timeout-minutes: 360
     env:
       KEYCHAIN: release-macos.keychain-db
     outputs:
@@ -205,7 +206,7 @@ jobs:
             --output-format json \
             | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
           echo "Submission id: $sub_id"
-          deadline=$((SECONDS + 180 * 60))
+          deadline=$((SECONDS + 330 * 60))
           status="In Progress"
           while [ "$SECONDS" -lt "$deadline" ]; do
             sleep 60

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -32,6 +32,9 @@ on:
         required: true
         type: string
   pull_request:
+    # Deliberately narrow: pyproject.toml/uv.lock bumps could in principle
+    # break this build too, but a 40-minute macOS job plus a real Apple
+    # notary submission on every dependency PR is the wrong trade.
     paths:
       - '.github/workflows/release-macos.yml'
       - 'tools/build_exe.py'
@@ -39,9 +42,23 @@ on:
 permissions:
   contents: read
 
+# A PR push mid-notarization should cancel the obsolete run (each one costs
+# a macos-14 slot and a real notary submission); release runs never cancel.
+concurrency:
+  group: release-macos-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || inputs.version }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
-    if: ${{ (github.event_name != 'workflow_run') || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
+    # Fork PRs get no secrets, so the signing steps can only fail there —
+    # run the PR proof for same-repo branches only.
+    if: >-
+      ${{ (github.event_name == 'workflow_dispatch')
+          || (github.event_name == 'pull_request'
+              && github.event.pull_request.head.repo.full_name == github.repository)
+          || (github.event_name == 'workflow_run'
+              && github.event.workflow_run.conclusion == 'success'
+              && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     runs-on: macos-14
     # Notarization budget: a routine submission takes single-digit minutes,
     # but extended vetting (seen on this account's maiden submission) can
@@ -116,6 +133,7 @@ jobs:
           APPLE_CERT_FINGERPRINT: ${{ secrets.APPLE_CERT_FINGERPRINT }}
         run: |
           set -euo pipefail
+          security find-identity -v -p codesigning "$KEYCHAIN"
           security find-identity -v -p codesigning "$KEYCHAIN" \
             | grep -q "Developer ID Application"
           actual="$(security find-certificate -c 'Developer ID Application' \
@@ -146,6 +164,8 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
+          # The asset name hard-codes arm64 — make sure that stays true.
+          file dist/dji-embed | grep arm64
           ./dist/dji-embed --version | grep -F "$VERSION"
           ./dist/dji-embed --help > /dev/null
           echo "Smoke test: OK ($(./dist/dji-embed --version))"
@@ -158,8 +178,16 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s' "$APPLE_NOTARY_KEY_P8" > notary-key.p8
-          # The submitted zip is the shipped release asset.
-          ditto -c -k --keepParent dist/dji-embed dist/dji-embed-macos-arm64.zip
+          # The submitted zip is the shipped release asset. Zip from inside
+          # dist/ so the binary sits at the archive root, then prove the
+          # asset in the exact form users download it — entry at the root,
+          # exec bit intact — before burning a notary submission.
+          (cd dist && ditto -c -k --keepParent dji-embed dji-embed-macos-arm64.zip)
+          rm -rf ziptest && mkdir ziptest
+          ditto -x -k dist/dji-embed-macos-arm64.zip ziptest
+          test -x ziptest/dji-embed
+          ziptest/dji-embed --version
+          rm -rf ziptest
           xcrun notarytool submit dist/dji-embed-macos-arm64.zip \
             --key notary-key.p8 \
             --key-id "$APPLE_NOTARY_KEY_ID" \

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,225 @@
+---
+name: Build macOS CLI
+
+# build + sign + notarize (macos, arm64) -> publish. (#414 Stage C)
+#
+# The PyInstaller onefile binary is a single Mach-O with the payload archive
+# appended, so notarization only ever inspects the outer binary — hardened
+# runtime + secure timestamp on it is what "Accepted" checks. The embedded
+# dylibs matter at *runtime* instead: hardened-runtime library validation
+# requires them to carry the same team ID, which PyInstaller's
+# --codesign-identity provides (MACOS_CODESIGN_IDENTITY in the build step).
+# The --version smoke test below runs the signed binary on the runner, so a
+# library-validation failure fails the workflow, not the first user.
+#
+# A bare binary has nowhere to staple the notarization ticket, so the first
+# run on a user's Mac needs network for the Gatekeeper check — documented in
+# the install docs.
+#
+# Signing/notary steps are copied from mac-sign-test.yml (the Stage A
+# credential proof); keep the two in sync when rotating credentials.
+# Same-repo pull requests touching this leg run the full chain end-to-end
+# (secrets are available there) but skip the publish job.
+
+on:
+  workflow_run:
+    workflows: ["Release to PyPI"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., 1.2.0)'
+        required: true
+        type: string
+  pull_request:
+    paths:
+      - '.github/workflows/release-macos.yml'
+      - 'tools/build_exe.py'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: ${{ (github.event_name != 'workflow_run') || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
+    runs-on: macos-14
+    # Notarization budget: a routine submission takes single-digit minutes,
+    # but extended vetting (seen on this account's maiden submission) can
+    # push past 30 — same allowance as mac-sign-test.yml.
+    timeout-minutes: 60
+    env:
+      KEYCHAIN: release-macos.keychain-db
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Determine release version
+        id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            workflow_dispatch) ver="$INPUT_VERSION" ;;
+            workflow_run) ver="${HEAD_BRANCH#v}" ;;
+            # PR proof run: build whatever version the branch is at.
+            pull_request) ver="$(sed -n 's/^__version__ = "\(.*\)"/\1/p' \
+              src/dji_metadata_embedder/__init__.py)" ;;
+          esac
+          # The version feeds later step interpolations: accept strict X.Y.Z only.
+          if ! printf '%s' "$ver" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::unexpected version: $ver"
+            exit 1
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "tag=v$ver" >> "$GITHUB_OUTPUT"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'uv.lock'
+      - name: Set up Python
+        run: uv python install 3.12
+      - name: Sync and verify project version
+        run: |
+          uv run python tools/sync_version.py ${{ steps.meta.outputs.version }}
+          uv run python tools/sync_version.py ${{ steps.meta.outputs.version }} --check
+      - name: Install dependencies
+        run: uv sync --extra build --extra terrain
+
+      - name: Import certificate into a throwaway keychain
+        env:
+          APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KC_PASSWORD="$(openssl rand -base64 24)"
+          printf '%s' "$APPLE_CERT_P12" | base64 -d > cert.p12
+          security create-keychain -p "$KC_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KC_PASSWORD" "$KEYCHAIN"
+          security import cert.p12 -k "$KEYCHAIN" -f pkcs12 \
+            -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign
+          rm -f cert.p12
+          # Let codesign use the key non-interactively.
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$KC_PASSWORD" "$KEYCHAIN" > /dev/null
+          # Search list, so PyInstaller's un-keychained codesign calls
+          # resolve the identity too.
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+
+      - name: Verify identity and pin the fingerprint
+        env:
+          APPLE_CERT_FINGERPRINT: ${{ secrets.APPLE_CERT_FINGERPRINT }}
+        run: |
+          set -euo pipefail
+          security find-identity -v -p codesigning "$KEYCHAIN" \
+            | grep -q "Developer ID Application"
+          actual="$(security find-certificate -c 'Developer ID Application' \
+            -Z "$KEYCHAIN" | awk '/SHA-256 hash/ {print $3}')"
+          if [ "$actual" != "$APPLE_CERT_FINGERPRINT" ]; then
+            echo "::error::certificate fingerprint does not match the pin"
+            exit 1
+          fi
+          echo "Fingerprint pin: MATCH"
+
+      - name: Build arm64 binary (PyInstaller, embedded dylibs signed)
+        env:
+          MACOS_CODESIGN_IDENTITY: Developer ID Application
+        run: uv run python tools/build_exe.py
+
+      - name: Sign the binary (hardened runtime + timestamp)
+        run: |
+          set -euo pipefail
+          codesign --force --sign "Developer ID Application" \
+            --options runtime --timestamp \
+            --keychain "$KEYCHAIN" dist/dji-embed
+          codesign --verify --strict --verbose=2 dist/dji-embed
+          codesign --display --verbose=2 dist/dji-embed 2>&1 \
+            | grep -E "Authority|TeamIdentifier"
+
+      - name: Smoke test the signed binary
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          ./dist/dji-embed --version | grep -F "$VERSION"
+          ./dist/dji-embed --help > /dev/null
+          echo "Smoke test: OK ($(./dist/dji-embed --version))"
+
+      - name: Notarize
+        env:
+          APPLE_NOTARY_KEY_P8: ${{ secrets.APPLE_NOTARY_KEY_P8 }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$APPLE_NOTARY_KEY_P8" > notary-key.p8
+          # The submitted zip is the shipped release asset.
+          ditto -c -k --keepParent dist/dji-embed dist/dji-embed-macos-arm64.zip
+          xcrun notarytool submit dist/dji-embed-macos-arm64.zip \
+            --key notary-key.p8 \
+            --key-id "$APPLE_NOTARY_KEY_ID" \
+            --issuer "$APPLE_NOTARY_ISSUER_ID" \
+            --wait --timeout 35m | tee notary.log
+          rm -f notary-key.p8
+          grep -q "status: Accepted" notary.log
+          echo "Notarization: Accepted"
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-dist
+          path: dist/dji-embed-macos-arm64.zip
+          if-no-files-found: error
+
+      - name: Delete the throwaway keychain
+        if: always()
+        run: |
+          security delete-keychain "$KEYCHAIN" || true
+          rm -f cert.p12 notary-key.p8
+
+  publish:
+    # PR runs prove the chain but ship nothing.
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Sigstore build provenance (verify with `gh attestation verify`).
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: macos-dist
+          path: dist
+      - name: Generate SHA256SUMS-macos.txt
+        # Separate file from the Windows leg's SHA256SUMS.txt — both legs
+        # race on the same release, and same-named assets clobber.
+        run: |
+          cd dist
+          sha256sum -- * > SHA256SUMS-macos.txt
+          cat SHA256SUMS-macos.txt
+      - name: Attest build provenance
+        # Sigstore-signed proof the zip came from this workflow:
+        #   gh attestation verify dji-embed-macos-arm64.zip -R CallMarcus/dji-drone-metadata-embedder
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: dist/dji-embed-macos-arm64.zip
+      - name: Create or update GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.build.outputs.tag }}
+          name: ${{ needs.build.outputs.tag }}
+          files: dist/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+      - name: Summary
+        env:
+          TAG: ${{ needs.build.outputs.tag }}
+        run: |
+          echo "Notarized macOS arm64 CLI attached to [release $TAG](https://github.com/${GITHUB_REPOSITORY}/releases/tag/$TAG)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -178,11 +178,14 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s' "$APPLE_NOTARY_KEY_P8" > notary-key.p8
-          # The submitted zip is the shipped release asset. Zip from inside
-          # dist/ so the binary sits at the archive root, then prove the
-          # asset in the exact form users download it — entry at the root,
-          # exec bit intact — before burning a notary submission.
-          (cd dist && ditto -c -k --keepParent dji-embed dji-embed-macos-arm64.zip)
+          # The submitted zip is the shipped release asset. Info-ZIP `zip`,
+          # not `ditto --keepParent`: for a plain file ditto embeds the
+          # parent directory name (the entry came out as dist/dji-embed),
+          # while zip puts the named entry at the archive root and records
+          # the exec bit. The round-trip below proves the asset in the
+          # exact form users download it — before burning a notary
+          # submission.
+          (cd dist && zip -X dji-embed-macos-arm64.zip dji-embed)
           rm -rf ziptest && mkdir ziptest
           ditto -x -k dist/dji-embed-macos-arm64.zip ziptest
           test -x ziptest/dji-embed

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -61,10 +61,10 @@ jobs:
               && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     runs-on: macos-14
     # Notarization budget: a routine submission takes single-digit minutes,
-    # but this account still gets extended vetting — the first PyInstaller
-    # submission sat In Progress ~40 minutes before Accepted (2026-07-31),
-    # blowing a 35m budget. Hence the generous allowance; runs just finish
-    # sooner once Apple trusts the account.
+    # but this young account gets extended vetting — 2026-07-31 observed
+    # 30m, then ~40m, then 75m+ In Progress on successive submissions.
+    # Hence the generous allowance; runs just finish sooner once Apple
+    # trusts the account.
     timeout-minutes: 80
     env:
       KEYCHAIN: release-macos.keychain-db
@@ -193,13 +193,40 @@ jobs:
           test -x ziptest/dji-embed
           ziptest/dji-embed --version
           rm -rf ziptest
-          xcrun notarytool submit dist/dji-embed-macos-arm64.zip \
+          # Submit without --wait and poll ourselves: notarytool's built-in
+          # wait aborts on the first transient network error (a runner blip
+          # 53 minutes in cost a whole run), while each poll below is an
+          # independent request.
+          sub_id="$(xcrun notarytool submit dist/dji-embed-macos-arm64.zip \
             --key notary-key.p8 \
             --key-id "$APPLE_NOTARY_KEY_ID" \
             --issuer "$APPLE_NOTARY_ISSUER_ID" \
-            --wait --timeout 60m | tee notary.log
+            --output-format json \
+            | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+          echo "Submission id: $sub_id"
+          deadline=$((SECONDS + 70 * 60))
+          status="In Progress"
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            sleep 60
+            if ! out="$(xcrun notarytool info "$sub_id" \
+                --key notary-key.p8 \
+                --key-id "$APPLE_NOTARY_KEY_ID" \
+                --issuer "$APPLE_NOTARY_ISSUER_ID" 2>&1)"; then
+              echo "poll failed (transient), retrying: $(printf '%s' "$out" | head -1)"
+              continue
+            fi
+            status="$(printf '%s\n' "$out" | sed -n 's/^ *status: //p' | head -1)"
+            echo "[$((SECONDS / 60))m] status: $status"
+            case "$status" in
+              "In Progress"|"") ;;
+              *) break ;;
+            esac
+          done
           rm -f notary-key.p8
-          grep -q "status: Accepted" notary.log
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::notarization did not accept (status: $status)"
+            exit 1
+          fi
           echo "Notarization: Accepted"
 
       - name: Upload dist

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -61,9 +61,11 @@ jobs:
               && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     runs-on: macos-14
     # Notarization budget: a routine submission takes single-digit minutes,
-    # but extended vetting (seen on this account's maiden submission) can
-    # push past 30 — same allowance as mac-sign-test.yml.
-    timeout-minutes: 60
+    # but this account still gets extended vetting — the first PyInstaller
+    # submission sat In Progress ~40 minutes before Accepted (2026-07-31),
+    # blowing a 35m budget. Hence the generous allowance; runs just finish
+    # sooner once Apple trusts the account.
+    timeout-minutes: 80
     env:
       KEYCHAIN: release-macos.keychain-db
     outputs:
@@ -195,7 +197,7 @@ jobs:
             --key notary-key.p8 \
             --key-id "$APPLE_NOTARY_KEY_ID" \
             --issuer "$APPLE_NOTARY_ISSUER_ID" \
-            --wait --timeout 35m | tee notary.log
+            --wait --timeout 60m | tee notary.log
           rm -f notary-key.p8
           grep -q "status: Accepted" notary.log
           echo "Notarization: Accepted"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -62,10 +62,11 @@ jobs:
     runs-on: macos-14
     # Notarization budget: a routine submission takes single-digit minutes,
     # but this young account gets extended vetting — 2026-07-31 observed
-    # 30m, then ~40m, then 75m+ In Progress on successive submissions.
-    # Hence the generous allowance; runs just finish sooner once Apple
-    # trusts the account.
-    timeout-minutes: 80
+    # 30m, ~40m, then 2h+ on successive submissions, with the Apple status
+    # page green throughout. The generous allowance costs nothing on a
+    # healthy day (the poll exits on Accepted) and saves the run on a slow
+    # one; it shrinks to minutes once Apple trusts the account.
+    timeout-minutes: 300
     env:
       KEYCHAIN: release-macos.keychain-db
     outputs:
@@ -204,7 +205,7 @@ jobs:
             --output-format json \
             | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
           echo "Submission id: $sub_id"
-          deadline=$((SECONDS + 70 * 60))
+          deadline=$((SECONDS + 180 * 60))
           status="In Progress"
           while [ "$SECONDS" -lt "$deadline" ]; do
             sleep 60

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ sudo apt update && sudo apt install ffmpeg exiftool   # Debian/Ubuntu
 pip install dji-drone-metadata-embedder
 ```
 
+On Apple Silicon you can also skip Python entirely: download the signed and
+notarized **dji-embed-macos-arm64.zip** from the
+[GitHub Releases page](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases),
+unzip, and run `./dji-embed` (first run needs network — Gatekeeper fetches
+the notarization ticket online).
+
 <details>
 <summary>Docker and building from source</summary>
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ repository's public build workflow. With the [GitHub CLI](https://cli.github.com
 gh attestation verify dji-metadata-embedder-setup-<version>.exe -R CallMarcus/dji-drone-metadata-embedder
 ```
 
-The same works for `dji-embed.exe`. PyPI wheels are attested separately by
+The same works for `dji-embed.exe` and `dji-embed-macos-arm64.zip`. PyPI
+wheels are attested separately by
 PyPI's [Trusted Publishing](https://docs.pypi.org/attestations/) — see the
 "provenance" details on each file at
 [pypi.org](https://pypi.org/project/dji-drone-metadata-embedder/#files).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -5,7 +5,8 @@ This project publishes packages to PyPI and Windows Package Manager (winget) via
 ## Release Workflow
 
 The release process is mostly automated. Pushing the tag runs the PyPI, EXE,
-and changelog workflows; the winget submission is a separate manual step.
+macOS CLI, and changelog workflows; the winget submission is a separate
+manual step.
 
 ### 1. PyPI Release (`release-pypi.yml`)
 1. Build the wheel and source distribution using `python -m build`
@@ -35,6 +36,25 @@ Five jobs: `build` → `sign-app` → `assemble` → `sign-installer` → `publi
    Inno-generated uninstaller is knowingly unsigned (compile-time-only)
 4. Sign the setup EXE
 5. Checksums + attestation + release upload
+
+### 2c. macOS CLI Build (`release-macos.yml`)
+Two jobs: `build` (arm64 macOS runner) → `publish`.
+1. Build a standalone `dji-embed` binary with PyInstaller (embedded dylibs
+   signed with the Developer ID identity so hardened-runtime library
+   validation passes at runtime), codesign the binary with hardened runtime
+   + secure timestamp, smoke-test `--version`, then notarize the zip with
+   `notarytool`
+2. Generate `SHA256SUMS-macos.txt` (a separate file — this leg races the
+   Windows leg on the same release, and same-named assets clobber), attest
+   build provenance (Sigstore), and attach `dji-embed-macos-arm64.zip` to
+   the GitHub release
+
+A bare binary has nowhere to staple the notarization ticket, so a user's
+first run needs network for Gatekeeper's online check. Apple credentials
+live in the `APPLE_*` repository secrets; after rotating any of them, run
+the manual **Mac sign test** workflow (`mac-sign-test.yml`) — it proves the
+whole chain without cutting a release. Same-repo PRs touching this leg run
+the full build + sign + notarize as a check, skipping only the publish job.
 
 ### Code signing (Certum SimplySign)
 Signing runs headlessly on Linux inside the pinned
@@ -105,7 +125,8 @@ The following workflows will run automatically:
 
 1. ✅ **PyPI Release** - Package uploaded to PyPI
 2. ✅ **Windows EXE** - Standalone executable built and attached (triggered by the PyPI workflow completing)
-3. ✅ **Auto-Changelog** - Changelog updated from commits
+3. ✅ **macOS CLI** - Notarized arm64 binary built and attached (also triggered by the PyPI workflow completing)
+4. ✅ **Auto-Changelog** - Changelog updated from commits
 
 **Winget Submission is a separate manual step** — see [Winget Integration](#winget-integration) below.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This project publishes packages to PyPI and Windows Package Manager (winget) via GitHub Actions. Pushing a git tag that follows the pattern `vX.Y.Z` triggers the automated release workflow.
+This project publishes packages to PyPI and Windows Package Manager (winget), plus standalone Windows and macOS binaries, via GitHub Actions. Pushing a git tag that follows the pattern `vX.Y.Z` triggers the automated release workflow.
 
 ## Release Workflow
 
@@ -125,8 +125,9 @@ The following workflows will run automatically:
 
 1. ✅ **PyPI Release** - Package uploaded to PyPI
 2. ✅ **Windows EXE** - Standalone executable built and attached (triggered by the PyPI workflow completing)
-3. ✅ **macOS CLI** - Notarized arm64 binary built and attached (also triggered by the PyPI workflow completing)
-4. ✅ **Auto-Changelog** - Changelog updated from commits
+3. ✅ **Windows Installer** - Signed GUI installer built and attached (also triggered by the PyPI workflow completing)
+4. ✅ **macOS CLI** - Notarized arm64 binary built and attached (also triggered by the PyPI workflow completing)
+5. ✅ **Auto-Changelog** - Changelog updated from commits
 
 **Winget Submission is a separate manual step** — see [Winget Integration](#winget-integration) below.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,7 +78,8 @@ Prefer no Python at all? On Apple Silicon, grab the standalone
 unzip it, and run `./dji-embed`. The binary is Developer ID-signed and
 notarized, but a bare binary can't carry a stapled notarization ticket, so
 the **first run needs a network connection** for Gatekeeper's online ticket
-check. FFmpeg and ExifTool still come from Homebrew
+check. Verify the download against `SHA256SUMS-macos.txt` from the same
+release. FFmpeg and ExifTool still come from Homebrew
 (`brew install ffmpeg exiftool`).
 
 ### Linux

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,6 +72,15 @@ error — `pipx` installs the tool into its own isolated environment and puts
 `dji-embed` on your PATH (run `pipx ensurepath` once if the command isn't
 found in a new terminal).
 
+Prefer no Python at all? On Apple Silicon, grab the standalone
+`dji-embed-macos-arm64.zip` from the
+[GitHub Releases page](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases),
+unzip it, and run `./dji-embed`. The binary is Developer ID-signed and
+notarized, but a bare binary can't carry a stapled notarization ticket, so
+the **first run needs a network connection** for Gatekeeper's online ticket
+check. FFmpeg and ExifTool still come from Homebrew
+(`brew install ffmpeg exiftool`).
+
 ### Linux
 
 ```bash

--- a/tests/test_build_exe.py
+++ b/tests/test_build_exe.py
@@ -28,9 +28,12 @@ build_exe = _load_module()
 
 
 def test_module_imports_without_pyinstaller():
-    # The dev/test environment does not install the ``build`` extra; loading
-    # the module (as this file and tools/test_exe.py do) must not require
-    # PyInstaller — only actually building does.
+    # Loading the module (as this file and tools/test_exe.py do) must not
+    # require PyInstaller — only actually building does. CI installs the
+    # ``build`` extra so this passes trivially there; the real guard is the
+    # module-level ``_load_module()`` above, which fails collection in any
+    # environment without PyInstaller (like a default dev checkout) if a
+    # top-level ``import PyInstaller`` ever comes back.
     assert hasattr(build_exe, "build_executable")
 
 
@@ -40,17 +43,29 @@ def test_dist_binary_is_exe_on_windows_and_bare_elsewhere():
     assert build_exe.dist_binary("linux") == Path("dist/dji-embed")
 
 
-def test_windows_args_keep_the_icon_and_historic_shape():
-    args = build_exe.pyinstaller_args(
+def test_windows_args_are_identical_to_the_pre_macos_build():
+    # Full-list equality, not membership: the Windows release leg must keep
+    # producing exactly the argument list the old inline literal did.
+    assert build_exe.pyinstaller_args(
         "_pyinstaller_entry.py", "win32", icon=Path("assets/icon.ico")
-    )
-    assert args[0] == "_pyinstaller_entry.py"
-    assert "--onefile" in args
-    assert "--name=dji-embed" in args
-    assert f"--icon={Path('assets/icon.ico')}" in args
-    assert "--hidden-import=dji_metadata_embedder.cli" in args
-    assert not any(a.startswith("--codesign-identity") for a in args)
-    assert "--noupx" not in args
+    ) == [
+        "_pyinstaller_entry.py",
+        "--name=dji-embed",
+        "--onefile",
+        "--console",
+        "--paths=src",
+        "--hidden-import=dji_metadata_embedder",
+        "--hidden-import=dji_metadata_embedder.cli",
+        "--hidden-import=dji_metadata_embedder.core",
+        "--hidden-import=dji_metadata_embedder.telemetry_converter",
+        "--hidden-import=dji_metadata_embedder.metadata_check",
+        "--hidden-import=click",
+        "--hidden-import=rich",
+        "--distpath=dist",
+        "--workpath=build",
+        "--clean",
+        f"--icon={Path('assets/icon.ico')}",
+    ]
 
 
 def test_macos_args_skip_windows_icon_and_disable_upx():

--- a/tests/test_build_exe.py
+++ b/tests/test_build_exe.py
@@ -1,0 +1,85 @@
+"""Tests for the platform seam in tools/build_exe.py.
+
+The build script originally hard-coded Windows everywhere (``dist/dji-embed.exe``,
+a ``.ico`` icon, implicit UPX). The macOS release leg (#414 Stage C) reuses the
+same script on an arm64 runner, so the argument list and output path are built
+by pure, platform-parameterized helpers that can be asserted here without
+running PyInstaller — the same explicit-platform-seam pattern the GUI uses.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    path = Path(__file__).resolve().parent.parent / "tools" / "build_exe.py"
+    spec = importlib.util.spec_from_file_location("build_exe", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+build_exe = _load_module()
+
+
+def test_module_imports_without_pyinstaller():
+    # The dev/test environment does not install the ``build`` extra; loading
+    # the module (as this file and tools/test_exe.py do) must not require
+    # PyInstaller — only actually building does.
+    assert hasattr(build_exe, "build_executable")
+
+
+def test_dist_binary_is_exe_on_windows_and_bare_elsewhere():
+    assert build_exe.dist_binary("win32") == Path("dist/dji-embed.exe")
+    assert build_exe.dist_binary("darwin") == Path("dist/dji-embed")
+    assert build_exe.dist_binary("linux") == Path("dist/dji-embed")
+
+
+def test_windows_args_keep_the_icon_and_historic_shape():
+    args = build_exe.pyinstaller_args(
+        "_pyinstaller_entry.py", "win32", icon=Path("assets/icon.ico")
+    )
+    assert args[0] == "_pyinstaller_entry.py"
+    assert "--onefile" in args
+    assert "--name=dji-embed" in args
+    assert f"--icon={Path('assets/icon.ico')}" in args
+    assert "--hidden-import=dji_metadata_embedder.cli" in args
+    assert not any(a.startswith("--codesign-identity") for a in args)
+    assert "--noupx" not in args
+
+
+def test_macos_args_skip_windows_icon_and_disable_upx():
+    # The .ico is Windows-only, and UPX-packed binaries break codesign.
+    args = build_exe.pyinstaller_args(
+        "_pyinstaller_entry.py", "darwin", icon=Path("assets/icon.ico")
+    )
+    assert not any(a.startswith("--icon") for a in args)
+    assert "--noupx" in args
+
+
+def test_macos_codesign_identity_signs_collected_binaries():
+    # Embedded dylibs must carry the team ID or hardened-runtime library
+    # validation kills the extracted onefile payload at runtime.
+    args = build_exe.pyinstaller_args(
+        "_pyinstaller_entry.py",
+        "darwin",
+        codesign_identity="Developer ID Application",
+    )
+    assert "--codesign-identity=Developer ID Application" in args
+
+
+def test_macos_without_identity_builds_adhoc():
+    args = build_exe.pyinstaller_args("_pyinstaller_entry.py", "darwin")
+    assert not any(a.startswith("--codesign-identity") for a in args)
+
+
+def test_codesign_identity_rejected_off_macos():
+    with pytest.raises(ValueError):
+        build_exe.pyinstaller_args(
+            "_pyinstaller_entry.py", "win32", codesign_identity="Developer ID"
+        )

--- a/tools/build_exe.py
+++ b/tools/build_exe.py
@@ -98,9 +98,11 @@ if __name__ == '__main__':
         args = pyinstaller_args(
             str(entry_script),
             icon=icon_path if icon_path.exists() else None,
-            codesign_identity=os.environ.get("MACOS_CODESIGN_IDENTITY")
-            if sys.platform == "darwin"
-            else None,
+            codesign_identity=(
+                os.environ.get("MACOS_CODESIGN_IDENTITY")
+                if sys.platform == "darwin"
+                else None
+            ),
         )
 
         print("Building executable...")

--- a/tools/build_exe.py
+++ b/tools/build_exe.py
@@ -1,16 +1,73 @@
 """
-Build standalone Windows executable for DJI Metadata Embedder
-Creates dji-embed.exe with all dependencies bundled
+Build the standalone dji-embed executable for the current platform.
+
+Windows (release-exe.yml) and macOS arm64 (release-macos.yml) share this
+script; the platform differences live in the pure helpers below so the
+argument list can be unit-tested without PyInstaller installed.
 """
 
 import os
 import shutil
+import sys
 from pathlib import Path
-import PyInstaller.__main__
+from typing import List, Optional
 
 
-def build_executable():
-    """Build the Windows executable using PyInstaller"""
+def dist_binary(platform: str = sys.platform) -> Path:
+    """Path of the built binary, relative to the project root."""
+    name = "dji-embed.exe" if platform == "win32" else "dji-embed"
+    return Path("dist") / name
+
+
+def pyinstaller_args(
+    entry_script: str,
+    platform: str = sys.platform,
+    icon: Optional[Path] = None,
+    codesign_identity: Optional[str] = None,
+) -> List[str]:
+    """PyInstaller argument list for *platform*."""
+    if codesign_identity and platform != "darwin":
+        raise ValueError("codesign_identity is macOS-only")
+
+    args = [
+        entry_script,
+        "--name=dji-embed",
+        "--onefile",  # Single executable
+        "--console",  # Console application
+        "--paths=src",  # Add src to Python path
+        "--hidden-import=dji_metadata_embedder",
+        "--hidden-import=dji_metadata_embedder.cli",
+        "--hidden-import=dji_metadata_embedder.core",
+        "--hidden-import=dji_metadata_embedder.telemetry_converter",
+        "--hidden-import=dji_metadata_embedder.metadata_check",
+        "--hidden-import=click",
+        "--hidden-import=rich",
+        "--distpath=dist",
+        "--workpath=build",
+        "--clean",
+    ]
+
+    if platform == "win32":
+        # The .ico is Windows-only; macOS icons only matter for the Stage D
+        # .app bundle, and a bare CLI binary has nowhere to show one.
+        if icon is not None:
+            args.append(f"--icon={icon}")
+    elif platform == "darwin":
+        # UPX-packed binaries break codesign, and every embedded dylib must
+        # carry the Developer ID team ID or hardened-runtime library
+        # validation kills the extracted onefile payload at runtime.
+        args.append("--noupx")
+        if codesign_identity:
+            args.append(f"--codesign-identity={codesign_identity}")
+
+    return args
+
+
+def build_executable() -> str:
+    """Build the executable with PyInstaller and return its SHA256."""
+    import hashlib
+
+    import PyInstaller.__main__
 
     # Ensure we're in the project root
     project_root = Path(__file__).parent.parent
@@ -37,47 +94,26 @@ if __name__ == '__main__':
     )
 
     try:
-        # PyInstaller arguments
-        args = [
-            str(entry_script),  # Entry point
-            "--name=dji-embed",  # Output name
-            "--onefile",  # Single executable
-            "--console",  # Console application
-            "--paths=src",  # Add src to Python path
-            "--hidden-import=dji_metadata_embedder",
-            "--hidden-import=dji_metadata_embedder.cli",
-            "--hidden-import=dji_metadata_embedder.core",
-            "--hidden-import=dji_metadata_embedder.telemetry_converter",
-            "--hidden-import=dji_metadata_embedder.metadata_check",
-            "--hidden-import=click",
-            "--hidden-import=rich",
-            "--distpath=dist",
-            "--workpath=build",
-            "--clean",
-        ]
-
-        # Add icon if it exists
         icon_path = Path("assets/icon.ico")
-        if icon_path.exists():
-            args.append(f"--icon={icon_path}")
+        args = pyinstaller_args(
+            str(entry_script),
+            icon=icon_path if icon_path.exists() else None,
+            codesign_identity=os.environ.get("MACOS_CODESIGN_IDENTITY")
+            if sys.platform == "darwin"
+            else None,
+        )
 
-        # Run PyInstaller
         print("Building executable...")
         PyInstaller.__main__.run(args)
 
-        print("SUCCESS: Executable built at dist/dji-embed.exe")
-
-
-        # Calculate SHA256
-        import hashlib
-
-        exe_path = Path("dist/dji-embed.exe")
-        if exe_path.exists():
-            sha256 = hashlib.sha256(exe_path.read_bytes()).hexdigest()
-            print(f"SHA256: {sha256}")
-            return sha256
-        else:
+        binary = dist_binary()
+        if not binary.exists():
             raise FileNotFoundError("Executable not created")
+
+        print(f"SUCCESS: Executable built at {binary}")
+        sha256 = hashlib.sha256(binary.read_bytes()).hexdigest()
+        print(f"SHA256: {sha256}")
+        return sha256
 
     finally:
         # Clean up temporary entry script

--- a/tools/test_exe.py
+++ b/tools/test_exe.py
@@ -2,11 +2,12 @@
 
 import subprocess
 import sys
-from pathlib import Path
+
+from build_exe import dist_binary
 
 
 def test_executable() -> bool:
-    exe_path = Path("dist/dji-embed.exe")
+    exe_path = dist_binary()
 
     if not exe_path.exists():
         print("\u274c Executable not found")


### PR DESCRIPTION
Part of #414 (Stage C of the macOS roadmap; needs nothing beyond Stage A's secrets, which are live).

## What

A new release leg, **`release-macos.yml`**, shipping `dji-embed-macos-arm64.zip` as a release asset alongside the Windows EXE:

- **Build**: PyInstaller onefile on `macos-14` (arm64), same `tools/build_exe.py` as Windows, terrain extra included. The script grew a pure, platform-parameterized argument seam (`pyinstaller_args()` / `dist_binary()`) so the macOS behavior is unit-tested in today's CI without PyInstaller installed — same explicit-platform-seam pattern as Stage B.
- **Sign**: embedded dylibs get the Developer ID team ID via PyInstaller's `--codesign-identity` (hardened-runtime **library validation** would otherwise kill the extracted onefile payload at runtime); the final binary is then signed with hardened runtime + secure timestamp. Keychain/pin steps copied verbatim from the Stage A-proven `mac-sign-test.yml`.
- **Smoke test**: `./dist/dji-embed --version` (must contain the release version) + `--help`, run on the runner **after** signing — so a library-validation failure fails the workflow, not the first user.
- **Notarize**: `notarytool submit --wait` on the exact zip that ships; 35m budget (maiden-submission vetting lesson from Stage A).
- **Publish** (skipped on PRs): `SHA256SUMS-macos.txt` (separate file — this leg races the Windows leg on the same release and same-named assets clobber), Sigstore attestation, release upload.

Triggers mirror the Windows leg (`workflow_run` on "Release to PyPI" + `workflow_dispatch`), **plus** `pull_request` on its own paths — so this very PR runs the full build → sign → notarize chain as its check.

## Notarization note (why onefile works)

The notary only inspects the outer Mach-O — PyInstaller's appended archive isn't unpacked — so "Accepted" hinges on the final binary's hardened runtime + timestamp. The embedded dylib signatures matter at runtime only. Entitlements are deliberately **none** for now; if the smoke test shows library validation biting despite the team-ID signing, the fallback is `com.apple.security.cs.disable-library-validation`.

A bare binary can't carry a stapled ticket, so first run needs network for Gatekeeper's online check — documented in README, `docs/installation.md`, and `docs/RELEASE.md` (new section 2c). Stapling gets exercised by the Stage D .app/DMG.

## Stage E must-verify (carried forward)

- Download the release zip on a real/cloud Mac, unzip via Finder, first run with network: Gatekeeper should pass without right-click→Open.
- Same but network-off on first run (expected: Gatekeeper can't fetch the ticket — document the observed behavior).
- Exec bit survives the user's unzip path (ditto-created zip should preserve it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FLcETZggQHMhxrmAQUXFK