### PR TITLE
fix(cli): platform-aware upgrade hint, and upgrade docs (#448)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,8 +83,14 @@ To use the bundled CLI from a terminal, symlink it rather than extending
 `PATH` — the directory also holds the app's two hundred runtime libraries:
 
 ```bash
-sudo ln -s "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed" /usr/local/bin/dji-embed
+sudo mkdir -p /usr/local/bin
+sudo ln -sf "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed" /usr/local/bin/dji-embed
 ```
+
+The `mkdir` is not ceremony: on an Apple Silicon Mac, Homebrew installs to
+`/opt/homebrew` and nothing else creates `/usr/local/bin`, so it is often
+missing and `ln` fails with *No such file or directory*. macOS lists it in
+`/etc/paths` regardless, so once it exists it is on your `PATH`.
 
 ### pipx (CLI only — works on any Mac, Intel included)
 
@@ -164,13 +170,19 @@ dji-embed` (`where dji-embed` on Windows) lists them in the order the
 shell searches. This bites most often on macOS, where a `pipx` install
 in `~/.local/bin` predates a later DMG install.
 
-On macOS the tidiest fix is to point one symlink at the app's bundled
-CLI and let it follow the app forever:
+On macOS the tidiest fix is to keep one copy — the app's — and point a
+symlink at it, so it follows the app from then on:
 
 ```bash
-sudo ln -sf "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed" /usr/local/bin/dji-embed
 pipx uninstall dji-drone-metadata-embedder   # if pipx put an older one on PATH
+sudo mkdir -p /usr/local/bin                 # often absent on Apple Silicon
+sudo ln -sf "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed" /usr/local/bin/dji-embed
+hash -r && dji-embed --version
 ```
+
+Loose copies you unzipped earlier are worth deleting rather than leaving
+around: they never update, and running one by its full path reports its
+own old version, which reads like a failed upgrade.
 
 ## Prefer clicking over typing?
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,6 +109,24 @@ the **first run needs a network connection** for Gatekeeper's online ticket
 check (the DMG app above is stapled and has no such requirement). Verify
 either download against `SHA256SUMS-macos.txt` from the same release.
 
+Run it from a terminal, not by double-clicking it in Finder. It is a
+command-line tool, so a double-click only opens a window, runs it with no
+arguments and closes; and because Finder applies the strictest Gatekeeper
+path to a downloaded executable, that is also where you may meet
+**"Apple could not verify 'dji-embed' is free of malware"**. That wording
+means the online ticket check could not be completed — it is not the
+"developer cannot be verified" message an unsigned binary gets. Check
+your network, then clear the download quarantine flag and run it
+normally:
+
+```bash
+xattr -d com.apple.quarantine ./dji-embed
+./dji-embed --version
+```
+
+If you would rather not think about any of this, use the DMG: its ticket
+is stapled, so it never needs the online check.
+
 ## Linux
 
 ```bash
@@ -124,6 +142,34 @@ copy in your user directory.
 
 ```bash
 docker run --rm -v "$PWD":/data callmarcus/dji-embed embed /data
+```
+
+## Upgrading
+
+`dji-embed doctor` tells you when a newer version exists, and names the
+command for the way *you* installed it. The paths, for reference:
+
+| How you installed | How you upgrade |
+| --- | --- |
+| Windows installer | Run the new installer over the old one, or `winget upgrade CallMarcus.DJIMetadataEmbedder.Desktop` |
+| Windows, winget CLI | `winget upgrade CallMarcus.DJIMetadataEmbedder` |
+| macOS DMG | Open the new DMG and drag the app to Applications, replacing the old one — the bundled `dji-embed` comes with it |
+| macOS standalone binary | Download the new `dji-embed-macos-arm64.zip` and replace the binary you unzipped |
+| pipx (any OS) | `pipx upgrade dji-drone-metadata-embedder` |
+| pip (any OS) | `pip install --upgrade dji-drone-metadata-embedder` |
+
+**If `dji-embed --version` still shows the old version afterwards**, you
+have two copies and the older one comes first on `PATH`. `which -a
+dji-embed` (`where dji-embed` on Windows) lists them in the order the
+shell searches. This bites most often on macOS, where a `pipx` install
+in `~/.local/bin` predates a later DMG install.
+
+On macOS the tidiest fix is to point one symlink at the app's bundled
+CLI and let it follow the app forever:
+
+```bash
+sudo ln -sf "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed" /usr/local/bin/dji-embed
+pipx uninstall dji-drone-metadata-embedder   # if pipx put an older one on PATH
 ```
 
 ## Prefer clicking over typing?

--- a/src/dji_metadata_embedder/utils/update_check.py
+++ b/src/dji_metadata_embedder/utils/update_check.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import platform
 import re
 import sys
 from pathlib import Path
@@ -29,6 +30,7 @@ PYPI_PROJECT = "dji-drone-metadata-embedder"
 PYPI_URL = f"https://pypi.org/pypi/{PYPI_PROJECT}/json"
 RELEASES_URL = "https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest"
 WINGET_ID = "CallMarcus.DJIMetadataEmbedder"
+MACOS_CLI_ASSET = "dji-embed-macos-arm64.zip"
 NO_UPDATE_CHECK_ENV = "DJIEMBED_NO_UPDATE_CHECK"
 
 # Hard latency bound for the one optional network call (issue #277: ~3 s).
@@ -183,14 +185,44 @@ def detect_install_environment(executable: str | None = None) -> str:
     return "pip"
 
 
-def upgrade_hint(env: str | None = None) -> str:
-    """Environment-aware upgrade command for an outdated dji-embed."""
-    env = env or detect_install_environment()
+def _in_app_bundle(executable: str) -> bool:
+    """True when the frozen binary sits inside a macOS ``.app`` bundle."""
+    return any(part.endswith(".app") for part in _norm_parts(executable))
+
+
+def upgrade_hint(
+    env: str | None = None,
+    system: str | None = None,
+    executable: str | None = None,
+) -> str:
+    """Environment-aware upgrade command for an outdated dji-embed.
+
+    ``frozen`` is not one artefact. It is the Windows EXE, the macOS
+    standalone binary, and the CLI inside the macOS app bundle — three
+    downloads, three upgrade paths. Before v2.5.0 it could only mean the
+    EXE, so the hint named winget unconditionally and told Mac users to
+    fetch a file that does not exist for them (#448). ``system`` and
+    ``executable`` are injectable so every platform's wording stays
+    assertable from a single CI runner.
+    """
+    exe = executable or sys.executable
+    env = env or detect_install_environment(exe)
     if env == "frozen":
-        return (
-            f"download the new EXE from {RELEASES_URL} "
-            f"or run: winget upgrade {WINGET_ID}"
-        )
+        system = system or platform.system()
+        if system == "Windows":
+            return (
+                f"download the new EXE from {RELEASES_URL} "
+                f"or run: winget upgrade {WINGET_ID}"
+            )
+        if system == "Darwin":
+            if _in_app_bundle(exe):
+                return (
+                    f"download the new DMG from {RELEASES_URL} and drag it "
+                    "to Applications, replacing the app (which carries this "
+                    "command line)"
+                )
+            return f"download the new {MACOS_CLI_ASSET} from {RELEASES_URL}"
+        return f"download the new release from {RELEASES_URL}"
     if env == "pipx":
         return f"pipx upgrade {PYPI_PROJECT}"
     # Literal interpreter path defeats the multi-Python trap: bare `pip`

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -227,10 +227,60 @@ def test_upgrade_hint_pipx():
     assert uc.upgrade_hint("pipx") == "pipx upgrade dji-drone-metadata-embedder"
 
 
-def test_upgrade_hint_frozen_mentions_winget_and_releases():
-    hint = uc.upgrade_hint("frozen")
+def test_upgrade_hint_frozen_windows_mentions_winget_and_releases():
+    hint = uc.upgrade_hint("frozen", system="Windows")
     assert "winget upgrade CallMarcus.DJIMetadataEmbedder" in hint
     assert "releases" in hint
+
+
+# The frozen hint is platform-shaped: both macOS artefacts (the standalone
+# zip binary and the CLI inside the .app) are PyInstaller builds, so "frozen"
+# alone used to hand Mac users an EXE and a winget command (#448). `system`
+# and `executable` are explicit so these assert from any CI runner.
+
+
+def test_upgrade_hint_frozen_macos_never_names_windows_things():
+    for executable in (
+        "/usr/local/bin/dji-embed",
+        "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed",
+    ):
+        hint = uc.upgrade_hint("frozen", system="Darwin", executable=executable)
+        assert "winget" not in hint.lower()
+        assert ".exe" not in hint.lower()
+        assert "EXE" not in hint
+        assert uc.RELEASES_URL in hint
+
+
+def test_upgrade_hint_frozen_macos_app_bundle_points_at_the_dmg():
+    hint = uc.upgrade_hint(
+        "frozen",
+        system="Darwin",
+        executable="/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed",
+    )
+    assert "DMG" in hint
+    assert "Applications" in hint
+
+
+def test_upgrade_hint_frozen_macos_standalone_points_at_the_zip():
+    hint = uc.upgrade_hint(
+        "frozen", system="Darwin", executable="/usr/local/bin/dji-embed"
+    )
+    assert uc.MACOS_CLI_ASSET in hint
+    assert "DMG" not in hint
+
+
+def test_upgrade_hint_frozen_elsewhere_names_no_package_manager():
+    hint = uc.upgrade_hint("frozen", system="Linux")
+    assert uc.RELEASES_URL in hint
+    assert "winget" not in hint.lower()
+    assert "brew" not in hint.lower()
+
+
+def test_upgrade_hint_non_frozen_ignores_platform():
+    # pipx and pip upgrade the same way everywhere; only frozen has artefacts.
+    assert uc.upgrade_hint("pipx", system="Darwin") == uc.upgrade_hint(
+        "pipx", system="Windows"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #448.

## The bug

`upgrade_hint()` branched on *how* dji-embed was installed (`frozen` / `pipx` / `pip`) and never on *which platform* it was running. Both macOS artefacts — the standalone `dji-embed-macos-arm64.zip` binary and the CLI inside `DJI Metadata Embedder.app` — are PyInstaller builds, so both detect as `frozen` and inherited wording written when frozen could only mean the Windows EXE:

> download the new EXE from … or run: `winget upgrade CallMarcus.DJIMetadataEmbedder`

## After

```
Windows EXE          -> download the new EXE from <releases> or run: winget upgrade CallMarcus.DJIMetadataEmbedder
macOS app bundle     -> download the new DMG from <releases> and drag it to Applications, replacing the app (which carries this command line)
macOS standalone     -> download the new dji-embed-macos-arm64.zip from <releases>
Linux frozen         -> download the new release from <releases>
pipx                 -> pipx upgrade dji-drone-metadata-embedder
```

`system` and `executable` are injectable parameters, so each platform's wording is asserted from any CI runner. The previous test took no platform argument — which is exactly why it passed everywhere and caught nothing.

## Docs

`docs/installation.md` documented installing on three platforms and upgrading on none. It gains:

- an upgrade table covering all six install routes;
- the failure that surfaced this: after upgrading, `--version` still reports the old build when an older copy sits earlier on `PATH` — a `pipx` install in `~/.local/bin` beating a later DMG, most often. `which -a` to find it, and the symlink that makes the bundled CLI track the app instead;
- the Gatekeeper dialog the standalone binary can produce. Double-clicking a CLI binary in Finder does nothing useful *and* takes the strictest Gatekeeper path, where an unstapled — but genuinely notarized — binary can report "Apple could not verify … is free of malware". That's the check-not-completed message, not the unsigned-developer one; the docs now say so and give the quarantine command.

## Verification

975 tests pass, mypy clean, ruff clean, `mkdocs build --strict` clean. Found on a real macOS VM still reporting 2.4.0 after the 2.5.0 DMG went on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYYj5wbL9XBjYi347LEN9M