### PR TITLE
feat(panoedit): Reset and saved-vs-composed comparison (#473)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -549,6 +549,14 @@ with ExifTool and moves on to the next panorama. Each original is kept
 beside the file as `<name>_original`. In the desktop app this is the
 "360° views" mode.
 
+Two keys matter when a panorama already has a view you like: **Esc**
+resets the viewer to the view the file opened at, so you can look around
+and then move on with `N` without rewriting anything, and **C** flips
+between the saved view and the one you are composing, so you can see what
+you would be replacing before you replace it. Saving is held back while
+the saved view is on screen — that write would only put back what is
+already there.
+
 Panoramas wider than 6000 px are shown downscaled to that width. Very
 large equirectangular images (8000 px and up) fail to render on older
 graphics hardware — often erratically, one image loading and the next

--- a/src/dji_metadata_embedder/geo/panoedit_html.py
+++ b/src/dji_metadata_embedder/geo/panoedit_html.py
@@ -33,9 +33,13 @@ _PAGE = """<!DOCTYPE html>
   #readout b {{ color: #ffd24d; }}
   #savebar {{ position: fixed; top: 12px; right: 12px; z-index: 10;
     text-align: right; }}
-  #save {{ font: inherit; padding: 8px 18px; border: 0; border-radius: 6px;
-    background: #2a81cb; color: #fff; cursor: pointer; }}
-  #save:disabled {{ background: #555; cursor: default; }}
+  #savebar button {{ font: inherit; padding: 8px 18px; border: 0;
+    border-radius: 6px; background: #2a81cb; color: #fff; cursor: pointer; }}
+  #savebar button:disabled {{ background: #555; color: #bbb;
+    cursor: default; }}
+  /* Reset and Compare are second thoughts next to Save, not rivals. */
+  #reset, #compare {{ background: #3a3a3a; padding: 8px 14px; }}
+  #compare.on {{ background: #7a5c14; color: #fff; }}
   #status {{ margin-top: 6px; min-height: 1.2em; }}
   #status.err {{ color: #ff7b6b; }}
   #strip {{ position: fixed; left: 0; right: 0; bottom: 0; height: 96px;
@@ -70,11 +74,17 @@ _PAGE = """<!DOCTYPE html>
 <div id="readout">loading…</div>
 <div id="savebar">
   <button id="save" type="button">Save view (Enter)</button>
+  <button id="reset" type="button" title="Back to this file's opening view"
+    >Reset (Esc)</button>
+  <button id="compare" type="button"
+    title="Compare the saved view with the one you are composing"
+    >Show saved (C)</button>
   <div id="status"></div>
 </div>
 <div id="counter"></div>
 <div id="note">Saving keeps a backup of each original beside it
-(<code>*_original</code>). N/P: next/previous.</div>
+(<code>*_original</code>). N/P: next/previous. Esc: back to the opening
+view. C: compare with the saved one.</div>
 <div id="strip"></div>
 <script src="https://unpkg.com/pannellum@{pannellum}/build/pannellum.js"
         integrity="{pannellum_js_sri}" crossorigin=""></script>
@@ -83,6 +93,10 @@ _PAGE = """<!DOCTYPE html>
 const TOKEN = {token};
 const SERVE = {serve};
 let files = [], idx = 0, viewer = null, saving = false;
+// The view this file opened at (its saved view, or Pannellum's defaults
+// where none is saved) and the one being composed when the comparison
+// flips away from it (#473).
+let openingView = null, pendingView = null, showingSaved = false;
 window.__panoReady = false;
 const $ = (id) => document.getElementById(id);
 
@@ -153,6 +167,69 @@ function currentView() {{
   }};
 }}
 
+// Reset / compare (#473) -------------------------------------------------
+
+const EASE_MS = 400;
+
+function viewerView() {{
+  return {{ yaw: viewer.getYaw(), pitch: viewer.getPitch(),
+    hfov: viewer.getHfov() }};
+}}
+
+function lookAt(v) {{ viewer.lookAt(v.pitch, v.yaw, v.hfov, EASE_MS); }}
+
+function updateCompare() {{
+  const f = files[idx] || {{}};
+  const compare = $("compare");
+  // Nothing to compare against until a view has been saved for this file.
+  compare.disabled = !(f.hasView && openingView);
+  compare.classList.toggle("on", showingSaved);
+  compare.textContent = showingSaved ? "Back to yours (C)" : "Show saved (C)";
+  // Saving while the saved view is on screen would rewrite the file with
+  // what it already contains, which is the pointless write #473 is about.
+  $("save").disabled = saving || showingSaved;
+  $("reset").disabled = !openingView;
+}}
+
+// Snap back to the view this file opened at: the point of Reset is to
+// leave a good existing view alone without rewriting the file.
+function resetView() {{
+  if (!viewer || !openingView) return;
+  showingSaved = false;
+  pendingView = null;
+  lookAt(openingView);
+  updateCompare();
+  $("status").className = "";
+  $("status").textContent = files[idx] && files[idx].hasView
+    ? "Back to the saved view" : "Back to the opening view";
+}}
+
+// Flip between what is on disk and what you have composed, so the choice
+// to overwrite is made against the alternative rather than from memory.
+function toggleCompare() {{
+  if (!viewer || !openingView || !files[idx] || !files[idx].hasView) return;
+  if (showingSaved) {{
+    const back = pendingView;
+    showingSaved = false;
+    pendingView = null;
+    if (back) lookAt(back);
+  }} else {{
+    pendingView = viewerView();
+    showingSaved = true;
+    lookAt(openingView);
+  }}
+  updateCompare();
+}}
+
+// Dragging while the saved view is shown means the user has moved on from
+// comparing: their new framing is the pending one from here.
+function dropCompare() {{
+  if (!showingSaved) return;
+  showingSaved = false;
+  pendingView = null;
+  updateCompare();
+}}
+
 function renderStrip() {{
   const strip = $("strip");
   strip.textContent = "";
@@ -173,6 +250,9 @@ function renderStrip() {{
 function open(i) {{
   idx = i;
   window.__panoReady = false;
+  openingView = null;
+  pendingView = null;
+  showingSaved = false;
   clearPanoError();
   if (viewer) {{ viewer.destroy(); viewer = null; }}
   const f = files[i];
@@ -183,9 +263,19 @@ function open(i) {{
   if (f.hfov !== null) cfg.hfov = f.hfov;
   viewer = pannellum.viewer("viewer", cfg);
   window.__viewer = viewer;
-  viewer.on("load", () => {{ window.__panoReady = true; }});
+  viewer.on("load", () => {{
+    // Read the opening view off the viewer rather than the file: for a
+    // panorama with no saved view that is Pannellum's own default, which
+    // is exactly what Reset should return to.
+    openingView = viewerView();
+    updateCompare();
+    window.__panoReady = true;
+  }});
   viewer.on("error", showPanoError);
+  viewer.on("mousedown", dropCompare);
+  viewer.on("touchstart", dropCompare);
   $("status").textContent = "";
+  updateCompare();
   renderStrip();
 }}
 
@@ -196,13 +286,18 @@ function readoutLoop() {{
       "<b>" + files[idx].name.replace(/[<>&]/g, "") + "</b><br>" +
       "Heading " + v.heading.toFixed(1) + "° · " +
       "Pitch " + v.pitch.toFixed(1) + "° · " +
-      "FOV " + v.hfov.toFixed(1) + "°";
+      "FOV " + v.hfov.toFixed(1) + "°" +
+      // Whose numbers these are matters while comparing (#473).
+      (showingSaved ? "<br>showing the saved view" : "");
   }}
   requestAnimationFrame(readoutLoop);
 }}
 
 async function save() {{
-  if (saving || !viewer) return;
+  // Enter reaches here even though the button is disabled while the saved
+  // view is on screen; rewriting the file with its own contents is not a
+  // save, it is noise.
+  if (saving || !viewer || showingSaved) return;
   saving = true;
   $("save").disabled = true;
   const status = $("status");
@@ -224,6 +319,10 @@ async function save() {{
       open(idx + 1);
       $("status").textContent = "Saved ✓";
     }} else {{
+      // Staying on this file: what was just written is now its saved view,
+      // so that is what Reset and the comparison must use from here.
+      openingView = viewerView();
+      pendingView = null;
       renderStrip();
       status.textContent = "Saved ✓ — all panoramas done";
     }}
@@ -232,13 +331,17 @@ async function save() {{
     status.textContent = "Save failed: " + e.message;
   }} finally {{
     saving = false;
-    $("save").disabled = false;
+    updateCompare();
   }}
 }}
 
 $("save").addEventListener("click", save);
+$("reset").addEventListener("click", resetView);
+$("compare").addEventListener("click", toggleCompare);
 document.addEventListener("keydown", (e) => {{
   if (e.key === "Enter") {{ e.preventDefault(); save(); }}
+  else if (e.key === "Escape") {{ e.preventDefault(); resetView(); }}
+  else if (e.key === "c" || e.key === "C") {{ toggleCompare(); }}
   else if (e.key === "n" || e.key === "N") {{
     if (idx + 1 < files.length) open(idx + 1);
   }} else if (e.key === "p" || e.key === "P") {{

--- a/src/dji_metadata_embedder/geo/panoedit_html.py
+++ b/src/dji_metadata_embedder/geo/panoedit_html.py
@@ -97,6 +97,7 @@ let files = [], idx = 0, viewer = null, saving = false;
 // where none is saved) and the one being composed when the comparison
 // flips away from it (#473).
 let openingView = null, pendingView = null, showingSaved = false;
+let compareArmed = false;
 window.__panoReady = false;
 const $ = (id) => document.getElementById(id);
 
@@ -178,6 +179,11 @@ function viewerView() {{
 
 function lookAt(v) {{ viewer.lookAt(v.pitch, v.yaw, v.hfov, EASE_MS); }}
 
+function viewsDiffer(a, b) {{
+  return !a || !b || Math.abs(a.yaw - b.yaw) > 0.5
+    || Math.abs(a.pitch - b.pitch) > 0.5 || Math.abs(a.hfov - b.hfov) > 0.5;
+}}
+
 function updateCompare() {{
   const f = files[idx] || {{}};
   const compare = $("compare");
@@ -194,7 +200,10 @@ function updateCompare() {{
 // Snap back to the view this file opened at: the point of Reset is to
 // leave a good existing view alone without rewriting the file.
 function resetView() {{
-  if (!viewer || !openingView) return;
+  // Not mid-save: the write in flight is of the view that was on screen
+  // when it started, and moving the camera under it would leave Reset
+  // and the comparison pointing at something that is not on disk.
+  if (!viewer || !openingView || saving) return;
   showingSaved = false;
   pendingView = null;
   lookAt(openingView);
@@ -207,7 +216,8 @@ function resetView() {{
 // Flip between what is on disk and what you have composed, so the choice
 // to overwrite is made against the alternative rather than from memory.
 function toggleCompare() {{
-  if (!viewer || !openingView || !files[idx] || !files[idx].hasView) return;
+  if (!viewer || !openingView || !files[idx] || !files[idx].hasView
+      || saving) return;
   if (showingSaved) {{
     const back = pendingView;
     showingSaved = false;
@@ -216,16 +226,24 @@ function toggleCompare() {{
   }} else {{
     pendingView = viewerView();
     showingSaved = true;
+    // Armed only once the ease has landed, so the animation towards the
+    // saved view is not itself read as the user moving away from it.
+    compareArmed = false;
+    setTimeout(() => {{ compareArmed = showingSaved; }}, EASE_MS + 150);
     lookAt(openingView);
   }}
   updateCompare();
 }}
 
-// Dragging while the saved view is shown means the user has moved on from
-// comparing: their new framing is the pending one from here.
+// Any movement while the saved view is shown means the user has moved on
+// from comparing: their new framing is the pending one from here. Watched
+// as a divergence rather than hooked to mousedown, because Pannellum also
+// pans with the arrow keys and zooms with the wheel — leaving Save
+// disabled on a view the user has visibly changed.
 function dropCompare() {{
   if (!showingSaved) return;
   showingSaved = false;
+  compareArmed = false;
   pendingView = null;
   updateCompare();
 }}
@@ -241,10 +259,18 @@ function renderStrip() {{
     dot.className = "dot";
     chip.appendChild(dot);
     chip.appendChild(document.createTextNode(f.name));
-    chip.addEventListener("click", () => open(i));
+    chip.addEventListener("click", () => navigate(i));
     strip.appendChild(chip);
   }});
   $("counter").textContent = (idx + 1) + " / " + files.length;
+}}
+
+// Every user-initiated move between panoramas. A save in flight owns the
+// file it started on: leaving mid-write would apply its answer to whatever
+// is on screen when it lands (#473/#475).
+function navigate(i) {{
+  if (saving || i < 0 || i >= files.length) return;
+  open(i);
 }}
 
 function open(i) {{
@@ -253,6 +279,7 @@ function open(i) {{
   openingView = null;
   pendingView = null;
   showingSaved = false;
+  compareArmed = false;
   clearPanoError();
   if (viewer) {{ viewer.destroy(); viewer = null; }}
   const f = files[i];
@@ -281,6 +308,10 @@ function open(i) {{
 
 function readoutLoop() {{
   if (viewer && files.length) {{
+    // Wheel zoom and arrow-key panning never reach the mousedown handler,
+    // so the comparison is retired by watching the view itself.
+    if (showingSaved && compareArmed
+        && viewsDiffer(viewerView(), openingView)) dropCompare();
     const v = currentView();
     $("readout").innerHTML =
       "<b>" + files[idx].name.replace(/[<>&]/g, "") + "</b><br>" +
@@ -298,6 +329,9 @@ async function save() {{
   // view is on screen; rewriting the file with its own contents is not a
   // save, it is noise.
   if (saving || !viewer || showingSaved) return;
+  // The write belongs to this panorama for its whole flight, however long
+  // ExifTool takes: `idx` after the await is not necessarily this file.
+  const target = idx;
   saving = true;
   $("save").disabled = true;
   const status = $("status");
@@ -308,20 +342,23 @@ async function save() {{
     const resp = await fetch("/api/save", {{
       method: "POST",
       headers: {{ "Content-Type": "application/json" }},
-      body: JSON.stringify({{ index: files[idx].index, token: TOKEN,
+      body: JSON.stringify({{ index: files[target].index, token: TOKEN,
         heading: v.heading, pitch: v.pitch, hfov: v.hfov }}),
     }});
     const body = await resp.json();
     if (!resp.ok) throw new Error(body.error || ("HTTP " + resp.status));
-    Object.assign(files[idx], body);
+    Object.assign(files[target], body);
     status.textContent = "Saved ✓";
-    if (idx + 1 < files.length) {{
-      open(idx + 1);
+    if (target + 1 < files.length) {{
+      open(target + 1);
       $("status").textContent = "Saved ✓";
     }} else {{
-      // Staying on this file: what was just written is now its saved view,
-      // so that is what Reset and the comparison must use from here.
-      openingView = viewerView();
+      // Staying on this file: what was just written is now its saved view.
+      // Taken from the server's verified read-back, not from the live
+      // camera, so Reset and the comparison point at what is on disk.
+      openingView = (body.yaw !== null && body.yaw !== undefined)
+        ? {{ yaw: body.yaw, pitch: body.pitch, hfov: body.hfov }}
+        : viewerView();
       pendingView = null;
       renderStrip();
       status.textContent = "Saved ✓ — all panoramas done";
@@ -342,11 +379,8 @@ document.addEventListener("keydown", (e) => {{
   if (e.key === "Enter") {{ e.preventDefault(); save(); }}
   else if (e.key === "Escape") {{ e.preventDefault(); resetView(); }}
   else if (e.key === "c" || e.key === "C") {{ toggleCompare(); }}
-  else if (e.key === "n" || e.key === "N") {{
-    if (idx + 1 < files.length) open(idx + 1);
-  }} else if (e.key === "p" || e.key === "P") {{
-    if (idx > 0) open(idx - 1);
-  }}
+  else if (e.key === "n" || e.key === "N") {{ navigate(idx + 1); }}
+  else if (e.key === "p" || e.key === "P") {{ navigate(idx - 1); }}
 }});
 
 fetch("/api/list").then((r) => r.json()).then((list) => {{

--- a/tests/browser/test_panoedit_editor.py
+++ b/tests/browser/test_panoedit_editor.py
@@ -155,3 +155,74 @@ def test_oversized_panorama_is_served_downscaled(tmp_path, page, monkeypatch):
     finally:
         httpd.shutdown()
     assert (tmp_path / "wide.jpg").read_bytes() == original
+
+
+@needs_exiftool
+def test_reset_and_compare_against_the_saved_view(tmp_path, page, monkeypatch):
+    # #473: Reset snaps back to the file's opening view without a write,
+    # and Compare flips between the saved view and the one being composed.
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    pano = tmp_path / "saved.jpg"
+    _make_pano(pano, pose=0.0)
+    subprocess.run(
+        ["exiftool", "-overwrite_original", "-n",
+         "-XMP-GPano:InitialViewHeadingDegrees=40",
+         "-XMP-GPano:InitialViewPitchDegrees=0",
+         "-XMP-GPano:InitialHorizontalFOVDegrees=90", str(pano)],
+        check=True, capture_output=True)
+    before = pano.read_bytes()
+    httpd, url = _serve(tmp_path, page)
+    try:
+        page.goto(url)
+        page.wait_for_function("window.__panoReady === true")
+        page.wait_for_function("window.__viewer.getYaw() !== 0")
+        saved_yaw = page.evaluate("window.__viewer.getYaw()")
+
+        def drag(dx):
+            box = page.locator("#viewer").bounding_box()
+            cx, cy = box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
+            page.mouse.move(cx, cy)
+            page.mouse.down()
+            page.mouse.move(cx + dx, cy, steps=10)
+            page.mouse.up()
+
+        drag(-160)
+        page.wait_for_function(
+            f"Math.abs(window.__viewer.getYaw() - {saved_yaw}) > 5")
+        composed = page.evaluate("window.__viewer.getYaw()")
+
+        # Compare: the saved view comes back, and saving is refused while
+        # it is on screen (that write would change nothing).
+        page.keyboard.press("c")
+        page.wait_for_function(
+            f"Math.abs(window.__viewer.getYaw() - {saved_yaw}) < 1")
+        assert page.locator("#save").is_disabled()
+        assert "saved view" in page.inner_text("#readout")
+
+        # ...and back to the composed view, with saving live again.
+        page.keyboard.press("c")
+        page.wait_for_function(
+            f"Math.abs(window.__viewer.getYaw() - {composed}) < 1")
+        assert page.locator("#save").is_enabled()
+
+        # Reset: back to the opening view, still with nothing written.
+        drag(-160)
+        page.wait_for_function(
+            f"Math.abs(window.__viewer.getYaw() - {saved_yaw}) > 5")
+        page.keyboard.press("Escape")
+        page.wait_for_function(
+            f"Math.abs(window.__viewer.getYaw() - {saved_yaw}) < 1")
+    finally:
+        httpd.shutdown()
+    assert pano.read_bytes() == before
+    assert not (tmp_path / "saved.jpg_original").exists()
+
+
+@needs_exiftool
+def test_compare_is_off_for_files_with_no_saved_view(editor, page):
+    url, _folder = editor
+    page.goto(url)
+    page.wait_for_function("window.__panoReady === true")
+    # a.jpg carries no initial-view tags: there is nothing to compare to.
+    assert page.locator("#compare").is_disabled()
+    assert page.locator("#reset").is_enabled()

--- a/tests/browser/test_panoedit_editor.py
+++ b/tests/browser/test_panoedit_editor.py
@@ -226,3 +226,74 @@ def test_compare_is_off_for_files_with_no_saved_view(editor, page):
     # a.jpg carries no initial-view tags: there is nothing to compare to.
     assert page.locator("#compare").is_disabled()
     assert page.locator("#reset").is_enabled()
+
+
+@needs_exiftool
+def test_navigation_is_blocked_while_a_save_is_in_flight(
+        tmp_path, page, monkeypatch):
+    # Review finding: `save()` used the post-await `idx`, and N was live
+    # during the save, so a save that landed after navigating wrote its
+    # answer onto a different file's entry — leaving the second panorama
+    # showing the first one's name and unreachable for the session.
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    _make_pano(tmp_path / "a.jpg", pose=0.0)
+    _make_pano(tmp_path / "b.jpg", pose=0.0)
+    release = threading.Event()
+
+    def slow(path, heading, pitch, hfov):
+        release.wait(10)
+        return {"heading": heading, "pitch": pitch, "hfov": hfov, "pose": 0.0}
+
+    monkeypatch.setattr(pe, "write_initial_view", slow)
+    httpd, url = _serve(tmp_path, page)
+    try:
+        page.goto(url)
+        page.wait_for_function("window.__panoReady === true")
+        page.click("#save")
+        page.wait_for_function(
+            "document.querySelector('#status').innerText.includes('Saving')")
+        page.keyboard.press("n")            # ignored: the save owns a.jpg
+        assert "a.jpg" in page.inner_text("#readout")
+        release.set()
+        # The save advances to b.jpg itself, and b.jpg is still b.jpg.
+        page.wait_for_function(
+            "document.querySelector('#readout').innerText.includes('b.jpg')")
+        names = page.evaluate(
+            "Array.from(document.querySelectorAll('.chip'))"
+            ".map(c => c.textContent)")
+        assert names == ["a.jpg", "b.jpg"]
+    finally:
+        release.set()
+        httpd.shutdown()
+
+
+@needs_exiftool
+def test_zooming_while_comparing_returns_control_to_the_user(
+        tmp_path, page, monkeypatch):
+    # Review finding: only mousedown/touchstart retired the comparison, so
+    # a wheel zoom left Save disabled on a view the user had visibly
+    # changed, with only a small line of text to explain it.
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    pano = tmp_path / "saved.jpg"
+    _make_pano(pano, pose=0.0)
+    subprocess.run(
+        ["exiftool", "-overwrite_original", "-n",
+         "-XMP-GPano:InitialViewHeadingDegrees=40",
+         "-XMP-GPano:InitialViewPitchDegrees=0",
+         "-XMP-GPano:InitialHorizontalFOVDegrees=90", str(pano)],
+        check=True, capture_output=True)
+    httpd, url = _serve(tmp_path, page)
+    try:
+        page.goto(url)
+        page.wait_for_function("window.__panoReady === true")
+        page.keyboard.press("c")
+        page.wait_for_function("document.querySelector('#save').disabled")
+        box = page.locator("#viewer").bounding_box()
+        page.mouse.move(box["x"] + box["width"] / 2,
+                        box["y"] + box["height"] / 2)
+        page.mouse.wheel(0, -300)           # zoom: no mousedown anywhere
+        page.wait_for_function(
+            "!document.querySelector('#save').disabled")
+        assert "saved view" not in page.inner_text("#readout")
+    finally:
+        httpd.shutdown()

--- a/tests/test_geo_panoedit_html.py
+++ b/tests/test_geo_panoedit_html.py
@@ -47,6 +47,24 @@ def test_page_offers_reset_and_comparison():
     assert "saving || !viewer || showingSaved" in html
 
 
+def test_page_protects_an_in_flight_save():
+    # Review finding: navigation during a save applied the save's answer to
+    # whichever file was on screen when it landed. One gate for every move.
+    html = build_editor_page("tok123")
+    assert "function navigate(i)" in html
+    assert "if (saving || i < 0 || i >= files.length) return;" in html
+    assert "const target = idx;" in html
+    assert "Object.assign(files[target], body)" in html
+
+
+def test_page_retires_the_comparison_on_any_movement():
+    # Review finding: mousedown/touchstart miss wheel zoom and arrow-key
+    # panning, which left Save disabled on a changed view.
+    html = build_editor_page("tok123")
+    assert "viewsDiffer(viewerView(), openingView)" in html
+    assert "compareArmed" in html
+
+
 def test_page_reports_load_failures_honestly():
     # Pannellum blames the file for every load failure ("could not be
     # accessed"), which sent a field tester hunting a corrupt image when

--- a/tests/test_geo_panoedit_html.py
+++ b/tests/test_geo_panoedit_html.py
@@ -31,6 +31,22 @@ def test_page_token_is_json_escaped():
     assert "</script><script>alert(1)" not in html
 
 
+def test_page_offers_reset_and_comparison():
+    # #473: leaving a good existing view alone must not cost a rewrite,
+    # and the choice to overwrite should be made against the alternative.
+    html = build_editor_page("tok123")
+    assert 'id="reset"' in html and 'id="compare"' in html
+    assert "Reset (Esc)" in html and "Show saved (C)" in html
+    for key in ('e.key === "Escape"', 'e.key === "c"'):
+        assert key in html
+    # Reset returns to the view the viewer opened at, which for a file
+    # with no saved view is Pannellum's own default.
+    assert "openingView = viewerView()" in html
+    # Comparing must not be a way to rewrite a file with its own contents.
+    assert "showingSaved" in html
+    assert "saving || !viewer || showingSaved" in html
+
+
 def test_page_reports_load_failures_honestly():
     # Pannellum blames the file for every load failure ("could not be
     # accessed"), which sent a field tester hunting a corrupt image when


### PR DESCRIPTION
Closes #473. Stacked on #483 (base retargets to master when that merges);
the diff here is the second commit only.

## The ask

From the field tester using the 360° views editor in earnest: when a
panorama's existing opening view is already good, the editor gave him two
options — save (rewriting the file for no reason) or eyeball his way back
to where it started. And there was no way to see what a new view would be
replacing before committing to it. His framing: *original data vs pending
data*.

## What this adds

- **Reset — `Esc` or the button.** Eases back to the view the file opened
  at. The target is read off the viewer on load rather than from the
  file, so a panorama with no saved view resets to Pannellum's own default
  — the view it actually opened with — instead of to nothing.
- **Compare — `C` or the button.** Eases between the saved view and the
  one being composed, remembering the pending framing to flip back to.
  Disabled for files with no saved view, where there is nothing to compare
  against. Dragging while the saved view is up ends the comparison: the
  new framing becomes the pending one.
- **Saving is held back while the saved view is on screen**, by keyboard
  as well as by button. That write would replace the file's contents with
  its own — precisely the pointless rewrite this issue is about.
- The readout says whose numbers it is showing, and the footer note
  teaches both keys.

## Verification

- Browser E2E: drag off a saved view, `C` returns to it (Save goes
  disabled, readout says so), `C` again returns to the composed view (Save
  live again), `Esc` after another drag returns to the opening view — and
  the file is byte-identical afterwards with no `_original` backup
  created, which is the whole point.
- Browser E2E: Compare is disabled, Reset enabled, for a panorama with no
  saved view.
- Static page contract test for the buttons, keys, reset target and the
  save guard. Full panoedit suite, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTAbG2MXmbDxoDTZCpiZKD