### PR TITLE
feat(embed): warn when MP4 output cannot carry DJI djmd/dbgi telemetry (#478)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -264,6 +264,12 @@ MP4. The MP4 muxer cannot tag these streams, so the default embed **drops
 them** (otherwise ffmpeg fails with `Could not find tag for codec none`). The
 video, audio, and telemetry subtitle are unaffected.
 
+`embed` warns per affected file when this happens, and `check` reports the
+streams' presence as `embedded_telemetry`. Keep the original file — it remains
+the authoritative source for the embedded telemetry — or use `--container mkv`
+below. With `--overwrite` the original *is* the output, so the telemetry is
+lost for good; prefer the default separate-output mode for these models.
+
 To keep those streams byte-for-byte, embed into a Matroska container instead:
 
 ```bash

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -45,6 +45,41 @@ def _ffprobe_duration(path: Path) -> Optional[float]:
         return None
 
 
+def _dji_data_stream_tags(path: Path) -> list[str]:
+    """DJI data-stream tags (``djmd``/``dbgi``) present in *path*.
+
+    Returns an empty list when the file has none, or when ffprobe is
+    missing/unreadable — detection is best-effort and must never block
+    processing (issue #478).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-select_streams", "d",
+                "-show_entries", "stream=codec_tag_string",
+                "-of", "json",
+                str(path),
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode != 0:
+        return []
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, dict):
+        return []
+    return [
+        s["codec_tag_string"]
+        for s in payload.get("streams", [])
+        if isinstance(s, dict) and s.get("codec_tag_string") in ("djmd", "dbgi")
+    ]
+
+
 def _validate_embedded_output(original_path: Path, temp_path: Path) -> bool:
     """Validate temp output before moving to final destination.
 
@@ -655,6 +690,33 @@ class DJIMetadataEmbedder:
 
                 progress.update(task, description=video_path.name)
                 logger.debug("Processing %s", video_path.name)
+
+                # The MP4 muxer cannot carry DJI's djmd/dbgi data streams
+                # (see embed_metadata_ffmpeg), so the "with metadata" output
+                # would silently lose the manufacturer's own embedded
+                # telemetry. Say so instead of staying quiet (issue #478).
+                if self.container != "mkv":
+                    dji_tags = _dji_data_stream_tags(video_path)
+                    if dji_tags:
+                        streams = "/".join(dji_tags)
+                        if self.overwrite:
+                            warning_msg = (
+                                f"{video_path.name} carries embedded DJI "
+                                f"telemetry ({streams}) that MP4 output cannot "
+                                "include; overwrite mode replaces the original, "
+                                "so this telemetry will be LOST. Use "
+                                "--container mkv to preserve it."
+                            )
+                        else:
+                            warning_msg = (
+                                f"{video_path.name} carries embedded DJI "
+                                f"telemetry ({streams}) that MP4 output cannot "
+                                "include; the original file remains the "
+                                "authoritative source for it. Use --container "
+                                "mkv to preserve it in the output."
+                            )
+                        logger.warning(warning_msg)
+                        result["warnings"].append(warning_msg)
 
                 # Parse SRT telemetry
                 telemetry = self.parse_dji_srt(srt_path)

--- a/src/dji_metadata_embedder/metadata_check.py
+++ b/src/dji_metadata_embedder/metadata_check.py
@@ -33,6 +33,7 @@ def run_ffprobe(path: Path) -> Optional[Dict]:
         "-print_format",
         "json",
         "-show_format",
+        "-show_streams",
         str(path),
     ]
     try:
@@ -67,10 +68,20 @@ def check_file(path: Path) -> Dict[str, bool]:
     altitude_present = "GPSAltitude" in exif_data or "altitude" in ff_tags
     creation_time_present = "creation_time" in ff_tags or "CreateDate" in exif_data
 
+    # DJI's djmd/dbgi data streams: per-frame telemetry embedded in the MP4
+    # itself. Reported so users know the file carries more than the sidecar
+    # SRT — and that a default (MP4) embed will not carry it over (#478).
+    embedded_telemetry = any(
+        s.get("codec_tag_string") in ("djmd", "dbgi")
+        for s in ffprobe_data.get("streams", [])
+        if s.get("codec_type") == "data"
+    )
+
     return {
         "gps": gps_present,
         "altitude": altitude_present,
         "creation_time": creation_time_present,
+        "embedded_telemetry": embedded_telemetry,
     }
 
 
@@ -140,6 +151,11 @@ def main() -> None:
                     f"{CHECK} creation_time"
                     if result["creation_time"]
                     else f"{CROSS} creation_time"
+                ),
+                (
+                    f"{CHECK} embedded_telemetry"
+                    if result["embedded_telemetry"]
+                    else f"{CROSS} embedded_telemetry"
                 ),
             ]
             logger.info("%s: %s", file, ", ".join(status_parts))

--- a/tests/test_embed_djmd_notice.py
+++ b/tests/test_embed_djmd_notice.py
@@ -1,0 +1,186 @@
+"""Embed warns when a source carries DJI djmd/dbgi streams (issue #478).
+
+The MP4 muxer cannot tag DJI's proprietary data streams, so the default
+embed drops them — previously in silence, leaving the "with metadata"
+output as the one variant *missing* the manufacturer's own embedded
+telemetry. The embed run now says so per affected file (and points at
+--container mkv), and ``check`` reports the streams' presence.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+from dji_metadata_embedder import metadata_check
+from dji_metadata_embedder.embedder import (
+    DJIMetadataEmbedder,
+    _dji_data_stream_tags,
+)
+
+
+def _fake_progress_class():
+    """Minimal Progress-like class (conftest stubs Progress as object)."""
+    class Task:
+        def advance(self, _=None):
+            pass
+
+    class FakeProgress:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def add_task(self, *args, **kwargs):
+            return Task()
+
+        def update(self, task, description=None):
+            pass
+
+        def advance(self, task):
+            pass
+
+    return FakeProgress
+
+
+def _fake_run(data_streams: list[dict]):
+    """subprocess.run replacement: ffmpeg writes its output, the data-stream
+    ffprobe query answers with *data_streams*, other ffprobe calls answer a
+    duration (so output validation passes)."""
+    streams_json = json.dumps({"streams": data_streams})
+
+    def run(cmd, *args, **kwargs):
+        ok = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        prog = str(cmd[0]).lower()
+        if "ffmpeg" in prog:
+            Path(cmd[-1]).write_bytes(b"embedded content")
+            return ok
+        if "ffprobe" in prog:
+            if "-select_streams" in cmd:
+                return type(
+                    "R", (), {"returncode": 0, "stdout": streams_json, "stderr": ""}
+                )()
+            return type("R", (), {"returncode": 0, "stdout": "10.0\n", "stderr": ""})()
+        return ok
+
+    return run
+
+
+DJI_STREAMS = [{"codec_tag_string": "djmd"}, {"codec_tag_string": "dbgi"}]
+
+
+class TestDjiDataStreamTags:
+    def test_returns_tags_from_ffprobe_json(self, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", _fake_run(DJI_STREAMS))
+        assert _dji_data_stream_tags(Path("clip.mp4")) == ["djmd", "dbgi"]
+
+    def test_ignores_other_data_streams(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run", _fake_run([{"codec_tag_string": "tmcd"}])
+        )
+        assert _dji_data_stream_tags(Path("clip.mp4")) == []
+
+    def test_missing_ffprobe_is_empty_not_fatal(self, monkeypatch):
+        def raise_missing(cmd, *args, **kwargs):
+            raise FileNotFoundError("ffprobe")
+
+        monkeypatch.setattr(subprocess, "run", raise_missing)
+        assert _dji_data_stream_tags(Path("clip.mp4")) == []
+
+    def test_unparseable_output_is_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: type(
+                "R", (), {"returncode": 0, "stdout": "10.0\n", "stderr": ""}
+            )(),
+        )
+        assert _dji_data_stream_tags(Path("clip.mp4")) == []
+
+
+class TestProcessDirectoryNotice:
+    def _prep(self, tmp_path: Path) -> Path:
+        video = tmp_path / "DJI_20240101_123456.mp4"
+        srt = tmp_path / "DJI_20240101_123456.srt"
+        video.write_bytes(b"fake mp4 content here")
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nGPS(1,2,3)")
+        out_dir = tmp_path / "processed"
+        out_dir.mkdir()
+        return out_dir
+
+    def _run(self, tmp_path, monkeypatch, *, streams, **embedder_kwargs):
+        out_dir = self._prep(tmp_path)
+        monkeypatch.setattr(subprocess, "run", _fake_run(streams))
+        monkeypatch.setattr(
+            "dji_metadata_embedder.embedder.Progress", _fake_progress_class()
+        )
+        embedder = DJIMetadataEmbedder(
+            str(tmp_path), output_dir=str(out_dir), **embedder_kwargs
+        )
+        return embedder.process_directory(use_exiftool=False)
+
+    def test_mp4_default_warns_and_still_processes(self, tmp_path, monkeypatch):
+        result = self._run(tmp_path, monkeypatch, streams=DJI_STREAMS)
+        assert result["processed"] == 1
+        notices = [w for w in result["warnings"] if "djmd" in w]
+        assert len(notices) == 1
+        assert "--container mkv" in notices[0]
+        assert "authoritative" in notices[0]
+        assert "LOST" not in notices[0]
+
+    def test_overwrite_mode_says_lost(self, tmp_path, monkeypatch):
+        result = self._run(
+            tmp_path, monkeypatch, streams=DJI_STREAMS, overwrite=True
+        )
+        notices = [w for w in result["warnings"] if "djmd" in w]
+        assert len(notices) == 1
+        assert "LOST" in notices[0]
+
+    def test_mkv_container_does_not_warn(self, tmp_path, monkeypatch):
+        result = self._run(
+            tmp_path, monkeypatch, streams=DJI_STREAMS, container="mkv"
+        )
+        assert result["processed"] == 1
+        assert not [w for w in result["warnings"] if "djmd" in w]
+
+    def test_no_data_streams_no_warning(self, tmp_path, monkeypatch):
+        result = self._run(tmp_path, monkeypatch, streams=[])
+        assert result["processed"] == 1
+        assert not [w for w in result["warnings"] if "djmd" in w]
+
+
+class TestCheckReportsEmbeddedTelemetry:
+    def _check(self, monkeypatch, ffprobe_data):
+        monkeypatch.setattr(metadata_check, "run_ffprobe", lambda p: ffprobe_data)
+        monkeypatch.setattr(metadata_check, "run_exiftool", lambda p: {})
+        return metadata_check.check_file(Path("clip.mp4"))
+
+    def test_djmd_stream_sets_flag(self, monkeypatch):
+        result = self._check(
+            monkeypatch,
+            {
+                "format": {"tags": {}},
+                "streams": [{"codec_type": "data", "codec_tag_string": "djmd"}],
+            },
+        )
+        assert result["embedded_telemetry"] is True
+
+    def test_plain_file_reports_false(self, monkeypatch):
+        result = self._check(
+            monkeypatch,
+            {
+                "format": {"tags": {}},
+                "streams": [{"codec_type": "video", "codec_tag_string": "hvc1"}],
+            },
+        )
+        assert result["embedded_telemetry"] is False
+
+    def test_non_dji_data_stream_reports_false(self, monkeypatch):
+        result = self._check(
+            monkeypatch,
+            {
+                "format": {"tags": {}},
+                "streams": [{"codec_type": "data", "codec_tag_string": "tmcd"}],
+            },
+        )
+        assert result["embedded_telemetry"] is False


### PR DESCRIPTION
## Summary

Filed from the Mini 4 Pro validation session: newer DJI models embed per-frame telemetry in the MP4 itself as `djmd`/`dbgi` data tracks, and the default embed remux drops them silently — so the file we label "with metadata" is the one variant *missing* the manufacturer's own embedded telemetry. Users deleting originals after processing would lose real data.

Per the issue's proposal (notice + docs, not atom surgery — and the repo already has the real preservation path, `--container mkv` from #197):

- **embed** now warns per affected file when the input carries `djmd`/`dbgi` and the output container is MP4. Detection is a best-effort ffprobe data-stream probe (`_dji_data_stream_tags`) that returns empty on any failure — it can never block processing. The warning flows into `result["warnings"]`, so `--progress jsonl` (and the GUI) get it as warning events for free. `--overwrite` gets a stronger wording: there the original *is* the output, so the telemetry is genuinely lost.
- **check** reports the streams' presence as a new `embedded_telemetry` field (ffprobe now runs with `-show_streams`), in both the text dict output and the JSONL summary.
- **docs/troubleshooting.md**: the existing "Preserving DJI Data Streams" section now states the runtime notice, the `check` field, and the overwrite caveat.

No behaviour change to the mux itself — MP4 output is unchanged, MKV still preserves the streams byte-for-byte.

Fixes #478

## Test plan
- [x] New `tests/test_embed_djmd_notice.py` (11 tests): probe parsing incl. non-DJI data streams, missing ffprobe, and non-dict JSON; process_directory warns on MP4, says LOST on overwrite, stays quiet on MKV and on clean files; `check_file` flag on/off/foreign-data-stream.
- [x] Full suite on the combined changes: 1179 passed; `mypy src/` clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTAbG2MXmbDxoDTZCpiZKD