### PR TITLE
fix(gui): a folder scan no longer overrides an explicit mode choice (#476)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceModeTests.cs
@@ -1,3 +1,4 @@
+using DjiEmbed.Gui.Services;
 using DjiEmbed.Gui.ViewModels;
 
 namespace DjiEmbed.Gui.Tests;
@@ -14,6 +15,29 @@ public class WorkspaceModeTests
                 WorkspaceModeKind.Setup,
             ],
             WorkspaceMode.All.Select(m => m.Kind));
+
+    // #476: what a mode needs from a folder is carried by the mode, so a
+    // new entry cannot compile without answering it — a switch elsewhere
+    // would quietly answer "nothing fits" and override the user's choice.
+    [Fact]
+    public void Every_folder_mode_declares_what_it_needs() =>
+        Assert.All(WorkspaceMode.All, m => Assert.Equal(
+            m.Sources.HasFlag(SourceKinds.Folder),
+            m.Needs != MediaKinds.None));
+
+    [Fact]
+    public void Fits_is_answered_from_the_folder_contents()
+    {
+        var photosOnly = new FolderContents(
+            false, true, false, false, true, false, null, null);
+        Assert.True(WorkspaceMode.Of(WorkspaceModeKind.PanoEdit).Fits(photosOnly));
+        Assert.True(WorkspaceMode.Of(WorkspaceModeKind.PhotoMap).Fits(photosOnly));
+        Assert.True(WorkspaceMode.Of(WorkspaceModeKind.Verify).Fits(photosOnly));
+        Assert.False(WorkspaceMode.Of(WorkspaceModeKind.Convert).Fits(photosOnly));
+        Assert.False(WorkspaceMode.Of(WorkspaceModeKind.FlightMap).Fits(photosOnly));
+        // Setup takes no source at all, so nothing ever fits it.
+        Assert.False(WorkspaceMode.Of(WorkspaceModeKind.Setup).Fits(photosOnly));
+    }
 
     [Fact]
     public void Verify_accepts_both_source_kinds() =>

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -1568,6 +1568,29 @@ public class WorkspaceScreenTests
         }
     }
 
+    // #476: the mode strip's suggestion is a hint, not a command. It shows
+    // only when it differs from what is selected — repeating the current
+    // mode back at the user is noise, and imposing it was the bug.
+    [AvaloniaFact]
+    public void Mode_suggestion_hint_shows_only_when_it_differs()
+    {
+        var window = ShowWorkspace();
+        var view = (WorkspaceView)window.Content!;
+        var vm = (WorkspaceViewModel)view.DataContext!;
+        var hint = view.FindControl<TextBlock>("ModeSuggestionHint")!;
+        Assert.False(hint.IsVisible);
+
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        vm.SuggestedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(hint.IsVisible);
+        Assert.Contains("Photo map", hint.Text!);
+
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(hint.IsVisible);
+    }
+
     // M4a: the Convert options panel renders only for Convert, with the
     // Advanced expander closed by default. The panel's freeze-while-busy
     // behaviour is covered alongside the other three panels' by

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -115,6 +115,87 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Equal(WorkspaceModeKind.Embed, vm.SuggestedMode!.Kind);
     }
 
+    // #476: the scan's suggestion used to overwrite SelectedMode
+    // unconditionally, so choosing 360° views and then picking the pano
+    // folder snapped straight back to Photo map — every time, since any
+    // folder with photos suggests Photo map.
+
+    [Fact]
+    public async Task A_chosen_mode_survives_a_folder_that_suggests_another()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        Assert.Equal(WorkspaceModeKind.PanoEdit, vm.SelectedMode.Kind);
+        Assert.Equal(WorkspaceModeKind.PhotoMap, vm.SuggestedMode!.Kind);
+        // The guess is still offered, just not imposed.
+        Assert.True(vm.ShowModeSuggestion);
+    }
+
+    [Fact]
+    public async Task A_chosen_mode_gives_way_when_the_folder_cannot_feed_it()
+    {
+        // Convert needs flight logs or videos; this folder has neither, so
+        // keeping the choice would only strand the user on a mode that
+        // cannot run here.
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        Assert.Equal(WorkspaceModeKind.PhotoMap, vm.SelectedMode.Kind);
+        Assert.False(vm.ShowModeSuggestion);
+    }
+
+    [Fact]
+    public async Task Setup_always_gives_way_to_a_folder_pick()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Setup);
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        Assert.Equal(WorkspaceModeKind.PhotoMap, vm.SelectedMode.Kind);
+    }
+
+    [Fact]
+    public async Task The_opening_mode_is_not_a_choice()
+    {
+        // Nothing was clicked, so the strip's starting entry must not
+        // outrank the suggestion — the first pick still lands where the
+        // folder points.
+        var vm = Vm("unused");
+        Assert.Equal(WorkspaceModeKind.FlightMap, vm.SelectedMode.Kind);
+        await vm.SetFolderAsync(MakeFolder(photos: true));
+        Assert.Equal(WorkspaceModeKind.PhotoMap, vm.SelectedMode.Kind);
+        Assert.False(vm.ShowModeSuggestion);
+    }
+
+    [Fact]
+    public async Task A_chosen_mode_that_still_fits_survives_the_next_folder()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        await vm.SetFolderAsync(MakeFolder(srt: true, videos: true));
+        Assert.Equal(WorkspaceModeKind.Verify, vm.SelectedMode.Kind);
+        Assert.Equal(WorkspaceModeKind.FlightMap, vm.SuggestedMode!.Kind);
+    }
+
+    [Fact]
+    public void A_chosen_file_capable_mode_survives_a_file_pick()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.Equal(WorkspaceModeKind.Verify, vm.SelectedMode.Kind);
+        Assert.Equal(WorkspaceModeKind.Convert, vm.SuggestedMode!.Kind);
+    }
+
+    [Fact]
+    public void A_folder_only_mode_gives_way_to_a_file_pick()
+    {
+        var vm = Vm("unused");
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PhotoMap);
+        vm.SetFile("C:/clips/DJI_0001.SRT");
+        Assert.Equal(WorkspaceModeKind.Convert, vm.SelectedMode.Kind);
+    }
+
     [Fact]
     public async Task Empty_folder_suggests_nothing_and_keeps_selection()
     {

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceMode.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using DjiEmbed.Gui.Services;
+
 namespace DjiEmbed.Gui.ViewModels;
 
 public enum WorkspaceModeKind
@@ -26,6 +28,22 @@ public enum SourceKinds
 }
 
 /// <summary>
+/// What a mode needs to find in a folder before it has anything to do
+/// there (#476). Carried by the mode itself rather than decided by a
+/// switch elsewhere: a mode added to <see cref="WorkspaceMode.All"/>
+/// cannot compile without answering this, where a switch would quietly
+/// answer "nothing fits" for it and silently override the user's choice.
+/// </summary>
+[Flags]
+public enum MediaKinds
+{
+    None = 0,
+    FlightLogs = 1,
+    Photos = 2,
+    Videos = 4,
+}
+
+/// <summary>
 /// One entry in the workspace mode strip (GUI 2.0 spec). M1 ships four;
 /// Convert joins in M4a, Verify in M4b.
 /// </summary>
@@ -34,30 +52,44 @@ public sealed record WorkspaceMode(
     string Title,
     string Verb,
     SourceKinds Sources,
+    MediaKinds Needs,
     string FailureMessage)
 {
+    /// <summary>Whether this mode has anything to work with in a folder
+    /// holding <paramref name="contents"/> (#476). Deliberately the loose
+    /// "anywhere in the tree" question, not the pre-flight guards' strict
+    /// "where this command will look": this only decides whether to keep a
+    /// user's choice, and those guards explain a real mismatch far better
+    /// than a silent mode switch ever could.</summary>
+    public bool Fits(FolderContents contents) =>
+        (Needs.HasFlag(MediaKinds.FlightLogs) && contents.HasFlightLogs)
+        || (Needs.HasFlag(MediaKinds.Photos) && contents.HasPhotos)
+        || (Needs.HasFlag(MediaKinds.Videos) && contents.HasVideos);
+
     public static readonly IReadOnlyList<WorkspaceMode> All =
     [
         new(WorkspaceModeKind.FlightMap, "Flight map", "Generate flight map",
-            Sources: SourceKinds.Folder,
+            Sources: SourceKinds.Folder, Needs: MediaKinds.FlightLogs,
             "Something went wrong while mapping your flights."),
         new(WorkspaceModeKind.PhotoMap, "Photo map", "Generate photo map",
-            Sources: SourceKinds.Folder,
+            Sources: SourceKinds.Folder, Needs: MediaKinds.Photos,
             "Something went wrong while mapping your photos."),
         new(WorkspaceModeKind.Embed, "Embed telemetry", "Embed telemetry",
-            Sources: SourceKinds.Folder,
+            Sources: SourceKinds.Folder, Needs: MediaKinds.Videos,
             "Something went wrong while embedding the flight data."),
         new(WorkspaceModeKind.Convert, "Convert telemetry", "Convert",
             Sources: SourceKinds.Folder | SourceKinds.File,
+            Needs: MediaKinds.FlightLogs | MediaKinds.Videos,
             "Something went wrong while converting the telemetry."),
         new(WorkspaceModeKind.Verify, "Verify footage", "Check metadata",
             Sources: SourceKinds.Folder | SourceKinds.File,
+            Needs: MediaKinds.Videos | MediaKinds.Photos,
             "Something went wrong while verifying the footage."),
         new(WorkspaceModeKind.PanoEdit, "360° views", "Open view editor",
-            Sources: SourceKinds.Folder,
+            Sources: SourceKinds.Folder, Needs: MediaKinds.Photos,
             "The 360° view editor could not be started."),
         new(WorkspaceModeKind.Setup, "Setup", "Check my setup",
-            Sources: SourceKinds.None,
+            Sources: SourceKinds.None, Needs: MediaKinds.None,
             "The setup check could not be completed."),
     ];
 

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -167,30 +167,6 @@ public partial class WorkspaceViewModel : FlowViewModel
         }
     }
 
-    /// <summary>
-    /// Whether <paramref name="mode"/> has anything to work with in a
-    /// folder holding <paramref name="contents"/>. Deliberately the loose
-    /// "anywhere in the tree" question, not the pre-flight guards' strict
-    /// "where this command will look": this only decides whether to keep a
-    /// user's choice, and the guards still explain a mismatch at Run time
-    /// with far better wording than a silent mode switch ever could.
-    /// </summary>
-    private static bool ModeFits(WorkspaceMode mode, FolderContents contents) =>
-        mode.Kind switch
-        {
-            WorkspaceModeKind.FlightMap => contents.HasFlightLogs,
-            WorkspaceModeKind.PhotoMap => contents.HasPhotos,
-            WorkspaceModeKind.PanoEdit => contents.HasPhotos,
-            WorkspaceModeKind.Embed => contents.HasVideos,
-            WorkspaceModeKind.Convert =>
-                contents.HasFlightLogs || contents.HasVideos,
-            WorkspaceModeKind.Verify =>
-                contents.HasVideos || contents.HasPhotos,
-            // Setup takes no source at all, so a folder pick always means
-            // the user has moved on from it.
-            _ => false,
-        };
-
     [ObservableProperty]
     public partial bool AllGood { get; set; }
 
@@ -557,7 +533,7 @@ public partial class WorkspaceViewModel : FlowViewModel
         // when nothing was chosen yet, or when what was chosen has nothing
         // to work with in this folder; otherwise the hint carries it.
         if (SuggestedMode is not null
-            && (!_modeChosenByUser || !ModeFits(SelectedMode, scan.contents)))
+            && (!_modeChosenByUser || !SelectedMode.Fits(scan.contents)))
         {
             AdoptSuggestion(SuggestedMode);
         }

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -137,6 +137,60 @@ public partial class WorkspaceViewModel : FlowViewModel
     [ObservableProperty]
     public partial WorkspaceMode? SuggestedMode { get; set; }
 
+    /// <summary>True once the user has picked a mode themselves; the
+    /// starting selection is where the strip happens to open, not a
+    /// choice. Session-only, like every other mode-related state — the
+    /// persisted state is folders and window bounds, nothing else.</summary>
+    private bool _modeChosenByUser;
+
+    /// <summary>Set while the app follows its own folder suggestion, so
+    /// <see cref="OnSelectedModeChanged"/> can tell that apart from a
+    /// click on the mode strip.</summary>
+    private bool _adoptingSuggestion;
+
+    /// <summary>The suggestion is worth showing only when it differs from
+    /// what is selected; repeating the current mode back at the user is
+    /// noise.</summary>
+    public bool ShowModeSuggestion =>
+        SuggestedMode is not null && SuggestedMode != SelectedMode;
+
+    private void AdoptSuggestion(WorkspaceMode mode)
+    {
+        _adoptingSuggestion = true;
+        try
+        {
+            SelectedMode = mode;
+        }
+        finally
+        {
+            _adoptingSuggestion = false;
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="mode"/> has anything to work with in a
+    /// folder holding <paramref name="contents"/>. Deliberately the loose
+    /// "anywhere in the tree" question, not the pre-flight guards' strict
+    /// "where this command will look": this only decides whether to keep a
+    /// user's choice, and the guards still explain a mismatch at Run time
+    /// with far better wording than a silent mode switch ever could.
+    /// </summary>
+    private static bool ModeFits(WorkspaceMode mode, FolderContents contents) =>
+        mode.Kind switch
+        {
+            WorkspaceModeKind.FlightMap => contents.HasFlightLogs,
+            WorkspaceModeKind.PhotoMap => contents.HasPhotos,
+            WorkspaceModeKind.PanoEdit => contents.HasPhotos,
+            WorkspaceModeKind.Embed => contents.HasVideos,
+            WorkspaceModeKind.Convert =>
+                contents.HasFlightLogs || contents.HasVideos,
+            WorkspaceModeKind.Verify =>
+                contents.HasVideos || contents.HasPhotos,
+            // Setup takes no source at all, so a folder pick always means
+            // the user has moved on from it.
+            _ => false,
+        };
+
     [ObservableProperty]
     public partial bool AllGood { get; set; }
 
@@ -411,8 +465,19 @@ public partial class WorkspaceViewModel : FlowViewModel
         RunCommand.NotifyCanExecuteChanged();
     }
 
+    partial void OnSuggestedModeChanged(WorkspaceMode? value) =>
+        OnPropertyChanged(nameof(ShowModeSuggestion));
+
     partial void OnSelectedModeChanged(WorkspaceMode value)
     {
+        // Anything that is not the app following its own suggestion is the
+        // user choosing (the mode strip binds SelectedItem straight to this
+        // property), and a choice outranks a suggestion from then on.
+        if (!_adoptingSuggestion)
+        {
+            _modeChosenByUser = true;
+        }
+        OnPropertyChanged(nameof(ShowModeSuggestion));
         OnPropertyChanged(nameof(CanRun));
         OnPropertyChanged(nameof(CommandPreview));
         OnPropertyChanged(nameof(IsFlightMapMode));
@@ -485,9 +550,16 @@ public partial class WorkspaceViewModel : FlowViewModel
             : scan.contents.HasPhotos ? WorkspaceMode.Of(WorkspaceModeKind.PhotoMap)
             : scan.contents.HasVideos ? WorkspaceMode.Of(WorkspaceModeKind.Embed)
             : null;
-        if (SuggestedMode is not null)
+        // A suggestion must not defeat a choice the user has already made
+        // and that still works here: picking 360° views and then the pano
+        // folder used to snap straight back to Photo map, every time, since
+        // any folder with photos suggests Photo map (#476). Switch only
+        // when nothing was chosen yet, or when what was chosen has nothing
+        // to work with in this folder; otherwise the hint carries it.
+        if (SuggestedMode is not null
+            && (!_modeChosenByUser || !ModeFits(SelectedMode, scan.contents)))
         {
-            SelectedMode = SuggestedMode;
+            AdoptSuggestion(SuggestedMode);
         }
         // A new folder is a fresh start: the previous run's outputs and
         // warnings must not frame a map that was already sitting here.
@@ -513,7 +585,12 @@ public partial class WorkspaceViewModel : FlowViewModel
         }
         SelectedFile = path;
         SuggestedMode = WorkspaceMode.Of(WorkspaceModeKind.Convert);
-        SelectedMode = SuggestedMode;
+        // Same rule as the folder pick (#476): Verify also takes a single
+        // file, so someone who chose it and then picked one keeps it.
+        if (!_modeChosenByUser || !SelectedMode.Sources.HasFlag(SourceKinds.File))
+        {
+            AdoptSuggestion(SuggestedMode);
+        }
         ResetDerivedSourceState();
         Step = FlowStep.Pick;
     }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -188,9 +188,14 @@
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
                             </ListBox>
-                            <TextBlock FontSize="11" Opacity="0.65" Margin="6,0,0,4"
-                                       IsVisible="{Binding SuggestedMode,
-                                           Converter={x:Static ObjectConverters.IsNotNull}}"
+                            <!-- Shown only when the suggestion differs from
+                                 the selection: an explicit choice is kept
+                                 and the hint is how the guess is offered
+                                 instead of imposed (#476). -->
+                            <TextBlock Name="ModeSuggestionHint"
+                                       FontSize="11" Opacity="0.65" Margin="6,0,0,4"
+                                       TextWrapping="Wrap"
+                                       IsVisible="{Binding ShowModeSuggestion}"
                                        Text="{Binding SuggestedMode,
                                            Converter={x:Static views:WorkspaceConverters.SuggestedModeHint}}" />
                         </StackPanel>


### PR DESCRIPTION
Closes #476. Independent of the panoedit stack (#483/#484/#485) — GUI
files only, so it can merge in any order.

## The bug

> Often fooled when selecting 360 mode then the folder and the mode auto
> switches to Map.

`SetFolderAsync`'s scan completion assigned `SelectedMode = SuggestedMode`
unconditionally, and *any* folder holding photos suggests Photo map. So
the sequence the app itself teaches — pick your mode, then pick your
folder — silently threw the mode away, every time. The #469 photo routing
made this path more travelled; the override predates it.

## The rule now

A suggestion yields to a choice that still works here. Concretely, the
mode is replaced only when:

- **nothing was chosen yet** — the strip's opening entry is where it
  happens to start, not a decision. Tracked session-only, by telling the
  app's own assignment apart from a click on the strip (the persisted
  state stays folders and window bounds, per the workspace spec); or
- **the chosen mode has nothing to work with in this folder** — the case
  the auto-switch exists for. Setup takes no source at all, so it always
  yields.

The same rule covers single-file picks: Verify takes a file too, so
choosing it and then picking one keeps it, while a folder-only mode still
gives way to Convert.

`ModeFits` deliberately asks the loose "is it anywhere in the tree"
question rather than the pre-flight guards' strict "is it where this
command will look": it only decides whether to keep a choice, and the
Run-time guards explain a real mismatch far better than a silent mode
switch ever did ("Those photos are in subfolders — turn on Include
subfolders").

The hint chip now shows exactly when the suggestion differs from the
selection — which is when it says anything at all. That is how the guess
gets offered instead of imposed.

## Verification

8 new tests, 573 green overall (0 failed):

- the reported sequence: 360° views chosen, photo folder picked → mode
  kept, Photo map still suggested, hint visible;
- a chosen mode the folder cannot feed (Convert on a photos-only folder)
  → switches, hint hidden;
- Setup always yields;
- the opening mode is not a choice: first pick still follows the folder;
- a chosen mode that still fits survives the next folder;
- file picks: Verify kept, Photo map replaced by Convert;
- a headless-UI test on the hint's visibility binding itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTAbG2MXmbDxoDTZCpiZKD