### PR TITLE
fix(panoedit): saves froze behind an undrained stderr pipe (#490)

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/FakeCli.cs
+++ b/gui/DjiEmbed.Gui.Tests/FakeCli.cs
@@ -100,6 +100,35 @@ internal static class FakeCli
             + EchoLinesSh(stdoutLines) + "exit 0\n");
     }
 
+    /// <summary>
+    /// A fake serve child that prints its URL line, floods one MB down the
+    /// chosen stream (far past any OS pipe buffer), touches
+    /// <paramref name="doneFile"/>, then stays alive. If the parent never
+    /// drains that stream, the flood blocks and the done-file never
+    /// appears — the #490 save deadlock in miniature.
+    /// </summary>
+    internal static string WritePipeFlood(string dir, string urlLine,
+        string doneFile, bool toStderr)
+    {
+        var redirect = toStderr ? " 1>&2" : "";
+        var chunk = new string('x', 250);
+        if (IsWindows)
+        {
+            return WriteScript(dir, "@echo off\r\n"
+                + $"echo {urlLine}\r\n"
+                + $"for /L %%i in (1,1,4000) do echo {chunk}{redirect}\r\n"
+                + $"type nul > \"{doneFile}\"\r\n"
+                + "ping -n 31 127.0.0.1 > nul\r\n");
+        }
+        return WriteScript(dir, "#!/bin/sh\n"
+            + $"echo '{urlLine}'\n"
+            + "i=0\nwhile [ $i -lt 4000 ]; do\n"
+            + $"echo '{chunk}'{redirect}\n"
+            + "i=$((i+1))\ndone\n"
+            + $": > '{doneFile}'\n"
+            + "sleep 30\n");
+    }
+
     private static string EchoLinesCmd(IEnumerable<string> lines) =>
         string.Concat(lines.Select(l =>
             "echo " + l.Replace("\"", "\"\"") + "\r\n"));

--- a/gui/DjiEmbed.Gui.Tests/MapServerTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/MapServerTests.cs
@@ -68,6 +68,37 @@ public class MapServerTests : IDisposable
         Assert.NotNull(second);
     }
 
+    // #490: MapServer redirects the child's stderr (and stdout) but only
+    // ever reads the URL line. A child that logs enough to fill the
+    // undrained pipe blocks in the kernel mid-write — in the field that
+    // froze panoedit's save chain until the app was closed. Both streams
+    // must be drained for the child's whole life.
+
+    private async Task AssertChildIsNotBlockedAsync(bool floodStderr)
+    {
+        using var server = new MapServer();
+        var done = Path.Combine(_dir, $"flood-done-{floodStderr}");
+        var cli = FakeCli.WritePipeFlood(_dir,
+            "http://127.0.0.1:54321/photomap.html", done, floodStderr);
+        var url = await server.GetUrlAsync(cli, MapFile(), CancellationToken.None);
+        Assert.NotNull(url);
+        var deadline = DateTime.UtcNow.AddSeconds(20);
+        while (!File.Exists(done) && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+        Assert.True(File.Exists(done),
+            "child blocked on an undrained pipe — the #490 save deadlock");
+    }
+
+    [Fact]
+    public Task A_stderr_flooding_child_is_never_blocked() =>
+        AssertChildIsNotBlockedAsync(floodStderr: true);
+
+    [Fact]
+    public Task A_stdout_flooding_child_is_never_blocked() =>
+        AssertChildIsNotBlockedAsync(floodStderr: false);
+
     [Fact]
     public async Task Unstartable_cli_yields_null()
     {

--- a/gui/DjiEmbed.Gui/Services/MapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/MapServer.cs
@@ -102,7 +102,18 @@ public sealed class MapServer : IMapServer, IDisposable
         {
             return null;
         }
+        // The child logs to stderr for its whole life, and nothing here
+        // reads it: an undrained pipe fills within a few KB, after which
+        // the child's next write blocks in the kernel. One of those writes
+        // sat inside panoedit's save chain, freezing every later save
+        // until this app exited and broke the pipe (#490). Drain and
+        // discard — the content is the CLI's terminal log, which has no
+        // reader inside the GUI.
+        _ = DrainAsync(process.StandardError);
         var url = await ReadUrlLineAsync(process, cancellationToken);
+        // Same hazard on stdout: only the URL line is ever read, so any
+        // later stdout output would hit the same full-pipe block.
+        _ = DrainAsync(process.StandardOutput);
         if (url is null)
         {
             TryKill(process);
@@ -136,6 +147,21 @@ public sealed class MapServer : IMapServer, IDisposable
             && line.StartsWith("http://127.0.0.1:", StringComparison.Ordinal)
             ? line
             : null;
+    }
+
+    /// <summary>Reads a child stream to the end, discarding, so the child
+    /// can never block on a full pipe (#490). Runs until the child exits;
+    /// any error just means the pipe is already gone.</summary>
+    private static async Task DrainAsync(StreamReader reader)
+    {
+        try
+        {
+            await reader.BaseStream.CopyToAsync(Stream.Null);
+        }
+        catch (Exception)
+        {
+            // Child exited or was killed; nothing left to drain.
+        }
     }
 
     private static void TryKill(Process process)

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -54,7 +54,12 @@ from .geo.record import build_records
 from .geo.record_html import write_flight_record
 from .mp4_telemetry import Mp4TelemetryError
 from .progress import NullProgress, make_progress
-from .utilities import check_dependencies, setup_logging, get_tool_versions
+from .utilities import (
+    check_dependencies,
+    make_logging_nonblocking,
+    setup_logging,
+    get_tool_versions,
+)
 
 
 # Exit codes for consistent CLI behavior
@@ -1414,6 +1419,11 @@ def panoedit(
     # INFO lines — including how long each save took, which the page tells
     # the user to come here for — went nowhere (#475).
     setup_logging(verbose=False, quiet=False)
+    # The GUI redirects this command's stderr to a pipe it may never read.
+    # A full pipe turns the next log write into a kernel-level block — one
+    # of those sat inside the save lock and froze every later save (#490).
+    # Queue the handler I/O so a request thread can never block on stderr.
+    make_logging_nonblocking()
     try:
         run_editor(
             Path(directory),

--- a/src/dji_metadata_embedder/geo/panoedit.py
+++ b/src/dji_metadata_embedder/geo/panoedit.py
@@ -84,6 +84,13 @@ _WRITE_TIMEOUT = 60
 # the early sign of the machine the timeout exists for.
 _SLOW_WRITE_SECONDS = 10
 
+# Ceiling on waiting for another save to release the file lock. A healthy
+# save can legitimately hold it for two ExifTool runs (2 × _WRITE_TIMEOUT),
+# so waiters must outlast that; anything longer is a wedged holder, and the
+# next save should come back as an honest error instead of queueing forever
+# (#490). The page's own fetch abort is 135 s, deliberately just above this.
+_SAVE_LOCK_TIMEOUT = 2 * _WRITE_TIMEOUT + 5
+
 # The folder scan's budget: unlike a save it grows with the folder, so it
 # is a per-file allowance rather than a constant, capped so that a truly
 # wedged scan still ends.
@@ -625,13 +632,21 @@ class _EditorHandler(_RangeHandler):
             return
         heading %= 360.0
         f = files[index]
+        lock = self.server.pano_lock              # type: ignore[attr-defined]
+        if not lock.acquire(timeout=_SAVE_LOCK_TIMEOUT):
+            self._send_json(HTTPStatus.SERVICE_UNAVAILABLE, {
+                "error": "Another save is still in progress. Wait for it "
+                         "to finish and try again — if this keeps "
+                         "happening, restart the editor."})
+            return
         try:
-            with self.server.pano_lock:           # type: ignore[attr-defined]
-                verified = write_initial_view(f.path, heading, pitch, hfov)
+            verified = write_initial_view(f.path, heading, pitch, hfov)
         except PanoEditError as exc:
             self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR,
                             {"error": str(exc)})
             return
+        finally:
+            lock.release()
         # The file on disk just changed, so any rendition of it is stale.
         self.server.drop_rendition(index)         # type: ignore[attr-defined]
         # The verified read is the new truth for /api/list and the client.

--- a/src/dji_metadata_embedder/geo/panoedit.py
+++ b/src/dji_metadata_embedder/geo/panoedit.py
@@ -88,7 +88,11 @@ _SLOW_WRITE_SECONDS = 10
 # save can legitimately hold it for two ExifTool runs (2 × _WRITE_TIMEOUT),
 # so waiters must outlast that; anything longer is a wedged holder, and the
 # next save should come back as an honest error instead of queueing forever
-# (#490). The page's own fetch abort is 135 s, deliberately just above this.
+# (#490). Note the budgets stack: a waiter that acquires late still gets
+# the full write time, so its response can land after the page's 135 s
+# fetch abort — the write is durable and the next list refresh shows it,
+# but the page will have reported a timeout. Only concurrent saves (a
+# second window on the same folder) can reach that state.
 _SAVE_LOCK_TIMEOUT = 2 * _WRITE_TIMEOUT + 5
 
 # The folder scan's budget: unlike a save it grows with the folder, so it
@@ -639,14 +643,21 @@ class _EditorHandler(_RangeHandler):
                          "to finish and try again — if this keeps "
                          "happening, restart the editor."})
             return
+        # The lock must be free before any response is written: the client
+        # socket is unbuffered and blocking, so a stalled reader would
+        # otherwise extend the save critical section (except-handlers run
+        # BEFORE finally — sending from one would send under the lock).
         try:
             verified = write_initial_view(f.path, heading, pitch, hfov)
+            error = None
         except PanoEditError as exc:
-            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR,
-                            {"error": str(exc)})
-            return
+            error = str(exc)
         finally:
             lock.release()
+        if error is not None:
+            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR,
+                            {"error": error})
+            return
         # The file on disk just changed, so any rendition of it is stale.
         self.server.drop_rendition(index)         # type: ignore[attr-defined]
         # The verified read is the new truth for /api/list and the client.

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -1,4 +1,5 @@
 import logging
+import logging.handlers
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -391,6 +392,41 @@ def setup_logging(
                 )
             ],
         )
+
+
+def make_logging_nonblocking(
+    target: logging.Logger | None = None,
+) -> logging.handlers.QueueListener | None:
+    """Move *target*'s handler I/O onto a sacrificial listener thread.
+
+    A long-lived server command launched by the GUI logs to a stderr pipe
+    the GUI may never read; once the pipe fills, the next log write blocks
+    the thread that made it — inside panoedit's save chain that froze every
+    later save until the app was closed (#490). After this call the calling
+    thread only ever enqueues; the listener thread does the real writes,
+    and if those wedge, only the listener wedges.
+
+    The listener thread is a daemon and is deliberately never joined at
+    exit: joining would trade the save deadlock for a shutdown hang on the
+    same wedged pipe. Returns the listener, or ``None`` when there was
+    nothing to wrap (no handlers, or already wrapped).
+    """
+    import queue
+
+    log = target if target is not None else logging.getLogger()
+    handlers = [
+        h for h in log.handlers
+        if not isinstance(h, logging.handlers.QueueHandler)
+    ]
+    if not handlers:
+        return None
+    q: queue.SimpleQueue = queue.SimpleQueue()
+    listener = logging.handlers.QueueListener(
+        q, *handlers, respect_handler_level=True
+    )
+    log.handlers = [logging.handlers.QueueHandler(q)]
+    listener.start()
+    return listener
 
 
 def get_tool_versions() -> dict[str, str]:

--- a/src/dji_metadata_embedder/utilities.py
+++ b/src/dji_metadata_embedder/utilities.py
@@ -408,23 +408,32 @@ def make_logging_nonblocking(
 
     The listener thread is a daemon and is deliberately never joined at
     exit: joining would trade the save deadlock for a shutdown hang on the
-    same wedged pipe. Returns the listener, or ``None`` when there was
-    nothing to wrap (no handlers, or already wrapped).
+    same wedged pipe. (``logging.shutdown`` may still flush the wrapped
+    handlers at exit via ``logging._handlerList`` — acceptable, since by
+    then nothing is holding application locks.) Two known costs of the
+    stock ``QueueHandler``: records cross the queue pre-formatted with
+    ``exc_info`` stripped, so RichHandler renders plain rather than rich
+    tracebacks, and ``args`` are burned into the message string. Both are
+    cosmetic here. Returns the listener, or ``None`` when there was
+    nothing to wrap (no handlers, or already fully wrapped).
     """
     import queue
 
     log = target if target is not None else logging.getLogger()
-    handlers = [
+    queued = [
         h for h in log.handlers
-        if not isinstance(h, logging.handlers.QueueHandler)
+        if isinstance(h, logging.handlers.QueueHandler)
     ]
+    handlers = [h for h in log.handlers if h not in queued]
     if not handlers:
         return None
     q: queue.SimpleQueue = queue.SimpleQueue()
     listener = logging.handlers.QueueListener(
         q, *handlers, respect_handler_level=True
     )
-    log.handlers = [logging.handlers.QueueHandler(q)]
+    # Existing queue handlers stay wired: dropping one would orphan its
+    # listener and silently cut off every handler behind it.
+    log.handlers = [*queued, logging.handlers.QueueHandler(q)]
     listener.start()
     return listener
 

--- a/tests/test_cli_panoedit.py
+++ b/tests/test_cli_panoedit.py
@@ -42,6 +42,20 @@ def test_panoedit_max_width_is_overridable(monkeypatch, tmp_path):
     assert calls["max_width"] == 0
 
 
+def test_panoedit_makes_logging_nonblocking(monkeypatch, tmp_path):
+    # The GUI redirects this command's stderr to a pipe it never reads; a
+    # blocking log write inside the save chain froze every later save
+    # (#490). The command must hand its logging to the queue wrapper.
+    assert hasattr(cli_mod, "make_logging_nonblocking")
+    calls = []
+    monkeypatch.setattr(cli_mod, "make_logging_nonblocking",
+                        lambda *a, **kw: calls.append(True))
+    monkeypatch.setattr(cli_mod, "run_editor", lambda directory, **kw: None)
+    result = CliRunner().invoke(cli_mod.main, ["panoedit", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert calls == [True]
+
+
 def test_panoedit_error_is_clean(monkeypatch, tmp_path):
     def fake_run(directory, **kwargs):
         raise PanoEditError("No 360-degree panoramas found")

--- a/tests/test_cli_panoedit.py
+++ b/tests/test_cli_panoedit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from dji_metadata_embedder import cli as cli_mod
@@ -11,6 +12,20 @@ from dji_metadata_embedder.geo.panoedit import (
     DEFAULT_MAX_SERVE_WIDTH,
     PanoEditError,
 )
+
+
+@pytest.fixture(autouse=True)
+def _stub_nonblocking_logging(monkeypatch):
+    """Keep the real make_logging_nonblocking away from pytest's root logger.
+
+    The command wires it for real, and under pytest that would swap out the
+    logging plugin's caplog/report handlers for a QueueHandler and leak one
+    listener thread per invocation (#490 review).
+    """
+    calls: list[bool] = []
+    monkeypatch.setattr(cli_mod, "make_logging_nonblocking",
+                        lambda *a, **kw: calls.append(True))
+    return calls
 
 
 def test_panoedit_forwards_options(monkeypatch, tmp_path):
@@ -42,18 +57,15 @@ def test_panoedit_max_width_is_overridable(monkeypatch, tmp_path):
     assert calls["max_width"] == 0
 
 
-def test_panoedit_makes_logging_nonblocking(monkeypatch, tmp_path):
+def test_panoedit_makes_logging_nonblocking(
+        _stub_nonblocking_logging, monkeypatch, tmp_path):
     # The GUI redirects this command's stderr to a pipe it never reads; a
     # blocking log write inside the save chain froze every later save
     # (#490). The command must hand its logging to the queue wrapper.
-    assert hasattr(cli_mod, "make_logging_nonblocking")
-    calls = []
-    monkeypatch.setattr(cli_mod, "make_logging_nonblocking",
-                        lambda *a, **kw: calls.append(True))
     monkeypatch.setattr(cli_mod, "run_editor", lambda directory, **kw: None)
     result = CliRunner().invoke(cli_mod.main, ["panoedit", str(tmp_path)])
     assert result.exit_code == 0, result.output
-    assert calls == [True]
+    assert _stub_nonblocking_logging == [True]
 
 
 def test_panoedit_error_is_clean(monkeypatch, tmp_path):

--- a/tests/test_geo_panoedit_server.py
+++ b/tests/test_geo_panoedit_server.py
@@ -105,6 +105,23 @@ def test_save_rejects_bad_token_and_input(editor):
     assert writes == []
 
 
+def test_save_returns_503_while_another_save_holds_the_lock(editor, monkeypatch):
+    # A wedged save must surface as an honest error on the next attempt,
+    # not as a request that waits forever on the lock (#490).
+    url, httpd, writes = editor
+    monkeypatch.setattr(pe, "_SAVE_LOCK_TIMEOUT", 0.2)
+    httpd.pano_lock.acquire()
+    try:
+        status, body = _post(url + "api/save", {
+            "index": 0, "heading": 1.0, "pitch": 0.0, "hfov": 90.0,
+            "token": httpd.pano_token})
+        assert status == 503
+        assert "save" in body["error"].lower()
+        assert writes == []                   # ExifTool was never reached
+    finally:
+        httpd.pano_lock.release()
+
+
 def test_save_write_failure_is_500(editor, monkeypatch):
     url, httpd, _ = editor
 

--- a/tests/test_geo_panoedit_server.py
+++ b/tests/test_geo_panoedit_server.py
@@ -6,6 +6,7 @@ import json
 import threading
 import urllib.error
 import urllib.request
+from http import HTTPStatus
 
 import pytest
 
@@ -120,6 +121,33 @@ def test_save_returns_503_while_another_save_holds_the_lock(editor, monkeypatch)
         assert writes == []                   # ExifTool was never reached
     finally:
         httpd.pano_lock.release()
+
+
+def test_error_response_is_sent_after_the_lock_is_released(editor, monkeypatch):
+    # Writing the 500 body is a blocking socket send to an unbuffered
+    # client socket; it must never happen while pano_lock is held, or a
+    # stalled client extends the save critical section (#490 review).
+    url, httpd, _ = editor
+
+    def boom(path, heading, pitch, hfov):
+        raise pe.PanoEditError("disk on fire")
+    monkeypatch.setattr(pe, "write_initial_view", boom)
+    observed = {}
+    orig = pe._EditorHandler._send_json
+
+    def spy(self, status, obj):
+        if status == HTTPStatus.INTERNAL_SERVER_ERROR:
+            free = httpd.pano_lock.acquire(blocking=False)
+            if free:
+                httpd.pano_lock.release()
+            observed["lock_free_during_error_send"] = free
+        return orig(self, status, obj)
+    monkeypatch.setattr(pe._EditorHandler, "_send_json", spy)
+    status, _body = _post(url + "api/save", {
+        "index": 0, "heading": 1.0, "pitch": 0.0, "hfov": 90.0,
+        "token": httpd.pano_token})
+    assert status == 500
+    assert observed["lock_free_during_error_send"] is True
 
 
 def test_save_write_failure_is_500(editor, monkeypatch):

--- a/tests/test_logging_nonblocking.py
+++ b/tests/test_logging_nonblocking.py
@@ -91,6 +91,29 @@ def test_wrapping_twice_is_a_no_op():
         listener.stop()
 
 
+def test_rewrap_of_a_mixed_state_keeps_the_first_queue_wired():
+    # If a handler is added after the first wrap, wrapping again must not
+    # discard the first QueueHandler — that would silently orphan its
+    # listener and cut off every handler behind it (#490 review).
+    h1 = _BlockingHandler()
+    h1.unblock.set()
+    log = _private_logger("nonblocking-test-rewrap", h1)
+    listener1 = make_logging_nonblocking(log)
+    assert listener1 is not None
+    h2 = _BlockingHandler()
+    h2.unblock.set()
+    log.addHandler(h2)
+    listener2 = make_logging_nonblocking(log)
+    assert listener2 is not None
+    try:
+        log.info("both please")
+        assert _wait_for(lambda: len(h2.records) == 1)
+        assert _wait_for(lambda: len(h1.records) == 1)
+    finally:
+        listener1.stop()
+        listener2.stop()
+
+
 def test_logger_without_handlers_is_left_alone():
     log = logging.getLogger("nonblocking-test-empty")
     log.handlers = []

--- a/tests/test_logging_nonblocking.py
+++ b/tests/test_logging_nonblocking.py
@@ -1,0 +1,98 @@
+"""Non-blocking logging for the long-lived server commands (#490).
+
+The GUI launches ``dji-embed panoedit`` with stderr redirected to a pipe
+it never reads. Once that pipe fills, a blocking log write freezes the
+request thread that made it — and when the write sits inside the save
+lock, every later save queues behind it forever. ``make_logging_nonblocking``
+moves the actual handler I/O onto a sacrificial listener thread: request
+threads only ever enqueue, so a wedged stderr can no longer stall a save.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+from dji_metadata_embedder.utilities import make_logging_nonblocking
+
+
+class _BlockingHandler(logging.Handler):
+    """Stands in for a stderr pipe nobody reads: emit blocks until told."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.unblock = threading.Event()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.unblock.wait(timeout=10)
+        self.records.append(record)
+
+
+def _private_logger(name: str, handler: logging.Handler) -> logging.Logger:
+    log = logging.getLogger(name)
+    log.handlers = [handler]
+    log.propagate = False
+    log.setLevel(logging.INFO)
+    return log
+
+
+def _wait_for(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_blocked_handler_no_longer_blocks_the_logging_call():
+    handler = _BlockingHandler()
+    log = _private_logger("nonblocking-test-blocked", handler)
+    listener = make_logging_nonblocking(log)
+    assert listener is not None
+    try:
+        started = time.monotonic()
+        log.warning("save finished")          # must return immediately
+        assert time.monotonic() - started < 1.0
+        assert handler.records == []          # handler is still blocked
+        handler.unblock.set()
+        assert _wait_for(lambda: len(handler.records) == 1)
+        assert handler.records[0].getMessage() == "save finished"
+    finally:
+        handler.unblock.set()
+        listener.stop()
+
+
+def test_records_still_reach_the_original_handler():
+    handler = _BlockingHandler()
+    handler.unblock.set()                     # behaves like a normal handler
+    log = _private_logger("nonblocking-test-passthrough", handler)
+    listener = make_logging_nonblocking(log)
+    assert listener is not None
+    try:
+        log.info("hello %s", "world")
+        assert _wait_for(lambda: len(handler.records) == 1)
+        assert handler.records[0].getMessage() == "hello world"
+    finally:
+        listener.stop()
+
+
+def test_wrapping_twice_is_a_no_op():
+    handler = _BlockingHandler()
+    handler.unblock.set()
+    log = _private_logger("nonblocking-test-idempotent", handler)
+    listener = make_logging_nonblocking(log)
+    assert listener is not None
+    try:
+        assert make_logging_nonblocking(log) is None
+        assert len(log.handlers) == 1
+    finally:
+        listener.stop()
+
+
+def test_logger_without_handlers_is_left_alone():
+    log = logging.getLogger("nonblocking-test-empty")
+    log.handlers = []
+    assert make_logging_nonblocking(log) is None
+    assert log.handlers == []


### PR DESCRIPTION
Closes #490. Field-tester evidence and full diagnosis are on the issue; short version: the GUI's `MapServer` redirects the panoedit child's stderr and stdout but only ever reads the single URL line. #475's per-save log line filled the undrained pipe, the blocked write sat inside the save lock, and every later save queued forever with no temp file — until app exit broke the pipe and the pending save completed, which is exactly what the tester observed.

## Changes

- **`MapServer.cs`** — drain both child streams (discarding) for the child's whole life. Root fix; also covers `serve` children and their `handle_error` tracebacks, and the symmetric stdout hazard.
- **`utilities.make_logging_nonblocking()`** — queues handler I/O onto a daemon `QueueListener` thread; the panoedit command installs it after `setup_logging`, so no request thread can ever block on stderr again, locked or not. Deliberately never joined at exit: joining would trade the save deadlock for a shutdown hang on the same wedged pipe.
- **`panoedit.do_POST`** — bounded `pano_lock` acquire (`2 × _WRITE_TIMEOUT + 5`, just under the page's 135 s fetch abort) answering 503 with an honest message instead of queueing forever behind a wedged save.

## Tests (written first, watched fail)

- Two new `MapServerTests` flood a fake child's stderr/stdout with 1 MB and assert the child is never blocked — on the old code both wedge at the pipe buffer, a live reproduction of the deadlock.
- `test_logging_nonblocking.py`: a blocking handler no longer blocks the logging call; records still arrive; wrap is idempotent.
- Server contract test: save returns 503 while another save holds the lock, and ExifTool is never reached.

Local gates: 1095 pytest + 7 panoedit browser tests + 561 GUI tests green; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P74zGMikqEPUnzF1kqtrTu