### PR TITLE
feat(airspace): 3D zone volumes + zoom-gated 2D ceiling labels (#424)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ it's a handful of copy-paste commands. For a guided tour see
   telemetry lines up.
 - **Flight records** — `dji-embed flightmap -f record` writes a printable
   logbook with airspace facts (FAA / ED-269) and honestly-labelled heights,
-  and `--airspace` overlays the same zones on the interactive map.
+  and `--airspace` overlays the same zones on the interactive maps — as translucent ceiling-height volumes in the 3D view.
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
   folder of stills on one clustered map, thumbnails included; 360° panoramas
   get their own marker color and toggle, and open in an interactive viewer.

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -452,10 +452,12 @@ On the 3D map, zones with a published ceiling rise from the terrain as
 translucent volumes, so you can see a flight thread pass under or over
 them. Ceilings published above ground level (all FAA grid cells) are exact
 by construction. Ceilings published above mean sea level are converted
-using the terrain elevation at the zone's centre — an approximation the
-map notes openly; the popup always states the published limit verbatim.
-Zones with no published ceiling stay flat on the terrain: the map never
-draws a height nobody published.
+using the terrain elevation at the centre of each zone polygon — an
+approximation the map notes openly; the popup always states the
+published limit verbatim. Zones with no published ceiling stay flat on
+the terrain: the map never draws a height nobody published. Inside a
+zone, clicking shows the zone's facts; untick "Airspace zones" in the
+panel to use the map's click-to-look-up-the-camera view instead.
 
 ## Photo map (`photomap`)
 

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -457,7 +457,8 @@ approximation the map notes openly; the popup always states the
 published limit verbatim. Zones with no published ceiling stay flat on
 the terrain: the map never draws a height nobody published. Inside a
 zone, clicking shows the zone's facts; untick "Airspace zones" in the
-panel to use the map's click-to-look-up-the-camera view instead.
+panel to get the gaze lookup back — clicking a spot to see which
+seconds of recording covered it.
 
 ## Photo map (`photomap`)
 

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -428,21 +428,34 @@ already reports.
 ### Airspace overlay (`--airspace`)
 
 `dji-embed flightmap FLIGHTS --airspace` overlays the official airspace zones
-for the flight area on the 2D HTML map — FAA UAS Facility Maps in the US,
-ED-269 UAS geographical zones where a national feed is available (currently
-Luxembourg, Finland and Switzerland). Zones draw in one neutral style; clicking one shows
+for the flight area on the HTML maps — the flat map and the 3D terrain view
+(`--3d`) — FAA UAS Facility Maps in the US, ED-269 UAS geographical zones
+where a national feed is available (currently Luxembourg, Finland and
+Switzerland). Zones draw in one neutral style; clicking one shows
 the published facts: restriction class, vertical limits (or "not stated"),
 applicability windows, and the feed, license and fetch time. Zones the
 flight entered get a slightly stronger outline plus the entry/exit times and
 maximum heights in the popup. The map states facts and makes no
 determination.
 
+On the flat map, zones with a published ceiling also carry a small ceiling
+label once you zoom in past the point where a metro-area grid would drown
+the map in text.
+
 Like `-f record`, the flag is the opt-in for network access: every fetch is
 announced before it happens, responses are cached in `airspace-cache/`
 beside the output (`--airspace-refresh` refetches), and areas without a
 supported feed get an honest "no data available" note on the map itself.
-`--airspace` needs exact coordinates, so it refuses `--redact`; the 3D map
-does not support the overlay yet.
+`--airspace` needs exact coordinates, so it refuses `--redact`.
+
+On the 3D map, zones with a published ceiling rise from the terrain as
+translucent volumes, so you can see a flight thread pass under or over
+them. Ceilings published above ground level (all FAA grid cells) are exact
+by construction. Ceilings published above mean sea level are converted
+using the terrain elevation at the zone's centre — an approximation the
+map notes openly; the popup always states the published limit verbatim.
+Zones with no published ceiling stay flat on the terrain: the map never
+draws a height nobody published.
 
 ## Photo map (`photomap`)
 

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -816,11 +816,11 @@ def photomap(
         ["html", "kml", "geojson", "record", "all"], case_sensitive=False
     ),
     default="html", show_default=True,
-    help="Map output format. 'record' (also written by 'all') writes a printable "
-         "flight record, fetching airspace data from official feeds (FAA / "
-         "ED-269) and terrain tiles from Mapterhorn. Along with --airspace, "
-         "these are the command's only network access; responses are cached "
-         "beside the output.",
+    help="Map output format. 'record' (also written by 'all') writes a "
+         "printable flight record; building it fetches airspace data from "
+         "official feeds (FAA / ED-269) and terrain tiles from Mapterhorn. "
+         "These fetches — and --airspace's — are the command's only network "
+         "access; responses are cached beside the output.",
 )
 @click.option(
     "--airspace-refresh", is_flag=True,
@@ -829,8 +829,9 @@ def photomap(
 @click.option(
     "--airspace", is_flag=True,
     help="Overlay official airspace zones (FAA UAS Facility Maps / ED-269) "
-         "on the 2D HTML map — announced, cached network fetches, exactly "
-         "like -f record. Zones draw in one neutral style; the map states "
+         "on the HTML map, flat or --3d — announced, cached network fetches, "
+         "exactly like -f record. Zones draw in one neutral style (in 3D, "
+         "published ceilings become translucent volumes); the map states "
          "facts and makes no determination.",
 )
 @click.option("-r", "--recursive", is_flag=True, help="Scan subdirectories too")
@@ -979,14 +980,9 @@ def flightmap(
                     "airspace features need exact coordinates; drop --redact "
                     "or --airspace"
                 )
-            if three_d:
-                raise click.UsageError(
-                    "--airspace draws on the flat 2D map; a 3D zone overlay is "
-                    "a planned follow-up — drop --3d"
-                )
             if fmt.lower() not in ("html", "all"):
                 raise click.UsageError(
-                    "--airspace overlays the 2D HTML map (use -f html or all); "
+                    "--airspace overlays the HTML maps (use -f html or all); "
                     "the flight record already includes airspace"
                 )
         if airspace_refresh and not (
@@ -1121,7 +1117,8 @@ def flightmap(
                 if f == "html":
                     if three_d:
                         write_flights_3d_html(
-                            tracks, out, map_title, redact=redact.lower()
+                            tracks, out, map_title, redact=redact.lower(),
+                            airspace_json=overlay_json,
                         )
                     else:
                         write_flights_html(

--- a/src/dji_metadata_embedder/geo/airspace/overlay.py
+++ b/src/dji_metadata_embedder/geo/airspace/overlay.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from ..track import Track
 from .evaluate import evaluate
 from .fetch import AirspaceData
-from .model import Applicability, VerticalLimit
+from .model import Applicability, M_PER_FT, VerticalLimit
 
 _MTIME_NOTE = (
     "times derived from file modification times, not telemetry datetimes"
@@ -30,6 +30,17 @@ def _fmt_utc(dt: datetime | None) -> str | None:
 
 def _fmt_limit(limit: VerticalLimit | None) -> str | None:
     return limit.label() if limit is not None else None
+
+
+def _upper_numeric(
+    limit: VerticalLimit | None,
+) -> tuple[float | None, str | None]:
+    """Published ceiling in metres + datum for the 3D volumes (#424);
+    (None, None) when not stated — the 3D map renders those flat."""
+    if limit is None:
+        return None, None
+    metres = limit.value * M_PER_FT if limit.unit == "ft" else limit.value
+    return metres, limit.reference
 
 
 def _fmt_window(win: Applicability) -> str:
@@ -71,12 +82,15 @@ def zones_to_overlay_json(
         for zone in data.zones:
             key = (zone.source.feed, zone.identifier)
             if key not in zone_dicts:
+                upper_m, upper_ref = _upper_numeric(zone.upper)
                 zone_dicts[key] = {
                     "id": zone.identifier,
                     "name": zone.name,
                     "restriction": zone.restriction,
                     "lower": _fmt_limit(zone.lower),
                     "upper": _fmt_limit(zone.upper),
+                    "upper_m": upper_m,
+                    "upper_ref": upper_ref,
                     "applicability": [
                         _fmt_window(w) for w in zone.applicability
                     ],

--- a/src/dji_metadata_embedder/geo/flightmap3d_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_airspace_js.py
@@ -13,8 +13,8 @@ opacity (a fact the evaluator established, not a verdict).
 
 Heights: fill-extrusion prisms are measured from the rendered terrain
 surface, so an AGL ceiling is exact by construction. An AMSL ceiling
-subtracts the surface elevation sampled once at the zone's centroid —
-constant per zone, so the volume top follows the terrain instead of
+subtracts the surface elevation sampled at the centroid of each of the zone's polygon parts —
+constant per part, so the volume top follows the terrain instead of
 sitting flat at the published altitude; a panel note discloses that, and
 the popup always states the published limit verbatim. With terrain off or
 failed, extrusion measures from sea level, where AMSL is again exact and

--- a/src/dji_metadata_embedder/geo/flightmap3d_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_airspace_js.py
@@ -1,0 +1,208 @@
+"""JS for the --airspace zone volumes on the 3D flightmap (#424).
+
+Same contract as :mod:`.flightmap3d_gaze_js`: plain browser JS embedded by
+string substitution, appended at the END of the 3D app so ``map``,
+``terrainElevAt`` and the flights panel exist. It registers its own
+``load`` listener; the app's own listener is registered first, so by the
+time this one runs the panel is built and the airspace toggle can append
+to it.
+
+Volumes state published data and make no determination: one neutral
+colour, restriction class in the popup only, entered-zone emphasis by
+opacity (a fact the evaluator established, not a verdict).
+
+Heights: fill-extrusion prisms are measured from the rendered terrain
+surface, so an AGL ceiling is exact by construction. An AMSL ceiling
+subtracts the surface elevation sampled once at the zone's centroid —
+constant per zone, so the volume top follows the terrain instead of
+sitting flat at the published altitude; a panel note discloses that, and
+the popup always states the published limit verbatim. With terrain off or
+failed, extrusion measures from sea level, where AMSL is again exact and
+AGL is the flat view's known approximation. A zone with no stated ceiling
+(or a computed height at/below the surface, where fill-extrusion cannot
+draw) renders as a draped footprint — never an invented volume.
+
+Cold DEM tiles read as elevation 0 (see sculptSettle), so AMSL heights
+re-sample on the same bounded-timer pattern once terrain firms up.
+"""
+
+from __future__ import annotations
+
+from .flightmap_airspace_js import AIRSPACE_POPUP_JS
+
+AIRSPACE_3D_JS = AIRSPACE_POPUP_JS + """\
+const airspace = JSON.parse(document.getElementById('airspace-data').textContent);
+const AIRSPACE_COLOR = '#4a6a8a';
+const airspaceState = { on: true };
+
+function zoneCentroid(ring) {
+  // Vertex mean of the exterior ring (closed: first point repeats last,
+  // so skip the closer) — enough precision for a disclosed approximation.
+  const n = ring.length > 1 ? ring.length - 1 : ring.length;
+  let x = 0, y = 0;
+  for (let i = 0; i < n; i++) { x += ring[i][0]; y += ring[i][1]; }
+  return [x / n, y / n];
+}
+
+function zoneHeightM(z, centroid) {
+  if (z.upper_ref !== 'AMSL') return z.upper_m;
+  const e = terrainElevAt(centroid);
+  return e == null ? z.upper_m : z.upper_m - e;
+}
+
+function airspaceFeatures() {
+  const vol = [], flat = [];
+  airspace.zones.forEach((z, zi) => {
+    z.polygons.forEach(ring => {
+      // Zone-level holes attach to every exterior — same convention as
+      // the 2D map and the evaluator's hole subtraction (#422).
+      const geom = { type: 'Polygon',
+                     coordinates: [ring].concat(z.holes || []) };
+      const props = { zi: zi, entered: z.entered.length > 0 };
+      if (z.upper_m != null) {
+        const hgt = zoneHeightM(z, zoneCentroid(ring));
+        if (hgt > 0) {
+          props.hgt = hgt;
+          vol.push({ type: 'Feature', properties: props, geometry: geom });
+          return;
+        }
+        // Ceiling at/below the rendered surface: fill-extrusion cannot
+        // draw there — fall through to the footprint; the popup still
+        // states the published limit.
+      }
+      flat.push({ type: 'Feature', properties: props, geometry: geom });
+    });
+  });
+  return { vol: vol, flat: flat };
+}
+
+function setAirspaceData() {
+  const f = airspaceFeatures();
+  const v = map.getSource('airspace-vol');
+  if (v) v.setData({ type: 'FeatureCollection', features: f.vol });
+  const s = map.getSource('airspace-flat');
+  if (s) s.setData({ type: 'FeatureCollection', features: f.flat });
+}
+
+function applyAirspaceVisibility() {
+  const v = airspaceState.on ? 'visible' : 'none';
+  ['airspace-volume', 'airspace-volume-entered', 'airspace-footprint']
+    .forEach(id => {
+      if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', v);
+    });
+}
+
+function hasAmslVolume() {
+  return airspace.zones.some(
+    z => z.upper_m != null && z.upper_ref === 'AMSL');
+}
+
+function airspaceSettle() {
+  // Cold DEM tiles answer elevation 0, so the first AMSL height pass can
+  // be sea-level based. Bounded retry, same shape as sculptSettle — and a
+  // genuine sea-level zone simply settles on the final pass.
+  if (!(map.getTerrain && map.getTerrain())) return;
+  const amsl = airspace.zones.find(
+    z => z.upper_m != null && z.upper_ref === 'AMSL');
+  if (!amsl) return;
+  const probe = zoneCentroid(amsl.polygons[0]);
+  let tries = 20;
+  const retry = () => {
+    const e = terrainElevAt(probe);
+    if ((typeof e === 'number' && e !== 0) || --tries <= 0) {
+      setAirspaceData();
+      return;
+    }
+    setTimeout(retry, 250);
+  };
+  setTimeout(retry, 250);
+}
+
+function mountAirspacePanel() {
+  const panel = document.getElementById('flights-panel');
+  if (!panel) return;
+  if (airspace.covered) {
+    // Toggle registered even for an empty fetch: "fetched and empty"
+    // must stay distinguishable from "never fetched" (2D parity).
+    panel.appendChild(document.createElement('hr'));
+    const label = document.createElement('label');
+    const box = document.createElement('input');
+    box.type = 'checkbox';
+    box.id = 'airspace-toggle';
+    box.checked = airspaceState.on;
+    box.addEventListener('change', () => {
+      airspaceState.on = box.checked;
+      applyAirspaceVisibility();
+    });
+    label.appendChild(box);
+    label.appendChild(document.createTextNode(' Airspace zones'));
+    panel.appendChild(label);
+  }
+  const notes = airspace.notes.slice();
+  if (hasAmslVolume()) {
+    notes.push('AMSL ceiling volumes are approximated from the terrain ' +
+               'elevation at each zone centre; popups state the ' +
+               'published limits.');
+  }
+  if (notes.length) {
+    const div = document.createElement('div');
+    div.className = 'panel-note';
+    div.id = 'airspace-notes';
+    notes.forEach(n => {
+      const line = document.createElement('div');
+      line.textContent = n;
+      div.appendChild(line);
+    });
+    panel.appendChild(div);
+  }
+}
+
+if (map) {
+  map.on('load', () => {
+    const f = airspaceFeatures();
+    map.addSource('airspace-vol', { type: 'geojson',
+      data: { type: 'FeatureCollection', features: f.vol } });
+    map.addSource('airspace-flat', { type: 'geojson',
+      data: { type: 'FeatureCollection', features: f.flat } });
+    // Two volume layers on one source: fill-extrusion-opacity is
+    // layer-level only (the sculpture documents why), so the entered
+    // emphasis needs a filtered twin, not a data-driven expression.
+    map.addLayer({ id: 'airspace-volume', type: 'fill-extrusion',
+      source: 'airspace-vol', filter: ['!', ['get', 'entered']],
+      paint: { 'fill-extrusion-color': AIRSPACE_COLOR,
+               'fill-extrusion-base': 0,
+               'fill-extrusion-height': ['get', 'hgt'],
+               'fill-extrusion-opacity': 0.25,
+               'fill-extrusion-vertical-gradient': false } });
+    map.addLayer({ id: 'airspace-volume-entered', type: 'fill-extrusion',
+      source: 'airspace-vol', filter: ['get', 'entered'],
+      paint: { 'fill-extrusion-color': AIRSPACE_COLOR,
+               'fill-extrusion-base': 0,
+               'fill-extrusion-height': ['get', 'hgt'],
+               'fill-extrusion-opacity': 0.4,
+               'fill-extrusion-vertical-gradient': false } });
+    map.addLayer({ id: 'airspace-footprint', type: 'fill',
+      source: 'airspace-flat',
+      paint: { 'fill-color': AIRSPACE_COLOR,
+               'fill-opacity': ['case', ['get', 'entered'], 0.3, 0.15] } });
+    ['airspace-volume', 'airspace-volume-entered', 'airspace-footprint']
+      .forEach(id => {
+        map.on('click', id, ev => {
+          const z = airspace.zones[ev.features[0].properties.zi];
+          const el = document.createElement('div');
+          el.innerHTML = zonePopupHtml(z);
+          new maplibregl.Popup({ maxWidth: '320px' })
+            .setLngLat(ev.lngLat).setDOMContent(el).addTo(map);
+        });
+        map.on('mouseenter', id, () => {
+          map.getCanvas().style.cursor = 'pointer';
+        });
+        map.on('mouseleave', id, () => {
+          map.getCanvas().style.cursor = '';
+        });
+      });
+    mountAirspacePanel();
+    airspaceSettle();
+  });
+}
+"""

--- a/src/dji_metadata_embedder/geo/flightmap3d_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_airspace_js.py
@@ -141,8 +141,8 @@ function mountAirspacePanel() {
   const notes = airspace.notes.slice();
   if (hasAmslVolume()) {
     notes.push('AMSL ceiling volumes are approximated from the terrain ' +
-               'elevation at each zone centre; popups state the ' +
-               'published limits.');
+               'elevation at the centre of each zone polygon; popups ' +
+               'state the published limits.');
   }
   if (notes.length) {
     const div = document.createElement('div');

--- a/src/dji_metadata_embedder/geo/flightmap3d_gaze_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_gaze_js.py
@@ -667,9 +667,16 @@ function gazeHighlight(entries) {
 
 function gazeLookup(ev) {
   const lineIds = flights.map(f => f.id).filter(id => map.getLayer(id));
-  if (lineIds.length
-      && map.queryRenderedFeatures(ev.point, { layers: lineIds }).length) {
-    return;                    // the flight line owns this click
+  // #424: airspace zone volumes/footprints are also click targets with their
+  // own published-facts popup -- same "owns this click" deferral the flight
+  // line already gets, so clicking a zone never doubles up with an unrelated
+  // gaze/no-footprint popup underneath it.
+  const ownedIds = lineIds.concat(
+    ['airspace-volume', 'airspace-volume-entered', 'airspace-footprint']
+      .filter(id => map.getLayer(id)));
+  if (ownedIds.length
+      && map.queryRenderedFeatures(ev.point, { layers: ownedIds }).length) {
+    return;                    // another layer's click handler owns this click
   }
   if (gazePopup) gazePopup.remove();   // see gazePopup's own comment above
   const el = document.createElement('div');

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -26,6 +26,7 @@ from html import escape
 from pathlib import Path
 
 from .flightmap import flights_to_geojson
+from .flightmap3d_airspace_js import AIRSPACE_3D_JS
 from .flightmap3d_gaze_js import GAZE_JS
 from .flightmap_js import FLIGHT_POPUP_JS
 from .track import Track
@@ -112,7 +113,7 @@ _TEMPLATE = """<!DOCTYPE html>
 <div id="map"></div>
 <script type="application/json" id="flight-data">
 {data}
-</script>
+</script>{airspace_block}
 <script src="https://unpkg.com/maplibre-gl@{maplibre}/dist/maplibre-gl.js" integrity="{js_sri}"
         crossorigin=""></script>
 <script>
@@ -1029,20 +1030,36 @@ function syncCrossfadePlayback() {
   // A slideshow is honest; a decoder falling silently behind is not.
   if (!v.paused) v.pause();
 }
+__AIRSPACE_3D_JS__
 """
 
 
 def flights_to_3d_html(
-    tracks: list[Track], title: str, redact: str = "none"
+    tracks: list[Track], title: str, redact: str = "none",
+    airspace_json: dict | None = None,
 ) -> str:
-    """Return a complete 3D-terrain HTML flight map (draped tracks)."""
+    """Return a complete 3D-terrain HTML flight map (draped tracks).
+
+    ``airspace_json`` (#424): the overlay dict from
+    :func:`~.airspace.overlay.zones_to_overlay_json`; None renders the
+    map exactly as before.
+    """
     geojson = flights_to_geojson(tracks, redact=redact)
     # Escape "<" to "\\u003c" (a JSON Unicode escape) so JSON.parse round-trips
     # it while no literal "</script>" can break out of the data block.
     data = json.dumps(geojson).replace("<", "\\u003c")
+    airspace_block = airspace_js = ""
+    if airspace_json is not None:
+        adata = json.dumps(airspace_json).replace("<", "\\u003c")
+        airspace_block = (
+            '\n<script type="application/json" id="airspace-data">\n'
+            f"{adata}\n</script>"
+        )
+        airspace_js = AIRSPACE_3D_JS
     app_js = (
         _APP_JS.replace("__SHARED_JS__", FLIGHT_POPUP_JS)
         .replace("__GAZE_JS__", GAZE_JS)
+        .replace("__AIRSPACE_3D_JS__", airspace_js)
         .replace("__OSM_TILES__", _OSM_TILES)
         .replace("__MAPTERHORN__", _MAPTERHORN_TILEJSON)
     )
@@ -1052,16 +1069,21 @@ def flights_to_3d_html(
         css_sri=_MAPLIBRE_CSS_SRI,
         js_sri=_MAPLIBRE_JS_SRI,
         data=data,
+        airspace_block=airspace_block,
         app_js=app_js,
     )
 
 
 def write_flights_3d_html(
-    tracks: list[Track], output_path: Path, title: str, redact: str = "none"
+    tracks: list[Track], output_path: Path, title: str, redact: str = "none",
+    airspace_json: dict | None = None,
 ) -> Path:
     """Write *tracks* as a 3D HTML map to *output_path* and return it."""
     output_path.write_text(
-        flights_to_3d_html(tracks, title, redact=redact), encoding="utf-8"
+        flights_to_3d_html(
+            tracks, title, redact=redact, airspace_json=airspace_json
+        ),
+        encoding="utf-8",
     )
     logger.info("3D HTML flight map created: %s", output_path)
     return output_path

--- a/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
@@ -75,8 +75,12 @@ function syncZoneLabels() {
   const show = map.getZoom() >= AIRSPACE_LABEL_MIN_ZOOM;
   labeledPolys.forEach(lp => {
     if (show && !lp.poly.getTooltip()) {
-      lp.poly.bindTooltip(lp.text, { permanent: true, direction: 'center',
-                                     className: 'airspace-label' });
+      // esc() pins the invariant: label text must never reach the DOM
+      // unescaped, even though today's VerticalLimit.label() emits only
+      // number+unit+datum.
+      lp.poly.bindTooltip(esc(lp.text),
+        { permanent: true, direction: 'center',
+          className: 'airspace-label' });
     } else if (!show && lp.poly.getTooltip()) {
       lp.poly.unbindTooltip();
     }

--- a/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
@@ -8,13 +8,19 @@ same layer control, and ``bringToBack()`` puts them under the tracks that
 were just added. One neutral style for every zone — the published
 restriction class is popup data, not a color: this map states facts and
 makes no determination.
+
+``AIRSPACE_POPUP_JS`` (the popup builder alone) is shared with the 3D
+map's :mod:`.flightmap3d_airspace_js` (#424): both maps must show the
+same published facts for the same zone.
+
+Ceiling labels (#424) are zoom-gated: a metro-area FAA grid is 300+
+cells, so below ``AIRSPACE_LABEL_MIN_ZOOM`` the labels come off rather
+than shout over the map.
 """
 
 from __future__ import annotations
 
-AIRSPACE_OVERLAY_JS = """\
-const airspace = JSON.parse(document.getElementById('airspace-data').textContent);
-
+AIRSPACE_POPUP_JS = """\
 function zonePopupHtml(z) {
   let html = `<div class="flight-popup"><b>${esc(z.name)}</b>`;
   if (z.id && z.id !== z.name) html += `<br>${esc(z.id)}`;
@@ -40,8 +46,14 @@ function zonePopupHtml(z) {
   html += '</div>';
   return html;
 }
+"""
+
+AIRSPACE_OVERLAY_JS = AIRSPACE_POPUP_JS + """\
+const airspace = JSON.parse(document.getElementById('airspace-data').textContent);
+const AIRSPACE_LABEL_MIN_ZOOM = 11;
 
 const zoneGroup = L.layerGroup();
+const labeledPolys = [];
 airspace.zones.forEach(z => {
   const entered = z.entered.length > 0;
   const style = { color: '#4a6a8a', weight: entered ? 3 : 1.5,
@@ -52,10 +64,30 @@ airspace.zones.forEach(z => {
     // holes attach to every exterior — right for single-volume zones,
     // which is every zone either live feed publishes today.
     const rings = [ring].concat(z.holes || []);
-    L.polygon(rings.map(r => r.map(c => [c[1], c[0]])), style)
+    const poly = L.polygon(rings.map(r => r.map(c => [c[1], c[0]])), style)
       .bindPopup(zonePopupHtml(z)).addTo(zoneGroup);
+    // Only a STATED ceiling earns a label — an unlabelled zone still has
+    // its "not stated" popup, and a label must never invent a limit.
+    if (z.upper) labeledPolys.push({ poly: poly, text: z.upper });
   });
 });
+function syncZoneLabels() {
+  const show = map.getZoom() >= AIRSPACE_LABEL_MIN_ZOOM;
+  labeledPolys.forEach(lp => {
+    if (show && !lp.poly.getTooltip()) {
+      lp.poly.bindTooltip(lp.text, { permanent: true, direction: 'center',
+                                     className: 'airspace-label' });
+    } else if (!show && lp.poly.getTooltip()) {
+      lp.poly.unbindTooltip();
+    }
+  });
+}
+if (labeledPolys.length) {
+  // Runs once now (harmless before the view is set: getZoom() is NaN and
+  // compares false) and again after fitBounds/setView fires zoomend.
+  map.on('zoomend', syncZoneLabels);
+  syncZoneLabels();
+}
 if (airspace.covered) {
   // Registered even when empty: "fetched and empty" must stay
   // distinguishable from "never fetched".

--- a/src/dji_metadata_embedder/geo/flightmap_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap_html.py
@@ -240,6 +240,10 @@ if (runs.length && maxT > 0) {
 _AIRSPACE_CSS = """  .airspace-note { background: rgba(255,255,255,.85);
                    border-radius: 4px; padding: 4px 8px;
                    font: 12px/1.5 sans-serif; max-width: 320px; }
+  .airspace-label { background: rgba(255,255,255,.75); border: none;
+                    box-shadow: none; color: #2b3a4a; padding: 1px 4px;
+                    font: 11px/1.2 sans-serif; }
+  .airspace-label::before { display: none; }
 """
 
 

--- a/tests/browser/test_flightmap_3d_airspace.py
+++ b/tests/browser/test_flightmap_3d_airspace.py
@@ -1,0 +1,131 @@
+"""3D --airspace zone volumes (#424) in a real headless Chromium."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect  # noqa: E402
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+
+def _flight() -> Track:
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name="DJI_0001", points=[
+        TrackPoint(lat=10.0, lon=20.0 + i * 0.0006, alt=100.0 + i,
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i * 10.0))
+        for i in range(5)
+    ])
+
+
+def _zone(upper="120 m AGL", upper_m=120.0, upper_ref="AGL", entered=None):
+    return {
+        "id": "Z1", "name": "Test zone", "restriction": "CEILING",
+        "lower": None, "upper": upper, "applicability": [],
+        "polygons": [[[19.999, 9.999], [20.01, 9.999], [20.01, 10.01],
+                      [19.999, 10.01], [19.999, 9.999]]],
+        "holes": [],
+        "upper_m": upper_m, "upper_ref": upper_ref,
+        "source": {"feed": "Test feed", "license": "CC0",
+                   "fetched": "2026-08-06"},
+        "entered": entered or [],
+    }
+
+
+def _overlay(zones, notes=None):
+    return {"zones": zones,
+            "notes": notes if notes is not None
+            else ["Airspace: Test feed, fetched 2026-08-06"],
+            "covered": True}
+
+
+def _vol_features(page):
+    return page.evaluate(
+        "() => map.getSource('airspace-vol').serialize().data.features")
+
+
+def _flat_features(page):
+    return page.evaluate(
+        "() => map.getSource('airspace-flat').serialize().data.features")
+
+
+def _wait_layers(page):
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.getLayer"
+        " && !!map.getLayer('airspace-volume')", timeout=20000)
+
+
+def test_agl_ceiling_is_an_exact_volume(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight()], "t", airspace_json=_overlay([_zone()]))
+    serve_map(html, terrain_stub=100.0)
+    _wait_layers(page)
+    feats = _vol_features(page)
+    assert len(feats) == 1
+    # AGL never touches terrainElevAt: exact by construction, even before
+    # DEM tiles are warm.
+    assert feats[0]["properties"]["hgt"] == 120.0
+    assert _flat_features(page) == []
+
+
+def test_amsl_ceiling_settles_to_terrain_relative_height(serve_map, page):
+    zone = _zone(upper="250 m AMSL", upper_m=250.0, upper_ref="AMSL")
+    html = flights_to_3d_html(
+        [_flight()], "t", airspace_json=_overlay([zone]))
+    serve_map(html, terrain_stub=100.0)
+    _wait_layers(page)
+    # airspaceSettle re-samples once the 100 m DEM firms up: 250 - 100.
+    page.wait_for_function(
+        "() => { const s = map.getSource('airspace-vol');"
+        " if (!s) return false;"
+        " const f = s.serialize().data.features;"
+        " return f.length === 1 && Math.abs(f[0].properties.hgt - 150) < 2; }",
+        timeout=20000)
+    expect(page.locator("#airspace-notes")).to_contain_text("AMSL")
+
+
+def test_no_ceiling_zone_renders_flat(serve_map, page):
+    zone = _zone(upper=None, upper_m=None, upper_ref=None)
+    html = flights_to_3d_html(
+        [_flight()], "t", airspace_json=_overlay([zone]))
+    serve_map(html, terrain_stub=100.0)
+    _wait_layers(page)
+    assert _vol_features(page) == []
+    assert len(_flat_features(page)) == 1
+    # No AMSL volume on the map: the approximation note must not appear.
+    note = page.locator("#airspace-notes")
+    expect(note).not_to_contain_text("AMSL")
+
+
+def test_zone_click_opens_published_facts_popup(serve_map, page):
+    zone = _zone(upper=None, upper_m=None, upper_ref=None)
+    html = flights_to_3d_html(
+        [_flight()], "t", airspace_json=_overlay([zone]))
+    serve_map(html, terrain_stub=100.0)
+    _wait_layers(page)
+    pos = page.evaluate(
+        "() => { const p = map.project([20.005, 10.005]);"
+        " return { x: p.x, y: p.y }; }")
+    page.mouse.click(pos["x"], pos["y"])
+    expect(page.locator(".flight-popup")).to_contain_text("Test zone")
+    expect(page.locator(".flight-popup")).to_contain_text(
+        "upper limit: not stated")
+
+
+def test_airspace_toggle_hides_all_layers(serve_map, page):
+    html = flights_to_3d_html(
+        [_flight()], "t", airspace_json=_overlay([_zone()]))
+    serve_map(html, terrain_stub=100.0)
+    _wait_layers(page)
+    page.locator("#airspace-toggle").uncheck()
+    for layer in ("airspace-volume", "airspace-volume-entered",
+                  "airspace-footprint"):
+        assert page.evaluate(
+            f"() => map.getLayoutProperty('{layer}', 'visibility')"
+        ) == "none"

--- a/tests/browser/test_flightmap_3d_airspace.py
+++ b/tests/browser/test_flightmap_3d_airspace.py
@@ -118,6 +118,29 @@ def test_zone_click_opens_published_facts_popup(serve_map, page):
         "upper limit: not stated")
 
 
+def test_entered_zone_lands_in_the_entered_layer(serve_map, page):
+    entered = [{"flight": "DJI_0001", "entry_utc": "2026-06-15 12:00:10 UTC",
+                "exit_utc": "2026-06-15 12:00:30 UTC",
+                "max_rel_alt_m": 45.0, "max_amsl_m": 145.0, "time_note": None}]
+    html = flights_to_3d_html(
+        [_flight()], "t", airspace_json=_overlay([_zone(entered=entered)]))
+    serve_map(html, terrain_stub=100.0)
+    _wait_layers(page)
+    feats = _vol_features(page)
+    assert len(feats) == 1
+    assert feats[0]["properties"]["entered"] is True
+    # The twin-layer filters partition the source on `entered`: assert the
+    # filter expressions directly rather than queryRenderedFeatures, which
+    # can read empty under SwiftShader's cold-render timing in CI and would
+    # then pass regardless of whether the filters were swapped or wrong.
+    assert page.evaluate(
+        "() => map.getFilter('airspace-volume-entered')"
+    ) == ["get", "entered"]
+    assert page.evaluate(
+        "() => map.getFilter('airspace-volume')"
+    ) == ["!", ["get", "entered"]]
+
+
 def test_airspace_toggle_hides_all_layers(serve_map, page):
     html = flights_to_3d_html(
         [_flight()], "t", airspace_json=_overlay([_zone()]))

--- a/tests/browser/test_flightmap_3d_airspace.py
+++ b/tests/browser/test_flightmap_3d_airspace.py
@@ -109,13 +109,22 @@ def test_zone_click_opens_published_facts_popup(serve_map, page):
         [_flight()], "t", airspace_json=_overlay([zone]))
     serve_map(html, terrain_stub=100.0)
     _wait_layers(page)
+    # Layer existence is not renderedness: on the CI software renderer the
+    # click can beat the first frame that makes the footprint hit-testable,
+    # and a click that queryRenderedFeatures can't see opens no popup.
+    page.wait_for_function(
+        "() => map.queryRenderedFeatures({layers: ['airspace-footprint']})"
+        ".length > 0",
+        timeout=20000,
+    )
     pos = page.evaluate(
         "() => { const p = map.project([20.005, 10.005]);"
         " return { x: p.x, y: p.y }; }")
     page.mouse.click(pos["x"], pos["y"])
-    expect(page.locator(".flight-popup")).to_contain_text("Test zone")
     expect(page.locator(".flight-popup")).to_contain_text(
-        "upper limit: not stated")
+        "Test zone", timeout=10000)
+    expect(page.locator(".flight-popup")).to_contain_text(
+        "upper limit: not stated", timeout=10000)
 
 
 def test_entered_zone_lands_in_the_entered_layer(serve_map, page):

--- a/tests/browser/test_flightmap_airspace.py
+++ b/tests/browser/test_flightmap_airspace.py
@@ -1,0 +1,71 @@
+"""2D --airspace zoom-gated ceiling labels (#424) in headless Chromium."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from playwright.sync_api import expect  # noqa: E402
+
+from dji_metadata_embedder.geo.flightmap_html import flights_to_html  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+
+def _flight() -> Track:
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name="DJI_0001", points=[
+        TrackPoint(lat=10.0, lon=20.0 + i * 0.0006, alt=100.0 + i,
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i * 10.0))
+        for i in range(5)
+    ])
+
+
+def _zone(upper="120 m AGL", upper_m=120.0, upper_ref="AGL"):
+    return {
+        "id": "Z1", "name": "Test zone", "restriction": "CEILING",
+        "lower": None, "upper": upper, "applicability": [],
+        "polygons": [[[19.999, 9.999], [20.01, 9.999], [20.01, 10.01],
+                      [19.999, 10.01], [19.999, 9.999]]],
+        "holes": [],
+        "upper_m": upper_m, "upper_ref": upper_ref,
+        "source": {"feed": "Test feed", "license": "CC0",
+                   "fetched": "2026-08-06"},
+        "entered": [],
+    }
+
+
+def _overlay(zones):
+    return {"zones": zones,
+            "notes": ["Airspace: Test feed, fetched 2026-08-06"],
+            "covered": True}
+
+
+def test_ceiling_labels_gate_on_zoom(serve_map, page):
+    html = flights_to_html([_flight()], "trip",
+                           airspace_json=_overlay([_zone()]))
+    serve_map(html)
+    # fitBounds on a ~30 m flight lands at maxZoom 17: labels visible.
+    expect(page.locator(".airspace-label")).to_have_count(1, timeout=15000)
+    expect(page.locator(".airspace-label")).to_contain_text("120 m AGL")
+    page.evaluate("() => map.setZoom(9)")
+    expect(page.locator(".airspace-label")).to_have_count(0, timeout=15000)
+    page.evaluate("() => map.setZoom(12)")
+    expect(page.locator(".airspace-label")).to_have_count(1, timeout=15000)
+
+
+def test_no_ceiling_zone_gets_no_label(serve_map, page):
+    zone = _zone(upper=None, upper_m=None, upper_ref=None)
+    html = flights_to_html([_flight()], "trip",
+                           airspace_json=_overlay([zone]))
+    serve_map(html)
+    # The zone polygon is on the map (popup says "not stated") but no label
+    # may claim a ceiling. Wait for the map to settle on the flight first.
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map.getZoom() > 11",
+        timeout=15000,
+    )
+    assert page.locator(".airspace-label").count() == 0

--- a/tests/test_airspace_overlay.py
+++ b/tests/test_airspace_overlay.py
@@ -2,9 +2,11 @@
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
 from dji_metadata_embedder.geo.airspace.ed269 import ED269_FEEDS, parse_ed269
 from dji_metadata_embedder.geo.airspace.fetch import AirspaceData
-from dji_metadata_embedder.geo.airspace.model import SourceInfo
+from dji_metadata_embedder.geo.airspace.model import SourceInfo, VerticalLimit, Zone
 from dji_metadata_embedder.geo.airspace.overlay import zones_to_overlay_json
 from dji_metadata_embedder.geo.track import Track, TrackPoint
 
@@ -80,8 +82,8 @@ def test_zone_dict_shape_and_source_footer():
     )
     z = out["zones"][0]
     assert set(z) == {
-        "id", "name", "restriction", "lower", "upper", "applicability",
-        "polygons", "holes", "source", "entered",
+        "id", "name", "restriction", "lower", "upper", "upper_m", "upper_ref",
+        "applicability", "polygons", "holes", "source", "entered",
     }
     assert z["source"] == {
         "feed": source.feed, "license": source.license, "fetched": source.fetched,
@@ -144,3 +146,33 @@ def test_no_verdict_vocabulary_in_output():
     blob = _json.dumps(out).lower()
     for banned in ("legal", "compliant", "violation"):  # "legal" subsumes "illegal"
         assert banned not in blob
+
+
+def test_zone_dicts_carry_numeric_ceilings_for_the_3d_map():
+    # #424: ft converts through M_PER_FT, metres pass through,
+    # "not stated" stays None (this is what keeps no-ceiling zones flat).
+    src = SourceInfo(feed="F", url="u", fetched="t", license="l", caveat="c")
+
+    def zone(upper, ident):
+        return Zone(
+            identifier=ident, name=ident, restriction="CEILING",
+            lower=None, upper=upper, applicability=[],
+            polygons=[[(6.0, 49.0), (6.1, 49.0), (6.1, 49.1), (6.0, 49.0)]],
+            source=src,
+        )
+
+    zones = [
+        zone(VerticalLimit(400, "ft", "AGL"), "FT"),
+        zone(VerticalLimit(2500, "m", "AMSL"), "M"),
+        zone(None, "NONE"),
+    ]
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(zones=zones, source=src)]
+    )
+    by_id = {z["id"]: z for z in out["zones"]}
+    assert by_id["FT"]["upper_m"] == pytest.approx(400 * 0.3048)
+    assert by_id["FT"]["upper_ref"] == "AGL"
+    assert by_id["M"]["upper_m"] == 2500.0
+    assert by_id["M"]["upper_ref"] == "AMSL"
+    assert by_id["NONE"]["upper_m"] is None
+    assert by_id["NONE"]["upper_ref"] is None

--- a/tests/test_cli_airspace.py
+++ b/tests/test_cli_airspace.py
@@ -109,7 +109,7 @@ def test_airspace_overlays_the_3d_map(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     html = (d / "flightmap-3d.html").read_text(encoding="utf-8")
     assert 'id="airspace-data"' in html
-    assert "airspace-volume" in html
+    assert "airspaceFeatures" in html
     assert fake.calls == 1
 
 

--- a/tests/test_cli_airspace.py
+++ b/tests/test_cli_airspace.py
@@ -98,10 +98,19 @@ def test_airspace_refuses_redact(tmp_path):
     assert "exact coordinates" in result.output
 
 
-def test_airspace_refuses_3d(tmp_path):
+def test_airspace_overlays_the_3d_map(tmp_path, monkeypatch):
+    # #424: the 3D map takes the same overlay the 2D map does.
+    fake = FakeTransport([_lux_body()])
+    monkeypatch.setattr(airspace_fetch, "urlopen", fake)
     d = _srt_dir(tmp_path)
-    result = CliRunner().invoke(main, ["flightmap", str(d), "--airspace", "--3d"])
-    assert result.exit_code != 0
+    result = CliRunner().invoke(
+        main, ["flightmap", str(d), "--airspace", "--3d"]
+    )
+    assert result.exit_code == 0, result.output
+    html = (d / "flightmap-3d.html").read_text(encoding="utf-8")
+    assert 'id="airspace-data"' in html
+    assert "airspace-volume" in html
+    assert fake.calls == 1
 
 
 def test_airspace_refuses_non_map_formats(tmp_path):

--- a/tests/test_geo_flightmap_3d_airspace.py
+++ b/tests/test_geo_flightmap_3d_airspace.py
@@ -21,13 +21,16 @@ def test_3d_html_embeds_airspace_when_given():
         airspace_json={"zones": [], "notes": [], "covered": True},
     )
     assert 'id="airspace-data"' in html
-    assert "airspace-volume" in html
+    assert "airspaceFeatures" in html
 
 
 def test_3d_html_omits_airspace_by_default():
     html = flights_to_3d_html([_flight()], "t")
     assert 'id="airspace-data"' not in html
-    assert "airspace-volume" not in html
+    # Not "airspace-volume": the gaze click-arbitration guard names the layer
+    # ids in every 3D map's JS (and no-ops when the layers don't exist);
+    # airspaceFeatures is defined only by the embedded airspace module.
+    assert "airspaceFeatures" not in html
 
 
 def test_airspace_data_block_escapes_script_breakout():

--- a/tests/test_geo_flightmap_3d_airspace.py
+++ b/tests/test_geo_flightmap_3d_airspace.py
@@ -1,0 +1,39 @@
+"""3D map embedding of the --airspace overlay (#424) — template level."""
+from datetime import datetime, timedelta
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html
+from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+
+def _flight() -> Track:
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name="DJI_0001", points=[
+        TrackPoint(lat=10.0, lon=20.0 + i * 0.0006, alt=100.0 + i,
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i * 10.0))
+        for i in range(5)
+    ])
+
+
+def test_3d_html_embeds_airspace_when_given():
+    html = flights_to_3d_html(
+        [_flight()], "t",
+        airspace_json={"zones": [], "notes": [], "covered": True},
+    )
+    assert 'id="airspace-data"' in html
+    assert "airspace-volume" in html
+
+
+def test_3d_html_omits_airspace_by_default():
+    html = flights_to_3d_html([_flight()], "t")
+    assert 'id="airspace-data"' not in html
+    assert "airspace-volume" not in html
+
+
+def test_airspace_data_block_escapes_script_breakout():
+    html = flights_to_3d_html(
+        [_flight()], "t",
+        airspace_json={"zones": [], "notes": ["</script><b>x</b>"],
+                       "covered": False},
+    )
+    assert "</script><b>x</b>" not in html


### PR DESCRIPTION
Closes #424. Follow-up to #423 (2D overlay) and #457 (Switzerland).

- 3D map (`--airspace --3d`): zones with a published ceiling render as
  translucent fill-extrusion volumes from the terrain to the ceiling.
  AGL ceilings are exact by construction (fill-extrusion measures from
  the terrain surface); AMSL ceilings subtract the terrain elevation at
  the centre of each zone polygon (disclosed in a panel note; popups
  state published limits verbatim). Zones with no published ceiling stay
  flat — no invented heights. One neutral colour; entered zones differ
  by opacity only. Toggle, popups and provenance notes match the 2D map.
- 2D map: zoom-gated ceiling labels (permanent centre tooltips at
  zoom >= 11) on zones with a stated ceiling.
- Click arbitration on the 3D map: clicking an airspace zone opens the
  zone popup instead of the gaze ground lookup; untick "Airspace zones"
  to get the lookup back. The guard no-ops on maps without airspace.
- CLI: the `--airspace --3d` guard is lifted; `-f/--format` help
  sentence reworded (#423 review). The other two #423 fold-ins
  (single-fetch for `-f all`, page-stable cell ids) already landed
  with #457.

Local gate: ruff clean, mypy clean, 996 passed (unit/CLI) + 126 passed
(browser leg, incl. 8 new airspace tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGmtf4qGfz6xgGSjnqL6mh