### PR TITLE
fix(gui): surface a denied macOS Terminal automation consent (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#345]: https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/345
 
+### Fixed
+
+- **gui**: Refusing macOS permission to open Terminal no longer fails in
+  silence. The command-line screen's launch button now waits for the
+  answer and, when it is refused, names the System Settings > Privacy &
+  Security > Automation switch that turns the permission back on.
+  Previously the click did nothing visible, and because macOS remembers
+  the refusal, so did every click after it (#443).
+
 ## [2.5.0] - 2026-08-01
 
 ### Added

--- a/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using DjiEmbed.Gui.Services;
 using DjiEmbed.Gui.ViewModels;
 
 namespace DjiEmbed.Gui.Tests;
@@ -141,5 +142,97 @@ public class CliDiscoveryViewModelTests : IDisposable
         var vm = new CliDiscoveryViewModel(cli, () => { });
         await vm.LoadHelpCommand.ExecuteAsync(null);
         Assert.Contains("dji-embed --help", vm.HelpText);
+    }
+
+    [Fact]
+    public void A_terminal_that_opened_says_nothing()
+    {
+        // The Terminal window in front of them is the feedback.
+        Assert.Null(CliDiscoveryViewModel.TerminalMessageFor(
+            TerminalLaunchResult.Started, OSPlatform.OSX));
+    }
+
+    [Fact]
+    public void Denied_automation_names_the_pane_that_undoes_it()
+    {
+        // #443: macOS remembers Don't Allow, so every later click is
+        // silent too — the way back out has to be on screen.
+        var text = CliDiscoveryViewModel.TerminalMessageFor(
+            TerminalLaunchResult.AutomationDenied, OSPlatform.OSX);
+
+        Assert.Contains("System Settings", text);
+        Assert.Contains("Privacy & Security", text);
+        Assert.Contains("Automation", text);
+        Assert.Contains("DJI Metadata Embedder", text);
+        Assert.Contains("Terminal", text);
+    }
+
+    [Fact]
+    public void A_failed_launch_hands_the_job_back_to_the_user()
+    {
+        foreach (var platform in
+                 new[] { OSPlatform.Windows, OSPlatform.OSX, OSPlatform.Linux })
+        {
+            var text = CliDiscoveryViewModel.TerminalMessageFor(
+                TerminalLaunchResult.Failed, platform);
+            Assert.False(string.IsNullOrWhiteSpace(text));
+        }
+    }
+
+    [Fact]
+    public void The_macos_fallback_never_tells_them_to_type_bare_dji_embed()
+    {
+        // #442 again: nothing puts the CLI on PATH on macOS, so the
+        // fallback advice cannot be "open Terminal and type dji-embed".
+        var text = CliDiscoveryViewModel.TerminalMessageFor(
+            TerminalLaunchResult.Failed, OSPlatform.OSX);
+
+        Assert.DoesNotContain("type dji-embed", text);
+        Assert.DoesNotContain("run dji-embed", text);
+    }
+
+    [Fact]
+    public async Task Clicking_the_button_surfaces_a_denied_launch()
+    {
+        var vm = new CliDiscoveryViewModel(null, () => { },
+            _ => Task.FromResult(TerminalLaunchResult.AutomationDenied));
+
+        await vm.OpenTerminalCommand.ExecuteAsync(null);
+
+        Assert.Contains("Automation", vm.TerminalMessage);
+    }
+
+    [Fact]
+    public async Task A_launch_that_works_clears_an_earlier_complaint()
+    {
+        var result = TerminalLaunchResult.AutomationDenied;
+        var vm = new CliDiscoveryViewModel(null, () => { },
+            _ => Task.FromResult(result));
+
+        await vm.OpenTerminalCommand.ExecuteAsync(null);
+        Assert.NotNull(vm.TerminalMessage);
+
+        // They granted the permission and clicked again.
+        result = TerminalLaunchResult.Started;
+        await vm.OpenTerminalCommand.ExecuteAsync(null);
+
+        Assert.Null(vm.TerminalMessage);
+    }
+
+    [Fact]
+    public async Task The_launch_gets_the_bundled_cli_path()
+    {
+        string? seen = null;
+        var vm = new CliDiscoveryViewModel("/Applications/x.app/dji-embed",
+            () => { },
+            path =>
+            {
+                seen = path;
+                return Task.FromResult(TerminalLaunchResult.Started);
+            });
+
+        await vm.OpenTerminalCommand.ExecuteAsync(null);
+
+        Assert.Equal("/Applications/x.app/dji-embed", seen);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/NavigationTests.cs
@@ -69,4 +69,32 @@ public class NavigationTests
         Assert.Contains(window.GetVisualDescendants().OfType<TextBlock>(),
             t => t.Text == discovery.IntroText);
     }
+
+    [AvaloniaFact]
+    public void The_terminal_note_appears_only_when_there_is_something_to_say()
+    {
+        // #443: on the deny path no window opens, so this note is the
+        // entire feedback — a wrong binding leaves the button silent
+        // exactly the way the bug did.
+        var main = new MainViewModel();
+        var window = new MainWindow { DataContext = main };
+        window.Show();
+        ((WorkspaceViewModel)main.CurrentPage)
+            .OpenCliDiscoveryCommand.Execute(null);
+        var discovery = Assert.IsType<CliDiscoveryViewModel>(main.CurrentPage);
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var note = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "TerminalMessageNote");
+        Assert.False(note.IsVisible);
+
+        discovery.TerminalMessage = "macOS is blocking this app.";
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        Assert.True(note.IsVisible);
+        Assert.Contains(window.GetVisualDescendants().OfType<TextBlock>(),
+            t => t.Text == discovery.TerminalMessage);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/TerminalLauncherTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/TerminalLauncherTests.cs
@@ -129,4 +129,55 @@ public class TerminalLauncherTests
         Assert.Equal("Open a terminal and try it",
             TerminalLauncher.ButtonLabelOn(OSPlatform.Linux));
     }
+
+    [Fact]
+    public void Macos_candidate_captures_the_error_stream()
+    {
+        // #443: osascript starts fine and fails asynchronously, so its
+        // stderr and exit code are the only evidence the tell was refused.
+        var osa = Assert.Single(TerminalLauncher.Candidates(
+            "/Users/demo", OSPlatform.OSX));
+
+        Assert.True(osa.RedirectStandardError);
+        Assert.False(osa.UseShellExecute);
+    }
+
+    [Fact]
+    public void A_clean_osascript_run_reports_started()
+    {
+        Assert.Equal(TerminalLaunchResult.Started,
+            TerminalLauncher.ClassifyOsascript(0, string.Empty));
+    }
+
+    [Fact]
+    public void A_refused_apple_event_reports_automation_denied()
+    {
+        // What Don't Allow on the automation consent prompt produces.
+        Assert.Equal(TerminalLaunchResult.AutomationDenied,
+            TerminalLauncher.ClassifyOsascript(1,
+                "execution error: Not authorized to send Apple events to "
+                + "Terminal. (-1743)\n"));
+    }
+
+    [Fact]
+    public void A_refused_apple_event_is_recognised_in_any_language()
+    {
+        // macOS localizes the message but never the error number, so the
+        // number is what the check hangs on.
+        Assert.Equal(TerminalLaunchResult.AutomationDenied,
+            TerminalLauncher.ClassifyOsascript(1,
+                "Fehler beim Ausführen: Keine Berechtigung, Apple-Events an "
+                + "\"Terminal\" zu senden. (-1743)\n"));
+    }
+
+    [Fact]
+    public void Other_osascript_errors_are_ordinary_failures()
+    {
+        // Not a permission problem — pointing the user at System Settings
+        // would send them somewhere that cannot help.
+        Assert.Equal(TerminalLaunchResult.Failed,
+            TerminalLauncher.ClassifyOsascript(1,
+                "execution error: Terminal got an error: Application isn't "
+                + "running. (-600)\n"));
+    }
 }

--- a/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
+++ b/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
@@ -3,8 +3,23 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace DjiEmbed.Gui.Services;
+
+/// <summary>How a terminal launch ended. The refused-permission case is
+/// separate because it is the only one with a way back out (#443).</summary>
+public enum TerminalLaunchResult
+{
+    /// <summary>A terminal opened.</summary>
+    Started,
+
+    /// <summary>macOS refused this app permission to drive Terminal.</summary>
+    AutomationDenied,
+
+    /// <summary>No terminal opened, for any other reason.</summary>
+    Failed,
+}
 
 /// <summary>
 /// Launches an interactive shell that lands the user on proof the CLI
@@ -15,6 +30,10 @@ namespace DjiEmbed.Gui.Services;
 /// </summary>
 public static class TerminalLauncher
 {
+    /// <summary>errAEEventNotPermitted, as osascript prints it. macOS
+    /// translates the message around it but never the number.</summary>
+    private const string AppleEventsDenied = "(-1743)";
+
     private const string ProofCommand = "dji-embed --help";
 
     /// <summary>What the launch button should say — the shell it will
@@ -57,6 +76,10 @@ public static class TerminalLauncher
             {
                 UseShellExecute = false,
                 WorkingDirectory = workingDirectory,
+                // The consent prompt is answered after osascript has
+                // already started, so this stream carries the only word
+                // of a refusal (#443).
+                RedirectStandardError = true,
             };
             osa.ArgumentList.Add("-e");
             osa.ArgumentList.Add(
@@ -103,26 +126,64 @@ public static class TerminalLauncher
         return [wt, ps];
     }
 
-    /// <summary>Tries each candidate in order; false when none started.</summary>
-    public static bool Launch(string? cliPath = null)
+    /// <summary>
+    /// Tries each candidate in order and reports what the user will see.
+    /// Starting is not the same as succeeding on macOS: osascript starts
+    /// cleanly and only then asks permission to drive Terminal, so a
+    /// refusal arrives on its error stream after the fact (#443).
+    /// </summary>
+    public static async Task<TerminalLaunchResult> LaunchAsync(
+        string? cliPath = null)
     {
         var home = Environment.GetFolderPath(
             Environment.SpecialFolder.UserProfile);
         foreach (var psi in Candidates(home, cliPath))
         {
+            Process? process;
             try
             {
-                Process.Start(psi);
-                return true;
+                process = Process.Start(psi);
             }
             catch (Exception e) when (e is Win32Exception
                 or InvalidOperationException or PlatformNotSupportedException)
             {
                 // Not installed on this machine — try the next one.
+                continue;
+            }
+            if (!psi.RedirectStandardError)
+            {
+                // A shell we handed a window to: it belongs to the user now
+                // and waiting on it would never return. A null Process here
+                // means the shell reused a running instance, which is still
+                // a window on screen — not a reason to open a second one.
+                process?.Dispose();
+                return TerminalLaunchResult.Started;
+            }
+            if (process is null)
+            {
+                continue;
+            }
+            using (process)
+            {
+                // osascript returns as soon as Terminal has been told, so
+                // this wait is short — and it lasts exactly as long as the
+                // consent prompt, which keeps the button busy meanwhile.
+                var stderr = await process.StandardError.ReadToEndAsync();
+                await process.WaitForExitAsync();
+                return ClassifyOsascript(process.ExitCode, stderr);
             }
         }
-        return false;
+        return TerminalLaunchResult.Failed;
     }
+
+    /// <summary>Reads an osascript run's outcome from what it left behind.
+    /// Pure so the refusal path can be tested off a Mac.</summary>
+    internal static TerminalLaunchResult ClassifyOsascript(
+        int exitCode, string stderr) =>
+        exitCode == 0 ? TerminalLaunchResult.Started
+        : stderr.Contains(AppleEventsDenied, StringComparison.Ordinal)
+            ? TerminalLaunchResult.AutomationDenied
+            : TerminalLaunchResult.Failed;
 
     /// <summary>POSIX single-quoting: '…' with embedded ' as '\''.</summary>
     private static string ShellSingleQuote(string s) =>

--- a/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
@@ -19,11 +19,17 @@ public sealed record StarterCommand(string Command, string Description);
 /// task cards. One shell-launch button, curated examples, the live --help
 /// output — no settings, no new task flows (anti-bloat rules).
 /// </summary>
-public partial class CliDiscoveryViewModel(string? cliPath, Action goHome)
+public partial class CliDiscoveryViewModel(
+    string? cliPath,
+    Action goHome,
+    Func<string?, Task<TerminalLaunchResult>>? launch = null)
     : ViewModelBase
 {
     public const string DocsUrl =
         "https://callmarcus.github.io/dji-drone-metadata-embedder/";
+
+    private readonly Func<string?, Task<TerminalLaunchResult>> _launch =
+        launch ?? TerminalLauncher.LaunchAsync;
 
     /// <summary>
     /// Curated to show what the GUI deliberately can't do. Static strings —
@@ -153,8 +159,39 @@ public partial class CliDiscoveryViewModel(string? cliPath, Action goHome)
         return stdout.Trim();
     }
 
+    /// <summary>Why no terminal appeared; null when one did.</summary>
+    [ObservableProperty]
+    public partial string? TerminalMessage { get; set; }
+
     [RelayCommand]
-    private void OpenTerminal() => TerminalLauncher.Launch(cliPath);
+    private async Task OpenTerminalAsync() =>
+        TerminalMessage = TerminalMessageFor(
+            await _launch(cliPath), Platforms.Current);
+
+    /// <summary>
+    /// What to say under the button when nothing opened. The refused-
+    /// permission wording carries the way back out: macOS remembers Don't
+    /// Allow, so without it the button is silently dead forever (#443).
+    /// </summary>
+    internal static string? TerminalMessageFor(
+        TerminalLaunchResult result, OSPlatform platform) => result switch
+    {
+        TerminalLaunchResult.Started => null,
+        TerminalLaunchResult.AutomationDenied =>
+            "⚠️ macOS is blocking this app from opening Terminal. To allow "
+            + "it, open System Settings > Privacy & Security > Automation, "
+            + "find DJI Metadata Embedder in the list, and switch Terminal "
+            + "back on. Then try this button again.",
+        _ => platform == OSPlatform.OSX
+            ? "⚠️ Terminal could not be opened. You can open it yourself — "
+              + "the guide below shows how to reach the command line from "
+              + "there."
+            : platform == OSPlatform.Windows
+            ? "⚠️ No terminal could be opened. Open PowerShell yourself and "
+              + "enter  dji-embed --help  to see the same thing."
+            : "⚠️ No terminal could be opened. Open your own and enter  "
+              + "dji-embed --help  to see the same thing.",
+    };
 
     [RelayCommand]
     private void OpenDocs() =>

--- a/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml
+++ b/gui/DjiEmbed.Gui/Views/CliDiscoveryView.axaml
@@ -38,6 +38,17 @@
                     <TextBlock Text="{x:Static services:TerminalLauncher.ButtonLabel}" />
                 </Button>
 
+                <!-- Nothing opens on the deny path, so the only feedback
+                     available is this note (#443). -->
+                <Border Name="TerminalMessageNote"
+                        Background="#20808080" CornerRadius="4"
+                        Padding="10,8"
+                        IsVisible="{Binding TerminalMessage,
+                                    Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <TextBlock Text="{Binding TerminalMessage}"
+                               TextWrapping="Wrap" FontSize="13" />
+                </Border>
+
                 <TextBlock Text="A few things only the command line can do:"
                            FontWeight="SemiBold" Margin="0,4,0,0" />
 


### PR DESCRIPTION
Closes #443.

## The bug

`osascript` starts cleanly and only *then* asks macOS for permission to drive Terminal, so `TerminalLauncher.Launch()` returned `true` on the refusal path and the app showed nothing: no window, no error, no hint. Because macOS remembers Don't Allow, every later click was silent too — the button looked permanently broken with no path out.

Found on hardware during the #414 Stage E run (macOS 15.6.1, M4); the deny was confirmed recorded in TCC.db while the UI stayed silent.

## The fix

`Launch` becomes `LaunchAsync` and waits for `osascript`, whose exit code and stderr are the only evidence the tell was allowed. The wait is short — `do script` returns as soon as Terminal has been told — and it lasts exactly as long as the consent prompt is up, which keeps the button busy meanwhile instead of letting clicks stack.

A refusal (`errAEEventNotPermitted`) now puts a note under the button naming the **System Settings > Privacy & Security > Automation** switch that undoes it. The match is on the error number `(-1743)`, not the English text, because macOS translates the message but never the number.

Any other failed launch, on any platform, now says so too rather than doing nothing — same defect class, one extra branch.

Windows and Linux candidates are untouched: their shells own the window they are handed, so waiting on them would never return. A null `Process` on that path still counts as started (the shell reused a running instance), so no second window opens.

## Deliberately not done

No proactive permission probe on screen load — probing is what triggers the prompt, so it would ask every user a question most of them never need to answer. The check stays reactive, on the click that needs it.

## Tests

All test-first; each was watched failing before the code existed, including the two halves of the view-binding test (note absent → `Sequence contains no matching element`; `IsVisible` unbound → `Assert.False() Failure`).

- `TerminalLauncherTests` — the macOS candidate captures stderr; a clean run, a refusal in English, a refusal in German (number-only match), and an unrelated osascript error each classify correctly.
- `CliDiscoveryViewModelTests` — the denied message names the pane that undoes it; a working launch clears an earlier complaint; the macOS fallback never tells a user to type bare `dji-embed` (#442 discipline); the bundled CLI path reaches the launcher.
- `NavigationTests` — headless: the note is hidden until there is something to say, then renders the message.

532 passed, 0 failed, 0 warnings in Release (same commands as CI).

## Verification gap

The classification and the UI are tested off a Mac, but the end-to-end path — real consent prompt, real Don't Allow, note appears — has not been re-run on hardware since the fix. Worth one pass on a real Mac before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DRqfiSK2sSGVRsAC85Hty