### PR TITLE
fix(tools): mtp-copy.ps1 finds DJI RC 2 flight records (new path + name prefix)

### DIFF
--- a/docs/how-to/flight-log-gimbal.md
+++ b/docs/how-to/flight-log-gimbal.md
@@ -20,17 +20,21 @@ several flights.
 ## Getting the TXT off your controller
 
 Flight records are small `.txt` files your DJI app or RC writes per
-flight — named like `DJIFlightRecord_2026-07-27_[17-28-49].txt`. Despite
-the extension they are encrypted binary, not text.
+flight — named like `DJIFlightRecord_2026-07-27_[17-28-49].txt` or, on
+the DJI RC 2 with current DJI Fly, `FlightRecord_2026-08-08_[15-43-20].txt`
+(no `DJI` prefix). Despite the extension they are encrypted binary, not
+text.
 
 **DJI RC (RC 2, RC Pro, ...):**
 
 1. Plug the RC into your computer over USB, with the RC **powered on and
    unlocked**. It appears in Explorer as a portable (MTP) device — no
    drive letter, which is why some copy tools cannot see it.
-2. Open the device › *Internal shared storage*. The flight records sit
-   at the **root** of that storage, not in a folder.
-3. Copy the `DJIFlightRecord_*.txt` files anywhere on your computer.
+2. Open the device › *Internal shared storage*. Where the records sit
+   depends on the controller generation: older RCs keep them at the
+   **root** of that storage; the **DJI RC 2** keeps them under
+   `Android\data\dji.go.v5\files\FlightRecord`.
+3. Copy the `*FlightRecord_*.txt` files anywhere on your computer.
 
 Or let the [helper script from the
 repository](https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/master/tools/mtp-copy.ps1)

--- a/tools/mtp-copy.ps1
+++ b/tools/mtp-copy.ps1
@@ -3,20 +3,27 @@
 Copy DJI flight records off a remote controller over USB (MTP).
 
 .DESCRIPTION
-DJI RCs expose flight records at the root of "Internal shared storage"
-over MTP, which has no drive letter - plain Copy-Item cannot see it.
-This script walks the Shell.Application COM namespace instead, so it
-works on a stock Windows PowerShell 5.1 with the RC plugged in, powered
-on, and unlocked.
+DJI RCs expose flight records over MTP, which has no drive letter -
+plain Copy-Item cannot see it. This script walks the Shell.Application
+COM namespace instead, so it works on a stock Windows PowerShell 5.1
+with the RC plugged in, powered on, and unlocked.
+
+Where the records live depends on the controller generation: older RCs
+keep DJIFlightRecord_*.txt at the root of "Internal shared storage",
+while the DJI RC 2 (current DJI Fly) keeps FlightRecord_*.txt - no DJI
+prefix - under Android\data\dji.go.v5\files\FlightRecord. Both
+locations and both name shapes are probed.
 
 .EXAMPLE
 powershell -ExecutionPolicy Bypass -File tools\mtp-copy.ps1
 .EXAMPLE
-powershell -ExecutionPolicy Bypass -File tools\mtp-copy.ps1 -Filter 'DJIFlightRecord_2026-07-*' -Destination D:\FlightRecords
+powershell -ExecutionPolicy Bypass -File tools\mtp-copy.ps1 -Filter '*FlightRecord_2026-07-*' -Destination D:\FlightRecords
 #>
 param(
   [string]$Destination = (Join-Path $env:USERPROFILE 'Documents\FlightRecords'),
-  [string]$Filter = 'DJIFlightRecord_*.txt',
+  # Matches both namings: DJIFlightRecord_*.txt (older RCs) and
+  # FlightRecord_*.txt (DJI RC 2 / current DJI Fly).
+  [string]$Filter = '*FlightRecord_*.txt',
   [int]$TimeoutSeconds = 120
 )
 
@@ -24,9 +31,23 @@ $ErrorActionPreference = 'Stop'
 $shell = New-Object -ComObject Shell.Application
 $pc = $shell.NameSpace(17)  # "This PC", where portable devices appear
 
-# Find the portable device exposing flight records: any device whose
-# storage root contains a matching file. Name-matching ("*MTP*") is not
-# reliable across RC models, so probe contents instead.
+# The DJI Fly app folder on Android-based controllers (DJI RC 2): records
+# live here rather than at the storage root.
+$djiFlySubPath = @('Android', 'data', 'dji.go.v5', 'files', 'FlightRecord')
+
+function Get-ChildFolderItem($folderItem, [string]$name) {
+  if ($null -eq $folderItem) { return $null }
+  try {
+    return ($folderItem.GetFolder.Items() |
+      Where-Object { $_.IsFolder -and $_.Name -eq $name } |
+      Select-Object -First 1)
+  } catch { return $null }
+}
+
+# Find the portable device exposing flight records: any device where the
+# storage root (older RCs) or the DJI Fly app folder (DJI RC 2) contains
+# a matching file. Name-matching ("*MTP*") is not reliable across RC
+# models, so probe contents instead.
 $records = @()
 $deviceName = $null
 $skipped = @()
@@ -50,16 +71,26 @@ foreach ($dev in $pc.Items()) {
   } catch { continue }
   foreach ($storage in $storages) {
     if (-not $storage.IsFolder) { continue }
-    try {
-      $storageFolder = $storage.GetFolder
-      if ($null -eq $storageFolder) { continue }
-      $found = @($storageFolder.Items() | Where-Object { $_.Name -like $Filter })
-    } catch { continue }
-    if ($found.Count -gt 0) {
-      $records = $found
-      $deviceName = $dev.Name
-      break
+    # Candidate folders, probed in order: the storage root, then the
+    # DJI Fly app folder. Walking the subpath just returns $null at the
+    # first missing hop on controllers that lack it.
+    $candidates = @($storage)
+    $deep = $storage
+    foreach ($name in $djiFlySubPath) { $deep = Get-ChildFolderItem $deep $name }
+    if ($null -ne $deep) { $candidates += $deep }
+    foreach ($candidate in $candidates) {
+      try {
+        $candidateFolder = $candidate.GetFolder
+        if ($null -eq $candidateFolder) { continue }
+        $found = @($candidateFolder.Items() | Where-Object { $_.Name -like $Filter })
+      } catch { continue }
+      if ($found.Count -gt 0) {
+        $records = $found
+        $deviceName = $dev.Name
+        break
+      }
     }
+    if ($deviceName) { break }
   }
   if ($deviceName) { break }
 }
@@ -67,7 +98,8 @@ foreach ($dev in $pc.Items()) {
 if (-not $deviceName) {
   Write-Output "No flight records matching '$Filter' found on any portable device."
   Write-Output 'Is the RC plugged in over USB, powered on, and unlocked?'
-  Write-Output '(Records sit at the root of "Internal shared storage".)'
+  Write-Output '(Records sit at the root of "Internal shared storage" on older RCs,'
+  Write-Output ' or under Android\data\dji.go.v5\files\FlightRecord on the DJI RC 2.)'
   # Say what was ruled out, so "the filter skipped the RC" and "the RC
   # was never there" do not produce the same silence.
   if ($skipped.Count -gt 0) {


### PR DESCRIPTION
Found on real hardware today: the DJI RC 2 running current DJI Fly does not keep flight records at the root of Internal shared storage, and drops the `DJI` filename prefix:

- Location: `Android\data\dji.go.v5\files\FlightRecord`
- Naming: `FlightRecord_2026-08-08_[15-43-20].txt`

`mtp-copy.ps1` now probes the storage root (older RCs) and the DJI Fly app folder, and the default `-Filter` (`*FlightRecord_*.txt`) matches both name generations. Failure hint and the flight-log how-to updated to describe both layouts.

E2E on a live RC 2 over PowerShell 5.1: found all 3 records, dedup copied 0 already-present files, mixed old/new-prefix destination folder listed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGmtf4qGfz6xgGSjnqL6mh