### PR TITLE
feat(panoedit): make the _original backups optional (#492)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -549,6 +549,17 @@ with ExifTool and moves on to the next panorama. Each original is kept
 beside the file as `<name>_original`. In the desktop app this is the
 "360° views" mode.
 
+The backups exist so a batch edit can never destroy an original, but the
+view tags themselves are re-editable and never touch the image data, so
+you may reasonably decide you don't need them — they do double the
+folder's size. `--no-backup` writes views straight into the files, and
+`dji-embed panoedit /path/to/panoramas --clean-backups` deletes the
+`_original` copies from earlier sessions once you're happy with the
+edits (only ever where the edited file still exists beside the backup;
+add `-r` to include subfolders). Either way the maps never reference
+the `_original` files, so if you publish a generated map there is no
+need to upload them.
+
 Two keys matter when a panorama already has a view you like: **Esc**
 resets the viewer to the view the file opened at, so you can look around
 and then move on with `N` without rewriting anything, and **C** flips

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -45,7 +45,12 @@ from .geo import (
     write_photos_kml,
 )
 from .geo.airspace import fetch as airspace_fetch
-from .geo.panoedit import DEFAULT_MAX_SERVE_WIDTH, PanoEditError, run_editor
+from .geo.panoedit import (
+    DEFAULT_MAX_SERVE_WIDTH,
+    PanoEditError,
+    clean_backups,
+    run_editor,
+)
 from .geo.airspace.overlay import zones_to_overlay_json
 from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
 from .geo.logfetch import LogFetchError, cache_path, fetch_log
@@ -1391,6 +1396,19 @@ def serve(
          "graphics hardware fails to display very large panoramas; the "
          "files themselves are never modified.",
 )
+@click.option(
+    "--no-backup", is_flag=True,
+    help="Write views straight into the files instead of keeping a "
+         "<name>_original copy beside each edited panorama. The tags are "
+         "re-editable and never touch the image data, but without backups "
+         "a save that goes wrong cannot be undone.",
+)
+@click.option(
+    "--clean-backups", "clean", is_flag=True,
+    help="Delete the <name>_original copies left by earlier edits — only "
+         "where the edited file still exists beside them — then exit "
+         "without opening the editor. Honours -r/--recursive.",
+)
 def panoedit(
     directory: str,
     recursive: bool,
@@ -1399,6 +1417,8 @@ def panoedit(
     url_only: bool,
     exit_with_stdin: bool,
     max_width: int,
+    no_backup: bool,
+    clean: bool,
 ) -> None:
     """Edit the opening view of 360° panoramas in DIRECTORY (#440).
 
@@ -1407,8 +1427,11 @@ def panoedit(
     GPano initial-view tags (InitialViewHeadingDegrees / Pitch /
     InitialHorizontalFOVDegrees) into the file via ExifTool and advances
     to the next one. Each original is kept beside the file as
-    ``<name>_original``. The photomap 360° viewer and Google Photos both
-    honor the saved view.
+    ``<name>_original`` unless --no-backup is given; --clean-backups
+    deletes the copies once the edits are confirmed (#492). The photomap
+    360° viewer and Google Photos both honor the saved view. Map output
+    never references the ``_original`` files, so they never need
+    uploading anywhere.
 
     Panoramas wider than --max-width are shown downscaled (#471): very
     large equirects fail to render on older graphics hardware, and the
@@ -1419,6 +1442,17 @@ def panoedit(
     # INFO lines — including how long each save took, which the page tells
     # the user to come here for — went nowhere (#475).
     setup_logging(verbose=False, quiet=False)
+    if clean:
+        deleted, freed = clean_backups(Path(directory), recursive=recursive)
+        if deleted:
+            click.echo(
+                f"Removed {len(deleted)} backup "
+                f"cop{'ies' if len(deleted) != 1 else 'y'} "
+                f"({freed / 1_000_000:.1f} MB freed)."
+            )
+        else:
+            click.echo("No backup copies to remove.")
+        return
     # The GUI redirects this command's stderr to a pipe it may never read.
     # A full pipe turns the next log write into a kernel-level block — one
     # of those sat inside the save lock and froze every later save (#490).
@@ -1433,6 +1467,7 @@ def panoedit(
             bare_url=url_only,
             stop_on_stdin_eof=exit_with_stdin,
             max_width=max_width,
+            backup=not no_backup,
         )
     except PanoEditError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/dji_metadata_embedder/geo/panoedit.py
+++ b/src/dji_metadata_embedder/geo/panoedit.py
@@ -239,14 +239,18 @@ def scan_panos(directory: Path, recursive: bool = False) -> list[PanoFile]:
 
 
 def write_initial_view(
-    path: Path, heading: float, pitch: float, hfov: float
+    path: Path, heading: float, pitch: float, hfov: float,
+    *, backup: bool = True,
 ) -> dict:
     """Write the three initial-view tags to *path* and read them back.
 
-    ExifTool's default sidecar backup (``<name>_original``) is deliberately
-    kept — batch editing must never be able to destroy an original. The
-    read-back is the write verification: what the map will see is what the
-    caller gets.
+    ExifTool's default sidecar backup (``<name>_original``) is kept by
+    default — batch editing must never be able to destroy an original
+    silently. ``backup=False`` (#492) is the caller's explicit opt-out
+    (``-overwrite_original``): the initial-view tags are re-editable and
+    non-destructive to the image data, so a user who knows that may
+    reasonably decline the doubled disk usage. The read-back is the write
+    verification: what the map will see is what the caller gets.
 
     Both ExifTool runs are bounded by :data:`_WRITE_TIMEOUT`. A rewrite of
     a 40 MB JPEG plus its backup copy can stall indefinitely behind an
@@ -257,6 +261,7 @@ def write_initial_view(
     exe = exiftool_exe()
     write_args = [
         exe, "-n",
+        *([] if backup else ["-overwrite_original"]),
         f"-XMP-GPano:InitialViewHeadingDegrees={heading}",
         f"-XMP-GPano:InitialViewPitchDegrees={pitch}",
         f"-XMP-GPano:InitialHorizontalFOVDegrees={hfov}",
@@ -315,6 +320,38 @@ def write_initial_view(
         "hfov": _maybe_float(entry.get("InitialHorizontalFOVDegrees")),
         "pose": _maybe_float(entry.get("PoseHeadingDegrees")) or 0.0,
     }
+
+
+_BACKUP_SUFFIX = "_original"
+
+
+def clean_backups(
+    directory: Path, recursive: bool = False
+) -> tuple[list[Path], int]:
+    """Delete ``*_original`` backups whose edited sibling still exists (#492).
+
+    Returns ``(deleted paths, bytes freed)``. Deliberately narrow: only
+    JPEG backups (the only kind panoedit writes), and only when the edited
+    file is still there beside them — an orphan backup is the last copy of
+    that image and is never touched. ``recursive`` mirrors the editor's
+    own scan scope.
+    """
+    pattern = f"**/*{_BACKUP_SUFFIX}" if recursive else f"*{_BACKUP_SUFFIX}"
+    deleted: list[Path] = []
+    freed = 0
+    for p in sorted(directory.glob(pattern)):
+        if not p.is_file():
+            continue
+        sibling = p.with_name(p.name[: -len(_BACKUP_SUFFIX)])
+        if sibling.suffix.lower() not in (".jpg", ".jpeg"):
+            continue
+        if not sibling.is_file():
+            continue
+        size = p.stat().st_size
+        p.unlink()
+        deleted.append(p)
+        freed += size
+    return deleted, freed
 
 
 # Renditions -----------------------------------------------------------
@@ -478,6 +515,7 @@ class _EditorServer(_MapServer):
     pano_page: bytes
     pano_max_width: int = 0
     pano_renditions: bool = True
+    pano_backup: bool = True
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)  # type: ignore[arg-type]
@@ -648,7 +686,10 @@ class _EditorHandler(_RangeHandler):
         # otherwise extend the save critical section (except-handlers run
         # BEFORE finally — sending from one would send under the lock).
         try:
-            verified = write_initial_view(f.path, heading, pitch, hfov)
+            verified = write_initial_view(
+                f.path, heading, pitch, hfov,
+                backup=self.server.pano_backup,   # type: ignore[attr-defined]
+            )
             error = None
         except PanoEditError as exc:
             error = str(exc)
@@ -689,6 +730,7 @@ def make_editor_server(
     recursive: bool = False,
     port: int = 0,
     max_width: int = DEFAULT_MAX_SERVE_WIDTH,
+    backup: bool = True,
 ) -> tuple[_EditorServer, str]:
     """Scan *directory* and return a ready (server, url) pair.
 
@@ -714,9 +756,10 @@ def make_editor_server(
     server.pano_token = token
     server.pano_max_width = max_width
     server.pano_renditions = renditions
+    server.pano_backup = backup
     server.pano_page = build_editor_page(
         token, max_width=max_width, renditions=renditions,
-        hint=_PILLOW_HINT,
+        hint=_PILLOW_HINT, backup=backup,
         # Outlast both server-side ExifTool timeouts (write, then the
         # read-back) so the page's backstop never pre-empts the server's
         # much better message.
@@ -753,10 +796,12 @@ def run_editor(
     bare_url: bool = False,
     stop_on_stdin_eof: bool = False,
     max_width: int = DEFAULT_MAX_SERVE_WIDTH,
+    backup: bool = True,
 ) -> None:
     """Serve the editor until Ctrl+C (same contract as ``serve_directory``)."""
     server, url = make_editor_server(
-        directory, recursive=recursive, port=port, max_width=max_width)
+        directory, recursive=recursive, port=port, max_width=max_width,
+        backup=backup)
     with server:
         if bare_url:
             click.echo(url)

--- a/src/dji_metadata_embedder/geo/panoedit_html.py
+++ b/src/dji_metadata_embedder/geo/panoedit_html.py
@@ -89,8 +89,7 @@ _PAGE = """<!DOCTYPE html>
   <div id="status"></div>
 </div>
 <div id="counter"></div>
-<div id="note">Saving keeps a backup of each original beside it
-(<code>*_original</code>). N/P: next/previous. Esc: back to the opening
+<div id="note">{backup_note} N/P: next/previous. Esc: back to the opening
 view. C: compare with the saved one.</div>
 <div id="strip"></div>
 <script src="https://unpkg.com/pannellum@{pannellum}/build/pannellum.js"
@@ -443,6 +442,7 @@ def build_editor_page(
     renditions: bool = True,
     hint: str = "",
     save_timeout_ms: int = _DEFAULT_SAVE_TIMEOUT_MS,
+    backup: bool = True,
 ) -> str:
     """The complete editor page with *token* embedded.
 
@@ -457,6 +457,8 @@ def build_editor_page(
     and the footer note (#471). ``save_timeout_ms`` is the page's backstop
     for a save request that never comes back; it must outlast the server's
     own ExifTool timeouts, which answer with a better message (#475).
+    ``backup`` mirrors the server's write mode (#492) so the footer never
+    promises a ``*_original`` copy that will not exist.
     """
     serve = {
         "maxWidth": max_width,
@@ -470,4 +472,10 @@ def build_editor_page(
         token=json.dumps(token).replace("<", "\\u003c"),
         serve=json.dumps(serve).replace("<", "\\u003c"),
         save_timeout_ms=int(save_timeout_ms),
+        backup_note=(
+            "Saving keeps a backup of each original beside it "
+            "(<code>*_original</code>)." if backup else
+            "Saving writes each view straight into the file - "
+            "no backup copies are kept."
+        ),
     ))

--- a/tests/browser/test_panoedit_editor.py
+++ b/tests/browser/test_panoedit_editor.py
@@ -241,7 +241,7 @@ def test_navigation_is_blocked_while_a_save_is_in_flight(
     _make_pano(tmp_path / "b.jpg", pose=0.0)
     release = threading.Event()
 
-    def slow(path, heading, pitch, hfov):
+    def slow(path, heading, pitch, hfov, backup=True):
         release.wait(10)
         return {"heading": heading, "pitch": pitch, "hfov": hfov, "pose": 0.0}
 
@@ -308,7 +308,7 @@ def test_save_timeout_frees_the_button(tmp_path, page, monkeypatch):
     monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
     _make_pano(tmp_path / "a.jpg", pose=0.0)
 
-    def stalls(path, heading, pitch, hfov):
+    def stalls(path, heading, pitch, hfov, backup=True):
         time.sleep(5)
         return {"heading": heading, "pitch": pitch, "hfov": hfov, "pose": 0.0}
 

--- a/tests/browser/test_panoedit_editor.py
+++ b/tests/browser/test_panoedit_editor.py
@@ -327,3 +327,26 @@ def test_save_timeout_frees_the_button(tmp_path, page, monkeypatch):
         assert page.locator("#save").is_enabled()
     finally:
         httpd.shutdown()
+
+
+@needs_exiftool
+def test_no_backup_save_leaves_no_original_copy(tmp_path, page, monkeypatch):
+    # #492: with backups declined, a save writes in place — no *_original —
+    # and the footer note stops promising one.
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    _make_pano(tmp_path / "a.jpg", pose=0.0)
+    httpd, url = _serve(tmp_path, page, backup=False)
+    try:
+        page.goto(url)
+        page.wait_for_function("window.__panoReady === true")
+        assert "no backup" in page.inner_text("#note")
+        page.keyboard.press("Enter")
+        page.wait_for_function(
+            "document.getElementById('status').textContent.includes('Saved')")
+    finally:
+        httpd.shutdown()
+    assert not (tmp_path / "a.jpg_original").exists()
+    out = subprocess.run(
+        ["exiftool", "-n", "-XMP-GPano:InitialViewHeadingDegrees",
+         str(tmp_path / "a.jpg")], capture_output=True, text=True, check=True)
+    assert "Initial View Heading" in out.stdout   # the write still landed

--- a/tests/test_cli_panoedit.py
+++ b/tests/test_cli_panoedit.py
@@ -42,7 +42,7 @@ def test_panoedit_forwards_options(monkeypatch, tmp_path):
     assert calls == {
         "directory": Path(tmp_path), "recursive": True, "port": 7777,
         "open_browser": False, "bare_url": True, "stop_on_stdin_eof": True,
-        "max_width": DEFAULT_MAX_SERVE_WIDTH}
+        "max_width": DEFAULT_MAX_SERVE_WIDTH, "backup": True}
 
 
 def test_panoedit_max_width_is_overridable(monkeypatch, tmp_path):
@@ -81,3 +81,35 @@ def test_panoedit_error_is_clean(monkeypatch, tmp_path):
 def test_panoedit_listed_in_help():
     result = CliRunner().invoke(cli_mod.main, ["--help"])
     assert "panoedit" in result.output
+
+
+def test_panoedit_no_backup_reaches_run_editor(monkeypatch, tmp_path):
+    calls = {}
+    monkeypatch.setattr(cli_mod, "run_editor",
+                        lambda directory, **kw: calls.update(kw))
+    result = CliRunner().invoke(cli_mod.main, [
+        "panoedit", str(tmp_path), "--no-backup"])
+    assert result.exit_code == 0, result.output
+    assert calls["backup"] is False
+
+
+def test_panoedit_clean_backups_deletes_and_never_serves(monkeypatch, tmp_path):
+    # #492: cleanup is a terminal action — report and exit, no server.
+    (tmp_path / "a.jpg").write_bytes(b"\xff\xd8new")
+    (tmp_path / "a.jpg_original").write_bytes(b"\xff\xd8old" * 100)
+    monkeypatch.setattr(cli_mod, "run_editor",
+                        lambda *a, **kw: pytest.fail("server must not start"))
+    result = CliRunner().invoke(cli_mod.main, [
+        "panoedit", str(tmp_path), "--clean-backups"])
+    assert result.exit_code == 0, result.output
+    assert not (tmp_path / "a.jpg_original").exists()
+    assert "1 backup" in result.output
+
+
+def test_panoedit_clean_backups_reports_nothing_to_do(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli_mod, "run_editor",
+                        lambda *a, **kw: pytest.fail("server must not start"))
+    result = CliRunner().invoke(cli_mod.main, [
+        "panoedit", str(tmp_path), "--clean-backups"])
+    assert result.exit_code == 0, result.output
+    assert "No backup copies" in result.output

--- a/tests/test_geo_panoedit.py
+++ b/tests/test_geo_panoedit.py
@@ -243,3 +243,54 @@ def test_write_timeout_is_logged_as_well_as_returned(monkeypatch, tmp_path,
             pe.write_initial_view(target, heading=1.0, pitch=0.0, hfov=90.0)
     assert any("did not finish writing pano.jpg" in r.getMessage()
                for r in caplog.records)
+
+
+# --- #492: backups become optional -----------------------------------------
+
+
+def test_write_initial_view_no_backup_overwrites_in_place(monkeypatch, tmp_path):
+    target = tmp_path / "pano.jpg"
+    target.write_bytes(b"\xff\xd8fake")
+    verified = json.dumps([{
+        "InitialViewHeadingDegrees": 1.0,
+        "InitialViewPitchDegrees": 0.0,
+        "InitialHorizontalFOVDegrees": 90.0,
+        "PoseHeadingDegrees": 0.0,
+    }])
+    calls = _fake_exiftool(monkeypatch, verified)
+    pe.write_initial_view(target, heading=1.0, pitch=0.0, hfov=90.0,
+                          backup=False)
+    # The flag belongs to the write; the verification read never rewrites
+    # anything, so it must not carry it.
+    assert "-overwrite_original" in calls[0]
+    assert "-overwrite_original" not in calls[1]
+
+
+def test_clean_backups_deletes_only_confirmed_edits(tmp_path):
+    # Deleted: a backup whose edited sibling still exists.
+    (tmp_path / "a.jpg").write_bytes(b"\xff\xd8new")
+    (tmp_path / "a.jpg_original").write_bytes(b"\xff\xd8old")
+    # Kept: an orphan backup is the only copy left — never touch it.
+    (tmp_path / "orphan.jpg_original").write_bytes(b"\xff\xd8only")
+    # Kept: not a JPEG backup, so not something panoedit ever wrote.
+    (tmp_path / "notes.txt").write_text("x")
+    (tmp_path / "notes.txt_original").write_text("x")
+    deleted, freed = pe.clean_backups(tmp_path)
+    assert [p.name for p in deleted] == ["a.jpg_original"]
+    assert freed == len(b"\xff\xd8old")
+    assert not (tmp_path / "a.jpg_original").exists()
+    assert (tmp_path / "a.jpg").exists()
+    assert (tmp_path / "orphan.jpg_original").exists()
+    assert (tmp_path / "notes.txt_original").exists()
+
+
+def test_clean_backups_recursive_matches_the_editor_scan(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.JPG").write_bytes(b"\xff\xd8new")
+    (sub / "b.JPG_original").write_bytes(b"\xff\xd8old")
+    deleted, _ = pe.clean_backups(tmp_path)
+    assert deleted == []                       # non-recursive stays shallow
+    deleted, _ = pe.clean_backups(tmp_path, recursive=True)
+    assert [p.name for p in deleted] == ["b.JPG_original"]
+    assert not (sub / "b.JPG_original").exists()

--- a/tests/test_geo_panoedit_html.py
+++ b/tests/test_geo_panoedit_html.py
@@ -131,3 +131,12 @@ def test_page_readout_carries_the_saved_view_values():
     assert "savedLine" in html
     assert "f.hasView" in html
     assert "f.pose + f.yaw" in html
+
+
+def test_page_note_tells_the_truth_about_backups():
+    # #492: with backups off, the footer must not promise a *_original
+    # copy that will never exist.
+    assert "keeps a backup" in build_editor_page("tok123")
+    no_backup = build_editor_page("tok123", backup=False)
+    assert "keeps a backup" not in no_backup
+    assert "no backup" in no_backup

--- a/tests/test_geo_panoedit_rendition.py
+++ b/tests/test_geo_panoedit_rendition.py
@@ -294,7 +294,7 @@ def test_saving_drops_the_stale_rendition(editor, monkeypatch):
     start, _ = editor
     monkeypatch.setattr(
         pe, "write_initial_view",
-        lambda path, heading, pitch, hfov: {
+        lambda path, heading, pitch, hfov, backup=True: {
             "heading": heading, "pitch": pitch, "hfov": hfov, "pose": 0.0})
     httpd, url = start(max_width=600)
     _get(url + "img/0")

--- a/tests/test_geo_panoedit_server.py
+++ b/tests/test_geo_panoedit_server.py
@@ -22,7 +22,7 @@ def editor(monkeypatch, tmp_path):
     monkeypatch.setattr(pe, "scan_panos", lambda d, recursive=False: files)
     writes: list[tuple] = []
 
-    def fake_write(path, heading, pitch, hfov):
+    def fake_write(path, heading, pitch, hfov, backup=True):
         writes.append((path, heading, pitch, hfov))
         return {"heading": heading, "pitch": pitch, "hfov": hfov,
                 "pose": 90.0}
@@ -129,7 +129,7 @@ def test_error_response_is_sent_after_the_lock_is_released(editor, monkeypatch):
     # stalled client extends the save critical section (#490 review).
     url, httpd, _ = editor
 
-    def boom(path, heading, pitch, hfov):
+    def boom(path, heading, pitch, hfov, backup=True):
         raise pe.PanoEditError("disk on fire")
     monkeypatch.setattr(pe, "write_initial_view", boom)
     observed = {}
@@ -153,10 +153,35 @@ def test_error_response_is_sent_after_the_lock_is_released(editor, monkeypatch):
 def test_save_write_failure_is_500(editor, monkeypatch):
     url, httpd, _ = editor
 
-    def boom(path, heading, pitch, hfov):
+    def boom(path, heading, pitch, hfov, backup=True):
         raise pe.PanoEditError("disk on fire")
     monkeypatch.setattr(pe, "write_initial_view", boom)
     status, body = _post(url + "api/save", {
         "index": 0, "heading": 1.0, "pitch": 0.0, "hfov": 90.0,
         "token": httpd.pano_token})
     assert status == 500 and "disk on fire" in body["error"]
+
+
+def test_save_without_backup_reaches_the_writer(monkeypatch, tmp_path):
+    # #492: the server carries the backup choice to every write.
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"\xff\xd8" + b"J" * 500)
+    files = [pe.PanoFile(path=img, name="a.jpg", pose=0.0,
+                         yaw=None, pitch=None, hfov=None)]
+    monkeypatch.setattr(pe, "scan_panos", lambda d, recursive=False: files)
+    seen = {}
+
+    def fake_write(path, heading, pitch, hfov, backup=True):
+        seen["backup"] = backup
+        return {"heading": heading, "pitch": pitch, "hfov": hfov, "pose": 0.0}
+    monkeypatch.setattr(pe, "write_initial_view", fake_write)
+    httpd, url = pe.make_editor_server(tmp_path, backup=False)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        status, _ = _post(url + "api/save", {
+            "index": 0, "heading": 10.0, "pitch": 0.0, "hfov": 90.0,
+            "token": httpd.pano_token})
+    finally:
+        httpd.shutdown()
+    assert status == 200
+    assert seen["backup"] is False


### PR DESCRIPTION
Closes #492.

Field-tester ask (the #475/#490 reporter): panoedit's always-on ExifTool backup doubles the folder size (36 MB panos become 72 MB pairs), gets swept into uploads, and buys little for this specific edit — the initial-view tags are re-editable and never touch the image data.

The default stays exactly as it was: every save keeps `<name>_original`, because a batch edit must never silently destroy an original. Two explicit opt-outs:

- **`--no-backup`** writes views straight into the files (ExifTool `-overwrite_original`), plumbed through `run_editor` → `make_editor_server` → the save handler. The editor page's footer note switches to say no backups are kept, so it never promises a copy that will not exist.
- **`--clean-backups`** deletes the `_original` copies from earlier sessions and exits without starting the editor, reporting the count and MB freed. Deliberately narrow: JPEG backups only (the only kind panoedit writes), and only where the edited file still exists beside them — an orphan backup is the last copy of that image and is never touched. Honours `-r`.

Docs gain the issue's requested line: map output never references `_original` files, so they never need uploading.

The GUI checkbox stays a follow-up, per the issue.

## Tests

TDD red-first: write argv (`-overwrite_original` on the write call, never the verification read), `clean_backups` safety cases (orphan kept, non-JPEG kept, recursion scope), server plumbing, page-note honesty, CLI forwarding and both cleanup outcomes; plus a real-ExifTool browser E2E proving an in-place save leaves no `_original` while the tags land. Ruff and mypy clean; full suite green after teaching the existing `write_initial_view` fakes the new kwarg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186pA6oi9yWBVJuLcuJpa6z