### PR TITLE
fix(provision): SourceForge first + retry — exiftool.org stopped hosting zips (#481)

### DIFF
--- a/src/dji_metadata_embedder/utils/provision.py
+++ b/src/dji_metadata_embedder/utils/provision.py
@@ -46,12 +46,19 @@ EXIFTOOL_SHA256 = {
     ),
 }
 
-# Tried in order. exiftool.org hosts only the current release (pinned URLs
-# 404 once the next version ships); SourceForge keeps every version.
+# Tried in order. SourceForge keeps every version and is where exiftool.org's
+# own download links point since it stopped hosting the zips itself (observed
+# 2026-08-10: even the current release 404s there — issue #481). exiftool.org
+# stays as a fallback in case it resumes hosting.
 _MIRRORS = (
-    "https://exiftool.org/{artifact}",
     "https://downloads.sourceforge.net/project/exiftool/{artifact}",
+    "https://exiftool.org/{artifact}",
 )
+
+# Attempts per mirror. The checksum pin — not the host — is what's trusted,
+# so a retry is free; it absorbs the transient TLS/connection hiccups a
+# single-host download would otherwise turn into a hard failure (#481).
+_FETCH_ATTEMPTS = 2
 
 
 class ProvisionError(RuntimeError):
@@ -89,16 +96,26 @@ def _download(url: str, dest: Path) -> None:
 
 
 def _fetch_artifact(artifact: str, dest: Path) -> None:
-    """Download ``artifact`` from the first mirror that responds."""
+    """Download ``artifact`` from the first mirror that responds.
+
+    Each mirror gets ``_FETCH_ATTEMPTS`` tries, except that an HTTP 404 is
+    deterministic (the mirror does not have the file) and moves straight to
+    the next mirror.
+    """
     errors: list[str] = []
     for mirror in _MIRRORS:
         url = mirror.format(artifact=artifact)
-        try:
-            logger.info("Downloading %s", url)
-            _download(url, dest)
-            return
-        except (URLError, HTTPError, OSError) as exc:
-            errors.append(f"{url}: {exc}")
+        for _attempt in range(_FETCH_ATTEMPTS):
+            try:
+                logger.info("Downloading %s", url)
+                _download(url, dest)
+                return
+            except HTTPError as exc:
+                errors.append(f"{url}: {exc}")
+                if exc.code == 404:
+                    break
+            except (URLError, OSError) as exc:
+                errors.append(f"{url}: {exc}")
     raise ProvisionError(
         "Could not download ExifTool from any mirror:\n  " + "\n  ".join(errors)
     )

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -4,7 +4,7 @@ import os
 import tarfile
 import zipfile
 from pathlib import Path
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -74,21 +74,79 @@ def test_verify_sha256_rejects_mismatch(tmp_path):
         _verify_sha256(f, hashlib.sha256(b"payload").hexdigest())
 
 
-def test_fetch_artifact_falls_back_to_second_mirror(monkeypatch, tmp_path):
+def test_fetch_artifact_tries_sourceforge_first(monkeypatch, tmp_path):
+    # SourceForge hosts every version; exiftool.org stopped hosting the zips
+    # entirely (#481), so it is the fallback, not the primary.
     calls = []
 
     def fake_download(url, dest):
         calls.append(url)
-        if "exiftool.org" in url:
-            raise URLError("404 gone after release rollover")
         dest.write_bytes(b"from-mirror")
 
     monkeypatch.setattr(provision, "_download", fake_download)
     dest = tmp_path / "artifact.zip"
     _fetch_artifact("exiftool-13.59_64.zip", dest)
     assert dest.read_bytes() == b"from-mirror"
+    assert calls == [
+        "https://downloads.sourceforge.net/project/exiftool/exiftool-13.59_64.zip"
+    ]
+
+
+def test_fetch_artifact_falls_back_to_second_mirror(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_download(url, dest):
+        calls.append(url)
+        if "sourceforge" in url:
+            raise URLError("handshake operation timed out")
+        dest.write_bytes(b"from-mirror")
+
+    monkeypatch.setattr(provision, "_download", fake_download)
+    dest = tmp_path / "artifact.zip"
+    _fetch_artifact("exiftool-13.59_64.zip", dest)
+    assert dest.read_bytes() == b"from-mirror"
+    # Transient failure: SourceForge is retried once, then exiftool.org serves.
+    assert len(calls) == 3
+    assert "sourceforge" in calls[0] and "sourceforge" in calls[1]
+    assert "exiftool.org" in calls[2]
+
+
+def test_fetch_artifact_retries_transient_failure_on_same_mirror(
+    monkeypatch, tmp_path
+):
+    calls = []
+
+    def fake_download(url, dest):
+        calls.append(url)
+        if len(calls) == 1:
+            raise URLError("connection reset")
+        dest.write_bytes(b"second-try")
+
+    monkeypatch.setattr(provision, "_download", fake_download)
+    dest = tmp_path / "artifact.zip"
+    _fetch_artifact("exiftool-13.59_64.zip", dest)
+    assert dest.read_bytes() == b"second-try"
     assert len(calls) == 2
-    assert "sourceforge" in calls[1]
+    assert calls[0] == calls[1]  # the retry hit the same mirror
+
+
+def test_fetch_artifact_404_skips_retry(monkeypatch, tmp_path):
+    # A 404 is deterministic — retrying the same URL cannot help.
+    calls = []
+
+    def fake_download(url, dest):
+        calls.append(url)
+        if "sourceforge" in url:
+            raise HTTPError(url, 404, "Not Found", None, None)
+        dest.write_bytes(b"from-fallback")
+
+    monkeypatch.setattr(provision, "_download", fake_download)
+    dest = tmp_path / "artifact.zip"
+    _fetch_artifact("exiftool-13.59_64.zip", dest)
+    assert dest.read_bytes() == b"from-fallback"
+    assert len(calls) == 2
+    assert "sourceforge" in calls[0]
+    assert "exiftool.org" in calls[1]
 
 
 def test_fetch_artifact_reports_all_mirrors_on_total_failure(monkeypatch, tmp_path):
@@ -96,8 +154,10 @@ def test_fetch_artifact_reports_all_mirrors_on_total_failure(monkeypatch, tmp_pa
         raise URLError("no route")
 
     monkeypatch.setattr(provision, "_download", fake_download)
-    with pytest.raises(ProvisionError, match="exiftool.org"):
+    with pytest.raises(ProvisionError) as excinfo:
         _fetch_artifact("exiftool-13.59_64.zip", tmp_path / "artifact.zip")
+    assert "exiftool.org" in str(excinfo.value)
+    assert "sourceforge" in str(excinfo.value)
 
 
 def _make_windows_zip(path, version=EXIFTOOL_VERSION):

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -74,6 +74,14 @@ def test_verify_sha256_rejects_mismatch(tmp_path):
         _verify_sha256(f, hashlib.sha256(b"payload").hexdigest())
 
 
+# Exact expected mirror URLs for the fetch tests. Full-URL comparisons keep
+# the tests strong and steer clear of CodeQL's URL-substring rule, which
+# flags host-fragment `in` checks even in assertions.
+_TEST_ARTIFACT = "exiftool-13.59_64.zip"
+_SF_URL = f"https://downloads.sourceforge.net/project/exiftool/{_TEST_ARTIFACT}"
+_ET_URL = f"https://exiftool.org/{_TEST_ARTIFACT}"
+
+
 def test_fetch_artifact_tries_sourceforge_first(monkeypatch, tmp_path):
     # SourceForge hosts every version; exiftool.org stopped hosting the zips
     # entirely (#481), so it is the fallback, not the primary.
@@ -85,11 +93,9 @@ def test_fetch_artifact_tries_sourceforge_first(monkeypatch, tmp_path):
 
     monkeypatch.setattr(provision, "_download", fake_download)
     dest = tmp_path / "artifact.zip"
-    _fetch_artifact("exiftool-13.59_64.zip", dest)
+    _fetch_artifact(_TEST_ARTIFACT, dest)
     assert dest.read_bytes() == b"from-mirror"
-    assert calls == [
-        "https://downloads.sourceforge.net/project/exiftool/exiftool-13.59_64.zip"
-    ]
+    assert calls == [_SF_URL]
 
 
 def test_fetch_artifact_falls_back_to_second_mirror(monkeypatch, tmp_path):
@@ -97,18 +103,16 @@ def test_fetch_artifact_falls_back_to_second_mirror(monkeypatch, tmp_path):
 
     def fake_download(url, dest):
         calls.append(url)
-        if "sourceforge" in url:
+        if url == _SF_URL:
             raise URLError("handshake operation timed out")
         dest.write_bytes(b"from-mirror")
 
     monkeypatch.setattr(provision, "_download", fake_download)
     dest = tmp_path / "artifact.zip"
-    _fetch_artifact("exiftool-13.59_64.zip", dest)
+    _fetch_artifact(_TEST_ARTIFACT, dest)
     assert dest.read_bytes() == b"from-mirror"
     # Transient failure: SourceForge is retried once, then exiftool.org serves.
-    assert len(calls) == 3
-    assert "sourceforge" in calls[0] and "sourceforge" in calls[1]
-    assert "exiftool.org" in calls[2]
+    assert calls == [_SF_URL, _SF_URL, _ET_URL]
 
 
 def test_fetch_artifact_retries_transient_failure_on_same_mirror(
@@ -124,10 +128,9 @@ def test_fetch_artifact_retries_transient_failure_on_same_mirror(
 
     monkeypatch.setattr(provision, "_download", fake_download)
     dest = tmp_path / "artifact.zip"
-    _fetch_artifact("exiftool-13.59_64.zip", dest)
+    _fetch_artifact(_TEST_ARTIFACT, dest)
     assert dest.read_bytes() == b"second-try"
-    assert len(calls) == 2
-    assert calls[0] == calls[1]  # the retry hit the same mirror
+    assert calls == [_SF_URL, _SF_URL]  # the retry hit the same mirror
 
 
 def test_fetch_artifact_404_skips_retry(monkeypatch, tmp_path):
@@ -136,17 +139,15 @@ def test_fetch_artifact_404_skips_retry(monkeypatch, tmp_path):
 
     def fake_download(url, dest):
         calls.append(url)
-        if "sourceforge" in url:
+        if url == _SF_URL:
             raise HTTPError(url, 404, "Not Found", None, None)
         dest.write_bytes(b"from-fallback")
 
     monkeypatch.setattr(provision, "_download", fake_download)
     dest = tmp_path / "artifact.zip"
-    _fetch_artifact("exiftool-13.59_64.zip", dest)
+    _fetch_artifact(_TEST_ARTIFACT, dest)
     assert dest.read_bytes() == b"from-fallback"
-    assert len(calls) == 2
-    assert "sourceforge" in calls[0]
-    assert "exiftool.org" in calls[1]
+    assert calls == [_SF_URL, _ET_URL]
 
 
 def test_fetch_artifact_reports_all_mirrors_on_total_failure(monkeypatch, tmp_path):
@@ -155,9 +156,13 @@ def test_fetch_artifact_reports_all_mirrors_on_total_failure(monkeypatch, tmp_pa
 
     monkeypatch.setattr(provision, "_download", fake_download)
     with pytest.raises(ProvisionError) as excinfo:
-        _fetch_artifact("exiftool-13.59_64.zip", tmp_path / "artifact.zip")
-    assert "exiftool.org" in str(excinfo.value)
-    assert "sourceforge" in str(excinfo.value)
+        _fetch_artifact(_TEST_ARTIFACT, tmp_path / "artifact.zip")
+    # Every attempted URL is named: two tries per mirror, in order.
+    attempted = [
+        line.strip().split(": ", 1)[0]
+        for line in str(excinfo.value).splitlines()[1:]
+    ]
+    assert attempted == [_SF_URL, _SF_URL, _ET_URL, _ET_URL]
 
 
 def _make_windows_zip(path, version=EXIFTOOL_VERSION):


### PR DESCRIPTION
## Summary

exiftool.org now returns 404 even for its **current** release (`ver.txt` says 13.59, `exiftool-13.59_64.zip` is gone; the homepage download links point exclusively at SourceForge). So the primary mirror in `_MIRRORS` was permanently dead, every provision ran on SourceForge alone, and one transient TLS hiccup became a hard failure — exactly how the Windows CI leg on #479 failed.

- **Mirror order flipped**: SourceForge first (hosts every version), exiftool.org kept as fallback in case it resumes hosting. Comment updated to match reality.
- **Retry added**: each mirror gets a second attempt (`_FETCH_ATTEMPTS = 2`) on transient failures — the SHA-256 pin, not the host, is what's trusted, so a retry is free. An HTTP 404 is deterministic and skips straight to the next mirror instead of retrying.
- `checksums.txt` still lives on exiftool.org (verified), so the pin-bump procedure in the module docstring is unchanged.

Fixes #481

## Test plan
- [x] Updated + new unit tests: SourceForge tried first, transient-failure retry on the same mirror, 404 skips retry and falls through, fallback after retries, total-failure error names both hosts (22 passed).
- [x] Real-network E2E: `DJIEMBED_NETWORK_TESTS=1 pytest tests/test_provision.py::test_provision_real_download` — passed, downloading through the new order.
- [x] `mypy src/` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTAbG2MXmbDxoDTZCpiZKD