### PR TITLE
fix(gui): field-report polish — photo picking, drop-zone hit-test, caption legibility

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/DropZoneAffordanceTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/DropZoneAffordanceTests.cs
@@ -62,6 +62,18 @@ public class DropZoneAffordanceTests
         Assert.DoesNotContain("dragover", zone.Classes);
     }
 
+    // Field report (2026-08-09): with a null Background the Border is
+    // invisible to hit-testing, so drags over the empty middle of the zone
+    // never reached AllowDrop — the highlight only fired over the text.
+    [AvaloniaFact]
+    public void Drop_zone_has_a_hit_testable_background()
+    {
+        var window = ShowView(PickView());
+        var zone = window.GetVisualDescendants().OfType<Border>()
+            .First(b => b.Name == "DropZone");
+        Assert.NotNull(zone.Background);
+    }
+
     // Carried from Task 9 review: the dragover style used to be beaten by a
     // local Stroke= value on the Rectangle, so the highlight never rendered.
     // This proves the Stroke brush itself changes, not just the class.

--- a/gui/DjiEmbed.Gui.Tests/FolderPickingTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FolderPickingTests.cs
@@ -74,4 +74,46 @@ public class FolderPickingTests : IDisposable
         Assert.Null(folder);
         Assert.Equal(file, resolvedFile);
     }
+
+    // Field report (2026-08-09): dropping a photo did nothing — the photo
+    // modes work on folders, so a dropped photo stands for its folder.
+    [Theory]
+    [InlineData("pano.jpg")]
+    [InlineData("pano.JPEG")]
+    public void Drop_resolution_maps_a_photo_to_its_folder(string fileName)
+    {
+        var file = Touch(fileName);
+
+        FolderPicking.ResolveDrop([file], out var folder, out var resolvedFile);
+
+        Assert.Equal(_dir, folder);
+        Assert.Null(resolvedFile);
+    }
+
+    [Fact]
+    public void Drop_resolution_prefers_telemetry_files_over_photos()
+    {
+        var photo = Touch("pano.jpg");
+        var srt = Touch("clip.srt");
+
+        FolderPicking.ResolveDrop([photo, srt], out var folder, out var file);
+
+        Assert.Null(folder);
+        Assert.Equal(srt, file);
+    }
+
+    [Theory]
+    [InlineData("pano.jpg", true)]
+    [InlineData("PANO.JPEG", true)]
+    [InlineData("clip.srt", false)]
+    [InlineData("movie.mp4", false)]
+    public void Photo_folder_resolution_claims_only_photos(
+        string fileName, bool isPhoto)
+    {
+        var path = Path.Combine(_dir, fileName);
+
+        var folder = FolderPicking.PhotoFolderFor(path);
+
+        Assert.Equal(isPhoto ? _dir : null, folder);
+    }
 }

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -1534,6 +1534,40 @@ public class WorkspaceScreenTests
         Assert.Equal("C:/x/DJI_1.SRT", vm.SelectedFile);
     }
 
+    // Field report (2026-08-09): the picker gained photo file types, and a
+    // picked photo must land as its FOLDER — the photo modes (Photo map,
+    // 360° views) work on folders; SetFile means "telemetry for Convert".
+    [AvaloniaFact]
+    public void Choose_file_button_routes_a_photo_to_its_folder()
+    {
+        var dir = Directory.CreateTempSubdirectory("djiembed-photo-pick");
+        try
+        {
+            var photo = Path.Combine(dir.FullName, "PANO0001.jpg");
+            File.WriteAllText(photo, "");
+            var view = new WorkspaceView { WebViewGate = static () => false };
+            var vm = NewWorkspaceViewModel();
+            view.FilePicker = (_) => Task.FromResult<string?>(photo);
+            view.DataContext = vm;
+            var button = view.FindControl<Button>("ChooseFileButton")!;
+            button.RaiseEvent(
+                new Avalonia.Interactivity.RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(dir.FullName, vm.SelectedFolder);
+            Assert.Null(vm.SelectedFile);
+            // Let the folder scan finish before the directory disappears.
+            for (var i = 0; i < 200 && vm.SuggestedMode is null; i++)
+            {
+                Thread.Sleep(10);
+                Dispatcher.UIThread.RunJobs();
+            }
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
     // M4a: the Convert options panel renders only for Convert, with the
     // Advanced expander closed by default. The panel's freeze-while-busy
     // behaviour is covered alongside the other three panels' by

--- a/gui/DjiEmbed.Gui/Views/FolderPicking.cs
+++ b/gui/DjiEmbed.Gui/Views/FolderPicking.cs
@@ -59,27 +59,53 @@ internal static class FolderPicking
     private static readonly string[] SourceFileExtensions =
         [".srt", ".mp4", ".mov"];
 
+    /// <summary>Photo extensions the SOURCE area accepts as a single file:
+    /// resolved to the photo's folder, because the photo modes (Photo map,
+    /// 360° views) work on folders, never on one file.</summary>
+    private static readonly string[] PhotoFileExtensions =
+        [".jpg", ".jpeg"];
+
+    private static bool HasExtension(string path, string[] extensions) =>
+        Array.Exists(extensions, e => path.EndsWith(
+            e, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The folder a picked photo stands for, or <c>null</c> when
+    /// *path* is not a photo.</summary>
+    internal static string? PhotoFolderFor(string path) =>
+        HasExtension(path, PhotoFileExtensions)
+            ? System.IO.Path.GetDirectoryName(path)
+            : null;
+
     /// <summary>Pure drop-payload resolution: the first directory wins,
-    /// otherwise the first telemetry file; anything else yields nothing.</summary>
+    /// otherwise the first telemetry file, otherwise the first photo's
+    /// folder; anything else yields nothing.</summary>
     internal static void ResolveDrop(
         IEnumerable<string> paths, out string? folder, out string? file)
     {
         folder = null;
         file = null;
+        string? photoFolder = null;
         foreach (var path in paths)
         {
             if (System.IO.Directory.Exists(path))
             {
                 folder = path;
+                file = null;
                 return;
             }
-            if (file is null
-                && System.IO.File.Exists(path)
-                && Array.Exists(SourceFileExtensions, e => path.EndsWith(
-                    e, StringComparison.OrdinalIgnoreCase)))
+            if (!System.IO.File.Exists(path))
+            {
+                continue;
+            }
+            if (file is null && HasExtension(path, SourceFileExtensions))
             {
                 file = path;
             }
+            photoFolder ??= PhotoFolderFor(path);
+        }
+        if (file is null)
+        {
+            folder = photoFolder;
         }
     }
 
@@ -169,13 +195,23 @@ internal static class FolderPicking
             new FilePickerOpenOptions
             {
                 AllowMultiple = false,
-                Title = "Choose a flight log or drone video",
+                Title = "Choose a flight log, drone video, or photo",
                 FileTypeFilter =
                 [
+                    new FilePickerFileType("All supported")
+                    {
+                        Patterns = ["*.srt", "*.SRT", "*.mp4", "*.MP4",
+                                    "*.mov", "*.MOV", "*.jpg", "*.JPG",
+                                    "*.jpeg", "*.JPEG"],
+                    },
                     new FilePickerFileType("Telemetry sources")
                     {
                         Patterns = ["*.srt", "*.SRT", "*.mp4", "*.MP4",
                                     "*.mov", "*.MOV"],
+                    },
+                    new FilePickerFileType("Photos")
+                    {
+                        Patterns = ["*.jpg", "*.JPG", "*.jpeg", "*.JPEG"],
                     },
                 ],
             });

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -96,7 +96,12 @@
                     <suki:GlassCard Name="SourceCard" Padding="14"
                                     IsEnabled="{Binding !IsBusy}">
                         <StackPanel Spacing="10">
+                            <!-- Background must not be null: a null-background
+                                 Border is invisible to hit-testing, so drags
+                                 over the empty middle of the zone would never
+                                 reach AllowDrop (only the text would). -->
                             <Border Name="DropZone" DragDrop.AllowDrop="True"
+                                    Background="Transparent"
                                     CornerRadius="10">
                                 <Panel>
                                     <Rectangle Classes="dropOutline"

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml.cs
@@ -154,7 +154,17 @@ public partial class WorkspaceView : UserControl
         if (DataContext is WorkspaceViewModel vm
             && await FilePicker(this) is { } path)
         {
-            vm.SetFile(path);
+            // A picked photo stands for its folder — the photo modes
+            // (Photo map, 360° views) work on folders, and SetFile means
+            // "a telemetry source for Convert".
+            if (FolderPicking.PhotoFolderFor(path) is { } photoFolder)
+            {
+                await vm.SetFolderAsync(photoFolder);
+            }
+            else
+            {
+                vm.SetFile(path);
+            }
         }
     }
 

--- a/src/dji_metadata_embedder/geo/panoedit_html.py
+++ b/src/dji_metadata_embedder/geo/panoedit_html.py
@@ -47,9 +47,11 @@ _PAGE = """<!DOCTYPE html>
     border-radius: 50%; background: #666; margin-right: 6px; }}
   .chip.hasview .dot {{ background: #5ec26a; }}
   #counter {{ position: fixed; right: 12px; bottom: 104px; z-index: 10;
-    color: #aaa; }}
+    color: #ddd; background: rgba(0,0,0,.55); padding: 4px 10px;
+    border-radius: 6px; }}
   #note {{ position: fixed; left: 12px; bottom: 104px; z-index: 10;
-    color: #888; font-size: 12px; }}
+    color: #ccc; font-size: 12px; background: rgba(0,0,0,.55);
+    padding: 4px 10px; border-radius: 6px; }}
 </style>
 </head>
 <body>

--- a/tests/test_geo_panoedit_html.py
+++ b/tests/test_geo_panoedit_html.py
@@ -29,3 +29,13 @@ def test_page_embeds_token_and_hooks():
 def test_page_token_is_json_escaped():
     html = build_editor_page('</script><script>alert(1)')
     assert "</script><script>alert(1)" not in html
+
+
+def test_caption_overlays_have_a_backdrop():
+    # Field report (2026-08-09): the counter and the backup note float over
+    # the panorama and were bare grey text — unreadable against bright
+    # skies. Both need the readout's backdrop-box treatment.
+    html = build_editor_page("tok123")
+    for elem in ("#counter", "#note"):
+        rule = html.split(elem, 1)[1].split("}", 1)[0]
+        assert "background: rgba(0,0,0" in rule, elem


### PR DESCRIPTION
Three fixes from Bill's (EWS) first field report on the v2.7.1 360° views feature.

## No JPG option in "Choose a file…"

The single global file picker offered only "Telemetry sources" (`*.srt/*.mp4/*.mov`), so in 360° views or Photo map mode a JPG was unpickable. The picker now offers **All supported** (default) / Telemetry sources / Photos, and a picked photo lands as its **folder** — the photo modes work on folders, and `SetFile` keeps meaning "a telemetry source for Convert". Consistent with today's folder behavior, the folder scan then suggests a mode (a photo folder suggests Photo map — 360° views stays one click away).

## Drag-drop only highlighted over the text

`Border Name="DropZone"` had no `Background`; a null-background Border is invisible to Avalonia hit-testing, so drags over the empty middle of the dashed box never reached the `AllowDrop` element — the highlight fired only over the child TextBlocks, and drops elsewhere did nothing (exactly the reported "spoty hilight over text"). `Background="Transparent"` makes the whole zone drop-receptive, with a comment + test pinning it. Dropped photos also resolve to their folder now (`ResolveDrop` previously ignored anything but folders and telemetry files, so a JPG drop was a silent no-op even when it landed).

## Editor captions unreadable over bright panos

The panoedit counter (bottom-right) and backup note (bottom-left) floated over the panorama as bare grey text; both now carry the same backdrop box the readout already has.

## Tests

- `FolderPickingTests`: photo→folder drop resolution (case-insensitive), telemetry-beats-photo priority, `PhotoFolderFor` claims only photos
- `WorkspaceScreenTests`: view-level seam test — a picked photo routes to `SelectedFolder`, not `SelectedFile`
- `DropZoneAffordanceTests`: drop zone must have a non-null (hit-testable) background
- `test_geo_panoedit_html.py`: `#counter`/`#note` rules carry a backdrop

Local gates: 1027 unit tests, 549 GUI tests, ruff, mypy — all green.

Not addressed here (tracked separately): the reported lock-ups loading a second large pano (evidence points at old-PC WebGL/memory limits — awaiting the tester's hardware details) and the Reset/Cancel + original-vs-current-view feature ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTAbG2MXmbDxoDTZCpiZKD