### PR TITLE
fix(cli): base install crashed — Pillow must import lazily (v2.7.0 regression)

### DIFF
--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -46,7 +46,6 @@ from .geo import (
 )
 from .geo.airspace import fetch as airspace_fetch
 from .geo.panoedit import PanoEditError, run_editor
-from .geo.panorender import apply_view_thumbnails
 from .geo.airspace.overlay import zones_to_overlay_json
 from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
 from .geo.logfetch import LogFetchError, cache_path, fetch_log
@@ -761,7 +760,19 @@ def photomap(
                 f"None of the {total} photos in {src} carry GPS coordinates"
             )
         if pano_view_thumbs:
-            replaced = apply_view_thumbnails(points, src)
+            # Imported here, not at module load: panorender needs Pillow
+            # (the [terrain] extra) and a base install must keep working
+            # when the flag is never used (v2.7.0 shipped this import at
+            # the top and broke every bare pip install).
+            from .geo.panorender import (
+                PanorenderUnavailable,
+                apply_view_thumbnails,
+            )
+
+            try:
+                replaced = apply_view_thumbnails(points, src)
+            except PanorenderUnavailable as e:
+                raise click.ClickException(str(e))
             if replaced and not quiet:
                 click.echo(
                     f"Rendered {replaced} opening-view thumbnail"

--- a/src/dji_metadata_embedder/geo/panorender.py
+++ b/src/dji_metadata_embedder/geo/panorender.py
@@ -15,11 +15,34 @@ import logging
 from math import asin, atan2, cos, pi, radians, sin, sqrt, tan
 from pathlib import Path
 
-from PIL import Image
-
 from .photomap import PhotoPoint
 
 logger = logging.getLogger(__name__)
+
+
+class PanorenderUnavailable(RuntimeError):
+    """Pillow is missing — opening-view thumbnails cannot be rendered."""
+
+
+def _pil_image():
+    """Import Pillow lazily, mirroring geo/terrain.py.
+
+    Pillow ships in the ``[terrain]`` extra, not the base install; importing
+    it at module load broke every bare ``pip install`` in v2.7.0 (the CLI
+    imports this module's caller). The import must happen only when an
+    opening-view render is actually requested, and fail with instructions
+    rather than a traceback.
+    """
+    try:
+        from PIL import Image  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise PanorenderUnavailable(
+            "opening-view thumbnails need Pillow, which is not installed. "
+            "Install the terrain extra: "
+            "pip install 'dji-drone-metadata-embedder[terrain]' "
+            "(pipx: pipx inject dji-drone-metadata-embedder pillow)"
+        ) from exc
+    return Image
 
 # The source is downscaled to this width before sampling: a 320 px crop of
 # a <=170 degree view never needs more than ~2x that angular resolution,
@@ -40,7 +63,11 @@ def render_view(
     ``pano_yaw``), so no pose handling is needed here — the equirect's own
     frame is the reference. Pitch/hfov are clamped to the same physical
     ranges the viewer enforces.
+
+    Raises :class:`PanorenderUnavailable` when Pillow is absent — that is
+    a setup problem to surface, never a per-file failure to swallow.
     """
+    Image = _pil_image()
     try:
         with Image.open(path) as im:
             im.draft("RGB", (_MAX_SRC_WIDTH, _MAX_SRC_WIDTH // 2))

--- a/tests/test_cli_lazy_extras.py
+++ b/tests/test_cli_lazy_extras.py
@@ -1,0 +1,68 @@
+"""Base installs must work without the optional extras.
+
+Pillow ships only in the ``[terrain]`` extra. v2.7.0 imported
+geo/panorender (and therefore PIL) at CLI module load, which broke every
+bare ``pip install`` — dev environments and CI always sync all extras, so
+no other gate can catch this class. These tests are that gate.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+
+def test_cli_imports_without_pillow():
+    # A fresh interpreter with PIL unimportable must still import the CLI,
+    # and the CLI import must not drag panorender in.
+    code = (
+        "import sys\n"
+        "sys.modules['PIL'] = None\n"      # any 'import PIL' now fails
+        "import dji_metadata_embedder.cli\n"
+        "assert 'dji_metadata_embedder.geo.panorender' not in sys.modules\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_pano_view_thumbs_without_pillow_is_clean_error(monkeypatch, tmp_path):
+    from dji_metadata_embedder import cli as cli_mod
+    from dji_metadata_embedder.geo.photomap import PhotoPoint
+
+    pano = PhotoPoint(lat=1.0, lon=2.0, alt=None, name="p.jpg",
+                      is_pano=True, pano_yaw=0.0)
+    monkeypatch.setattr(cli_mod, "scan_photos",
+                        lambda d, recursive=False: ([pano], []))
+    # Block Pillow: a None sys.modules entry makes `from PIL import Image`
+    # raise ImportError even though the test env has Pillow installed.
+    monkeypatch.setitem(sys.modules, "PIL", None)
+    result = CliRunner().invoke(cli_mod.main, [
+        "photomap", str(tmp_path), "--pano-view-thumbs",
+        "-o", str(tmp_path / "m.html")])
+    assert result.exit_code != 0
+    assert "terrain" in result.output          # names the extra to install
+    assert "Traceback" not in result.output
+
+
+def test_pano_view_thumbs_unavailable_error_names_the_extra():
+    from dji_metadata_embedder.geo.panorender import (
+        PanorenderUnavailable,
+        _pil_image,
+    )
+
+    saved = sys.modules.get("PIL")
+    sys.modules["PIL"] = None  # type: ignore[assignment]
+    try:
+        with pytest.raises(PanorenderUnavailable, match=r"\[terrain\]"):
+            _pil_image()
+    finally:
+        if saved is None:
+            sys.modules.pop("PIL", None)
+        else:
+            sys.modules["PIL"] = saved

--- a/tests/test_cli_photomap.py
+++ b/tests/test_cli_photomap.py
@@ -444,7 +444,8 @@ def test_pano_view_thumbs_flag_replaces_thumbnails(monkeypatch, tmp_path):
         points[0].thumbnail_b64 = "dmlldw=="
         points[0].thumb_is_view = True
         return 1
-    monkeypatch.setattr(cli_mod, "apply_view_thumbnails", fake_apply)
+    import dji_metadata_embedder.geo.panorender as panorender
+    monkeypatch.setattr(panorender, "apply_view_thumbnails", fake_apply)
 
     result = CliRunner().invoke(cli_mod.main, [
         "photomap", str(tmp_path), "--pano-view-thumbs",
@@ -467,7 +468,8 @@ def test_no_flag_no_render(monkeypatch, tmp_path):
     monkeypatch.setattr(cli_mod, "scan_photos",
                         lambda d, recursive=False: ([pano], []))
     called = []
-    monkeypatch.setattr(cli_mod, "apply_view_thumbnails",
+    import dji_metadata_embedder.geo.panorender as panorender
+    monkeypatch.setattr(panorender, "apply_view_thumbnails",
                         lambda pts, root: called.append(1))
     result = CliRunner().invoke(cli_mod.main, [
         "photomap", str(tmp_path), "-o", str(tmp_path / "m.html")])


### PR DESCRIPTION
The v2.7.0 PyPI fresh-install check caught a release blocker: `--pano-view-thumbs` wiring imported `geo/panorender` → `PIL` at `cli.py` module load, and Pillow only ships in the `[terrain]` extra — every bare `pip install dji-drone-metadata-embedder` crashed on any command. Dev and CI environments sync all extras, so no other gate could see it.

Fix follows the `geo/terrain.py` pattern: lazy `_pil_image()` with a `PanorenderUnavailable` error that names the extra (`pip install 'dji-drone-metadata-embedder[terrain]'` / `pipx inject`), and the CLI imports panorender only inside the flag branch, converting the error to a clean ClickException.

New `tests/test_cli_lazy_extras.py` pins the class: the CLI must import in a fresh interpreter with PIL blocked (subprocess), and using the flag without Pillow must fail with instructions rather than a traceback.

v2.7.1 follows immediately; binaries (EXE/DMG/installer) were never affected — they bundle Pillow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGmtf4qGfz6xgGSjnqL6mh