### PR TITLE
release: prepare version 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,45 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Switzerland airspace coverage (#456): `-f record` and `flightmap
-  --airspace` now resolve Swiss plateau flights against BAZL's ED-269
-  UAS-geozone feed (O-BY licence, attribution confirmed in writing by
-  BAZL). The feed's `99999 m` "no effective ceiling" sentinel renders as
-  an open-ended zone, never as a literal altitude.
-
-- `dji-embed fetch-log` — opt-in decode of TXT flight records through the
-  Flight Reader API with your own key (`FLIGHTREADER_API_KEY`); writes
-  `NAME.flightreader.csv` beside each record for `flightmap --flight-log`,
-  never uploads the same record twice, and states plainly that the whole
-  log is transmitted (#390).
-- `tools/mtp-copy.ps1` — bulk-copy flight records off a DJI RC over
-  USB/MTP, plus a how-to walkthrough for finding them by hand (#390).
-
-### Changed
-
-- Photo map hover previews are now opt-in ([#345]): pins go straight to the
-  click popup, and a "Hover previews" toggle in the map's top-right corner
-  (mouse devices only, remembered by the browser) restores the thumbnail
-  preview for skimming. Previously the preview was always on, which meant
-  interacting with a pin twice to reach its details and link.
-
-[#345]: https://github.com/CallMarcus/dji-drone-metadata-embedder/issues/345
-
-### Fixed
-
-- **gui**: Refusing macOS permission to open Terminal no longer fails in
-  silence. The command-line screen's launch button now waits for the
-  answer and, when it is refused, names the System Settings > Privacy &
-  Security > Automation switch that turns the permission back on.
-  Previously the click did nothing visible, and because macOS remembers
-  the refusal, so did every click after it (#443).
-- **gui**: The command-line screen's fallback advice, shown when the live
-  command list cannot be read, no longer tells macOS users to run a bare
-  `dji-embed` that is not on their PATH. It now names the bundled CLI by
-  its absolute path, the same rule the launch button already followed
-  (#454).
 
 ## [2.7.1] - 2026-08-08
 

--- a/HOUSEKEEPING.md
+++ b/HOUSEKEEPING.md
@@ -1,7 +1,7 @@
 # Repository Housekeeping Recommendations
 
 **Last refreshed:** 2026-06-21
-**Current state:** v2.7.1, production-ready, root directory already slim
+**Current state:** v2.8.0, production-ready, root directory already slim
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release](https://img.shields.io/github/v/release/CallMarcus/dji-drone-metadata-embedder?logo=github)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
-[![Version](https://img.shields.io/badge/version-2.7.1-blue)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
+[![Version](https://img.shields.io/badge/version-2.8.0-blue)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
 [![PyPI](https://img.shields.io/pypi/v/dji-drone-metadata-embedder?logo=pypi)](https://pypi.org/project/dji-drone-metadata-embedder/)
 [![Winget](https://img.shields.io/winget/v/CallMarcus.DJIMetadataEmbedder?logo=windows&label=winget)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/CallMarcus/DJIMetadataEmbedder)
 

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "2.7.1"
+__version__ = "2.8.0"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -1,6 +1,6 @@
 # Development Roadmap
 
-_Last updated: 2026-07-30 · Current version: **v2.7.1** · Status: **Production Ready**_
+_Last updated: 2026-07-30 · Current version: **v2.8.0** · Status: **Production Ready**_
 
 This roadmap tracks the evolution of **DJI Drone Metadata Embedder**. The
 original Phase 1–6 plan (standalone Windows GUI, dependency bootstrap,

--- a/docs/external-tool-versions.md
+++ b/docs/external-tool-versions.md
@@ -81,10 +81,10 @@ The image installs ExifTool from apt with no version pin (`apt-get install ffmpe
 
 | dji-embed | FFmpeg | ExifTool | Status |
 |-----------|---------|----------|--------|
-| 2.7.1    | 6.1.1   | 13.59    | ✅ Recommended |
-| 2.7.1    | 6.0.x   | 12.70+   | ✅ Supported |
-| 2.7.1    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
-| 2.7.1    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
+| 2.8.0    | 6.1.1   | 13.59    | ✅ Recommended |
+| 2.8.0    | 6.0.x   | 12.70+   | ✅ Supported |
+| 2.8.0    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
+| 2.8.0    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
 
 ## Known Issues
 
@@ -101,7 +101,7 @@ The image installs ExifTool from apt with no version pin (`apt-get install ffmpe
 The `dji-embed --version` command now shows detected tool versions:
 
 ```
-dji-embed 2.7.1
+dji-embed 2.8.0
   python: python
   ffmpeg: 6.1.1
   exiftool: 13.59

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,6 +1,6 @@
 """DJI Drone Metadata Embedder."""
 
-__version__ = "2.7.1"
+__version__ = "2.8.0"
 
 # Import check to ensure files were moved correctly
 try:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -196,7 +196,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "2.7.1"
+    $fallbackVersion = "2.8.0"
     
     try{
         LogInfo "Checking for latest version..."

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.7.1
+PackageVersion: 2.8.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -16,7 +16,7 @@ FileExtensions:
 - dat
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.7.1/dji-embed.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.8.0/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.7.1
+PackageVersion: 2.8.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus
@@ -37,7 +37,7 @@ Tags:
 - srt
 - ffmpeg
 - cli
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.7.1
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.8.0
 PurchaseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder
 InstallationNotes: |
   After installation, run 'dji-embed doctor' to verify dependencies are installed.

--- a/winget/CallMarcus.DJIMetadataEmbedder.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.7.1
+PackageVersion: 2.8.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.7.1
+PackageVersion: 2.8.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -14,7 +14,7 @@ AppsAndFeaturesEntries:
 - ProductCode: '{A0F2FECD-3BEB-4832-9BC6-4A57B20ED947}_is1'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.7.1/dji-metadata-embedder-setup-2.7.1.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.8.0/dji-metadata-embedder-setup-2.8.0.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.7.1
+PackageVersion: 2.8.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus
@@ -37,7 +37,7 @@ Tags:
 - map
 - panorama
 - gui
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.7.1
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.8.0
 InstallationNotes: |
   Start the app from the Start menu ("DJI Metadata Embedder"). The
   dji-embed command is also available in new terminals.

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.7.1
+PackageVersion: 2.8.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Version bump to **2.8.0** via `tools/sync_version.py` (`--check` passes),
plus a changelog cleanup.

The handwritten `## [Unreleased]` section was stale: Switzerland airspace
(#456/#457), `fetch-log` (#390), the opt-in hover previews (#345) and the
two macOS GUI fixes (#443/#454) all shipped in **v2.6.0** — confirmed with
`git tag --contains`, and v2.6.0's own generated section documents them.
Left in place they would have been re-announced as new in 2.8.0. The
section is now empty for `auto-changelog.yml` to fill after the tag.

## What 2.8.0 contains

Field-test wave, from a 360° panorama tester's reports plus the Mini 4
Pro validation:

- **#471** panoedit serves oversized panoramas downscaled (default 6000 px,
  a measured ceiling), carrying and verifying the GPano packet; both
  viewers now explain load failures instead of blaming the file.
- **#473** Reset (`Esc`) and saved-vs-composed comparison (`C`), with
  saving held back while the saved view is on screen.
- **#475** the save chain and the folder scan are bounded, so a stalled
  ExifTool cannot leave a dead Save button or a silent hang.
- **#476** a folder scan no longer overrides an explicit mode choice in
  the desktop app.
- **#474** provenance stamp: every emitted page names its generator.
- **#469** GUI field-report polish.
- **#477** validate's text report no longer crashes on legacy Windows
  consoles; **#478** embed warns when an MP4 output cannot carry DJI
  djmd/dbgi telemetry; **#481** ExifTool provisioning survives
  exiftool.org dropping its release zips.

**Packaging note:** the `terrain` extra now requires `pillow>=11.0` —
older Pillow cannot carry an XMP packet through a JPEG save, which the
panorama downscaler depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTAbG2MXmbDxoDTZCpiZKD