### PR TITLE
fix(gui): platform-honest CLI discovery intro + bundled-CLI proof command

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
@@ -23,6 +23,48 @@ public class CliDiscoveryViewModelTests : IDisposable
     }
 
     [Fact]
+    public void Windows_intro_keeps_the_installer_path_claim()
+    {
+        // On Windows the sentence is true: the installer appends the CLI
+        // to PATH, so bare dji-embed works in any terminal.
+        var text = CliDiscoveryViewModel.IntroTextFor(OSPlatform.Windows);
+        Assert.Contains("put it on your PATH", text);
+        Assert.Contains("type dji-embed", text);
+    }
+
+    [Fact]
+    public void Macos_intro_never_claims_path_or_bare_typing()
+    {
+        // #442: the DMG install puts the CLI inside the app bundle and
+        // touches no PATH — telling a Mac user to "type dji-embed" lands
+        // on command-not-found.
+        var text = CliDiscoveryViewModel.IntroTextFor(OSPlatform.OSX);
+        Assert.DoesNotContain("PATH", text);
+        Assert.DoesNotContain("type dji-embed", text);
+        Assert.Contains("inside this app", text);
+    }
+
+    [Fact]
+    public void Linux_intro_points_at_pipx()
+    {
+        // No installer exists on Linux (#360); pipx is the documented
+        // route to a CLI that works in any terminal.
+        var text = CliDiscoveryViewModel.IntroTextFor(OSPlatform.Linux);
+        Assert.DoesNotContain("installer", text);
+        Assert.Contains("pipx install dji-drone-metadata-embedder", text);
+    }
+
+    [Fact]
+    public void Intro_text_property_follows_the_current_platform()
+    {
+        var vm = new CliDiscoveryViewModel(null, () => { });
+        Assert.Equal(
+            CliDiscoveryViewModel.IntroTextFor(
+                DjiEmbed.Gui.Services.Platforms.Current),
+            vm.IntroText);
+    }
+
+    [Fact]
     public void Starter_command_sample_folders_match_the_platform()
     {
         // The examples are copy-paste bait — a D:\ drive path handed to a

--- a/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
@@ -51,4 +51,22 @@ public class NavigationTests
         Assert.NotNull(window.GetVisualDescendants()
             .OfType<CliDiscoveryView>().FirstOrDefault());
     }
+
+    [AvaloniaFact]
+    public void Discovery_intro_renders_the_view_models_platform_text()
+    {
+        // #442/#336: the intro was a hardcoded literal; assert the view
+        // actually renders the platform-aware VM text, not a stale copy.
+        var main = new MainViewModel();
+        var window = new MainWindow { DataContext = main };
+        window.Show();
+        ((WorkspaceViewModel)main.CurrentPage)
+            .OpenCliDiscoveryCommand.Execute(null);
+        var discovery = Assert.IsType<CliDiscoveryViewModel>(main.CurrentPage);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        Assert.Contains(window.GetVisualDescendants().OfType<TextBlock>(),
+            t => t.Text == discovery.IntroText);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/TerminalLauncherTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/TerminalLauncherTests.cs
@@ -62,6 +62,43 @@ public class TerminalLauncherTests
     }
 
     [Fact]
+    public void Macos_proof_command_runs_the_bundled_cli_when_its_path_is_known()
+    {
+        // #442: nothing puts dji-embed on PATH on macOS, so the bare
+        // proof command lands a DMG-only user on "command not found".
+        // With the bundled CLI's location known, the do-script runs it
+        // by absolute path (single-quoted — the bundle name has spaces).
+        var osa = Assert.Single(TerminalLauncher.Candidates(
+            "/Users/demo", OSPlatform.OSX,
+            "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed"));
+
+        var doScript = osa.ArgumentList.Single(a => a.Contains("do script"));
+        Assert.Contains(
+            "'/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed'"
+            + " --help", doScript);
+        Assert.DoesNotContain(" dji-embed --help", doScript);
+    }
+
+    [Fact]
+    public void Windows_candidates_ignore_the_cli_path()
+    {
+        // The installer put dji-embed on PATH — the bare command is the
+        // proof the sentence promises, so a known CLI path changes nothing.
+        var bare = TerminalLauncher.Candidates(
+            @"C:\Users\demo", OSPlatform.Windows);
+        var withPath = TerminalLauncher.Candidates(
+            @"C:\Users\demo", OSPlatform.Windows,
+            @"C:\Program Files\DjiEmbed\dji-embed.exe");
+
+        Assert.Equal(bare.Count, withPath.Count);
+        for (var i = 0; i < bare.Count; i++)
+        {
+            Assert.Equal(bare[i].FileName, withPath[i].FileName);
+            Assert.Equal(bare[i].ArgumentList, withPath[i].ArgumentList);
+        }
+    }
+
+    [Fact]
     public void Macos_do_script_survives_a_folder_with_a_single_quote()
     {
         var osa = Assert.Single(TerminalLauncher.Candidates(

--- a/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
+++ b/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
@@ -28,19 +28,27 @@ public static class TerminalLauncher
 
     /// <summary>Candidate launches for this machine, best first.</summary>
     public static IReadOnlyList<ProcessStartInfo> Candidates(
-        string workingDirectory) =>
-        Candidates(workingDirectory, Platforms.Current);
+        string workingDirectory, string? cliPath = null) =>
+        Candidates(workingDirectory, Platforms.Current, cliPath);
 
     /// <summary>
     /// Candidate launches for a platform, best first. Pure so tests can
     /// assert every platform's exact invocations on any CI host without
-    /// spawning shells.
+    /// spawning shells. On macOS the proof command runs the bundled CLI
+    /// by absolute path when known — the DMG install touches no PATH, so
+    /// the bare command would land on "command not found" (#442); on
+    /// Windows the installer's PATH entry makes the bare command the
+    /// proof the discovery screen promises.
     /// </summary>
     internal static IReadOnlyList<ProcessStartInfo> Candidates(
-        string workingDirectory, OSPlatform platform)
+        string workingDirectory, OSPlatform platform, string? cliPath = null)
     {
         if (platform == OSPlatform.OSX)
         {
+            var proof = cliPath is null
+                ? ProofCommand
+                : $"{ShellSingleQuote(cliPath)} --help";
+
             // Terminal.app is always present and its windows stay open on
             // their own; "do script" opens a fresh window running the
             // proof command in the requested folder, and the second -e
@@ -54,7 +62,7 @@ public static class TerminalLauncher
             osa.ArgumentList.Add(
                 "tell application \"Terminal\" to do script "
                 + AppleScriptString(
-                    $"cd {ShellSingleQuote(workingDirectory)} && {ProofCommand}"));
+                    $"cd {ShellSingleQuote(workingDirectory)} && {proof}"));
             osa.ArgumentList.Add("-e");
             osa.ArgumentList.Add("tell application \"Terminal\" to activate");
             return [osa];
@@ -96,11 +104,11 @@ public static class TerminalLauncher
     }
 
     /// <summary>Tries each candidate in order; false when none started.</summary>
-    public static bool Launch()
+    public static bool Launch(string? cliPath = null)
     {
         var home = Environment.GetFolderPath(
             Environment.SpecialFolder.UserProfile);
-        foreach (var psi in Candidates(home))
+        foreach (var psi in Candidates(home, cliPath))
         {
             try
             {

--- a/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
@@ -32,6 +32,29 @@ public partial class CliDiscoveryViewModel(string? cliPath, Action goHome)
     public IReadOnlyList<StarterCommand> StarterCommands { get; } =
         StarterCommandsFor(Platforms.Current);
 
+    /// <summary>The opening revelation, phrased per platform.</summary>
+    public string IntroText { get; } = IntroTextFor(Platforms.Current);
+
+    /// <summary>How the CLI reaches a terminal differs per install: the
+    /// Windows installer appends it to PATH, the macOS DMG keeps it inside
+    /// the bundle, and Linux has no installer at all (#442).</summary>
+    internal static string IntroTextFor(OSPlatform platform) =>
+        platform == OSPlatform.Windows
+            ? "Everything this app does — and a lot more — runs on the "
+              + "dji-embed command line, and it is already installed: the "
+              + "app's installer put it on your PATH. Open any terminal, "
+              + "type dji-embed, and it just works."
+        : platform == OSPlatform.OSX
+            ? "Everything this app does — and a lot more — runs on the "
+              + "dji-embed command line, and it is already installed: it "
+              + "ships inside this app. The button below opens Terminal "
+              + "ready to use it; the guide below shows how to make it "
+              + "available in every terminal."
+        : "Everything this app does — and a lot more — runs on the "
+          + "dji-embed command line. Install it once with pipx "
+          + "(pipx install dji-drone-metadata-embedder) and it works "
+          + "in any terminal.";
+
     /// <summary>The examples are copy-paste bait, so the sample folder
     /// follows the OS — a D:\ drive path is Windows-only truth.</summary>
     internal static IReadOnlyList<StarterCommand> StarterCommandsFor(
@@ -131,7 +154,7 @@ public partial class CliDiscoveryViewModel(string? cliPath, Action goHome)
     }
 
     [RelayCommand]
-    private void OpenTerminal() => TerminalLauncher.Launch();
+    private void OpenTerminal() => TerminalLauncher.Launch(cliPath);
 
     [RelayCommand]
     private void OpenDocs() =>

--- a/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml
+++ b/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml
@@ -27,13 +27,11 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="16" Margin="0,0,12,0">
 
-                <!-- The key revelation: the CLI is already installed. -->
-                <TextBlock TextWrapping="Wrap" FontSize="14">
-                    Everything this app does — and a lot more — runs on the
-                    dji-embed command line, and it is already installed:
-                    the app's installer put it on your PATH. Open any
-                    terminal, type dji-embed, and it just works.
-                </TextBlock>
+                <!-- The key revelation: the CLI is already installed.
+                     Platform-phrased in the VM — the PATH claim is only
+                     true of the Windows installer (#442). -->
+                <TextBlock TextWrapping="Wrap" FontSize="14"
+                           Text="{Binding IntroText}" />
 
                 <Button HorizontalAlignment="Left"
                         Command="{Binding OpenTerminalCommand}">


### PR DESCRIPTION
Closes #442. Found during the #414 Stage E rented-Mac run.

## What changed

- **Intro sentence is now platform-phrased** (`CliDiscoveryViewModel.IntroTextFor`, bound from the VM): Windows keeps the true "installer put it on your PATH" claim verbatim; macOS says the CLI ships inside the app and points at the button + guide instead of telling the user to type `dji-embed` (which is command-not-found on a DMG-only install); Linux points at pipx, since no installer exists there (#360).
- **The "Open Terminal and try it" proof command on macOS now runs the bundled CLI by absolute path** when CliLocator knows it (single-quoted — the bundle name has spaces), falling back to the bare command otherwise. Same root cause as the sentence: nothing puts `dji-embed` on PATH on macOS, so the bare proof command opened Terminal onto "command not found". Stage E masked this because pipx had installed the CLI on the test machine.
- Windows candidates are byte-identical with or without a known CLI path, pinned by test.

## Test design

TDD; all new contracts asserted per-platform on today's Windows/Linux CI via the existing explicit-`OSPlatform` seams (PR #428 pattern). The intro also gets a view-level rendering test (the #336 lesson: without one, a wrong-object binding survives every VM test). Full GUI suite: 519 passed / 0 failed / 0 warnings in Release.

## Stage E note

The rented Mac (up for the rest of the 24h window) can re-verify the button end-to-end once this merges, but the seam tests pin the exact osascript invocation the hardware run already proved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYYj5wbL9XBjYi347LEN9M