### PR TITLE
fix(gui): the --help fallback names a command the platform can run (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Security > Automation switch that turns the permission back on.
   Previously the click did nothing visible, and because macOS remembers
   the refusal, so did every click after it (#443).
+- **gui**: The command-line screen's fallback advice, shown when the live
+  command list cannot be read, no longer tells macOS users to run a bare
+  `dji-embed` that is not on their PATH. It now names the bundled CLI by
+  its absolute path, the same rule the launch button already followed
+  (#454).
 
 ## [2.5.0] - 2026-08-01
 

--- a/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CliDiscoveryViewModelTests.cs
@@ -145,6 +145,33 @@ public class CliDiscoveryViewModelTests : IDisposable
     }
 
     [Fact]
+    public void The_macos_help_fallback_names_the_bundled_cli_by_path()
+    {
+        // #454/#442: nothing puts dji-embed on PATH on macOS, so advice to
+        // run the bare command sends a user whose CLI is already misbehaving
+        // straight to command-not-found.
+        var text = CliDiscoveryViewModel.HelpFallbackFor(OSPlatform.OSX,
+            "/Applications/DJI Metadata Embedder.app/Contents/MacOS/dji-embed");
+
+        Assert.Contains(
+            "'/Applications/DJI Metadata Embedder.app/Contents/MacOS/"
+            + "dji-embed' --help", text);
+        Assert.DoesNotContain(" dji-embed --help", text);
+    }
+
+    [Fact]
+    public void The_windows_help_fallback_keeps_the_bare_command()
+    {
+        // The installer put it on PATH, so the bare command is both true
+        // and the shorter thing to type.
+        var text = CliDiscoveryViewModel.HelpFallbackFor(OSPlatform.Windows,
+            @"C:\Program Files\DjiEmbed\dji-embed.exe");
+
+        Assert.Contains("dji-embed --help", text);
+        Assert.DoesNotContain(@"C:\Program Files", text);
+    }
+
+    [Fact]
     public void A_terminal_that_opened_says_nothing()
     {
         // The Terminal window in front of them is the feedback.

--- a/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
+++ b/gui/DjiEmbed.Gui/Services/TerminalLauncher.cs
@@ -64,9 +64,7 @@ public static class TerminalLauncher
     {
         if (platform == OSPlatform.OSX)
         {
-            var proof = cliPath is null
-                ? ProofCommand
-                : $"{ShellSingleQuote(cliPath)} --help";
+            var proof = ProofCommandFor(platform, cliPath);
 
             // Terminal.app is always present and its windows stay open on
             // their own; "do script" opens a fresh window running the
@@ -184,6 +182,19 @@ public static class TerminalLauncher
         : stderr.Contains(AppleEventsDenied, StringComparison.Ordinal)
             ? TerminalLaunchResult.AutomationDenied
             : TerminalLaunchResult.Failed;
+
+    /// <summary>
+    /// The command that proves the CLI works, written the way this platform
+    /// can actually run it: bare where an installer put it on PATH, absolute
+    /// where nothing did. On macOS the DMG keeps the CLI inside the bundle
+    /// and touches no PATH, so the bare command is command-not-found (#442).
+    /// Anything showing the user a command to type owes them this rule.
+    /// </summary>
+    internal static string ProofCommandFor(
+        OSPlatform platform, string? cliPath) =>
+        platform == OSPlatform.OSX && cliPath is not null
+            ? $"{ShellSingleQuote(cliPath)} --help"
+            : ProofCommand;
 
     /// <summary>POSIX single-quoting: '…' with embedded ' as '\''.</summary>
     private static string ShellSingleQuote(string s) =>

--- a/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/CliDiscoveryViewModel.cs
@@ -126,10 +126,20 @@ public partial class CliDiscoveryViewModel(
         }
         catch (Exception)
         {
-            HelpText = "The command list could not be loaded. Open a "
-                + "terminal and run  dji-embed --help  to see it.";
+            HelpText = HelpFallbackFor(Platforms.Current, cliPath);
         }
     }
+
+    /// <summary>
+    /// The manual way to the command list when reading it failed. Only a
+    /// user whose CLI is already misbehaving ever sees this, so the command
+    /// it names has to be one their machine can actually run (#454).
+    /// </summary>
+    internal static string HelpFallbackFor(
+        OSPlatform platform, string? cliPath) =>
+        "The command list could not be loaded. Open a terminal and run  "
+        + TerminalLauncher.ProofCommandFor(platform, cliPath)
+        + "  to see it.";
 
     private static async Task<string> RunHelpAsync(string cliPath)
     {


### PR DESCRIPTION
Closes #454. Follow-up to #443 (PR #453), same screen.

## The bug

`CliDiscoveryViewModel.LoadHelpAsync` falls back to this when the bundled CLI's `--help` cannot be read:

> The command list could not be loaded. Open a terminal and run  `dji-embed --help`  to see it.

Platform-blind, and on macOS wrong for the same reason #442 was: the DMG keeps the CLI inside the app bundle and touches no PATH, so following it lands on `zsh: command not found`. It is the *fallback*, so the only user who ever reads it is one whose CLI is already misbehaving — handing that user a second thing that fails is a poor second impression.

## The fix

`TerminalLauncher.Candidates` already encoded the correct rule for the launch button, so this lifts it into `ProofCommandFor` instead of duplicating the shell-quoting in the view model:

> bare where an installer put the CLI on PATH, absolute and shell-quoted where nothing did

The button and the fallback text now read that rule from one place. `cliPath` is non-null on this branch (the null case returns earlier with its own reinstall message), so macOS always gets a real, copy-pasteable command.

Net production change is a three-line extraction plus one call site — `Candidates`' own behaviour is unchanged, which the pre-existing `Macos_proof_command_runs_the_bundled_cli_when_its_path_is_known` test confirms still passes untouched.

## Tests

Both written first and watched failing.

- `The_macos_help_fallback_names_the_bundled_cli_by_path` — the quoted absolute path appears, the bare command does not.
- `The_windows_help_fallback_keeps_the_bare_command` — the installer's PATH entry makes bare both true and shorter to type, so a known path must *not* change it.

534 passed, 0 failed, 0 warnings in Release (same commands as CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DRqfiSK2sSGVRsAC85Hty