### PR TITLE
feat: 360° opening-view editor + view thumbnails (#440, #441)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ it's a handful of copy-paste commands. For a guided tour see
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
   folder of stills on one clustered map, thumbnails included; 360° panoramas
   get their own marker color and toggle, and open in an interactive viewer.
+- **Choose each panorama's opening view** — `dji-embed panoedit` is a
+  drag-and-save editor for the GPano initial-view tags, honored by the photo
+  map and Google Photos; `photomap --pano-view-thumbs` turns the saved views
+  into square popup thumbnails.
 - **Make videos searchable by location** — `dji-embed embed` writes the GPS
   data into the video files so Windows Photos, Google Photos, and similar apps
   can find them by place. No re-encoding, no quality loss, and the full

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -532,6 +532,28 @@ stitcher, records where the image center points; without it the center is
 assumed to face North). `InitialViewPitchDegrees` tilts the opening view
 above/below the horizon.
 
+### Setting the opening view
+
+DJI cameras don't write initial-view tags in camera, and hand-typing
+ExifTool commands per pano doesn't scale, so there is an editor:
+
+```bash
+dji-embed panoedit /path/to/panoramas
+```
+
+This opens a local editor page (your machine only): drag and zoom each
+panorama to the view it should open with — the live readout shows the
+exact GPano values — then Save writes `InitialViewHeadingDegrees`,
+`InitialViewPitchDegrees` and `InitialHorizontalFOVDegrees` into the file
+with ExifTool and moves on to the next panorama. Each original is kept
+beside the file as `<name>_original`. In the desktop app this is the
+"360° views" mode.
+
+With views saved, `photomap --pano-view-thumbs` renders each tagged
+panorama's popup thumbnail as a square crop of that opening view instead
+of the distorted 2:1 strip (panoramas without a saved view keep the
+strip).
+
 Photos that carry `Artist`/`Copyright` EXIF (or the XMP Dublin Core
 equivalents) get an attribution line in their popup, and the 360° viewer
 shows it as a byline — add it once with

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -498,17 +498,33 @@ public class CommandBuilderTests
     }
 
     [Fact]
+    public void Photo_map_emits_pano_view_thumbs_when_set()
+    {
+        var argv = CommandBuilder.PhotoMap("/x",
+            PhotoMapOptions.Defaults with { PanoViewThumbs = true });
+        Assert.Contains("--pano-view-thumbs", argv);
+    }
+
+    [Fact]
+    public void Photo_map_default_omits_pano_view_thumbs()
+    {
+        Assert.DoesNotContain("--pano-view-thumbs",
+            CommandBuilder.PhotoMap("/x", PhotoMapOptions.Defaults));
+    }
+
+    [Fact]
     public void Photo_map_all_options_compose_in_a_stable_order()
     {
         var opts = new PhotoMapOptions(
             Recursive: true, TileStyle: "cyclosm", Privacy: MapPrivacy.Fuzz,
-            LinkOriginals: true,
+            LinkOriginals: true, PanoViewThumbs: true,
             Popup: new PopupFields(Name: true, Timestamp: false, Camera: true,
                                     Altitude: false, Credit: true),
             ExportAll: true, Title: "T", Output: "/o.html");
         Assert.Equal(
             ["photomap", "/x", "-r", "--tile-style", "cyclosm", "--redact", "fuzz",
-             "--link-originals", "--popup-fields", "name,camera,credit",
+             "--link-originals", "--pano-view-thumbs",
+             "--popup-fields", "name,camera,credit",
              "--format", "all", "--title", "T", "--output", "/o.html"],
             CommandBuilder.PhotoMap("/x", opts));
     }

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -37,6 +37,13 @@ public class CommandBuilderTests
     }
 
     [Fact]
+    public void Pano_edit_is_panoedit_folder()
+    {
+        string[] expected = ["panoedit", "/x"];
+        Assert.Equal(expected, CommandBuilder.Build(WorkspaceModeKind.PanoEdit, "/x"));
+    }
+
+    [Fact]
     public void No_mode_ever_includes_the_progress_flag()
     {
         foreach (var kind in Enum.GetValues<WorkspaceModeKind>())

--- a/gui/DjiEmbed.Gui.Tests/FakeMapServer.cs
+++ b/gui/DjiEmbed.Gui.Tests/FakeMapServer.cs
@@ -11,10 +11,19 @@ internal sealed class FakeMapServer(string? url) : IMapServer
 {
     public List<string> Requests { get; } = [];
 
+    public List<string> EditorRequests { get; } = [];
+
     public Task<string?> GetUrlAsync(
         string cliPath, string htmlPath, CancellationToken cancellationToken)
     {
         Requests.Add(htmlPath);
+        return Task.FromResult(url);
+    }
+
+    public Task<string?> GetEditorUrlAsync(
+        string cliPath, string folder, CancellationToken cancellationToken)
+    {
+        EditorRequests.Add(folder);
         return Task.FromResult(url);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/PhotoMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/PhotoMapOptionsViewModelTests.cs
@@ -49,6 +49,7 @@ public class PhotoMapOptionsViewModelTests
         {
             Recursive = false,
             LinkOriginals = false,
+            PanoViewThumbs = true,
             ShowCamera = false,
             ShowAltitude = false,
             ExportAll = true,
@@ -65,6 +66,7 @@ public class PhotoMapOptionsViewModelTests
             TileStyle: "opentopomap",
             Privacy: MapPrivacy.Fuzz,
             LinkOriginals: false,
+            PanoViewThumbs: true,
             Popup: new PopupFields(Name: true, Timestamp: true, Camera: false,
                                    Altitude: false, Credit: true),
             ExportAll: true,

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
@@ -5,12 +5,13 @@ namespace DjiEmbed.Gui.Tests;
 public class WorkspaceModeTests
 {
     [Fact]
-    public void Catalogue_has_the_six_modes_in_strip_order() =>
+    public void Catalogue_has_the_seven_modes_in_strip_order() =>
         Assert.Equal(
             [
                 WorkspaceModeKind.FlightMap, WorkspaceModeKind.PhotoMap,
                 WorkspaceModeKind.Embed, WorkspaceModeKind.Convert,
-                WorkspaceModeKind.Verify, WorkspaceModeKind.Setup,
+                WorkspaceModeKind.Verify, WorkspaceModeKind.PanoEdit,
+                WorkspaceModeKind.Setup,
             ],
             WorkspaceMode.All.Select(m => m.Kind));
 

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -100,12 +100,12 @@ public class WorkspaceScreenTests
     }
 
     [AvaloniaFact]
-    public void Mode_strip_shows_exactly_the_six_modes()
+    public void Mode_strip_shows_exactly_the_seven_modes()
     {
         var window = ShowWorkspace();
         var strip = window.GetVisualDescendants().OfType<ListBox>()
             .Single(l => l.Name == "ModeStrip");
-        Assert.Equal(6, strip.ItemCount);
+        Assert.Equal(7, strip.ItemCount);
     }
 
     [AvaloniaFact]

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -2078,10 +2078,55 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Null(vm.VerifyHeadline);
     }
 
+    // ---- 360° view editor mode (#440) -----------------------------------
+
+    [Fact]
+    public async Task Pano_edit_run_launches_editor_and_shows_preview()
+    {
+        var cli = Path.Combine(_dir, "dji-embed-fake");
+        File.WriteAllText(cli, "");
+        var folder = MakeFolder(photos: true);
+        var fake = new FakeMapServer("http://127.0.0.1:9/");
+        var vm = Vm(cli, mapServer: fake, previewAvailable: static () => true);
+        await vm.SetFolderAsync(folder);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal([folder], fake.EditorRequests);
+        Assert.Equal("http://127.0.0.1:9/", vm.PreviewUrl);
+        Assert.Equal(FlowStep.Done, vm.Step);
+    }
+
+    [Fact]
+    public async Task Pano_edit_run_fails_cleanly_when_editor_cannot_start()
+    {
+        var cli = Path.Combine(_dir, "dji-embed-fake");
+        File.WriteAllText(cli, "");
+        var folder = MakeFolder(photos: true);
+        var vm = Vm(cli, mapServer: new FakeMapServer(null),
+                    previewAvailable: static () => true);
+        await vm.SetFolderAsync(folder);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal(FlowStep.Failed, vm.Step);
+        Assert.Null(vm.PreviewUrl);
+    }
+
+    [Fact]
+    public void Pano_edit_command_preview_teaches_panoedit()
+    {
+        var vm = Vm(null);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        Assert.Equal("dji-embed panoedit <folder>", vm.CommandPreview);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(
             string cliPath, string htmlPath, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("server exploded");
+
+        public Task<string?> GetEditorUrlAsync(
+            string cliPath, string folder, CancellationToken cancellationToken) =>
             throw new InvalidOperationException("server exploded");
     }
 
@@ -2089,6 +2134,10 @@ public class WorkspaceViewModelTests : IDisposable
     {
         public Task<string?> GetUrlAsync(
             string cliPath, string htmlPath, CancellationToken cancellationToken) =>
+            throw new OperationCanceledException();
+
+        public Task<string?> GetEditorUrlAsync(
+            string cliPath, string folder, CancellationToken cancellationToken) =>
             throw new OperationCanceledException();
     }
 

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -139,6 +139,10 @@ public static class CommandBuilder
         {
             args.Add("--link-originals");
         }
+        if (opts.PanoViewThumbs)
+        {
+            args.Add("--pano-view-thumbs");
+        }
         if (PopupFieldsValue(opts.Popup) is { } popup)
         {
             args.Add("--popup-fields");

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -28,6 +28,7 @@ public static class CommandBuilder
             Convert(folder!, batch: true, ConvertTelemetryOptions.Defaults),
         WorkspaceModeKind.Verify =>
             Verify(folder!, VerifyTelemetryOptions.Defaults),
+        WorkspaceModeKind.PanoEdit => PanoEdit(folder!),
         WorkspaceModeKind.Setup => ["doctor"],
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
     };
@@ -344,6 +345,12 @@ public static class CommandBuilder
                     nameof(opts), opts.SubAction, null);
         }
     }
+
+    /// <summary>The 360° view editor argv (#440). The strip teaches
+    /// <c>panoedit &lt;folder&gt;</c>; MapServer appends
+    /// <c>--no-browser --url-only --exit-with-stdin</c> at launch, the
+    /// same split the serve child uses.</summary>
+    public static string[] PanoEdit(string folder) => ["panoedit", folder];
 
     /// <summary>
     /// The <c>--popup-fields</c> value, or <c>null</c> to omit the flag.

--- a/gui/DjiEmbed.Gui/Services/IMapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/IMapServer.cs
@@ -15,4 +15,11 @@ public interface IMapServer
     /// OperationCanceledException, never as null.</summary>
     Task<string?> GetUrlAsync(
         string cliPath, string htmlPath, CancellationToken cancellationToken);
+
+    /// <summary>Launches (or reuses) a <c>dji-embed panoedit</c> child for
+    /// <paramref name="folder"/> and returns its editor URL (#440). Null
+    /// when the editor could not start (no panoramas, no CLI);
+    /// cancellation surfaces as OperationCanceledException.</summary>
+    Task<string?> GetEditorUrlAsync(
+        string cliPath, string folder, CancellationToken cancellationToken);
 }

--- a/gui/DjiEmbed.Gui/Services/MapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/MapServer.cs
@@ -39,14 +39,44 @@ public sealed class MapServer : IMapServer, IDisposable
             return null;
         }
         var page = Path.GetFileName(htmlPath);
-        if (_running.TryGetValue(dir, out var live))
+        var baseUrl = await LaunchAsync(
+            cliPath, dir,
+            ["serve", dir, "--page", page, "--no-browser", "--url-only",
+             "--exit-with-stdin"],
+            cancellationToken);
+        return baseUrl is null ? null : baseUrl + page;
+    }
+
+    public Task<string?> GetEditorUrlAsync(
+        string cliPath, string folder, CancellationToken cancellationToken)
+    {
+        var dir = Path.GetFullPath(folder);
+        // The key prefix keeps a served map folder and an edited pano
+        // folder from colliding in the reuse table; the editor's URL is
+        // its base URL (the child prints "http://127.0.0.1:PORT/").
+        return LaunchAsync(
+            cliPath, "panoedit:" + dir,
+            ["panoedit", dir, "--no-browser", "--url-only",
+             "--exit-with-stdin"],
+            cancellationToken);
+    }
+
+    /// <summary>One child per <paramref name="key"/>: reuses a live one,
+    /// reaps a dead one, else spawns <paramref name="args"/> and reads the
+    /// URL contract. Returns the child's base URL (through the trailing
+    /// slash), or null when it could not start.</summary>
+    private async Task<string?> LaunchAsync(
+        string cliPath, string key, string[] args,
+        CancellationToken cancellationToken)
+    {
+        if (_running.TryGetValue(key, out var live))
         {
             if (!live.Process.HasExited)
             {
-                return live.BaseUrl + page;
+                return live.BaseUrl;
             }
             live.Process.Dispose();   // dead child: reap the handle too
-            _running.Remove(dir);
+            _running.Remove(key);
         }
 
         var psi = new ProcessStartInfo
@@ -59,9 +89,6 @@ public sealed class MapServer : IMapServer, IDisposable
             CreateNoWindow = true,
             StandardOutputEncoding = Encoding.UTF8,
         };
-        string[] args =
-            ["serve", dir, "--page", page, "--no-browser", "--url-only",
-             "--exit-with-stdin"];
         foreach (var a in args)
         {
             psi.ArgumentList.Add(a);
@@ -82,8 +109,9 @@ public sealed class MapServer : IMapServer, IDisposable
             process.Dispose();
             return null;
         }
-        _running[dir] = (process, url[..(url.LastIndexOf('/') + 1)]);
-        return url;
+        var baseUrl = url[..(url.LastIndexOf('/') + 1)];
+        _running[key] = (process, baseUrl);
+        return baseUrl;
     }
 
     private static async Task<string?> ReadUrlLineAsync(

--- a/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptions.cs
@@ -35,11 +35,15 @@ public sealed record PopupFields(
 /// Off produces a self-contained map with no local paths in it.</param>
 /// <param name="ExportAll">Also write KML + GeoJSON (<c>--format all</c>); the
 /// CLI format is single-valued, so this is one honest toggle, not per-format.</param>
+/// <param name="PanoViewThumbs">Popup thumbnails for tagged panoramas are
+/// square opening-view crops (<c>--pano-view-thumbs</c>, #441) instead of the
+/// full 2:1 strip. Off by default, matching the CLI.</param>
 public sealed record PhotoMapOptions(
     bool Recursive,
     string TileStyle,
     MapPrivacy Privacy,
     bool LinkOriginals,
+    bool PanoViewThumbs,
     PopupFields Popup,
     bool ExportAll,
     string Title,
@@ -50,6 +54,7 @@ public sealed record PhotoMapOptions(
         TileStyle: "osm",
         Privacy: MapPrivacy.Keep,
         LinkOriginals: true,
+        PanoViewThumbs: false,
         Popup: PopupFields.All,
         ExportAll: false,
         Title: "",

--- a/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/PhotoMapOptionsViewModel.cs
@@ -33,6 +33,9 @@ public partial class PhotoMapOptionsViewModel : ViewModelBase
     public partial bool LinkOriginals { get; set; } = true;
 
     [ObservableProperty]
+    public partial bool PanoViewThumbs { get; set; }
+
+    [ObservableProperty]
     public partial bool ShowName { get; set; } = true;
 
     [ObservableProperty]
@@ -85,6 +88,7 @@ public partial class PhotoMapOptionsViewModel : ViewModelBase
         TileStyle: SelectedTileStyle.Key,
         Privacy: SelectedPrivacy.Value,
         LinkOriginals: LinkOriginals,
+        PanoViewThumbs: PanoViewThumbs,
         Popup: new PopupFields(
             Name: ShowName,
             Timestamp: ShowTimestamp,

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
@@ -11,6 +11,7 @@ public enum WorkspaceModeKind
     Embed,
     Convert,
     Verify,
+    PanoEdit,
     Setup,
 }
 
@@ -52,6 +53,9 @@ public sealed record WorkspaceMode(
         new(WorkspaceModeKind.Verify, "Verify footage", "Check metadata",
             Sources: SourceKinds.Folder | SourceKinds.File,
             "Something went wrong while verifying the footage."),
+        new(WorkspaceModeKind.PanoEdit, "360° views", "Open view editor",
+            Sources: SourceKinds.Folder,
+            "The 360° view editor could not be started."),
         new(WorkspaceModeKind.Setup, "Setup", "Check my setup",
             Sources: SourceKinds.None,
             "The setup check could not be completed."),

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -229,6 +229,10 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// <summary>Whether the Verify options panel applies to the current mode.</summary>
     public bool IsVerifyMode => SelectedMode.Kind == WorkspaceModeKind.Verify;
 
+    /// <summary>The 360° view editor mode (#440) is selected.</summary>
+    public bool IsPanoEditMode =>
+        SelectedMode.Kind == WorkspaceModeKind.PanoEdit;
+
     /// <summary>Validate pairing needs a folder — a single file greys its
     /// segment out (the M4b enablement table).</summary>
     public bool VerifyValidateEnabled => SelectedFile is null;
@@ -353,6 +357,8 @@ public partial class WorkspaceViewModel : FlowViewModel
                     CommandBuilder.Verify(
                         SelectedFile ?? SelectedFolder ?? "<source>",
                         VerifyOptions.ToOptions()),
+                WorkspaceModeKind.PanoEdit =>
+                    CommandBuilder.PanoEdit(folder!),
                 _ => CommandBuilder.Build(SelectedMode.Kind, folder),
             };
             return CommandLine.Format("dji-embed", argv);
@@ -414,6 +420,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         OnPropertyChanged(nameof(IsEmbedMode));
         OnPropertyChanged(nameof(IsConvertMode));
         OnPropertyChanged(nameof(IsVerifyMode));
+        OnPropertyChanged(nameof(IsPanoEditMode));
         OnPropertyChanged(nameof(ActionVerb));
         RunCommand.NotifyCanExecuteChanged();
     }
@@ -754,6 +761,40 @@ public partial class WorkspaceViewModel : FlowViewModel
             await RunSetupAsync();
             return;
         }
+        if (mode.Kind == WorkspaceModeKind.PanoEdit
+            && SelectedFolder is { } panoFolder && SelectedFile is null)
+        {
+            // No runner child here: the editor IS the product, launched
+            // through the same stdin-lifeline contract as the serve
+            // preview and shown in the preview pane (#440).
+            ResetPreview();
+            await ExecuteFlowAsync(async () =>
+            {
+                var url = await _mapServer.GetEditorUrlAsync(
+                    CliPath!, panoFolder, FlowToken);
+                if (url is null)
+                {
+                    Fail("The 360° view editor could not be started — "
+                         + "check that the folder contains 360° panoramas "
+                         + "(equirectangular JPGs).");
+                    return false;
+                }
+                if (_previewAvailable())
+                {
+                    PreviewPath = panoFolder;  // path first: view reads it
+                    PreviewUrl = url;          // when the URL lands
+                }
+                else
+                {
+                    // No WebView2: the editor still works — in the
+                    // default browser (same open pattern as outputs).
+                    Process.Start(
+                        new ProcessStartInfo(url) { UseShellExecute = true });
+                }
+                return true;
+            });
+            return;
+        }
         // A file in the slot with a folder-only mode selected: say which folder
         // the mode wants instead of failing into the CLI's usage error (#346
         // discipline — reach-aware guidance in the panel's own language).
@@ -770,6 +811,9 @@ public partial class WorkspaceViewModel : FlowViewModel
                 WorkspaceModeKind.Embed =>
                     "Embed telemetry works on a folder of videos with their .SRT "
                     + "flight logs — pick that folder, not a single file.",
+                WorkspaceModeKind.PanoEdit =>
+                    "The 360° view editor works on a folder of panoramas — "
+                    + "pick the folder that holds them, not a single file.",
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode.Kind, null),
             });
             return;

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -488,6 +488,11 @@
                                               Content="Link pins to the original photos"
                                               ToolTip.Tip="Needed for the 360° panorama viewer. Off writes a map that stands alone." />
 
+                                    <CheckBox Name="PanoViewThumbsCheck"
+                                              IsChecked="{Binding PhotoOptions.PanoViewThumbs}"
+                                              Content="Square pano thumbnails (opening view)"
+                                              ToolTip.Tip="Popup thumbnails show each panorama's saved opening view instead of the full 2:1 strip. Set views with the 360° views mode." />
+
                                     <StackPanel Spacing="4">
                                         <TextBlock Text="Popup details" Opacity="0.7"
                                                    FontSize="12" />

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -906,6 +906,20 @@
                         </StackPanel>
                     </Border>
 
+                    <Border Name="PanoEditOptionsPanel"
+                            IsVisible="{Binding IsPanoEditMode}"
+                            IsEnabled="{Binding !IsBusy}">
+                        <StackPanel>
+                            <TextBlock Classes="zone" Text="OPTIONS" />
+                            <suki:GlassCard Padding="14">
+                                <TextBlock Name="PanoEditHint"
+                                           TextWrapping="Wrap" Opacity="0.7"
+                                           FontSize="12"
+                                           Text="Pick the folder with your 360° panoramas. Drag each one to its best opening view, then Save — the view is written into the photo itself (a backup is kept beside it) and the photo map opens it that way." />
+                            </suki:GlassCard>
+                        </StackPanel>
+                    </Border>
+
                     <TextBlock Classes="zone" Text="ACTION" />
                     <Button Name="RunButton" Classes="Flat"
                             HorizontalAlignment="Stretch"

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -46,6 +46,7 @@ from .geo import (
 )
 from .geo.airspace import fetch as airspace_fetch
 from .geo.panoedit import PanoEditError, run_editor
+from .geo.panorender import apply_view_thumbnails
 from .geo.airspace.overlay import zones_to_overlay_json
 from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
 from .geo.logfetch import LogFetchError, cache_path, fetch_log
@@ -652,6 +653,12 @@ def convert(
          "browsers block when the map is opened straight from disk. "
          "With -v, each HTTP request is logged.",
 )
+@click.option(
+    "--pano-view-thumbs", "pano_view_thumbs", is_flag=True,
+    help="Render square popup thumbnails at each panorama's saved opening "
+         "view (GPano initial-view tags; set them with 'dji-embed "
+         "panoedit'). Panoramas without a saved view keep the 2:1 strip.",
+)
 @_tile_style_option
 @_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
@@ -667,6 +674,7 @@ def photomap(
     popup_fields: str | None,
     redact: str,
     serve_map: bool,
+    pano_view_thumbs: bool,
     tile_style: str,
     progress_mode: str | None,
     verbose: bool,
@@ -752,6 +760,13 @@ def photomap(
             raise click.ClickException(
                 f"None of the {total} photos in {src} carry GPS coordinates"
             )
+        if pano_view_thumbs:
+            replaced = apply_view_thumbnails(points, src)
+            if replaced and not quiet:
+                click.echo(
+                    f"Rendered {replaced} opening-view thumbnail"
+                    f"{'s' if replaced != 1 else ''}"
+                )
         for name in skipped:
             progress.warning("No GPS data", item=name)
             if verbose:

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -1350,8 +1350,7 @@ def serve(
 
 
 @main.command()
-@click.argument("directory", type=click.Path(exists=True, file_okay=False,
-                                             path_type=Path))
+@click.argument("directory", type=click.Path(exists=True, file_okay=False))
 @click.option("-r", "--recursive", is_flag=True,
               help="Include panoramas in subfolders.")
 @click.option("--port", type=int, default=0, show_default="random",
@@ -1369,7 +1368,7 @@ def serve(
          "the app that started it.",
 )
 def panoedit(
-    directory: Path,
+    directory: str,
     recursive: bool,
     port: int,
     no_browser: bool,
@@ -1388,7 +1387,7 @@ def panoedit(
     """
     try:
         run_editor(
-            directory,
+            Path(directory),
             recursive=recursive,
             port=port,
             open_browser=not no_browser,

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -45,6 +45,7 @@ from .geo import (
     write_photos_kml,
 )
 from .geo.airspace import fetch as airspace_fetch
+from .geo.panoedit import PanoEditError, run_editor
 from .geo.airspace.overlay import zones_to_overlay_json
 from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
 from .geo.logfetch import LogFetchError, cache_path, fetch_log
@@ -205,6 +206,7 @@ def main(ctx: click.Context, log_json: bool) -> None:
       convert   Convert SRT telemetry to GPX or CSV formats
       flightmap Map every flight in a folder of SRT logs on one combined map
       photomap  Map GPS-tagged still photos to an HTML/KML/GeoJSON map
+      panoedit  Edit the opening view of 360° panoramas (drag, save, next)
       check     Analyze video files for embedded metadata
       doctor    Check system dependencies and configuration
     """
@@ -1330,6 +1332,56 @@ def serve(
         bare_url=url_only,
         stop_on_stdin_eof=exit_with_stdin,
     )
+
+
+@main.command()
+@click.argument("directory", type=click.Path(exists=True, file_okay=False,
+                                             path_type=Path))
+@click.option("-r", "--recursive", is_flag=True,
+              help="Include panoramas in subfolders.")
+@click.option("--port", type=int, default=0, show_default="random",
+              help="Local port to serve the editor on.")
+@click.option("--no-browser", is_flag=True,
+              help="Do not open the browser; just print the URL and serve.")
+@click.option(
+    "--url-only", is_flag=True,
+    help="Print the bare URL as the first output line — a stable contract "
+         "for wrapper apps that parse it.",
+)
+@click.option(
+    "--exit-with-stdin", is_flag=True,
+    help="Stop serving when stdin closes, tying the server's lifetime to "
+         "the app that started it.",
+)
+def panoedit(
+    directory: Path,
+    recursive: bool,
+    port: int,
+    no_browser: bool,
+    url_only: bool,
+    exit_with_stdin: bool,
+) -> None:
+    """Edit the opening view of 360° panoramas in DIRECTORY (#440).
+
+    Opens a local editor (http://127.0.0.1, loopback only): drag and zoom
+    each panorama to the view it should open with, then Save writes the
+    GPano initial-view tags (InitialViewHeadingDegrees / Pitch /
+    InitialHorizontalFOVDegrees) into the file via ExifTool and advances
+    to the next one. Each original is kept beside the file as
+    ``<name>_original``. The photomap 360° viewer and Google Photos both
+    honor the saved view.
+    """
+    try:
+        run_editor(
+            directory,
+            recursive=recursive,
+            port=port,
+            open_browser=not no_browser,
+            bare_url=url_only,
+            stop_on_stdin_eof=exit_with_stdin,
+        )
+    except PanoEditError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 @main.command(hidden=True)

--- a/src/dji_metadata_embedder/geo/panoedit.py
+++ b/src/dji_metadata_embedder/geo/panoedit.py
@@ -1,0 +1,173 @@
+"""Interactive opening-view editor for GPano panoramas (#440).
+
+Scans a folder for equirectangular panoramas, serves a localhost Pannellum
+editor page, and writes the composed view back as the three GPano
+initial-view tags via ExifTool (default ``_original`` backup kept). The
+compass heading written is ``PoseHeadingDegrees + viewer yaw`` — the exact
+inverse of the read-side mapping in :func:`.photomap._pano_view`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..utils.exiftool import exiftool_exe
+from .photomap import _maybe_float, _pano_view
+
+_EXIFTOOL_INSTALL_HINT = (
+    "ExifTool not found. Run: dji-embed doctor --install exiftool "
+    "(downloads a pinned, checksum-verified copy; no admin rights needed). "
+    "Alternatively install it from https://exiftool.org or set "
+    "DJIEMBED_EXIFTOOL_PATH to the executable."
+)
+
+# The read half of the editor: pose anchors compass headings to the image
+# frame; the three InitialView* tags are what Save writes back.
+_SCAN_TAGS = [
+    "-XMP-GPano:ProjectionType",
+    "-XMP-GPano:PoseHeadingDegrees",
+    "-XMP-GPano:InitialViewHeadingDegrees",
+    "-XMP-GPano:InitialViewPitchDegrees",
+    "-XMP-GPano:InitialHorizontalFOVDegrees",
+]
+_PANO_EXTS = ("jpg", "jpeg")
+
+
+class PanoEditError(Exception):
+    """A panoedit failure with a user-facing message."""
+
+
+@dataclass
+class PanoFile:
+    """One editable panorama: absolute path, display name, pose heading
+    (0.0 when the stitcher wrote none), and the current viewer-ready
+    initial view (``None`` where tags are absent)."""
+
+    path: Path
+    name: str
+    pose: float
+    yaw: float | None
+    pitch: float | None
+    hfov: float | None
+
+
+def compass_heading(pose: float, yaw: float) -> float:
+    """Viewer yaw -> the compass ``InitialViewHeadingDegrees`` to write."""
+    return (pose + yaw) % 360.0
+
+
+def _run_scan(directory: Path, recursive: bool) -> list[dict]:
+    args = [exiftool_exe(), "-json", "-n"]
+    if recursive:
+        args.append("-r")
+    args += _SCAN_TAGS
+    for ext in _PANO_EXTS:
+        args += ["-ext", ext]
+    args.append(str(directory))
+    try:
+        proc = subprocess.run(
+            args, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+        )
+    except FileNotFoundError:
+        raise PanoEditError(_EXIFTOOL_INSTALL_HINT) from None
+    out = proc.stdout.strip()
+    if not out:
+        if proc.returncode != 0:
+            stderr = proc.stderr.strip()[-300:]
+            raise PanoEditError(
+                f"ExifTool scan of {directory} failed "
+                f"(exit {proc.returncode}): {stderr or 'no error output'}"
+            )
+        return []
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise PanoEditError(f"Could not parse ExifTool JSON: {exc}") from exc
+    if not isinstance(data, list):
+        raise PanoEditError("Unexpected ExifTool JSON shape (expected a list)")
+    return data
+
+
+def scan_panos(directory: Path, recursive: bool = False) -> list[PanoFile]:
+    """Scan *directory* and return its equirectangular panoramas, sorted.
+
+    Raises :class:`PanoEditError` when the folder holds no panoramas — the
+    editor has nothing to edit, and a blank page would look like a bug.
+    """
+    entries = _run_scan(directory, recursive)
+    files: list[PanoFile] = []
+    for entry in entries:
+        proj = entry.get("ProjectionType")
+        if not (isinstance(proj, str)
+                and proj.strip().lower() == "equirectangular"):
+            continue
+        path = Path(str(entry.get("SourceFile", "?")))
+        yaw, pitch, hfov = _pano_view(entry)
+        files.append(PanoFile(
+            path=path,
+            name=path.name,
+            pose=_maybe_float(entry.get("PoseHeadingDegrees")) or 0.0,
+            yaw=yaw, pitch=pitch, hfov=hfov,
+        ))
+    if not files:
+        raise PanoEditError(
+            f"No 360-degree panoramas found in {directory} "
+            f"({len(entries)} JPEGs scanned; a panorama carries "
+            "XMP-GPano:ProjectionType=equirectangular)"
+        )
+    files.sort(key=lambda f: f.name)
+    return files
+
+
+def write_initial_view(
+    path: Path, heading: float, pitch: float, hfov: float
+) -> dict:
+    """Write the three initial-view tags to *path* and read them back.
+
+    ExifTool's default sidecar backup (``<name>_original``) is deliberately
+    kept — batch editing must never be able to destroy an original. The
+    read-back is the write verification: what the map will see is what the
+    caller gets.
+    """
+    exe = exiftool_exe()
+    write_args = [
+        exe, "-n",
+        f"-XMP-GPano:InitialViewHeadingDegrees={heading}",
+        f"-XMP-GPano:InitialViewPitchDegrees={pitch}",
+        f"-XMP-GPano:InitialHorizontalFOVDegrees={hfov}",
+        str(path),
+    ]
+    try:
+        proc = subprocess.run(
+            write_args, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+        )
+    except FileNotFoundError:
+        raise PanoEditError(_EXIFTOOL_INSTALL_HINT) from None
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()[-300:]
+        raise PanoEditError(
+            f"ExifTool could not write {path.name}: "
+            f"{stderr or 'no error output'}"
+        )
+    read_args = [exe, "-json", "-n", *_SCAN_TAGS[1:], str(path)]
+    proc = subprocess.run(
+        read_args, capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    )
+    try:
+        entry = json.loads(proc.stdout)[0]
+    except (json.JSONDecodeError, IndexError) as exc:
+        raise PanoEditError(
+            f"Could not verify the write to {path.name}: {exc}"
+        ) from exc
+    return {
+        "heading": _maybe_float(entry.get("InitialViewHeadingDegrees")),
+        "pitch": _maybe_float(entry.get("InitialViewPitchDegrees")),
+        "hfov": _maybe_float(entry.get("InitialHorizontalFOVDegrees")),
+        "pose": _maybe_float(entry.get("PoseHeadingDegrees")) or 0.0,
+    }

--- a/src/dji_metadata_embedder/geo/panoedit.py
+++ b/src/dji_metadata_embedder/geo/panoedit.py
@@ -9,13 +9,24 @@ inverse of the read-side mapping in :func:`.photomap._pano_view`.
 
 from __future__ import annotations
 
+import hmac
 import json
+import re
+import secrets
 import subprocess
+import sys
+import threading
+import webbrowser
 from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import ThreadingHTTPServer
 from pathlib import Path
+
+import click
 
 from ..utils.exiftool import exiftool_exe
 from .photomap import _maybe_float, _pano_view
+from .serve import _MapServer, _RangeHandler, _shutdown_on_stdin_eof
 
 _EXIFTOOL_INSTALL_HINT = (
     "ExifTool not found. Run: dji-embed doctor --install exiftool "
@@ -171,3 +182,190 @@ def write_initial_view(
         "hfov": _maybe_float(entry.get("InitialHorizontalFOVDegrees")),
         "pose": _maybe_float(entry.get("PoseHeadingDegrees")) or 0.0,
     }
+
+
+# Server ---------------------------------------------------------------
+
+_IMG_RE = re.compile(r"^/img/(\d+)$")
+
+# Cap on the /api/save request body: a heading/pitch/hfov triple plus the
+# token never comes close, so anything larger is not this page talking.
+_MAX_SAVE_BODY = 4096
+
+
+def _view_payload(f: PanoFile, index: int) -> dict:
+    return {
+        "index": index, "name": f.name, "pose": f.pose,
+        "yaw": f.yaw, "pitch": f.pitch, "hfov": f.hfov,
+        "hasView": f.yaw is not None,
+    }
+
+
+class _EditorHandler(_RangeHandler):
+    """Routes: the editor page, the JSON API, and ranged pano images.
+
+    Images are addressed by index into the scanned list — the client can
+    never name a path. POSTs require the per-session token: pages on other
+    origins can reach 127.0.0.1, the token is what stops them writing.
+    """
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+    def do_GET(self) -> None:
+        path = self.path.split("?", 1)[0]
+        if path == "/":
+            body = self.server.pano_page          # type: ignore[attr-defined]
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/api/list":
+            files = self.server.pano_files        # type: ignore[attr-defined]
+            self._send_json(HTTPStatus.OK, [
+                _view_payload(f, i) for i, f in enumerate(files)
+            ])
+            return
+        if _IMG_RE.match(path):
+            super().do_GET()          # ranged serving via translate_path
+            return
+        self.send_error(HTTPStatus.NOT_FOUND)
+
+    def translate_path(self, path: str) -> str:
+        # Only /img/<index> resolves to a real file. Anything else maps to
+        # a file that cannot exist, so the base handler's open() raises
+        # FileNotFoundError and answers 404. (Not a NUL-byte sentinel:
+        # open("\0...") raises ValueError, which SimpleHTTPRequestHandler
+        # does not catch.)
+        m = _IMG_RE.match(path.split("?", 1)[0])
+        if m:
+            files = self.server.pano_files        # type: ignore[attr-defined]
+            i = int(m.group(1))
+            if i < len(files):
+                return str(files[i].path)
+        return str(Path(self.directory) / ".panoedit-404-not-a-real-file")
+
+    def do_POST(self) -> None:
+        if self.path.split("?", 1)[0] != "/api/save":
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            length = 0
+        if not 0 < length <= _MAX_SAVE_BODY:
+            self._send_json(HTTPStatus.BAD_REQUEST,
+                            {"error": "bad request body"})
+            return
+        try:
+            payload = json.loads(self.rfile.read(length))
+        except json.JSONDecodeError:
+            self._send_json(HTTPStatus.BAD_REQUEST,
+                            {"error": "invalid JSON"})
+            return
+        token = self.server.pano_token            # type: ignore[attr-defined]
+        sent = payload.get("token")
+        if not (isinstance(sent, str)
+                and hmac.compare_digest(sent, token)):
+            self._send_json(HTTPStatus.FORBIDDEN, {"error": "bad token"})
+            return
+        files = self.server.pano_files            # type: ignore[attr-defined]
+        index = payload.get("index")
+        heading = _maybe_float(payload.get("heading"))
+        pitch = _maybe_float(payload.get("pitch"))
+        hfov = _maybe_float(payload.get("hfov"))
+        if (not isinstance(index, int) or not 0 <= index < len(files)
+                or heading is None or pitch is None or hfov is None
+                or not -90.0 <= pitch <= 90.0
+                or not 10.0 <= hfov <= 170.0):
+            self._send_json(HTTPStatus.BAD_REQUEST,
+                            {"error": "invalid index or view values"})
+            return
+        heading %= 360.0
+        f = files[index]
+        try:
+            with self.server.pano_lock:           # type: ignore[attr-defined]
+                verified = write_initial_view(f.path, heading, pitch, hfov)
+        except PanoEditError as exc:
+            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR,
+                            {"error": str(exc)})
+            return
+        # The verified read is the new truth for /api/list and the client.
+        f.pose = verified["pose"]
+        f.yaw, f.pitch, f.hfov = _pano_view({
+            "InitialViewHeadingDegrees": verified["heading"],
+            "PoseHeadingDegrees": verified["pose"],
+            "InitialViewPitchDegrees": verified["pitch"],
+            "InitialHorizontalFOVDegrees": verified["hfov"],
+        })
+        self._send_json(HTTPStatus.OK, {**verified,
+                                        **_view_payload(f, index)})
+
+    def _send_json(self, status: HTTPStatus, obj: object) -> None:
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def make_editor_server(
+    directory: Path, *, recursive: bool = False, port: int = 0
+) -> tuple[ThreadingHTTPServer, str]:
+    """Scan *directory* and return a ready (server, url) pair.
+
+    Binds 127.0.0.1 only. Raises :class:`PanoEditError` when the folder
+    holds no panoramas (see :func:`scan_panos`).
+    """
+    from functools import partial
+
+    from .panoedit_html import build_editor_page
+
+    files = scan_panos(directory, recursive=recursive)
+    token = secrets.token_urlsafe(32)
+    handler = partial(_EditorHandler, directory=str(directory))
+    server = _MapServer(("127.0.0.1", port), handler)
+    server.daemon_threads = True
+    server.pano_files = files                     # type: ignore[attr-defined]
+    server.pano_token = token                     # type: ignore[attr-defined]
+    server.pano_lock = threading.Lock()           # type: ignore[attr-defined]
+    server.pano_page = build_editor_page(token).encode(  # type: ignore[attr-defined]
+        "utf-8")
+    url = f"http://127.0.0.1:{server.server_address[1]}/"
+    return server, url
+
+
+def run_editor(
+    directory: Path,
+    *,
+    recursive: bool = False,
+    port: int = 0,
+    open_browser: bool = True,
+    bare_url: bool = False,
+    stop_on_stdin_eof: bool = False,
+) -> None:
+    """Serve the editor until Ctrl+C (same contract as ``serve_directory``)."""
+    server, url = make_editor_server(directory, recursive=recursive, port=port)
+    with server:
+        if bare_url:
+            click.echo(url)
+            sys.stdout.flush()
+        else:
+            n = len(server.pano_files)            # type: ignore[attr-defined]
+            click.echo(
+                f"Editing {n} panorama{'s' if n != 1 else ''} at {url} "
+                "— press Ctrl+C to stop"
+            )
+        if open_browser:
+            webbrowser.open(url)
+        if stop_on_stdin_eof:
+            threading.Thread(
+                target=_shutdown_on_stdin_eof, args=(server,), daemon=True
+            ).start()
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            pass

--- a/src/dji_metadata_embedder/geo/panoedit_html.py
+++ b/src/dji_metadata_embedder/geo/panoedit_html.py
@@ -1,7 +1,201 @@
-"""Editor page for panoedit (#440). Stub — full page lands with the
-editor-page task."""
+"""Editor page for panoedit (#440): Pannellum viewer + live GPano readout
++ save/auto-advance. Served by :mod:`.panoedit`; no build step, hand-rolled
+JS like the other geo HTML modules. The Pannellum pin/SRI is imported from
+photomap_html so the two viewers can never drift apart."""
+
 from __future__ import annotations
+
+import json
+
+from .photomap_html import (
+    _PANNELLUM_CSS_SRI,
+    _PANNELLUM_JS_SRI,
+    _PANNELLUM_VERSION,
+)
+
+_PAGE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>360° view editor</title>
+<link rel="stylesheet"
+      href="https://unpkg.com/pannellum@{pannellum}/build/pannellum.css"
+      integrity="{pannellum_css_sri}" crossorigin="" />
+<style>
+  html, body {{ margin: 0; height: 100%; background: #111; color: #eee;
+    font: 14px system-ui, sans-serif; }}
+  #viewer {{ position: fixed; inset: 0 0 96px 0; }}
+  #readout {{ position: fixed; top: 12px; left: 12px; z-index: 10;
+    background: rgba(0,0,0,.65); padding: 8px 12px; border-radius: 6px;
+    font-variant-numeric: tabular-nums; line-height: 1.5; }}
+  #readout b {{ color: #ffd24d; }}
+  #savebar {{ position: fixed; top: 12px; right: 12px; z-index: 10;
+    text-align: right; }}
+  #save {{ font: inherit; padding: 8px 18px; border: 0; border-radius: 6px;
+    background: #2a81cb; color: #fff; cursor: pointer; }}
+  #save:disabled {{ background: #555; cursor: default; }}
+  #status {{ margin-top: 6px; min-height: 1.2em; }}
+  #status.err {{ color: #ff7b6b; }}
+  #strip {{ position: fixed; left: 0; right: 0; bottom: 0; height: 96px;
+    background: #1b1b1b; display: flex; align-items: center; gap: 6px;
+    overflow-x: auto; padding: 0 12px; box-sizing: border-box; }}
+  .chip {{ flex: 0 0 auto; padding: 6px 10px; border-radius: 5px;
+    background: #2a2a2a; cursor: pointer; white-space: nowrap; }}
+  .chip.active {{ outline: 2px solid #2a81cb; }}
+  .chip .dot {{ display: inline-block; width: 8px; height: 8px;
+    border-radius: 50%; background: #666; margin-right: 6px; }}
+  .chip.hasview .dot {{ background: #5ec26a; }}
+  #counter {{ position: fixed; right: 12px; bottom: 104px; z-index: 10;
+    color: #aaa; }}
+  #note {{ position: fixed; left: 12px; bottom: 104px; z-index: 10;
+    color: #888; font-size: 12px; }}
+</style>
+</head>
+<body>
+<div id="viewer"></div>
+<div id="readout">loading…</div>
+<div id="savebar">
+  <button id="save" type="button">Save view (Enter)</button>
+  <div id="status"></div>
+</div>
+<div id="counter"></div>
+<div id="note">Saving keeps a backup of each original beside it
+(<code>*_original</code>). N/P: next/previous.</div>
+<div id="strip"></div>
+<script src="https://unpkg.com/pannellum@{pannellum}/build/pannellum.js"
+        integrity="{pannellum_js_sri}" crossorigin=""></script>
+<script>
+"use strict";
+const TOKEN = {token};
+let files = [], idx = 0, viewer = null, saving = false;
+window.__panoReady = false;
+const $ = (id) => document.getElementById(id);
+
+function norm360(d) {{ return ((d % 360) + 360) % 360; }}
+
+function currentView() {{
+  const f = files[idx];
+  return {{
+    heading: norm360(f.pose + viewer.getYaw()),
+    pitch: Math.max(-90, Math.min(90, viewer.getPitch())),
+    hfov: Math.max(10, Math.min(170, viewer.getHfov())),
+  }};
+}}
+
+function renderStrip() {{
+  const strip = $("strip");
+  strip.textContent = "";
+  files.forEach((f, i) => {{
+    const chip = document.createElement("div");
+    chip.className = "chip" + (i === idx ? " active" : "")
+      + (f.hasView ? " hasview" : "");
+    const dot = document.createElement("span");
+    dot.className = "dot";
+    chip.appendChild(dot);
+    chip.appendChild(document.createTextNode(f.name));
+    chip.addEventListener("click", () => open(i));
+    strip.appendChild(chip);
+  }});
+  $("counter").textContent = (idx + 1) + " / " + files.length;
+}}
+
+function open(i) {{
+  idx = i;
+  window.__panoReady = false;
+  if (viewer) {{ viewer.destroy(); viewer = null; }}
+  const f = files[i];
+  const cfg = {{ type: "equirectangular", panorama: "/img/" + f.index,
+    autoLoad: true, minHfov: 10, maxHfov: 170, showFullscreenCtrl: false }};
+  if (f.yaw !== null) cfg.yaw = f.yaw;
+  if (f.pitch !== null) cfg.pitch = f.pitch;
+  if (f.hfov !== null) cfg.hfov = f.hfov;
+  viewer = pannellum.viewer("viewer", cfg);
+  window.__viewer = viewer;
+  viewer.on("load", () => {{ window.__panoReady = true; }});
+  $("status").textContent = "";
+  renderStrip();
+}}
+
+function readoutLoop() {{
+  if (viewer && files.length) {{
+    const v = currentView();
+    $("readout").innerHTML =
+      "<b>" + files[idx].name.replace(/[<>&]/g, "") + "</b><br>" +
+      "Heading " + v.heading.toFixed(1) + "° · " +
+      "Pitch " + v.pitch.toFixed(1) + "° · " +
+      "FOV " + v.hfov.toFixed(1) + "°";
+  }}
+  requestAnimationFrame(readoutLoop);
+}}
+
+async function save() {{
+  if (saving || !viewer) return;
+  saving = true;
+  $("save").disabled = true;
+  const status = $("status");
+  status.className = "";
+  status.textContent = "Saving…";
+  const v = currentView();
+  try {{
+    const resp = await fetch("/api/save", {{
+      method: "POST",
+      headers: {{ "Content-Type": "application/json" }},
+      body: JSON.stringify({{ index: files[idx].index, token: TOKEN,
+        heading: v.heading, pitch: v.pitch, hfov: v.hfov }}),
+    }});
+    const body = await resp.json();
+    if (!resp.ok) throw new Error(body.error || ("HTTP " + resp.status));
+    Object.assign(files[idx], body);
+    status.textContent = "Saved ✓";
+    if (idx + 1 < files.length) {{
+      open(idx + 1);
+      $("status").textContent = "Saved ✓";
+    }} else {{
+      renderStrip();
+      status.textContent = "Saved ✓ — all panoramas done";
+    }}
+  }} catch (e) {{
+    status.className = "err";
+    status.textContent = "Save failed: " + e.message;
+  }} finally {{
+    saving = false;
+    $("save").disabled = false;
+  }}
+}}
+
+$("save").addEventListener("click", save);
+document.addEventListener("keydown", (e) => {{
+  if (e.key === "Enter") {{ e.preventDefault(); save(); }}
+  else if (e.key === "n" || e.key === "N") {{
+    if (idx + 1 < files.length) open(idx + 1);
+  }} else if (e.key === "p" || e.key === "P") {{
+    if (idx > 0) open(idx - 1);
+  }}
+}});
+
+fetch("/api/list").then((r) => r.json()).then((list) => {{
+  files = list;
+  open(0);
+  readoutLoop();
+}});
+</script>
+</body>
+</html>
+"""
 
 
 def build_editor_page(token: str) -> str:
-    return "<!DOCTYPE html><title>panoedit</title>"
+    """The complete editor page with *token* embedded.
+
+    ``json.dumps`` alone leaves ``<`` intact, so a hostile token could
+    close the script tag; ``\\u003c`` keeps the JS value identical while
+    making breakout impossible. Real tokens are ``token_urlsafe`` output,
+    but the page must be safe by construction, not by caller convention.
+    """
+    return _PAGE.format(
+        pannellum=_PANNELLUM_VERSION,
+        pannellum_css_sri=_PANNELLUM_CSS_SRI,
+        pannellum_js_sri=_PANNELLUM_JS_SRI,
+        token=json.dumps(token).replace("<", "\\u003c"),
+    )

--- a/src/dji_metadata_embedder/geo/panoedit_html.py
+++ b/src/dji_metadata_embedder/geo/panoedit_html.py
@@ -1,0 +1,7 @@
+"""Editor page for panoedit (#440). Stub — full page lands with the
+editor-page task."""
+from __future__ import annotations
+
+
+def build_editor_page(token: str) -> str:
+    return "<!DOCTYPE html><title>panoedit</title>"

--- a/src/dji_metadata_embedder/geo/panorender.py
+++ b/src/dji_metadata_embedder/geo/panorender.py
@@ -1,0 +1,107 @@
+"""Square perspective crops of equirectangular panoramas at their GPano
+opening view (#441). Pure Pillow, per-pixel inverse mapping.
+
+Per-pixel (not Pillow's MESH transform) is a measured decision: mesh quads
+interpolate source coordinates linearly, which breaks across the equirect
+longitude seam and near the poles — and nadir opening views are common for
+drone panos. A 320x320 crop costs ~0.07 s in pure Python; JPEG decode of
+the source dominates the runtime either way."""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+from math import asin, atan2, cos, pi, radians, sin, sqrt, tan
+from pathlib import Path
+
+from PIL import Image
+
+from .photomap import PhotoPoint
+
+logger = logging.getLogger(__name__)
+
+# The source is downscaled to this width before sampling: a 320 px crop of
+# a <=170 degree view never needs more than ~2x that angular resolution,
+# and Image.draft lets JPEG decode skip DCT blocks entirely.
+_MAX_SRC_WIDTH = 2048
+
+
+def render_view(
+    path: Path,
+    yaw_deg: float,
+    pitch_deg: float = 0.0,
+    hfov_deg: float = 90.0,
+    size: int = 320,
+) -> bytes | None:
+    """JPEG bytes of a size x size perspective crop, or None on failure.
+
+    ``yaw_deg`` is viewer yaw relative to the image center (photomap's
+    ``pano_yaw``), so no pose handling is needed here — the equirect's own
+    frame is the reference. Pitch/hfov are clamped to the same physical
+    ranges the viewer enforces.
+    """
+    try:
+        with Image.open(path) as im:
+            im.draft("RGB", (_MAX_SRC_WIDTH, _MAX_SRC_WIDTH // 2))
+            src = im.convert("RGB")
+        if src.width > _MAX_SRC_WIDTH:
+            src.thumbnail((_MAX_SRC_WIDTH, _MAX_SRC_WIDTH))
+        W, H = src.size
+        if W < 2 or H < 2 or size < 1:
+            return None
+        px = src.load()
+        yaw = radians(yaw_deg)
+        p = radians(max(-90.0, min(90.0, pitch_deg)))
+        hfov = radians(max(10.0, min(170.0, hfov_deg)))
+        f = (size / 2.0) / tan(hfov / 2.0)
+        cp, sp = cos(p), sin(p)
+        out = Image.new("RGB", (size, size))
+        opx = out.load()
+        half = size / 2.0
+        two_pi = 2.0 * pi
+        for j in range(size):
+            v = half - (j + 0.5)
+            # Pitch rotates the ray about the x-axis; +pitch looks up.
+            # y/z depend only on the row, so they hoist out of the column
+            # loop — that hoist is what makes pure Python fast enough.
+            y = v * cp + f * sp
+            z = f * cp - v * sp
+            for i in range(size):
+                u = (i + 0.5) - half
+                lon = atan2(u, z) + yaw
+                lat = asin(y / sqrt(u * u + y * y + z * z))
+                sx = int(((lon / two_pi + 0.5) % 1.0) * W)
+                sy = int((0.5 - lat / pi) * H)
+                opx[i, j] = px[min(sx, W - 1), min(max(sy, 0), H - 1)]
+        buf = io.BytesIO()
+        out.save(buf, "JPEG", quality=85)
+        return buf.getvalue()
+    except Exception:
+        # Degrade presentation, never lose the popup: the caller keeps
+        # the 2:1 strip thumbnail for this pano.
+        logger.debug("opening-view render failed for %s", path, exc_info=True)
+        return None
+
+
+def apply_view_thumbnails(points: list[PhotoPoint], root: Path) -> int:
+    """Swap tagged panos' popup thumbnails for opening-view crops, in place.
+
+    Only panoramas with a saved heading qualify (missing pitch/hfov fall
+    back to level/90 degrees, same as the viewer). Returns how many were
+    replaced; failures silently keep the 2:1 strip."""
+    count = 0
+    for point in points:
+        if not (point.is_pano and point.pano_yaw is not None):
+            continue
+        data = render_view(
+            root / point.name,
+            point.pano_yaw,
+            point.pano_pitch if point.pano_pitch is not None else 0.0,
+            point.pano_hfov if point.pano_hfov is not None else 90.0,
+        )
+        if data is not None:
+            point.thumbnail_b64 = base64.b64encode(data).decode("ascii")
+            point.thumb_is_view = True
+            count += 1
+    return count

--- a/src/dji_metadata_embedder/geo/panorender.py
+++ b/src/dji_metadata_embedder/geo/panorender.py
@@ -51,6 +51,8 @@ def render_view(
         if W < 2 or H < 2 or size < 1:
             return None
         px = src.load()
+        if px is None:
+            return None
         yaw = radians(yaw_deg)
         p = radians(max(-90.0, min(90.0, pitch_deg)))
         hfov = radians(max(10.0, min(170.0, hfov_deg)))
@@ -58,6 +60,8 @@ def render_view(
         cp, sp = cos(p), sin(p)
         out = Image.new("RGB", (size, size))
         opx = out.load()
+        if opx is None:
+            return None
         half = size / 2.0
         two_pi = 2.0 * pi
         for j in range(size):

--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -107,6 +107,9 @@ class PhotoPoint:
     pano_pitch: float | None = None
     pano_hfov: float | None = None
     credit: str | None = None
+    # True when thumbnail_b64 is an opening-view crop (#441), not the
+    # EXIF strip — popups label the two honestly.
+    thumb_is_view: bool = False
 
 
 def _display_datetime(value: object) -> str | None:

--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -419,6 +419,8 @@ def photos_to_geojson(
             props["credit"] = p.credit
         if include_thumbnails and p.thumbnail_b64:
             props["thumb"] = p.thumbnail_b64
+            if p.thumb_is_view:
+                props["vthumb"] = True
         features.append(
             {
                 "type": "Feature",

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -45,7 +45,8 @@ _PANNELLUM_JS_SRI = "sha256-oosvezOf0KYCxnad8dymrUOvc7yMalvmcglxUonBKpo="
 # not leak in its source what it hides in its UI. thumb/link/pano always
 # survive (the thumbnail is the photo itself, the link powers the 360°
 # viewer, and pano is marker-type metadata), as do the pano initial-view
-# props (yaw/pitch/hfov, #309 — view configuration, not personal data).
+# props (yaw/pitch/hfov, #309 — view configuration, not personal data) and
+# vthumb (#441 — marks the thumb as an opening-view crop, same category).
 POPUP_FIELDS = ("name", "timestamp", "camera", "altitude", "credit")
 _FIELD_TO_PROP = {
     "name": "name",
@@ -304,7 +305,12 @@ function buildPopup(f) {
   const p = f.properties || {};
   let inner = '';
   if (p.thumb) {
-    inner += `<img src="data:image/jpeg;base64,${esc(p.thumb)}" alt="">`;
+    // Honest thumbnails (#441): a square opening-view crop and the full
+    // 2:1 strip look nothing alike — the title says which one this is.
+    const kind = p.vthumb ? 'Opening view of the panorama'
+      : (p.pano ? 'Full 360° panorama' : '');
+    inner += `<img src="data:image/jpeg;base64,${esc(p.thumb)}" alt=""` +
+      (kind ? ` title="${kind}"` : '') + `>`;
   }
   // Every text line is presence-guarded: --popup-fields (issue #296) strips
   // properties from the embedded data, so nothing here may assume one exists.

--- a/tests/browser/test_panoedit_editor.py
+++ b/tests/browser/test_panoedit_editor.py
@@ -1,0 +1,110 @@
+"""End-to-end editor test: a real panoedit server, real exiftool writes,
+headless Chromium driving the page. Waits are on renderedness
+(window.__panoReady), never on element existence."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import threading
+
+import pytest
+
+pytest.importorskip("playwright")
+from PIL import Image  # noqa: E402
+
+from dji_metadata_embedder.geo import panoedit as pe  # noqa: E402
+from dji_metadata_embedder.geo.panoedit_html import build_editor_page  # noqa: E402
+
+from .conftest import _ASSET_RE, _fetch_asset  # noqa: E402
+
+needs_exiftool = pytest.mark.skipif(
+    shutil.which("exiftool") is None, reason="ExifTool not installed")
+
+
+def _make_pano(path, pose: float) -> None:
+    im = Image.new("RGB", (256, 128), (30, 60, 200))
+    for x in range(128, 256):
+        for y in range(128):
+            im.putpixel((x, y), (200, 60, 30))
+    im.save(path, "JPEG")
+    subprocess.run(
+        ["exiftool", "-overwrite_original",
+         "-XMP-GPano:ProjectionType=equirectangular",
+         f"-XMP-GPano:PoseHeadingDegrees={pose}", str(path)],
+        check=True, capture_output=True)
+
+
+@pytest.fixture
+def editor(tmp_path, page, monkeypatch):
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    _make_pano(tmp_path / "a.jpg", pose=90.0)
+    _make_pano(tmp_path / "b.jpg", pose=0.0)
+    httpd, url = pe.make_editor_server(tmp_path)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    assets = {u: _fetch_asset(u, sri)
+              for u, sri in _ASSET_RE.findall(build_editor_page("x"))}
+
+    def route(r):
+        u = r.request.url
+        if u.startswith("http://127.0.0.1"):
+            return r.continue_()
+        if u in assets:
+            ctype = ("text/css" if u.endswith(".css")
+                     else "application/javascript")
+            return r.fulfill(path=str(assets[u]), content_type=ctype)
+        return r.abort()
+
+    page.route("**/*", route)
+    yield url, tmp_path
+    httpd.shutdown()
+
+
+@needs_exiftool
+def test_edit_save_advance_and_reopen(editor, page):
+    url, folder = editor
+    page.goto(url)
+    page.wait_for_function("window.__panoReady === true")
+    assert "a.jpg" in page.inner_text("#readout")
+    # Pose 90 + yaw 0 => the readout heading starts at 90.
+    assert "Heading 90.0" in page.inner_text("#readout")
+
+    # Drag the sphere: readout heading must move off 90.
+    box = page.locator("#viewer").bounding_box()
+    cx, cy = box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
+    page.mouse.move(cx, cy)
+    page.mouse.down()
+    page.mouse.move(cx - 200, cy, steps=10)
+    page.mouse.up()
+    page.wait_for_function(
+        "!document.querySelector('#readout').innerText.includes"
+        "('Heading 90.0')")
+    heading_line = page.inner_text("#readout")
+
+    with page.expect_response("**/api/save") as resp_info:
+        page.click("#save")
+    assert resp_info.value.status == 200
+
+    # Auto-advance to b.jpg, and the tags landed on disk for a.jpg.
+    page.wait_for_function(
+        "document.querySelector('#readout').innerText.includes('b.jpg')")
+    out = subprocess.run(
+        ["exiftool", "-json", "-n",
+         "-XMP-GPano:InitialViewHeadingDegrees",
+         "-XMP-GPano:InitialHorizontalFOVDegrees",
+         str(folder / "a.jpg")],
+        check=True, capture_output=True, text=True).stdout
+    assert "InitialViewHeadingDegrees" in out
+    assert "InitialHorizontalFOVDegrees" in out
+    assert (folder / "a.jpg_original").exists()   # backup kept
+
+    # Reload: a.jpg reopens at the saved heading (round-trip through
+    # _pano_view on the server side). Compare as floats: the value
+    # survives a float -> exiftool -> float round trip.
+    page.goto(url)
+    page.wait_for_function("window.__panoReady === true")
+    saved = float(heading_line.split("Heading ")[1].split("°")[0])
+    shown = float(
+        page.inner_text("#readout").split("Heading ")[1].split("°")[0])
+    assert shown == pytest.approx(saved, abs=0.2)

--- a/tests/test_cli_panoedit.py
+++ b/tests/test_cli_panoedit.py
@@ -1,0 +1,41 @@
+"""CLI wiring tests for `dji-embed panoedit` (run_editor is monkeypatched:
+the server itself is covered by tests/test_geo_panoedit_server.py)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from dji_metadata_embedder import cli as cli_mod
+from dji_metadata_embedder.geo.panoedit import PanoEditError
+
+
+def test_panoedit_forwards_options(monkeypatch, tmp_path):
+    calls = {}
+
+    def fake_run(directory, **kwargs):
+        calls["directory"] = directory
+        calls.update(kwargs)
+    monkeypatch.setattr(cli_mod, "run_editor", fake_run)
+    result = CliRunner().invoke(cli_mod.main, [
+        "panoedit", str(tmp_path), "--recursive", "--no-browser",
+        "--url-only", "--exit-with-stdin", "--port", "7777"])
+    assert result.exit_code == 0, result.output
+    assert calls == {
+        "directory": Path(tmp_path), "recursive": True, "port": 7777,
+        "open_browser": False, "bare_url": True, "stop_on_stdin_eof": True}
+
+
+def test_panoedit_error_is_clean(monkeypatch, tmp_path):
+    def fake_run(directory, **kwargs):
+        raise PanoEditError("No 360-degree panoramas found")
+    monkeypatch.setattr(cli_mod, "run_editor", fake_run)
+    result = CliRunner().invoke(cli_mod.main, ["panoedit", str(tmp_path)])
+    assert result.exit_code != 0
+    assert "No 360-degree panoramas found" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_panoedit_listed_in_help():
+    result = CliRunner().invoke(cli_mod.main, ["--help"])
+    assert "panoedit" in result.output

--- a/tests/test_cli_photomap.py
+++ b/tests/test_cli_photomap.py
@@ -420,3 +420,56 @@ def test_photomap_tile_style_selects_basemap(monkeypatch, tmp_path):
     text = (tmp_path / "photomap.html").read_text(encoding="utf-8")
     assert "tile.openstreetmap.fr/hot" in text
     assert "Humanitarian" in text
+
+
+def test_pano_view_thumbs_flag_replaces_thumbnails(monkeypatch, tmp_path):
+    from click.testing import CliRunner
+
+    from dji_metadata_embedder import cli as cli_mod
+    from dji_metadata_embedder.geo.photomap import PhotoPoint
+
+    pano = PhotoPoint(lat=59.3, lon=18.1, alt=10.0, name="p.jpg",
+                      thumbnail_b64="c3RyaXA=", is_pano=True,
+                      pano_yaw=10.0, pano_pitch=None, pano_hfov=None)
+    flat = PhotoPoint(lat=59.3, lon=18.1, alt=None, name="f.jpg",
+                      thumbnail_b64="ZmxhdA==")
+    monkeypatch.setattr(cli_mod, "scan_photos",
+                        lambda d, recursive=False: ([pano, flat], []))
+
+    calls = {}
+
+    def fake_apply(points, root):
+        calls["points"] = points
+        calls["root"] = root
+        points[0].thumbnail_b64 = "dmlldw=="
+        points[0].thumb_is_view = True
+        return 1
+    monkeypatch.setattr(cli_mod, "apply_view_thumbnails", fake_apply)
+
+    result = CliRunner().invoke(cli_mod.main, [
+        "photomap", str(tmp_path), "--pano-view-thumbs",
+        "-o", str(tmp_path / "map.html")])
+    assert result.exit_code == 0, result.output
+    assert calls["points"][0] is pano
+    html = (tmp_path / "map.html").read_text(encoding="utf-8")
+    assert "dmlldw==" in html   # the vthumb prop itself is asserted
+                                # precisely in test_geo_photomap_html.py
+
+
+def test_no_flag_no_render(monkeypatch, tmp_path):
+    from click.testing import CliRunner
+
+    from dji_metadata_embedder import cli as cli_mod
+    from dji_metadata_embedder.geo.photomap import PhotoPoint
+
+    pano = PhotoPoint(lat=1.0, lon=2.0, alt=None, name="p.jpg",
+                      is_pano=True, pano_yaw=0.0)
+    monkeypatch.setattr(cli_mod, "scan_photos",
+                        lambda d, recursive=False: ([pano], []))
+    called = []
+    monkeypatch.setattr(cli_mod, "apply_view_thumbnails",
+                        lambda pts, root: called.append(1))
+    result = CliRunner().invoke(cli_mod.main, [
+        "photomap", str(tmp_path), "-o", str(tmp_path / "m.html")])
+    assert result.exit_code == 0, result.output
+    assert called == []

--- a/tests/test_geo_panoedit.py
+++ b/tests/test_geo_panoedit.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -60,36 +59,43 @@ def test_scan_panos_no_panos_raises(monkeypatch, tmp_path):
         pe.scan_panos(tmp_path)
 
 
-def _fake_exiftool(tmp_path: Path, monkeypatch, log: Path,
-                   read_json: str) -> None:
-    """A shim exiftool that logs argv (one element per line) and answers
-    -json reads."""
-    shim = tmp_path / "exiftool"
-    shim.write_text(
-        "#!/bin/sh\n"
-        f'printf \'%s\\n\' "$@" >> "{log}"\n'
-        'case "$*" in *-json*) cat <<\'EOF\'\n'
-        f"{read_json}\n"
-        "EOF\n"
-        ";; esac\n"
-    )
-    shim.chmod(0o755)
-    monkeypatch.setenv("DJIEMBED_EXIFTOOL_PATH", str(shim))
+def _fake_exiftool(monkeypatch, read_json: str,
+                   returncode: int = 0, stderr: str = "") -> list[list[str]]:
+    """Fake ``subprocess.run`` inside panoedit, recording every argv.
+
+    A monkeypatch rather than an on-disk shim script: a ``#!/bin/sh`` file
+    is not executable on the Windows CI leg (WinError 193), and the write
+    path's real-exiftool behaviour is covered end-to-end by
+    tests/browser/test_panoedit_editor.py.
+    """
+    calls: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, args: list[str]):
+            self.returncode = returncode
+            self.stderr = stderr
+            self.stdout = read_json if "-json" in args else ""
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return _Result(args)
+
+    monkeypatch.setattr(pe.subprocess, "run", fake_run)
+    return calls
 
 
 def test_write_initial_view_argv_and_verify(monkeypatch, tmp_path):
     target = tmp_path / "pano.jpg"
     target.write_bytes(b"\xff\xd8fake")
-    log = tmp_path / "argv.log"
     verified = json.dumps([{
         "InitialViewHeadingDegrees": 123.456,
         "InitialViewPitchDegrees": -4.0,
         "InitialHorizontalFOVDegrees": 100.0,
         "PoseHeadingDegrees": 90.0,
     }])
-    _fake_exiftool(tmp_path, monkeypatch, log, verified)
+    calls = _fake_exiftool(monkeypatch, verified)
     result = pe.write_initial_view(target, heading=123.456, pitch=-4.0, hfov=100.0)
-    argv = log.read_text().splitlines()
+    argv = [a for call in calls for a in call]
     assert "-XMP-GPano:InitialViewHeadingDegrees=123.456" in argv
     assert "-XMP-GPano:InitialViewPitchDegrees=-4.0" in argv
     assert "-XMP-GPano:InitialHorizontalFOVDegrees=100.0" in argv
@@ -102,9 +108,7 @@ def test_write_initial_view_argv_and_verify(monkeypatch, tmp_path):
 def test_write_initial_view_failure_raises(monkeypatch, tmp_path):
     target = tmp_path / "pano.jpg"
     target.write_bytes(b"\xff\xd8fake")
-    shim = tmp_path / "exiftool"
-    shim.write_text("#!/bin/sh\necho 'Error: not writable' >&2\nexit 1\n")
-    shim.chmod(0o755)
-    monkeypatch.setenv("DJIEMBED_EXIFTOOL_PATH", str(shim))
+    _fake_exiftool(monkeypatch, "", returncode=1,
+                   stderr="Error: not writable")
     with pytest.raises(pe.PanoEditError, match="not writable"):
         pe.write_initial_view(target, heading=1.0, pitch=0.0, hfov=90.0)

--- a/tests/test_geo_panoedit.py
+++ b/tests/test_geo_panoedit.py
@@ -1,0 +1,110 @@
+"""Tests for the panoedit scan + write core."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder.geo import panoedit as pe
+from dji_metadata_embedder.geo.photomap import _pano_view
+
+
+def test_compass_heading_inverts_pano_view():
+    # For every (pose, yaw): writing compass_heading(pose, yaw) and reading
+    # it back through _pano_view must return the original yaw.
+    for pose in (0.0, 37.5, 180.0, 359.9):
+        for yaw in (-179.9, -90.0, 0.0, 45.25, 179.9):
+            heading = pe.compass_heading(pose, yaw)
+            assert 0.0 <= heading < 360.0
+            got_yaw, _, _ = _pano_view({
+                "InitialViewHeadingDegrees": heading,
+                "PoseHeadingDegrees": pose,
+            })
+            assert got_yaw == pytest.approx(yaw, abs=1e-6)
+
+
+def test_compass_heading_missing_pose_is_north():
+    # pose 0.0 (the "stitcher wrote none" default) -> heading == yaw mod 360
+    assert pe.compass_heading(0.0, -90.0) == pytest.approx(270.0)
+
+
+def test_scan_panos_filters_and_sorts(monkeypatch, tmp_path):
+    def fake_scan(directory, recursive):
+        return [
+            {"SourceFile": str(tmp_path / "b.jpg"),
+             "ProjectionType": "equirectangular",
+             "PoseHeadingDegrees": 90.0,
+             "InitialViewHeadingDegrees": 100.0,
+             "InitialViewPitchDegrees": -5.0,
+             "InitialHorizontalFOVDegrees": 95.0},
+            {"SourceFile": str(tmp_path / "a.jpg"),
+             "ProjectionType": "equirectangular"},
+            {"SourceFile": str(tmp_path / "flat.jpg")},   # not a pano
+        ]
+    monkeypatch.setattr(pe, "_run_scan", fake_scan)
+    files = pe.scan_panos(tmp_path)
+    assert [f.name for f in files] == ["a.jpg", "b.jpg"]
+    a, b = files
+    assert a.pose == 0.0 and a.yaw is None and a.pitch is None and a.hfov is None
+    assert b.pose == 90.0
+    assert b.yaw == pytest.approx(10.0)      # 100 - 90
+    assert b.pitch == pytest.approx(-5.0)
+    assert b.hfov == pytest.approx(95.0)
+
+
+def test_scan_panos_no_panos_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        pe, "_run_scan", lambda d, r: [{"SourceFile": str(tmp_path / "x.jpg")}])
+    with pytest.raises(pe.PanoEditError, match="No 360"):
+        pe.scan_panos(tmp_path)
+
+
+def _fake_exiftool(tmp_path: Path, monkeypatch, log: Path,
+                   read_json: str) -> None:
+    """A shim exiftool that logs argv (one element per line) and answers
+    -json reads."""
+    shim = tmp_path / "exiftool"
+    shim.write_text(
+        "#!/bin/sh\n"
+        f'printf \'%s\\n\' "$@" >> "{log}"\n'
+        'case "$*" in *-json*) cat <<\'EOF\'\n'
+        f"{read_json}\n"
+        "EOF\n"
+        ";; esac\n"
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("DJIEMBED_EXIFTOOL_PATH", str(shim))
+
+
+def test_write_initial_view_argv_and_verify(monkeypatch, tmp_path):
+    target = tmp_path / "pano.jpg"
+    target.write_bytes(b"\xff\xd8fake")
+    log = tmp_path / "argv.log"
+    verified = json.dumps([{
+        "InitialViewHeadingDegrees": 123.456,
+        "InitialViewPitchDegrees": -4.0,
+        "InitialHorizontalFOVDegrees": 100.0,
+        "PoseHeadingDegrees": 90.0,
+    }])
+    _fake_exiftool(tmp_path, monkeypatch, log, verified)
+    result = pe.write_initial_view(target, heading=123.456, pitch=-4.0, hfov=100.0)
+    argv = log.read_text().splitlines()
+    assert "-XMP-GPano:InitialViewHeadingDegrees=123.456" in argv
+    assert "-XMP-GPano:InitialViewPitchDegrees=-4.0" in argv
+    assert "-XMP-GPano:InitialHorizontalFOVDegrees=100.0" in argv
+    assert "-overwrite_original" not in argv          # backup stays
+    assert not any("VerticalFOV" in a for a in argv)  # the wrong tag, banned
+    assert result == {"heading": 123.456, "pitch": -4.0, "hfov": 100.0,
+                      "pose": 90.0}
+
+
+def test_write_initial_view_failure_raises(monkeypatch, tmp_path):
+    target = tmp_path / "pano.jpg"
+    target.write_bytes(b"\xff\xd8fake")
+    shim = tmp_path / "exiftool"
+    shim.write_text("#!/bin/sh\necho 'Error: not writable' >&2\nexit 1\n")
+    shim.chmod(0o755)
+    monkeypatch.setenv("DJIEMBED_EXIFTOOL_PATH", str(shim))
+    with pytest.raises(pe.PanoEditError, match="not writable"):
+        pe.write_initial_view(target, heading=1.0, pitch=0.0, hfov=90.0)

--- a/tests/test_geo_panoedit_html.py
+++ b/tests/test_geo_panoedit_html.py
@@ -1,0 +1,31 @@
+"""Static contract tests for the panoedit editor page."""
+from __future__ import annotations
+
+from dji_metadata_embedder.geo.panoedit_html import build_editor_page
+from dji_metadata_embedder.geo.photomap_html import (
+    _PANNELLUM_CSS_SRI,
+    _PANNELLUM_JS_SRI,
+    _PANNELLUM_VERSION,
+)
+
+
+def test_page_pins_pannellum_with_sri():
+    html = build_editor_page("tok123")
+    assert f"pannellum@{_PANNELLUM_VERSION}" in html
+    assert _PANNELLUM_CSS_SRI in html and _PANNELLUM_JS_SRI in html
+
+
+def test_page_embeds_token_and_hooks():
+    html = build_editor_page("tok123")
+    assert '"tok123"' in html
+    assert "__panoReady" in html and "__viewer" in html
+    assert "/api/list" in html and "/api/save" in html
+    # The save math: compass heading from pose + yaw, normalized.
+    assert "pose + " in html and "% 360" in html
+    # Originals note (save semantics decision).
+    assert "_original" in html
+
+
+def test_page_token_is_json_escaped():
+    html = build_editor_page('</script><script>alert(1)')
+    assert "</script><script>alert(1)" not in html

--- a/tests/test_geo_panoedit_server.py
+++ b/tests/test_geo_panoedit_server.py
@@ -1,0 +1,116 @@
+"""HTTP contract tests for the panoedit server (no browser, no exiftool:
+scan and write are monkeypatched; the server logic is what's under test)."""
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+from dji_metadata_embedder.geo import panoedit as pe
+
+
+@pytest.fixture
+def editor(monkeypatch, tmp_path):
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"\xff\xd8" + b"J" * 500)
+    files = [pe.PanoFile(path=img, name="a.jpg", pose=90.0,
+                         yaw=None, pitch=None, hfov=None)]
+    monkeypatch.setattr(pe, "scan_panos", lambda d, recursive=False: files)
+    writes: list[tuple] = []
+
+    def fake_write(path, heading, pitch, hfov):
+        writes.append((path, heading, pitch, hfov))
+        return {"heading": heading, "pitch": pitch, "hfov": hfov,
+                "pose": 90.0}
+    monkeypatch.setattr(pe, "write_initial_view", fake_write)
+    httpd, url = pe.make_editor_server(tmp_path)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield url, httpd, writes
+    httpd.shutdown()
+
+
+def _get(url: str):
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        return resp.status, resp.read()
+
+
+def _post(url: str, payload: dict):
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read() or b"{}")
+
+
+def test_page_and_list(editor):
+    url, httpd, _ = editor
+    status, body = _get(url)
+    assert status == 200 and b"<!DOCTYPE html" in body
+    status, body = _get(url + "api/list")
+    data = json.loads(body)
+    assert status == 200
+    assert data == [{"index": 0, "name": "a.jpg", "pose": 90.0,
+                     "yaw": None, "pitch": None, "hfov": None,
+                     "hasView": False}]
+
+
+def test_image_by_index_only(editor):
+    url, _, _ = editor
+    status, body = _get(url + "img/0")
+    assert status == 200 and body.startswith(b"\xff\xd8")
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _get(url + "img/1")
+    assert e.value.code == 404
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _get(url + "img/../../etc/passwd")
+    assert e.value.code == 404
+
+
+def test_save_happy_path_updates_list(editor):
+    url, httpd, writes = editor
+    token = httpd.pano_token
+    status, body = _post(url + "api/save", {
+        "index": 0, "heading": 135.5, "pitch": -3.0, "hfov": 100.0,
+        "token": token})
+    assert status == 200
+    assert body["heading"] == 135.5
+    assert writes and writes[0][1] == 135.5
+    _, listing = _get(url + "api/list")
+    entry = json.loads(listing)[0]
+    assert entry["hasView"] is True
+    assert entry["yaw"] == pytest.approx(45.5)   # 135.5 - pose 90
+    assert entry["pitch"] == -3.0
+
+
+def test_save_rejects_bad_token_and_input(editor):
+    url, httpd, writes = editor
+    token = httpd.pano_token
+    ok = {"index": 0, "heading": 10.0, "pitch": 0.0, "hfov": 90.0}
+    assert _post(url + "api/save", {**ok, "token": "wrong"})[0] == 403
+    assert _post(url + "api/save", {**ok, "token": token, "index": 9})[0] == 400
+    assert _post(url + "api/save",
+                 {**ok, "token": token, "pitch": 91.0})[0] == 400
+    assert _post(url + "api/save",
+                 {**ok, "token": token, "hfov": 5.0})[0] == 400
+    assert _post(url + "api/save",
+                 {**ok, "token": token, "heading": "x"})[0] == 400
+    assert writes == []
+
+
+def test_save_write_failure_is_500(editor, monkeypatch):
+    url, httpd, _ = editor
+
+    def boom(path, heading, pitch, hfov):
+        raise pe.PanoEditError("disk on fire")
+    monkeypatch.setattr(pe, "write_initial_view", boom)
+    status, body = _post(url + "api/save", {
+        "index": 0, "heading": 1.0, "pitch": 0.0, "hfov": 90.0,
+        "token": httpd.pano_token})
+    assert status == 500 and "disk on fire" in body["error"]

--- a/tests/test_geo_panorender.py
+++ b/tests/test_geo_panorender.py
@@ -1,0 +1,88 @@
+"""Golden math tests for the equirect -> perspective opening-view render.
+
+The fixture equirect encodes position as color: four vertical longitude
+stripes (A red, B green, C blue, D yellow reading left to right), a white
+zenith band and a black nadir band. yaw/pitch then predict the center
+pixel's color exactly. Image center (yaw 0) falls at x = W/2 — the
+boundary between stripes B and C — so stripe tests target stripe centers
+(yaw -135, -45, +45, +135), never boundaries."""
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from dji_metadata_embedder.geo.panorender import render_view
+
+RED, GREEN, BLUE, YELLOW = ((255, 0, 0), (0, 200, 0),
+                            (0, 0, 255), (240, 220, 0))
+WHITE, BLACK = (255, 255, 255), (0, 0, 0)
+
+
+@pytest.fixture
+def equirect(tmp_path) -> Path:
+    W, H = 256, 128
+    im = Image.new("RGB", (W, H))
+    for x in range(W):
+        color = [RED, GREEN, BLUE, YELLOW][min(x * 4 // W, 3)]
+        for y in range(H):
+            im.putpixel((x, y), color)
+    for y in range(8):                       # zenith band
+        for x in range(W):
+            im.putpixel((x, y), WHITE)
+    for y in range(H - 8, H):                # nadir band
+        for x in range(W):
+            im.putpixel((x, y), BLACK)
+    p = tmp_path / "eq.jpg"
+    im.save(p, "JPEG", quality=95)
+    return p
+
+
+def _center_pixel(data: bytes) -> tuple:
+    im = Image.open(io.BytesIO(data))
+    assert im.size == (64, 64)
+    return im.getpixel((32, 32))
+
+
+def _close(a, b, tol=40):
+    return all(abs(x - y) <= tol for x, y in zip(a, b))
+
+
+def test_yaw_selects_longitude_stripe(equirect):
+    # yaw 0 = image center = x W/2; stripe centers are at yaw -135/-45/45/135.
+    for yaw, color in ((-135.0, RED), (-45.0, GREEN),
+                       (45.0, BLUE), (135.0, YELLOW)):
+        data = render_view(equirect, yaw, 0.0, 90.0, size=64)
+        assert data is not None
+        assert _close(_center_pixel(data), color), f"yaw {yaw}"
+
+
+def test_pitch_reaches_zenith_and_nadir(equirect):
+    up = render_view(equirect, 0.0, 89.0, 90.0, size=64)
+    down = render_view(equirect, 0.0, -89.0, 90.0, size=64)
+    assert _close(_center_pixel(up), WHITE)
+    assert _close(_center_pixel(down), BLACK)
+
+
+def test_yaw_wraps_across_seam(equirect):
+    # yaw 179 looks at the seam (x ~ 0/W): stripe A/D territory, and must
+    # not produce a smear of all stripes (the mesh-transform failure mode).
+    data = render_view(equirect, 179.0, 0.0, 20.0, size=64)
+    im = Image.open(io.BytesIO(data))
+    colors = {im.getpixel((x, 32)) for x in (8, 32, 56)}
+    assert all(_close(c, RED) or _close(c, YELLOW) for c in colors)
+
+
+def test_output_is_jpeg_and_size(equirect):
+    data = render_view(equirect, 0.0, 0.0, 90.0, size=48)
+    assert data[:2] == b"\xff\xd8"
+    assert Image.open(io.BytesIO(data)).size == (48, 48)
+
+
+def test_bad_input_returns_none(tmp_path):
+    bad = tmp_path / "corrupt.jpg"
+    bad.write_bytes(b"not a jpeg")
+    assert render_view(bad, 0.0) is None
+    assert render_view(tmp_path / "missing.jpg", 0.0) is None

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -487,3 +487,25 @@ def test_html_alternate_tile_style_swaps_provider():
     assert "CyclOSM" in html
     assert "tile.openstreetmap.org" not in html
     assert "__TILE_LAYER__" not in html
+
+
+def test_vthumb_prop_and_popup_title():
+    from dji_metadata_embedder.geo.photomap import photos_to_geojson
+
+    p = PhotoPoint(lat=1.0, lon=2.0, alt=None, name="p.jpg",
+                   thumbnail_b64="QUJD", is_pano=True, pano_yaw=5.0,
+                   thumb_is_view=True)
+    geo = photos_to_geojson([p], include_thumbnails=True)
+    assert geo["features"][0]["properties"]["vthumb"] is True
+    html = photos_to_html([p], title="t")
+    assert "Opening view of the panorama" in html
+    assert "Full 360" in html
+
+
+def test_no_vthumb_prop_for_strip_thumbs():
+    from dji_metadata_embedder.geo.photomap import photos_to_geojson
+
+    p = PhotoPoint(lat=1.0, lon=2.0, alt=None, name="p.jpg",
+                   thumbnail_b64="QUJD", is_pano=True, pano_yaw=5.0)
+    geo = photos_to_geojson([p], include_thumbnails=True)
+    assert "vthumb" not in geo["features"][0]["properties"]


### PR DESCRIPTION
Closes #440, closes #441.

- `dji-embed panoedit <folder>`: localhost Pannellum editor — drag each
  pano to its opening view, live GPano readout, Save writes
  InitialViewHeadingDegrees/Pitch/InitialHorizontalFOVDegrees via the
  provisioned ExifTool (default `_original` backup kept), auto-advance.
  Heading = PoseHeadingDegrees + yaw — the exact inverse of the #309
  read side.
- GUI "360° views" mode: launches the editor with the serve-child
  pattern (`--url-only --exit-with-stdin`) into the WebView pane.
- `photomap --pano-view-thumbs` (+ GUI checkbox): square popup
  thumbnails rendered at the saved opening view (pure-Pillow per-pixel
  reprojection; untagged panos keep the 2:1 strip).

Community request from the mavicpilots thread (EyesWideShut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGmtf4qGfz6xgGSjnqL6mh