### PR TITLE
fix(validate): text report crashed on legacy Windows consoles (#477)

### DIFF
--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -1642,8 +1642,11 @@ def validate(
             click.echo(f"Valid pairs: {validation_result.get('valid_pairs', 0)}")
             click.echo(f"Issues found: {len(validation_result.get('issues', []))}")
             
+            # ASCII marker: legacy Windows consoles (cp1252/cp437) cannot
+            # encode emoji, and the resulting UnicodeEncodeError would be
+            # swallowed below and rebranded "Validation failed" (#477).
             for issue in validation_result.get('issues', []):
-                click.echo(f"  ⚠️ {issue}")
+                click.echo(f"  [!] {issue}")
         
         # Exit with appropriate code
         if validation_result.get('issues'):

--- a/src/dji_metadata_embedder/geo/panoedit.py
+++ b/src/dji_metadata_embedder/geo/panoedit.py
@@ -357,7 +357,7 @@ def run_editor(
             n = len(server.pano_files)            # type: ignore[attr-defined]
             click.echo(
                 f"Editing {n} panorama{'s' if n != 1 else ''} at {url} "
-                "— press Ctrl+C to stop"
+                "- press Ctrl+C to stop"
             )
         if open_browser:
             webbrowser.open(url)

--- a/src/dji_metadata_embedder/geo/serve.py
+++ b/src/dji_metadata_embedder/geo/serve.py
@@ -241,7 +241,7 @@ def serve_directory(
             click.echo(url)
             sys.stdout.flush()
         else:
-            click.echo(f"Serving map at {url} — press Ctrl+C to stop")
+            click.echo(f"Serving map at {url} - press Ctrl+C to stop")
         if open_browser:
             webbrowser.open(url)
         if stop_on_stdin_eof:

--- a/tests/test_cli_validate_text.py
+++ b/tests/test_cli_validate_text.py
@@ -1,0 +1,49 @@
+"""Text-format ``validate`` report stays legacy-console safe (#477).
+
+On Windows consoles using a legacy code page (cp1252, cp437), any emoji in
+the report raised UnicodeEncodeError, which the command's broad exception
+handler rebranded as "Validation failed" — hiding the very issue lines the
+user ran the command for. The report must therefore stay ASCII-encodable.
+"""
+
+from click.testing import CliRunner
+
+from dji_metadata_embedder.cli import ExitCode, main
+
+
+def _mock_validate_directory(monkeypatch, canned):
+    from dji_metadata_embedder.core import validator
+
+    monkeypatch.setattr(
+        validator, "validate_directory", lambda directory, drift_threshold: canned
+    )
+
+
+CANNED_WITH_ISSUES = {
+    "total_files": 3,
+    "valid_pairs": 1,
+    "issues": [
+        "No SRT file found for DJI_0002.mp4",
+        "Drift above threshold in DJI_0001.mp4",
+    ],
+    "warnings": [],
+    "file_analyses": [],
+}
+
+
+def test_validate_text_report_lists_issues(monkeypatch, tmp_path):
+    _mock_validate_directory(monkeypatch, CANNED_WITH_ISSUES)
+    res = CliRunner().invoke(main, ["validate", str(tmp_path)])
+    assert res.exit_code == ExitCode.VALIDATION_ERROR
+    assert "Issues found: 2" in res.output
+    for issue in CANNED_WITH_ISSUES["issues"]:
+        assert f"[!] {issue}" in res.output
+    # The failure mode of #477: the handler ate the report entirely.
+    assert "Validation failed" not in res.output
+
+
+def test_validate_text_report_encodes_on_legacy_code_pages(monkeypatch, tmp_path):
+    _mock_validate_directory(monkeypatch, CANNED_WITH_ISSUES)
+    res = CliRunner().invoke(main, ["validate", str(tmp_path)])
+    for codec in ("cp1252", "cp437"):
+        res.output.encode(codec)  # raises UnicodeEncodeError on regression


### PR DESCRIPTION
## Summary

- `dji-embed validate <dir>` in text mode printed each issue line with a warning emoji; legacy Windows consoles (cp1252, cp437) cannot encode it, the `UnicodeEncodeError` was swallowed by the command's broad handler and rebranded "Validation failed" — exit `GENERAL_ERROR` and none of the issue lines the user ran the command for. Observed live on Windows 10 PowerShell 5.1 against a real Mini 4 Pro flight folder.
- Fix per the issue's proposal: ASCII `[!]` marker instead of the emoji (no encoding workaround), with a comment explaining why it must stay ASCII.
- Same bug class swept across the package: the only other non-ASCII console output was the em-dash in the `serve`/`panoedit` "press Ctrl+C to stop" lines (fine on cp1252, crashes on OEM code pages like cp437 when redirected) — replaced with a plain hyphen.
- Regression test `tests/test_cli_validate_text.py`: issue lines render with `[!]`, the report never degenerates into "Validation failed", and the full text output round-trips through cp1252 and cp437.

Fixes #477

## Test plan
- [x] `pytest tests/test_cli_validate_text.py tests/test_geo_serve.py tests/test_cli_panoedit.py tests/test_progress_jsonl.py` — 47 passed
- [x] `mypy src/` clean, `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTAbG2MXmbDxoDTZCpiZKD