### PR TITLE
fix(geo): airspace refetch + FAA identifier fallback (#424 fold-ins)

### DIFF
--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -817,9 +817,10 @@ def photomap(
     ),
     default="html", show_default=True,
     help="Map output format. 'record' (also written by 'all') writes a printable "
-         "flight record and fetches airspace data from official feeds (FAA / "
-         "ED-269) and terrain tiles from Mapterhorn — with --airspace, the only "
-         "network access in this command; data is cached beside the output.",
+         "flight record, fetching airspace data from official feeds (FAA / "
+         "ED-269) and terrain tiles from Mapterhorn. Along with --airspace, "
+         "these are the command's only network access; responses are cached "
+         "beside the output.",
 )
 @click.option(
     "--airspace-refresh", is_flag=True,
@@ -1135,7 +1136,12 @@ def flightmap(
                     records = build_records(
                         tracks,
                         cache_dir=out.parent / "airspace-cache",
-                        refresh=airspace_refresh,
+                        # The overlay loop above already refreshed this
+                        # same cache in this run — a second refresh pass
+                        # would refetch the feed it just wrote (#424).
+                        # Terrain tiles have no refresh notion, so nothing
+                        # else is suppressed.
+                        refresh=airspace_refresh and not airspace,
                         announce=lambda m: click.echo(m, err=True),
                     )
                     write_flight_record(records, out, map_title)

--- a/src/dji_metadata_embedder/geo/airspace/arcgis_faa.py
+++ b/src/dji_metadata_embedder/geo/airspace/arcgis_faa.py
@@ -8,6 +8,7 @@ complete — a truncated grid must never present itself as full coverage.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 from urllib.error import HTTPError, URLError
@@ -117,10 +118,9 @@ def fetch_faa_pages(
 def parse_faa(pages: list[bytes], source: SourceInfo) -> list[Zone]:
     """Normalize UASFM grid cells: CEILING feet AGL -> Zone. All-or-nothing."""
     zones: list[Zone] = []
-    # One running index across pages: the cell-{n} identifier fallback must
-    # not restart per page, or OBJECTID-less features at the same index of
-    # two pages collide on the overlay's (feed, identifier) dedupe key and
-    # a zone silently vanishes from the map (#424).
+    # One running index across pages so error messages carry the true
+    # position ("cell 1043", not a second "cell 0") — the identifier
+    # fallback below is content-derived, not index-based (#424).
     index = 0
     for page in pages:
         doc = json.loads(page)
@@ -146,7 +146,21 @@ def parse_faa(pages: list[bytes], source: SourceInfo) -> list[Zone]:
             polygons = rings[:1]
             holes = rings[1:]
             apt = props.get("APT1_NAME") or props.get("APT1_ICAO") or "UASFM"
-            ident = str(props.get("OBJECTID", f"cell-{index}"))
+            oid = props.get("OBJECTID")
+            if oid is None:
+                # Content-derived fallback, stable across pages, fetches
+                # and reruns: any counter restarts somewhere (per page, or
+                # per parse_faa call when each track fetches its own bbox)
+                # and collides on the overlay's (feed, identifier) dedupe
+                # key, silently dropping a zone. Identical geometry+ceiling
+                # hashing identically is correct — that IS the same cell,
+                # and collapsing it is deduplication, not loss (#424).
+                digest = hashlib.sha1(
+                    f"{ceiling}:{rings!r}".encode()
+                ).hexdigest()[:10]
+                ident = f"cell-{digest}"
+            else:
+                ident = str(oid)
             index += 1
             zones.append(
                 Zone(

--- a/src/dji_metadata_embedder/geo/airspace/arcgis_faa.py
+++ b/src/dji_metadata_embedder/geo/airspace/arcgis_faa.py
@@ -117,11 +117,16 @@ def fetch_faa_pages(
 def parse_faa(pages: list[bytes], source: SourceInfo) -> list[Zone]:
     """Normalize UASFM grid cells: CEILING feet AGL -> Zone. All-or-nothing."""
     zones: list[Zone] = []
+    # One running index across pages: the cell-{n} identifier fallback must
+    # not restart per page, or OBJECTID-less features at the same index of
+    # two pages collide on the overlay's (feed, identifier) dedupe key and
+    # a zone silently vanishes from the map (#424).
+    index = 0
     for page in pages:
         doc = json.loads(page)
-        for i, feat in enumerate(doc.get("features") or []):
+        for feat in doc.get("features") or []:
             props = feat.get("properties") or {}
-            where = f"{source.feed}: cell {i}"
+            where = f"{source.feed}: cell {index}"
             ceiling = props.get("CEILING")
             if not isinstance(ceiling, (int, float)):
                 raise AirspaceError(f"{where}: CEILING is {ceiling!r}")
@@ -141,7 +146,8 @@ def parse_faa(pages: list[bytes], source: SourceInfo) -> list[Zone]:
             polygons = rings[:1]
             holes = rings[1:]
             apt = props.get("APT1_NAME") or props.get("APT1_ICAO") or "UASFM"
-            ident = str(props.get("OBJECTID", f"cell-{i}"))
+            ident = str(props.get("OBJECTID", f"cell-{index}"))
+            index += 1
             zones.append(
                 Zone(
                     identifier=f"UASFM-{ident}",

--- a/tests/test_airspace_faa.py
+++ b/tests/test_airspace_faa.py
@@ -134,3 +134,22 @@ def test_interior_rings_parse_into_holes():
                               (0.0, 0.0)]]
     assert zone.holes == [[(0.2, 0.2), (0.4, 0.2), (0.4, 0.4), (0.2, 0.4),
                            (0.2, 0.2)]]
+
+
+def test_objectid_less_cells_get_distinct_identifiers_across_pages():
+    # #424: the cell-{i} fallback restarted per page, so OBJECTID-less
+    # features at the same index of two pages collided on the overlay's
+    # (feed, identifier) dedupe key — silently dropping a zone.
+    outer = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
+
+    def page():
+        return json.dumps({
+            "type": "FeatureCollection",
+            "features": [{
+                "properties": {"CEILING": 400},
+                "geometry": {"type": "Polygon", "coordinates": [outer]},
+            }],
+        }).encode()
+
+    zones = parse_faa([page(), page()], SRC)
+    assert len({z.identifier for z in zones}) == 2

--- a/tests/test_airspace_faa.py
+++ b/tests/test_airspace_faa.py
@@ -136,20 +136,55 @@ def test_interior_rings_parse_into_holes():
                            (0.2, 0.2)]]
 
 
+def _objectid_less_page(x, ceiling=400, objectid_null=False):
+    outer = [[x, 0.0], [x + 1.0, 0.0], [x + 1.0, 1.0], [x, 1.0], [x, 0.0]]
+    props = {"CEILING": ceiling}
+    if objectid_null:
+        props["OBJECTID"] = None
+    return json.dumps({
+        "type": "FeatureCollection",
+        "features": [{
+            "properties": props,
+            "geometry": {"type": "Polygon", "coordinates": [outer]},
+        }],
+    }).encode()
+
+
 def test_objectid_less_cells_get_distinct_identifiers_across_pages():
-    # #424: the cell-{i} fallback restarted per page, so OBJECTID-less
-    # features at the same index of two pages collided on the overlay's
-    # (feed, identifier) dedupe key — silently dropping a zone.
-    outer = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]
-
-    def page():
-        return json.dumps({
-            "type": "FeatureCollection",
-            "features": [{
-                "properties": {"CEILING": 400},
-                "geometry": {"type": "Polygon", "coordinates": [outer]},
-            }],
-        }).encode()
-
-    zones = parse_faa([page(), page()], SRC)
+    # #424: an index fallback restarting per page collided on the
+    # overlay's (feed, identifier) dedupe key — silently dropping a zone.
+    zones = parse_faa([_objectid_less_page(0.0), _objectid_less_page(5.0)], SRC)
     assert len({z.identifier for z in zones}) == 2
+
+
+def test_objectid_less_cells_from_different_fetches_stay_distinct():
+    # #433 review F1: two tracks mean two fetches mean two parse_faa
+    # calls; any per-call counter restarts and collides across them. The
+    # identifier is content-derived, so it is stable across pages,
+    # fetches and reruns.
+    (a,) = parse_faa([_objectid_less_page(0.0)], SRC)
+    (b,) = parse_faa([_objectid_less_page(5.0)], SRC)
+    assert a.identifier != b.identifier
+
+
+def test_identical_objectid_less_cells_share_an_identifier():
+    # Two features with the same geometry and ceiling ARE one cell; the
+    # overlay dedupe collapsing them is correct, not a drop.
+    (a,) = parse_faa([_objectid_less_page(0.0)], SRC)
+    (b,) = parse_faa([_objectid_less_page(0.0)], SRC)
+    assert a.identifier == b.identifier
+
+
+def test_a_null_objectid_falls_back_like_a_missing_one():
+    # #433 review F2: an explicit "OBJECTID": null must not become the
+    # shared identifier "UASFM-None" for every such cell.
+    (a,) = parse_faa([_objectid_less_page(0.0, objectid_null=True)], SRC)
+    (b,) = parse_faa([_objectid_less_page(5.0, objectid_null=True)], SRC)
+    assert "None" not in a.identifier
+    assert a.identifier != b.identifier
+
+
+def test_different_ceilings_on_the_same_footprint_stay_distinct():
+    (a,) = parse_faa([_objectid_less_page(0.0, ceiling=400)], SRC)
+    (b,) = parse_faa([_objectid_less_page(0.0, ceiling=100)], SRC)
+    assert a.identifier != b.identifier

--- a/tests/test_cli_airspace.py
+++ b/tests/test_cli_airspace.py
@@ -136,3 +136,38 @@ def test_gap_track_still_renders_map_with_note(tmp_path, monkeypatch):
     html = (d / "flightmap.html").read_text(encoding="utf-8")
     assert 'id="airspace-data"' in html      # gap note embedded in the map
     assert "airspace-note" in html
+
+
+class _UrlRecorder:
+    """Records every requested URL and stays offline — lets a test tell a
+    zone-feed request apart from a terrain-tile request."""
+
+    def __init__(self):
+        self.urls = []
+
+    def __call__(self, req, timeout=None):
+        self.urls.append(req.full_url if hasattr(req, "full_url") else str(req))
+        raise URLError("offline")
+
+
+def test_refresh_with_airspace_does_not_refetch_for_the_record(
+    tmp_path, monkeypatch
+):
+    # #424: -f all --airspace --airspace-refresh used to refetch the feed
+    # twice — once for the overlay, then again for the record, past the
+    # cache the overlay had just written.
+    from dji_metadata_embedder.geo import record as record_mod
+
+    fake = FakeTransport([_lux_body()])          # the overlay's refreshed fetch
+    monkeypatch.setattr(airspace_fetch, "urlopen", fake)
+    rec_transport = _UrlRecorder()               # terrain may knock; zones must not
+    monkeypatch.setattr(record_mod, "urlopen", rec_transport)
+    d = _srt_dir(tmp_path)
+    result = CliRunner().invoke(
+        main,
+        ["flightmap", str(d), "-f", "all", "--airspace", "--airspace-refresh"],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.calls == 1                       # one refreshed fetch, overlay-side
+    zone_urls = [u for u in rec_transport.urls if "geoportail" in u]
+    assert zone_urls == []                       # the record reused the fresh cache

--- a/tests/test_cli_airspace.py
+++ b/tests/test_cli_airspace.py
@@ -169,5 +169,7 @@ def test_refresh_with_airspace_does_not_refetch_for_the_record(
     )
     assert result.exit_code == 0, result.output
     assert fake.calls == 1                       # one refreshed fetch, overlay-side
-    zone_urls = [u for u in rec_transport.urls if "geoportail" in u]
-    assert zone_urls == []                       # the record reused the fresh cache
+    # Positive form (#433 review F4): the record touched the network for
+    # terrain tiles only — any zone-feed host would fail this, not just
+    # the fixture's spelling.
+    assert all("mapterhorn" in u for u in rec_transport.urls), rec_transport.urls


### PR DESCRIPTION
Part of #424 — the three small fold-ins from the #423 final review, TDD'd (both behavior fixes had observed-failing tests first). The 3D fill-extrusion volumes + zoom-gated labels headline stays open on #424.

- **Double-refetch**: `-f all --airspace --airspace-refresh` fetched the feed twice — the overlay loop refreshed the cache, then the record's own fetch refreshed it again. The record now reuses the cache the overlay just wrote (`refresh=airspace_refresh and not airspace`). Terrain is untouched — DEM tiles have no refresh notion at all, so the #424 caveat (don't suppress terrain refresh) is satisfied trivially. The test pins it by URL: the record-side transport must never see a zone-feed request.
- **`cell-{n}` collision**: the OBJECTID-less identifier fallback restarted per page, so features at the same index of two pages collided on the overlay's `(feed, identifier)` dedupe key — silently dropping a zone from the map. One running index across pages now (error messages inherit the more precise position too).
- **Help text**: the `-f/--format` sentence got its comma pass.

Gates: 915 passed, ruff, mypy clean.

Note: touches `parse_faa` near PR #432's hole-model change — whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FLcETZggQHMhxrmAQUXFK