### PR TITLE
feat(panoedit): show the saved opening values beside the live readout (#493)

### DIFF
--- a/src/dji_metadata_embedder/geo/panoedit_html.py
+++ b/src/dji_metadata_embedder/geo/panoedit_html.py
@@ -37,6 +37,7 @@ _PAGE = """<!DOCTYPE html>
     background: rgba(0,0,0,.65); padding: 8px 12px; border-radius: 6px;
     font-variant-numeric: tabular-nums; line-height: 1.5; }}
   #readout b {{ color: #ffd24d; }}
+  #readout .saved {{ color: #9fc7e8; }}
   #savebar {{ position: fixed; top: 12px; right: 12px; z-index: 10;
     text-align: right; }}
   #savebar button {{ font: inherit; padding: 8px 18px; border: 0;
@@ -320,11 +321,23 @@ function readoutLoop() {{
     if (showingSaved && compareArmed
         && viewsDiffer(viewerView(), openingView)) dropCompare();
     const v = currentView();
+    // The file's saved opening values beside the live ones (#493), so a
+    // view can be lined up against them deliberately. Compass heading via
+    // the same pose + yaw math as the save path; kept current by the
+    // server's read-back after each save. No saved view, no line.
+    const f = files[idx];
+    let savedLine = "";
+    if (f.hasView && f.yaw !== null && f.pitch !== null && f.hfov !== null) {{
+      savedLine = "<br><span class=\\"saved\\">Saved " +
+        norm360(f.pose + f.yaw).toFixed(1) + "° · " +
+        f.pitch.toFixed(1) + "° · " +
+        f.hfov.toFixed(1) + "°</span>";
+    }}
     $("readout").innerHTML =
       "<b>" + files[idx].name.replace(/[<>&]/g, "") + "</b><br>" +
       "Heading " + v.heading.toFixed(1) + "° · " +
       "Pitch " + v.pitch.toFixed(1) + "° · " +
-      "FOV " + v.hfov.toFixed(1) + "°" +
+      "FOV " + v.hfov.toFixed(1) + "°" + savedLine +
       // Whose numbers these are matters while comparing (#473).
       (showingSaved ? "<br>showing the saved view" : "");
   }}

--- a/tests/browser/test_panoedit_readout.py
+++ b/tests/browser/test_panoedit_readout.py
@@ -1,0 +1,74 @@
+"""Saved-vs-live numeric readout (#493) in a real headless Chromium.
+
+The editor's readout already shows the live heading/pitch/hFOV; #493 adds
+the file's saved opening values beside them, so a view can be lined up
+deliberately (e.g. matching headings across panos taken from the same spot)
+instead of eyeballed.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from .test_panoedit_editor import _make_pano, _serve  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+needs_exiftool = pytest.mark.skipif(
+    shutil.which("exiftool") is None, reason="ExifTool not installed")
+
+
+@needs_exiftool
+def test_readout_shows_saved_values_beside_live_ones(
+        tmp_path, page, monkeypatch):
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    pano = tmp_path / "saved.jpg"
+    _make_pano(pano, pose=10.0)
+    subprocess.run(
+        ["exiftool", "-overwrite_original", "-n",
+         "-XMP-GPano:InitialViewHeadingDegrees=40",
+         "-XMP-GPano:InitialViewPitchDegrees=-5",
+         "-XMP-GPano:InitialHorizontalFOVDegrees=90", str(pano)],
+        check=True, capture_output=True)
+    httpd, url = _serve(tmp_path, page)
+    try:
+        page.goto(url)
+        page.wait_for_function("window.__panoReady === true")
+        # The saved line shows compass values: the 40/-5/90 that were written,
+        # not the pose-relative yaw the viewer runs on.
+        readout = page.inner_text("#readout")
+        assert "Saved" in readout
+        assert "40.0" in readout and "-5.0" in readout and "90.0" in readout
+
+        # Drag away: the live line moves, the saved line stays put.
+        box = page.locator("#viewer").bounding_box()
+        cx, cy = box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
+        page.mouse.move(cx, cy)
+        page.mouse.down()
+        page.mouse.move(cx - 160, cy, steps=10)
+        page.mouse.up()
+        # Stored yaw is heading - pose = 30; wait until the camera has moved.
+        page.wait_for_function("Math.abs(window.__viewer.getYaw() - 30) > 5")
+        readout = page.inner_text("#readout")
+        assert "Saved" in readout and "40.0" in readout
+    finally:
+        httpd.shutdown()
+
+
+@needs_exiftool
+def test_readout_stays_plain_without_a_saved_view(tmp_path, page, monkeypatch):
+    # No saved view means nothing to show: the readout keeps its old shape
+    # rather than inventing a "saved" row from Pannellum's defaults.
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    _make_pano(tmp_path / "plain.jpg", pose=0.0)
+    httpd, url = _serve(tmp_path, page)
+    try:
+        page.goto(url)
+        page.wait_for_function("window.__panoReady === true")
+        assert "Saved" not in page.inner_text("#readout")
+    finally:
+        httpd.shutdown()

--- a/tests/test_geo_panoedit_html.py
+++ b/tests/test_geo_panoedit_html.py
@@ -121,3 +121,13 @@ def test_page_save_backstop_outlasts_the_server_timeouts():
     assert _DEFAULT_SAVE_TIMEOUT_MS > worst_case_ms
     assert f"const SAVE_TIMEOUT_MS = {_DEFAULT_SAVE_TIMEOUT_MS};" in \
         build_editor_page("t")
+
+
+def test_page_readout_carries_the_saved_view_values():
+    # #493: beside the live heading/pitch/hFOV, the readout shows the values
+    # saved in the file — compass heading via the same pose + yaw math as the
+    # save path — and shows nothing when the file has no saved view.
+    html = build_editor_page("tok123")
+    assert "savedLine" in html
+    assert "f.hasView" in html
+    assert "f.pose + f.yaw" in html


### PR DESCRIPTION
Closes #493.

Field-tester ask: the editor's readout showed only the live heading/pitch/hFOV, so lining a view up against what is already saved — or matching headings across panos taken from the same spot — meant eyeballing it.

The readout now carries a second, dimmer line with the file's saved opening values: compass heading via the same `pose + yaw` math as the save path, kept current by the server's verified read-back after each save. Files with no saved view show no line at all rather than one invented from Pannellum's defaults.

Display-only change to the editor page; no server or CLI surface touched.

## Tests

TDD red-first: a browser E2E (saved-view file shows the saved compass values and keeps them fixed while dragging the live view away; a file without a saved view keeps the plain readout) plus a template contract pin. Full local gate green: 1233 passed, 3 skipped (unit + browser), ruff, mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186pA6oi9yWBVJuLcuJpa6z