### PR TITLE
fix(photomap): popups mis-anchored because thumbnails carried no declared size (#472)

### DIFF
--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -7,10 +7,12 @@ GeoJSON and KML here, the clustered HTML map in :mod:`.photomap_html`.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
 import re
+import struct
 import subprocess
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -187,6 +189,49 @@ def _clean_base64(raw: object) -> str | None:
         if _BASE64_RE.fullmatch(candidate):
             return candidate
     return None
+
+
+def _jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
+    """Return ``(width, height)`` from JPEG bytes, or ``None`` when unreadable.
+
+    Walks the marker segments to the first SOF frame header (#472). Pure
+    Python on purpose: thumbnails must gain dimensions on a bare install,
+    and Pillow is an optional extra the map writers cannot import.
+    """
+    if len(data) < 4 or data[:2] != b"\xff\xd8":
+        return None
+    i = 2
+    while i + 3 < len(data):
+        if data[i] != 0xFF:
+            return None
+        marker = data[i + 1]
+        if marker == 0xFF:  # fill byte before a marker
+            i += 1
+            continue
+        if 0xD0 <= marker <= 0xD9:  # RST/SOI/EOI: standalone, no length word
+            i += 2
+            continue
+        if marker == 0xDA:  # SOS: entropy data follows, SOF never after this
+            return None
+        (length,) = struct.unpack(">H", data[i + 2 : i + 4])
+        if length < 2:
+            return None
+        # SOF0-SOF15 hold the frame size; C4/C8/CC are DHT/JPG/DAC, not frames.
+        if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+            if i + 9 > len(data):
+                return None
+            height, width = struct.unpack(">HH", data[i + 5 : i + 9])
+            return (width, height) if width and height else None
+        i += 2 + length
+    return None
+
+
+def _thumb_dimensions(thumb_b64: str) -> tuple[int, int] | None:
+    """Pixel size of a base64 thumbnail, ``None`` for anything unparseable."""
+    try:
+        return _jpeg_dimensions(base64.b64decode(thumb_b64))
+    except (ValueError, struct.error):
+        return None
 
 
 def _extract_thumbnail_b64(entry: dict) -> str | None:
@@ -421,6 +466,12 @@ def photos_to_geojson(
             props["thumb"] = p.thumbnail_b64
             if p.thumb_is_view:
                 props["vthumb"] = True
+            # Pixel size for the popup <img> (#472): declared up front so the
+            # viewer's pre-decode layout is already correct. Unparseable
+            # thumbs simply carry no dimensions.
+            dims = _thumb_dimensions(p.thumbnail_b64)
+            if dims is not None:
+                props["tw"], props["th"] = dims
         features.append(
             {
                 "type": "Feature",

--- a/src/dji_metadata_embedder/geo/photomap_html.py
+++ b/src/dji_metadata_embedder/geo/photomap_html.py
@@ -117,9 +117,9 @@ _TEMPLATE = """<!DOCTYPE html>
 <style>
   html, body {{ height: 100%; margin: 0; }}
   #map {{ height: 100%; }}
-  .photo-popup img {{ max-width: 260px; display: block; margin-bottom: 4px; }}
+  .photo-popup img {{ max-width: 260px; height: auto; display: block; margin-bottom: 4px; }}
   .photo-popup .photo-credit {{ opacity: .75; font-size: 90%; }}
-  .photo-tooltip img {{ max-width: 160px; display: block; margin-bottom: 2px; }}
+  .photo-tooltip img {{ max-width: 160px; height: auto; display: block; margin-bottom: 2px; }}
   /* The hover-previews toggle (issue #345) borrows the layer-control card. */
   .hover-control {{ padding: 5px 8px; font: 12px/1.4 sans-serif; }}
   .hover-control label {{ cursor: pointer; user-select: none; }}
@@ -314,6 +314,15 @@ const photoMarkers = [];
 const panoMarkers = [];
 const latlngs = [];
 
+// #472: thumbnails are data URIs and still decode async, so Leaflet measures
+// the popup before the image has a size. Declaring the known pixel size up
+// front makes that pre-decode layout (and the tip anchor) correct; thumbs
+// without parsed dimensions fall back to the bare tag.
+function imgDims(p) {
+  return (typeof p.tw === 'number' && typeof p.th === 'number')
+    ? ` width="${p.tw}" height="${p.th}"` : '';
+}
+
 function buildPopup(f) {
   const p = f.properties || {};
   let inner = '';
@@ -323,7 +332,7 @@ function buildPopup(f) {
     const kind = p.vthumb ? 'Opening view of the panorama'
       : (p.pano ? 'Full 360° panorama' : '');
     inner += `<img src="data:image/jpeg;base64,${esc(p.thumb)}" alt=""` +
-      (kind ? ` title="${kind}"` : '') + `>`;
+      imgDims(p) + (kind ? ` title="${kind}"` : '') + `>`;
   }
   // Every text line is presence-guarded: --popup-fields (issue #296) strips
   // properties from the embedded data, so nothing here may assume one exists.
@@ -365,7 +374,7 @@ function buildTooltip(f) {
   const p = f.properties || {};
   let html = '<div class="photo-tooltip">';
   if (p.thumb) {
-    html += `<img src="data:image/jpeg;base64,${esc(p.thumb)}" alt="">`;
+    html += `<img src="data:image/jpeg;base64,${esc(p.thumb)}" alt=""${imgDims(p)}>`;
   }
   html += `${esc(p.name || '')}</div>`;
   return html;
@@ -407,6 +416,16 @@ photoCluster.addLayers(photoMarkers);
 panoCluster.addLayers(panoMarkers);
 if (photoMarkers.length) map.addLayer(photoCluster);
 if (panoMarkers.length) map.addLayer(panoCluster);
+
+// #472 belt-and-braces: a thumbnail that finishes decoding after the popup
+// opened (no declared dimensions, or a cache-cold decode) re-runs the popup's
+// layout pass so the box and tip anchor match the real content size.
+map.on('popupopen', e => {
+  const img = e.popup.getElement().querySelector('.photo-popup img');
+  if (img && !img.complete) {
+    img.addEventListener('load', () => e.popup.update(), { once: true });
+  }
+});
 if (photoMarkers.length && panoMarkers.length) {
   // Expanded control doubles as the legend: the labels reuse the pin CSS as
   // colored swatches. Only shown when the folder actually mixes types.

--- a/tests/browser/test_photomap_popups.py
+++ b/tests/browser/test_photomap_popups.py
@@ -1,0 +1,68 @@
+"""Popup thumbnail layout (#472) in a real headless Chromium.
+
+The field bug: ``buildPopup`` emitted the base64 thumbnail ``<img>`` with no
+``width``/``height`` attributes, so Leaflet measured the popup before the
+image decoded (data URIs still decode async). A short filename left a narrow
+text-only box with the tip anchored to it, and the image then overflowed to
+the right — the reported popup-offset. Explicit dimension attributes make the
+pre-decode layout correct.
+"""
+
+import base64
+import io
+
+import pytest
+
+pytest.importorskip("playwright")
+from PIL import Image  # noqa: E402
+from playwright.sync_api import expect  # noqa: E402
+
+from dji_metadata_embedder.geo.photomap import PhotoPoint  # noqa: E402
+from dji_metadata_embedder.geo.photomap_html import photos_to_html  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+PIN = ".leaflet-marker-icon"
+POPUP_IMG = ".leaflet-popup-content img"
+
+
+def _jpeg_b64(width: int, height: int) -> str:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (30, 90, 160)).save(buf, format="JPEG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+# The short single-character name is the trigger: the text line alone measures
+# far narrower than the 240 px thumbnail above it.
+POINTS = [
+    PhotoPoint(lat=34.0567, lon=-84.1234, alt=95.3, name="a",
+               thumbnail_b64=_jpeg_b64(240, 120)),
+]
+
+HTML = photos_to_html(POINTS, title="popup layout e2e")
+
+
+def test_popup_thumbnail_stays_inside_the_popup_box(serve_map, page):
+    serve_map(HTML)
+    page.locator(PIN).first.click()
+    img = page.locator(POPUP_IMG)
+    expect(img).to_be_visible()
+
+    # The generator knows the JPEG's pixel size and must say so up front,
+    # so Leaflet's pre-decode measurement is already right.
+    assert img.get_attribute("width") == "240"
+    assert img.get_attribute("height") == "120"
+
+    # Wait for the actual decode, then the rendered image must sit inside
+    # the popup content box instead of overflowing it (the field symptom).
+    page.wait_for_function(
+        "() => { const i = document.querySelector('.leaflet-popup-content img');"
+        " return i && i.complete && i.naturalWidth > 0; }"
+    )
+    boxes = page.evaluate(
+        "() => { const i = document.querySelector('.leaflet-popup-content img');"
+        " const c = document.querySelector('.leaflet-popup-content');"
+        " return { img: i.getBoundingClientRect(), box: c.getBoundingClientRect() }; }"
+    )
+    assert boxes["img"]["right"] <= boxes["box"]["right"] + 1
+    assert boxes["img"]["width"] > 100  # the image really rendered wide

--- a/tests/test_geo_photomap.py
+++ b/tests/test_geo_photomap.py
@@ -709,3 +709,72 @@ def test_redact_photo_points_none_is_identity():
 
     pts = [PhotoPoint(lat=60.170278, lon=24.952222, alt=None, name="a.jpg")]
     assert redact_photo_points(pts, "none") == pts
+
+
+# --- #472: thumbnail pixel dimensions ride into the GeoJSON properties ------
+# The popup <img> needs explicit width/height so Leaflet's pre-decode layout
+# is correct; the dimensions are parsed from the JPEG bytes at build time
+# (pure Python — Pillow is an optional extra the CLI cannot rely on).
+
+
+def _tiny_jpeg_b64(width: int, height: int) -> str:
+    import base64
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (10, 20, 30)).save(buf, format="JPEG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def test_jpeg_dimensions_reads_a_real_jpeg():
+    import base64
+
+    from dji_metadata_embedder.geo.photomap import _jpeg_dimensions
+
+    data = base64.b64decode(_tiny_jpeg_b64(160, 90))
+    assert _jpeg_dimensions(data) == (160, 90)
+
+
+def test_jpeg_dimensions_reads_progressive_sof2():
+    import base64
+    import io
+
+    from PIL import Image
+
+    from dji_metadata_embedder.geo.photomap import _jpeg_dimensions
+
+    buf = io.BytesIO()
+    Image.new("RGB", (64, 32)).save(buf, format="JPEG", progressive=True)
+    data = buf.getvalue()
+    assert _jpeg_dimensions(data) == (64, 32)
+    assert base64.b64encode(data)  # sanity: same shape the pipeline carries
+
+
+def test_jpeg_dimensions_rejects_non_jpeg_bytes():
+    from dji_metadata_embedder.geo.photomap import _jpeg_dimensions
+
+    assert _jpeg_dimensions(b"") is None
+    assert _jpeg_dimensions(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32) is None
+    assert _jpeg_dimensions(b"\xff\xd8\xff") is None  # truncated after SOI
+
+
+def test_geojson_thumbnails_carry_pixel_dimensions():
+    pts = [PhotoPoint(lat=1.0, lon=2.0, alt=None, name="a.jpg",
+                      thumbnail_b64=_tiny_jpeg_b64(240, 120))]
+    props = photos_to_geojson(pts, include_thumbnails=True)["features"][0][
+        "properties"]
+    assert props["tw"] == 240
+    assert props["th"] == 120
+
+
+def test_geojson_omits_dimensions_for_unparseable_thumb():
+    # A blob that is valid base64 but not a JPEG (or not decodable at all)
+    # degrades to the old behaviour: thumb present, no tw/th.
+    pts = [PhotoPoint(lat=1.0, lon=2.0, alt=None, name="a.jpg",
+                      thumbnail_b64="QUJD")]
+    props = photos_to_geojson(pts, include_thumbnails=True)["features"][0][
+        "properties"]
+    assert props["thumb"] == "QUJD"
+    assert "tw" not in props and "th" not in props

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -519,3 +519,34 @@ def test_no_vthumb_prop_for_strip_thumbs():
                    thumbnail_b64="QUJD", is_pano=True, pano_yaw=5.0)
     geo = photos_to_geojson([p], include_thumbnails=True)
     assert "vthumb" not in geo["features"][0]["properties"]
+
+
+# --- #472: popup/tooltip images declare their pixel size ---------------------
+
+
+def test_popup_and_tooltip_imgs_declare_dimensions():
+    # Leaflet measures the popup before a data-URI image decodes; explicit
+    # width/height attributes (from the tw/th props) make that pre-decode
+    # measurement correct. Emission is guarded so dimension-less thumbs
+    # degrade to the old markup.
+    html = photos_to_html(POINTS, title="t")
+    assert "typeof p.tw === 'number' && typeof p.th === 'number'" in html
+    assert 'width="${p.tw}" height="${p.th}"' in html
+    # Both the popup and the tooltip builder go through the helper.
+    assert html.count("imgDims(p)") >= 2
+
+
+def test_popup_img_css_keeps_aspect_ratio():
+    # With width AND height attributes present, a max-width clamp alone would
+    # squash the image; height:auto keeps the declared aspect ratio.
+    html = photos_to_html(POINTS, title="t")
+    assert re.search(r"\.photo-popup img \{[^}]*height: auto", html)
+    assert re.search(r"\.photo-tooltip img \{[^}]*height: auto", html)
+
+
+def test_popup_reanchors_when_thumbnail_loads_late():
+    # Belt-and-braces for thumbs without dimensions (or cached-vs-fresh decode
+    # differences): a late image load re-runs the popup's layout pass.
+    html = photos_to_html(POINTS, title="t")
+    assert "popupopen" in html
+    assert ".update()" in html


### PR DESCRIPTION
Closes #472.

## The bug

Leaflet measures a popup when it opens, before its base64 data-URI thumbnail has decoded, so the measured width came from the text line alone. A short or absent filename produced a narrow white box with the tip anchored to it, and the thumbnail then rendered up to 260 px wide, overflowing to the right of the box — the field-reported "popup offset from its pin". A thumbnail that never rendered at all (the #471 class) left the mis-anchored narrow box permanently, which is why the reporter saw offsets precede no-loads. Confirmed against the reporter's published repro map: short-named files show the offset, long-named ones hold the box open and hide it.

## The fix

- `photos_to_geojson` parses each thumbnail's pixel size from the JPEG SOF header and embeds it as `tw`/`th` props. Pure-Python marker walk — Pillow stays an optional extra the map writers cannot import. Unparseable thumbs degrade to the old markup.
- `buildPopup` and `buildTooltip` emit explicit `width`/`height` attributes via a shared `imgDims` helper, so the pre-decode layout (and the tip anchor) is already correct; `height: auto` in the CSS keeps the declared aspect ratio under the `max-width` clamp.
- Belt-and-braces: a `popupopen` hook re-runs `popup.update()` when an image finishes decoding late.

## Tests

TDD red-first throughout: a browser E2E repro (short-named point, real JPEG thumb — asserts the declared attributes and that the rendered image stays inside the popup content box), SOF-parser units (baseline, progressive SOF2, non-JPEG/truncated input), `tw`/`th` prop emission + degradation, and template contract pins. Full local gate green: 1239 passed, 3 skipped (unit + browser), ruff, mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186pA6oi9yWBVJuLcuJpa6z