### PR TITLE
docs: make macOS a first-class platform across README and docs

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -33,7 +33,7 @@ Free, open-source (MIT) tool for DJI drone footage. Everything runs locally.
 
 Two ways to use it — same engine:
 
-1. **Windows app** ("DJI Metadata Embedder"): install, open, drop a folder,
+1. **Desktop app** ("DJI Metadata Embedder", Windows and macOS): install, open, drop a folder,
    pick a mode (*Flight map*, *Photo map*, *Embed telemetry*,
    *Convert telemetry*, *Verify footage*, *Setup*), and press the action
    button; finished maps render right in the app's preview pane, with an
@@ -48,7 +48,8 @@ Two ways to use it — same engine:
    logs, and does the sun's computed position over a clip match the shadows
    you see.
 2. **`dji-embed` command line**: every feature, all platforms. The Windows
-   app's installer puts `dji-embed` on your PATH automatically.
+   app's installer puts `dji-embed` on your PATH automatically; on macOS
+   the CLI ships inside the app bundle (symlink it, or install via pipx).
 
 ## Installing
 
@@ -56,7 +57,8 @@ Two ways to use it — same engine:
 | --- | --- |
 | **Windows, simplest** | Download `dji-metadata-embedder-setup-<version>.exe` from the GitHub Releases page. One installer = app + CLI + FFmpeg + ExifTool, nothing else needed. Installers from v1.23.0 onwards are code-signed (publisher: "Open Source Developer, Marcus Westermark"); SmartScreen may still warn while the certificate builds reputation — click **More info → Run anyway**. Older releases are unsigned. The app remembers your window size and recent folders (stored locally in %APPDATA%\DjiEmbed\state.json — delete that file to reset). |
 | Windows, CLI only | `winget install CallMarcus.DJIMetadataEmbedder` (portable exe), or `pip install dji-drone-metadata-embedder` with Python 3.10–3.12. |
-| macOS | `brew install pipx ffmpeg exiftool` then `pipx install dji-drone-metadata-embedder` (plain `pip3` is blocked on Homebrew Python). |
+| **macOS, simplest** (Apple Silicon, macOS 14+) | Download the signed, notarized `dji-metadata-embedder-<version>-macos-arm64.dmg` from the GitHub Releases page and drag the app to Applications. FFmpeg/ExifTool come from Homebrew (`brew install ffmpeg exiftool`). State lives in ~/Library/Application Support/DjiEmbed/state.json. |
+| macOS, CLI only (any Mac, Intel included) | `brew install pipx ffmpeg exiftool` then `pipx install dji-drone-metadata-embedder` (plain `pip3` is blocked on Homebrew Python). |
 | Linux | `pip install dji-drone-metadata-embedder` (or pipx) + `ffmpeg`/`exiftool` from your package manager. |
 
 After installing, `dji-embed doctor` verifies everything. Missing ExifTool?
@@ -126,7 +128,7 @@ Every command accepts `--help` for its options.
 - Supported drones include Mini 3/4/5 Pro, Air 3/3S, Avata 2/360, Neo 2,
   Mavic 3 Enterprise, Matrice 300, Phantom 4 RTK — and photo mapping works
   for **any** GPS-tagged photos, not just DJI's.
-- The Windows app is a front end over the same CLI: anything the app does,
+- The desktop app is a front end over the same CLI: anything the app does,
   the `dji-embed` command can do with more options.
 - Photo-map pins open their popup on click/tap; thumbnail previews on hover
   are **off by default** — a "Hover previews" toggle in the map's top-right

--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ it's a handful of copy-paste commands. For a guided tour see
 
 Works on Windows, macOS, and Linux; whole folders are processed in one go,
 with a progress bar. `.DAT` flight logs can be merged in where available.
+The desktop app runs on Windows and macOS; the command line runs anywhere.
 
 ## Get started
 
-You'll need Python 3.10+ and FFmpeg (ExifTool is optional, but unlocks the
-photo map and a few other features). On Windows the bootstrap script below
-installs all of it for you.
+The desktop app needs nothing else — the Windows installer bundles FFmpeg
+and ExifTool, and the macOS app gets them from Homebrew. For the
+`pip`/`pipx` command-line route you'll need Python 3.10+ and FFmpeg
+(ExifTool is optional, but unlocks the photo map and a few other features).
 
 ### Windows
 
@@ -137,21 +139,49 @@ PyPI's [Trusted Publishing](https://docs.pypi.org/attestations/) — see the
 
 </details>
 
-### macOS / Linux
+### macOS
+
+Download the signed, notarized **DMG**
+(`dji-metadata-embedder-<version>-macos-arm64.dmg`) from the
+[latest release](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest),
+open it, and drag **DJI Metadata Embedder** to Applications — it's the same
+desktop app shown above, with the full `dji-embed` CLI inside the bundle.
+Install FFmpeg and ExifTool with `brew install ffmpeg exiftool` and the
+Setup screen in the app will confirm it found them.
+
+The app is for Apple Silicon Macs (M1 or later) on macOS 14 Sonoma or
+newer. It's the newest arrival here — if anything looks off on your Mac,
+[an issue](https://github.com/CallMarcus/dji-drone-metadata-embedder/issues)
+is very welcome.
+
+<details>
+<summary>Other ways to install on macOS (Intel Macs, CLI only)</summary>
+
+- **pipx** (any Mac, Intel included):
+
+  ```bash
+  brew install ffmpeg exiftool pipx
+  pipx install dji-drone-metadata-embedder
+  ```
+
+  Homebrew's Python refuses a bare `pip install`
+  ([externally managed](https://peps.python.org/pep-0668/)); `pipx` gives
+  the CLI its own isolated environment and puts `dji-embed` on your PATH.
+
+- **Standalone CLI binary** (Apple Silicon): grab
+  **dji-embed-macos-arm64.zip** from the same release page, unzip, and run
+  `./dji-embed`. Signed and notarized, but a bare binary can't carry a
+  stapled ticket, so the first run needs a network connection for
+  Gatekeeper's online check.
+
+</details>
+
+### Linux
 
 ```bash
-brew install ffmpeg exiftool                          # macOS
 sudo apt update && sudo apt install ffmpeg exiftool   # Debian/Ubuntu
 pip install dji-drone-metadata-embedder
 ```
-
-On Apple Silicon you can also skip Python entirely: download the signed,
-notarized **DMG** (`dji-metadata-embedder-<version>-macos-arm64.dmg`) from
-the [GitHub Releases page](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
-and drag the app to Applications — the `dji-embed` CLI ships inside the
-bundle. A standalone CLI zip (**dji-embed-macos-arm64.zip**) is on the same
-page (first run needs network — Gatekeeper fetches the notarization ticket
-online).
 
 <details>
 <summary>Docker and building from source</summary>

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -1,16 +1,17 @@
 # Desktop App
 
-The **DJI Metadata Embedder** desktop app is a Windows front-end for the
-`dji-embed` command line: drop a folder of footage, pick what to make, and
-watch the exact CLI command it runs in the strip under the Run button —
-everything the app does, the terminal can do too.
+The **DJI Metadata Embedder** desktop app is a Windows and macOS
+front-end for the `dji-embed` command line: drop a folder of footage,
+pick what to make, and watch the exact CLI command it runs in the strip
+under the Run button — everything the app does, the terminal can do too.
 
 ![The workspace](assets/gui/workspace-home.png)
 
 ## Install
 
-Download the installer (`dji-metadata-embedder-setup-<version>.exe`) from
-the [latest release](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest)
+**Windows:** download the installer
+(`dji-metadata-embedder-setup-<version>.exe`) from the
+[latest release](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest)
 and run it — no admin rights needed. You get the desktop app in the Start
 menu plus the full `dji-embed` command line in any terminal, with FFmpeg
 and ExifTool bundled.
@@ -18,6 +19,12 @@ and ExifTool bundled.
 Already using winget? `winget install CallMarcus.DJIMetadataEmbedder`
 installs the portable command line only — the desktop app ships with the
 installer.
+
+**macOS** (Apple Silicon, macOS 14+): download the signed, notarized DMG
+(`dji-metadata-embedder-<version>-macos-arm64.dmg`) from the same page
+and drag the app to Applications. FFmpeg and ExifTool come from Homebrew
+(`brew install ffmpeg exiftool`) — the Setup screen confirms the app
+found them. Full details in [Installation](installation.md#macos).
 
 ## The six modes
 
@@ -56,9 +63,10 @@ Finished maps open right in the app, panoramas included:
 
 ![Inline map preview](assets/gui/workspace-preview.png)
 
-Inline preview uses Microsoft Edge WebView2, preinstalled from Windows 11
-on. Without it the app quietly opens results in your browser instead —
-nothing is lost.
+Inline preview uses Microsoft Edge WebView2 on Windows (preinstalled from
+Windows 11 on) and the system WKWebView on macOS (always present).
+Without a usable WebView the app quietly opens results in your browser
+instead — nothing is lost.
 
 ![Setup check](assets/gui/workspace-setup-done.png)
 
@@ -66,5 +74,7 @@ nothing is lost.
 
 Everything runs on your computer; nothing is uploaded, and there is no
 telemetry. The app stores exactly two things locally in
-`%APPDATA%\DjiEmbed\state.json`: your recent folders and the window
-size/position. Delete that file to reset both.
+`%APPDATA%\DjiEmbed\state.json` on Windows
+(`~/Library/Application Support/DjiEmbed/state.json` on macOS): your
+recent folders and the window size/position. Delete that file to reset
+both.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 # DJI Drone Metadata Embedder
 
-Welcome to the documentation for **DJI Drone Metadata Embedder**. This project embeds telemetry from DJI drone SRT files into videos, maps flights and GPS-tagged photos as interactive HTML maps, and converts telemetry to other formats — all locally on your machine, via a Windows desktop app or the `dji-embed` command line.
+Welcome to the documentation for **DJI Drone Metadata Embedder**. This project embeds telemetry from DJI drone SRT files into videos, maps flights and GPS-tagged photos as interactive HTML maps, and converts telemetry to other formats — all locally on your machine, via a desktop app (Windows and macOS) or the `dji-embed` command line.
 
 Use the guides in this site to embed GPS data in your footage, map where you've flown, redact sensitive information and generate GPX tracks.
 
 - [Installation](installation.md)
-- [Desktop App](desktop-app.md) — the Windows workspace, no terminal needed
+- [Desktop App](desktop-app.md) — the workspace for Windows and macOS, no terminal needed
 - [User Guide](user_guide.md)
 - [Maps & Panoramas](geospatial.md) — photo maps, flight maps, the 360° viewer
 - [Decision Table](decision-table.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,9 +2,9 @@
 
 [← Back to Home](index.md)
 
-## Easy Windows install
+## Windows
 
-### Windows – installer with desktop app (recommended)
+### Installer with desktop app (recommended)
 
 Download `dji-metadata-embedder-setup-<version>.exe` from the
 [latest release](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest)
@@ -22,7 +22,7 @@ PATH entries again. From v1.23.0 the installer and every binary inside it
 are Authenticode code-signed, so Windows shows a verified publisher instead
 of an "unknown publisher" warning.
 
-### Windows – bootstrap script
+### Bootstrap script
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedder/master/tools/bootstrap.ps1 | iex
@@ -31,7 +31,7 @@ iwr -useb https://raw.githubusercontent.com/CallMarcus/dji-drone-metadata-embedd
 The bootstrap script also installs FFmpeg and ExifTool (CLI only, no
 desktop app).
 
-### Windows – winget
+### winget
 
 ```powershell
 winget install CallMarcus.DJIMetadataEmbedder
@@ -53,13 +53,40 @@ winget install CallMarcus.DJIMetadataEmbedder.Desktop
 
 Install one or the other — both put `dji-embed` on PATH.
 
-### Windows – manual path
+### Manual path
 
 ```powershell
 pip install dji-drone-metadata-embedder
 ```
 
-### macOS
+## macOS
+
+### DMG with desktop app (recommended)
+
+Download `dji-metadata-embedder-<version>-macos-arm64.dmg` from the
+[latest release](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest),
+open it, and drag **DJI Metadata Embedder** to Applications. The app is
+Developer ID-signed, notarized and stapled — first launch works offline
+and shows only the standard "downloaded from the internet" dialog. It's
+the same workspace as on Windows, and carries the full `dji-embed` CLI
+inside the bundle (at
+`/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed`).
+
+The app supports Apple Silicon Macs (M1 or later) on macOS 14 Sonoma or
+newer — that floor is deliberate. On Intel Macs or older macOS, use the
+pipx route below.
+
+FFmpeg and ExifTool come from Homebrew: `brew install ffmpeg exiftool`.
+The app's Setup screen confirms it found them.
+
+To use the bundled CLI from a terminal, symlink it rather than extending
+`PATH` — the directory also holds the app's two hundred runtime libraries:
+
+```bash
+sudo ln -s "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed" /usr/local/bin/dji-embed
+```
+
+### pipx (CLI only — works on any Mac, Intel included)
 
 ```bash
 brew install ffmpeg exiftool pipx
@@ -72,24 +99,9 @@ error — `pipx` installs the tool into its own isolated environment and puts
 `dji-embed` on your PATH (run `pipx ensurepath` once if the command isn't
 found in a new terminal).
 
-The easiest install on Apple Silicon is the desktop app: download
-`dji-metadata-embedder-<version>-macos-arm64.dmg` from the
-[latest release](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest),
-open it, and drag **DJI Metadata Embedder** to Applications. The app is
-Developer ID-signed, notarized and stapled, and carries the full
-`dji-embed` CLI inside (at
-`/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed`). To
-use that CLI from a terminal, symlink it rather than extending `PATH` —
-the directory also holds the app's two hundred runtime libraries:
+### Standalone CLI binary
 
-```bash
-ln -s "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed" /usr/local/bin/dji-embed
-```
-
-FFmpeg and ExifTool still come from Homebrew: `brew install ffmpeg exiftool`.
-
-Prefer a bare CLI binary? On Apple Silicon, grab the standalone
-`dji-embed-macos-arm64.zip` from the
+On Apple Silicon, grab the standalone `dji-embed-macos-arm64.zip` from the
 [GitHub Releases page](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases),
 unzip it, and run `./dji-embed`. The binary is Developer ID-signed and
 notarized, but a bare binary can't carry a stapled notarization ticket, so
@@ -97,7 +109,7 @@ the **first run needs a network connection** for Gatekeeper's online ticket
 check (the DMG app above is stapled and has no such requirement). Verify
 either download against `SHA256SUMS-macos.txt` from the same release.
 
-### Linux
+## Linux
 
 ```bash
 sudo apt update && sudo apt install ffmpeg exiftool
@@ -108,7 +120,7 @@ Distro ExifTool packages are often too old for DJI MP4 timed metadata —
 run `dji-embed doctor --install exiftool` to get a current, checksum-verified
 copy in your user directory.
 
-### Docker
+## Docker
 
 ```bash
 docker run --rm -v "$PWD":/data callmarcus/dji-embed embed /data
@@ -116,9 +128,9 @@ docker run --rm -v "$PWD":/data callmarcus/dji-embed embed /data
 
 ## Prefer clicking over typing?
 
-On Windows, the installer bundles the [desktop app](desktop-app.md) —
-folder in, map or telemetry out, no terminal. For viewing maps from any
-OS there's `dji-embed photomap <folder> --serve`.
+The [desktop app](desktop-app.md) — folder in, map or telemetry out, no
+terminal — comes with the Windows installer and the macOS DMG. For
+viewing maps from any OS there's `dji-embed photomap <folder> --serve`.
 See the [User Guide](user_guide.md#web-ui-deprecated) for details.
 
 <details>


### PR DESCRIPTION
Prep for the macOS-headline release (#414 follow-through). The install content shipped by Stages C/D was correct but buried: the DMG appeared as "you can also skip Python entirely" inside a pip section, docs/index.md called the app "the Windows workspace", and HELP.md's install table had no DMG row at all.

Restructure only — no new claims beyond what Stage E verified on hardware:

- **README**: macOS gets its own Get-started section (DMG first, floor stated plainly: Apple Silicon + macOS 14+, feedback invited; pipx/zip in a details block); Linux split out.
- **docs/installation.md**: Windows / macOS / Linux / Docker as sibling top-level sections; macOS reordered DMG-first; the symlink command gains the `sudo` a stock Mac needs (review finding from PR #444).
- **docs/index.md / desktop-app.md / HELP.md**: the desktop app is described as Windows + macOS everywhere, with the WKWebView preview note and both state.json locations.

`mkdocs build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYYj5wbL9XBjYi347LEN9M