### PR TITLE
feat(geo): Ireland UAS geographical zones via the IAA's published ED-318 file (#452)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -429,9 +429,11 @@ already reports.
 
 `dji-embed flightmap FLIGHTS --airspace` overlays the official airspace zones
 for the flight area on the HTML maps — the flat map and the 3D terrain view
-(`--3d`) — FAA UAS Facility Maps in the US, ED-269 UAS geographical zones
-where a national feed is available (currently Luxembourg, Finland and
-Switzerland). Zones draw in one neutral style; clicking one shows
+(`--3d`) — FAA UAS Facility Maps in the US, and national UAS
+geographical-zone feeds where a country publishes one (currently
+Luxembourg, Finland and Switzerland via ED-269, and Ireland via the IAA's
+published ED-318 file, which the IAA labels reference-only — that caveat
+rides into the map). Zones draw in one neutral style; clicking one shows
 the published facts: restriction class, vertical limits (or "not stated"),
 applicability windows, and the feed, license and fetch time. Zones the
 flight entered get a slightly stronger outline plus the entry/exit times and

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -335,7 +335,7 @@
                                                   IsEnabled="{Binding !FlightOptions.ThreeD}"
                                                   Content="Airspace zones" />
                                         <TextBlock Name="FlightAirspaceNote"
-                                                   Text="Draws official airspace zones on the map — US FAA, plus ED-269 feeds where a country publishes one (currently Luxembourg and Finland). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
+                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland and Ireland). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
                                                    IsVisible="{Binding FlightOptions.ShowsAirspaceNote}"
                                                    TextWrapping="Wrap"
                                                    Opacity="0.5" FontSize="11" />

--- a/samples/airspace/ed318-ie.json
+++ b/samples/airspace/ed318-ie.json
@@ -1,0 +1,185 @@
+{
+  "type": "FeatureCollection",
+  "name": "UAS_Zones_Ireland",
+  "datasetMetadata": {
+    "provider": "Irish Aviation Authority",
+    "issued": "2026-08-04T22:00:00+00:00",
+    "validFrom": "2026-08-04T22:00:00+00:00",
+    "technicalLimitation": null
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "identifier": "U901",
+        "country": "IRL",
+        "name": "Example Control Zone - Red Zone",
+        "type": "REQ_AUTHORIZATION",
+        "variant": "COMMON",
+        "restrictionConditions": null,
+        "reason": "AIR_TRAFFIC",
+        "otherReasonInfo": null,
+        "regulationExemption": null,
+        "message": "Authorization required from ATC prior to flight.",
+        "region": null,
+        "zoneAuthority": [
+          {
+            "purpose": "AUTHORIZATION",
+            "intervalBefore": null,
+            "name": "AirNav Ireland",
+            "service": "Example ATC",
+            "contactName": null,
+            "siteURL": null,
+            "email": "suaairspace@airnav.ie",
+            "phone": null
+          }
+        ]
+      },
+      "geometry": {
+        "type": "MultiPolygon",
+        "layer": {
+          "upper": 2500.0,
+          "upperReference": "AMSL",
+          "lower": 0.0,
+          "lowerReference": "AGL",
+          "uom": "ft"
+        },
+        "coordinates": [
+          [
+            [
+              [-8.50, 51.60],
+              [-8.40, 51.60],
+              [-8.40, 51.70],
+              [-8.50, 51.70],
+              [-8.50, 51.60]
+            ],
+            [
+              [-8.47, 51.63],
+              [-8.43, 51.63],
+              [-8.43, 51.66],
+              [-8.47, 51.66],
+              [-8.47, 51.63]
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "identifier": "T901",
+        "country": "IRL",
+        "name": "Example Stadium Event",
+        "type": "PROHIBITED",
+        "variant": "COMMON",
+        "restrictionConditions": null,
+        "reason": "SENSITIVE",
+        "otherReasonInfo": null,
+        "regulationExemption": null,
+        "message": "Temporary restriction during listed events.",
+        "region": null,
+        "zoneAuthority": [],
+        "limitedApplicability": [
+          {
+            "startDateTime": "2026-08-05T11:00:00+00:00",
+            "endDateTime": "2026-08-05T22:59:00+00:00"
+          },
+          {
+            "startDateTime": "2026-08-29T11:00:00+00:00",
+            "endDateTime": "2026-08-29T22:59:00+00:00"
+          }
+        ]
+      },
+      "geometry": {
+        "type": "MultiPolygon",
+        "layer": {
+          "upper": 3000.0,
+          "upperReference": "AMSL",
+          "lower": 0.0,
+          "lowerReference": "AGL",
+          "uom": "ft"
+        },
+        "coordinates": [
+          [
+            [
+              [-6.24, 53.33],
+              [-6.22, 53.33],
+              [-6.22, 53.34],
+              [-6.24, 53.34],
+              [-6.24, 53.33]
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "identifier": "U902",
+        "country": "IRL",
+        "name": "Example Aerodrome Green Zone",
+        "type": "CONDITIONAL",
+        "variant": "CUSTOMIZED",
+        "restrictionConditions": "PERMITTED/MAX HEIGHT=YES",
+        "reason": "AIR_TRAFFIC",
+        "otherReasonInfo": null,
+        "regulationExemption": null,
+        "message": "Flight permitted below the stated ceiling.",
+        "region": null,
+        "zoneAuthority": []
+      },
+      "geometry": {
+        "type": "MultiPolygon",
+        "layer": {
+          "upper": 400.0,
+          "upperReference": "AGL",
+          "lower": 0.0,
+          "lowerReference": "AGL",
+          "uom": "ft"
+        },
+        "coordinates": [
+          [
+            [
+              [-8.90, 52.68],
+              [-8.88, 52.68],
+              [-8.88, 52.70],
+              [-8.90, 52.70],
+              [-8.90, 52.68]
+            ]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "identifier": "U903",
+        "country": "IRL",
+        "name": "Example Zone Without Published Limits",
+        "type": "NO_RESTRICTION",
+        "variant": "COMMON",
+        "restrictionConditions": null,
+        "reason": "OTHER",
+        "otherReasonInfo": "Exemption Zone",
+        "regulationExemption": null,
+        "message": null,
+        "region": null,
+        "zoneAuthority": []
+      },
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [
+            [
+              [-9.05, 53.27],
+              [-9.03, 53.27],
+              [-9.03, 53.28],
+              [-9.05, 53.28],
+              [-9.05, 53.27]
+            ]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/src/dji_metadata_embedder/geo/airspace/ed318.py
+++ b/src/dji_metadata_embedder/geo/airspace/ed318.py
@@ -1,0 +1,207 @@
+"""ED-318 GeoJSON-profile UAS geographical-zone parser (#452).
+
+Ireland's official publication (iaa.ie) is a plain GeoJSON
+FeatureCollection in the ED-318 shape: zone fields live in ``properties``
+(restriction class under ``type``), vertical limits ride in a non-standard
+``layer`` member inside each feature's ``geometry``, and timed windows are
+``properties.limitedApplicability``. All-or-nothing like the ED-269
+parser: any malformed zone raises rather than silently thinning the set.
+
+The published filename is dated and versioned
+(``20260804_uas_zones_ireland_v1.geojson``), so the registry pins the
+stable zones *page* and the current file href is discovered at fetch time.
+
+Permission record (issue #452): the IAA's Airspace & U-space Inspector
+rejected the ArcGIS service and pointed at this published file in reply to
+our stated open-source reuse request, 2026-08-11. The page carries no
+formal licence; its "reference only, not to be used for navigation"
+wording is preserved in the feed note.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from urllib.parse import urljoin
+
+from .ed269 import _utc
+from .model import Applicability, AirspaceError, SourceInfo, VerticalLimit, Zone
+
+
+@dataclass(frozen=True)
+class Ed318Feed:
+    code: str
+    page_url: str
+    feed_name: str
+    license: str
+    caveat: str
+    note: str | None = None
+
+
+_CAVEAT = (
+    "UAS geographical-zone data is informational and is not an "
+    "authorization to fly."
+)
+
+ED318_FEEDS: dict[str, Ed318Feed] = {
+    "IE": Ed318Feed(
+        code="IE",
+        page_url=(
+            "https://www.iaa.ie/general-aviation/drones/uas-geographic-zones"
+        ),
+        feed_name="Ireland UAS geographical zones (ED-318, IAA)",
+        license=(
+            "© Irish Aviation Authority (iaa.ie), official published "
+            "UAS geographical-zone dataset"
+        ),
+        caveat=_CAVEAT,
+        # The IAA page's own wording, preserved verbatim in spirit: the
+        # published file is a reference product, not a navigation source.
+        note=(
+            "IAA publication note: reference only — not to be used for "
+            "navigation."
+        ),
+    ),
+}
+
+# The current file is the only .geojson href on the zones page whose name
+# carries the uas_zones_ireland stem; the leading date and trailing
+# Sitefinity version parameter both churn between publications.
+_FEED_HREF_RE = re.compile(
+    r'href="([^"]*uas_zones_ireland[^"]*\.geojson[^"]*)"', re.IGNORECASE
+)
+
+
+def discover_feed_url(page: bytes, page_url: str) -> str:
+    """The current zones-file URL from the IAA page's HTML."""
+    match = _FEED_HREF_RE.search(page.decode("utf-8", errors="replace"))
+    if not match:
+        raise AirspaceError(
+            "could not find the UAS zones file on the IAA page "
+            f"({page_url}) — the page layout may have changed"
+        )
+    href = match.group(1).replace("&amp;", "&")
+    return urljoin(page_url, href)
+
+
+def _limit(layer: dict, side: str, unit: str, where: str) -> VerticalLimit | None:
+    value = layer.get(side)
+    if value is None:
+        return None  # "not stated" — never 0
+    ref = layer.get(f"{side}Reference")
+    if ref not in ("AGL", "AMSL"):
+        raise AirspaceError(
+            f"{where}: {side}Reference is {ref!r}, expected AGL/AMSL"
+        )
+    if not isinstance(value, (int, float)):
+        raise AirspaceError(f"{where}: {side} limit {value!r} is not a number")
+    return VerticalLimit(float(value), unit, ref)
+
+
+def _rings(
+    geometry: dict, ident: str, where: str
+) -> tuple[list[list[tuple[float, float]]], list[list[tuple[float, float]]]]:
+    gtype = geometry.get("type")
+    coords = geometry.get("coordinates") or []
+    if gtype == "Polygon":
+        polys = [coords]
+    elif gtype == "MultiPolygon":
+        polys = coords
+    else:
+        raise AirspaceError(
+            f"{where} ({ident}): geometry type {gtype!r} is not supported"
+        )
+    polygons: list[list[tuple[float, float]]] = []
+    holes: list[list[tuple[float, float]]] = []
+    for poly in polys:
+        for ring_index, ring in enumerate(poly):
+            try:
+                parsed = [(float(x), float(y)) for x, y in ring]
+            except (TypeError, ValueError) as exc:
+                raise AirspaceError(
+                    f"{where} ({ident}): malformed ring coordinates"
+                ) from exc
+            # GeoJSON ring order: 0 is an exterior, the rest are holes —
+            # kept apart so the evaluator subtracts them (#422).
+            (polygons if ring_index == 0 else holes).append(parsed)
+    return polygons, holes
+
+
+def parse_ed318(raw: bytes, source: SourceInfo) -> list[Zone]:
+    """Every zone of an ED-318 GeoJSON document as normalized :class:`Zone`s."""
+    try:
+        data = json.loads(raw.decode("utf-8-sig"))
+    except ValueError as exc:
+        raise AirspaceError(f"{source.feed}: feed is not JSON ({exc})") from exc
+    features = data.get("features") if isinstance(data, dict) else None
+    if not isinstance(features, list):
+        raise AirspaceError(
+            f"{source.feed}: not an ED-318 document (no 'features' list)"
+        )
+    zones: list[Zone] = []
+    for i, feat in enumerate(features):
+        where = f"{source.feed}: zone {i}"
+        if not isinstance(feat, dict):
+            raise AirspaceError(f"{where}: not an object")
+        props = feat.get("properties")
+        if not isinstance(props, dict):
+            raise AirspaceError(f"{where}: missing properties")
+        ident = props.get("identifier")
+        restriction = props.get("type")
+        if not isinstance(ident, str) or not ident:
+            raise AirspaceError(f"{where}: missing identifier")
+        if not isinstance(restriction, str) or not restriction:
+            raise AirspaceError(f"{where} ({ident}): missing restriction type")
+        # One concept, one label across countries: the ED-269 feeds spell
+        # REQ_AUTHORISATION with an S, this profile with a Z. Normalized
+        # here at the provider boundary; `native` keeps the feed's spelling.
+        if restriction == "REQ_AUTHORIZATION":
+            restriction = "REQ_AUTHORISATION"
+        applicability: list[Applicability] = []
+        windows = props.get("limitedApplicability")
+        if windows is not None:
+            if not isinstance(windows, list):
+                raise AirspaceError(
+                    f"{where} ({ident}): limitedApplicability is not a list"
+                )
+            for win in windows:
+                start = win.get("startDateTime")
+                end = win.get("endDateTime")
+                applicability.append(
+                    Applicability(
+                        start=_utc(start, f"{where}: startDateTime")
+                        if start else None,
+                        end=_utc(end, f"{where}: endDateTime") if end else None,
+                        permanent=False,
+                    )
+                )
+        geometry = feat.get("geometry")
+        if not isinstance(geometry, dict):
+            raise AirspaceError(f"{where} ({ident}): missing geometry")
+        layer = geometry.get("layer")
+        lower = upper = None
+        if layer is not None:
+            if not isinstance(layer, dict):
+                raise AirspaceError(f"{where} ({ident}): layer is not an object")
+            unit = "ft" if str(layer.get("uom", "M")).upper() == "FT" else "m"
+            lower = _limit(layer, "lower", unit, f"{where} ({ident})")
+            upper = _limit(layer, "upper", unit, f"{where} ({ident})")
+        polygons, holes = _rings(geometry, ident, where)
+        if not polygons:
+            raise AirspaceError(f"{where} ({ident}): no polygon geometry")
+        zones.append(
+            Zone(
+                identifier=ident,
+                name=str(props.get("name") or ident),
+                restriction=restriction,
+                lower=lower,
+                upper=upper,
+                applicability=applicability,
+                polygons=polygons,
+                holes=holes,
+                source=source,
+                native=feat,
+            )
+        )
+    return zones

--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -19,6 +19,7 @@ from urllib.request import Request, urlopen
 from ..track import Track
 from .arcgis_faa import FAA_FEED, FAA_QUERY_URL, fetch_faa_pages, parse_faa, snap_bbox
 from .ed269 import ED269_FEEDS, parse_ed269
+from .ed318 import ED318_FEEDS, discover_feed_url, parse_ed318
 from .jurisdiction import resolve_jurisdiction
 from .model import AirspaceError, SourceInfo, Zone
 
@@ -116,12 +117,22 @@ def fetch_zones(
         feed_name, license_line, caveat = FAA_FEED
         url = FAA_QUERY_URL
         note = None
-    else:
+    elif code in ED269_FEEDS:
         feed = ED269_FEEDS[code]
         body_path = cache_dir / f"ed269-{code}.json"
         feed_name, license_line, caveat = feed.feed_name, feed.license, feed.caveat
         url = feed.url
         note = feed.note
+    else:
+        feed318 = ED318_FEEDS[code]
+        body_path = cache_dir / f"ed318-{code}.json"
+        feed_name = feed318.feed_name
+        license_line, caveat = feed318.license, feed318.caveat
+        # The published filename is dated and churns; the zones page is
+        # the stable, user-checkable entry point, so it is what the
+        # record cites. The current file href is discovered per fetch.
+        url = feed318.page_url
+        note = feed318.note
 
     cached = None if refresh else _read_cache(body_path)
     try:
@@ -136,8 +147,13 @@ def fetch_zones(
                 body = json.dumps(
                     {"pages": [json.loads(p) for p in pages]}
                 ).encode("utf-8")
-            else:
+            elif code in ED269_FEEDS:
                 body = _fetch_ed269(url, transport)
+            else:
+                page = _fetch_ed269(url, transport)
+                body = _fetch_ed269(
+                    discover_feed_url(page, url), transport
+                )
             fetched = _write_cache(body_path, body, url)
             from_cache = False
 
@@ -149,10 +165,12 @@ def fetch_zones(
             doc = _load_faa_doc(body)
             pages_raw = _faa_pages_from_doc(doc)
             zones = parse_faa(pages_raw, source)
-        else:
+        elif code in ED269_FEEDS:
             zones = parse_ed269(
                 body, source, no_ceiling_m=feed.no_ceiling_m
             )
+        else:
+            zones = parse_ed318(body, source)
         if from_cache:
             # Only claim the cache was usable once it has actually
             # parsed — an announce made before this point could be a lie.
@@ -172,10 +190,12 @@ def fetch_zones(
                     doc = _load_faa_doc(body)
                     pages_raw = _faa_pages_from_doc(doc)
                     zones = parse_faa(pages_raw, source)
-                else:
+                elif code in ED269_FEEDS:
                     zones = parse_ed269(
                         body, source, no_ceiling_m=feed.no_ceiling_m
                     )
+                else:
+                    zones = parse_ed318(body, source)
             except AirspaceError as exc2:
                 return AirspaceData(
                     gap_reason=f"airspace data unavailable: {exc2}"

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -69,6 +69,15 @@ _CORE: dict[str, list[Box]] = {
         (7.3, 47.0, 8.0, 47.3),     # Biel / Solothurn / Zofingen
         (8.0, 46.8, 8.9, 47.42),    # Lucerne / Zug / Zurich
     ],
+    # Island geometry (#452): the only land border is with Northern
+    # Ireland, whose southernmost reach is ~54.03 (Carlingford Lough) and
+    # westernmost ~-8.18 (Belleek) — every core edge Nominatim-verified IE
+    # on 2026-08-14 with >=15 km buffer. Donegal and the border counties
+    # sit beyond the cores and gap honestly as border bands.
+    "IE": [
+        (-10.5, 51.45, -5.99, 53.85),  # south + centre (Cork/Dublin/Galway)
+        (-10.2, 53.85, -8.4, 54.4),    # northwest coast (Mayo, Sligo)
+    ],
 }
 _HULL: dict[str, list[Box]] = {
     "US": [
@@ -79,10 +88,17 @@ _HULL: dict[str, list[Box]] = {
     "LU": [(5.70, 49.44, 6.60, 50.20)],
     "FI": [(19.0, 59.5, 31.6, 70.1)],
     "CH": [(5.9, 45.8, 10.5, 47.85)],
+    # Covers the whole island including Northern Ireland on purpose: an NI
+    # flight then gaps as a border band instead of "no provider", the same
+    # semantics the CH hull gives Konstanz.
+    "IE": [(-11.0, 51.3, -5.3, 55.6)],
 }
 # CH takes the EU measure: Regulation (EU) 2019/947 applies in Switzerland
 # since 2023-01-01 under the CH-EU air transport agreement.
-_MEASURE = {"US": MEASURE_US, "LU": MEASURE_EU, "FI": MEASURE_EU, "CH": MEASURE_EU}
+_MEASURE = {
+    "US": MEASURE_US, "LU": MEASURE_EU, "FI": MEASURE_EU, "CH": MEASURE_EU,
+    "IE": MEASURE_EU,
+}
 
 
 @dataclass(frozen=True)
@@ -112,7 +128,8 @@ def resolve_jurisdiction(track: Track) -> Resolution:
         return Resolution(
             None,
             "no supported airspace data source for this location "
-            "(covered: the US, Luxembourg, Finland and Switzerland)",
+            "(covered: the US, Luxembourg, Finland, Switzerland and "
+            "Ireland)",
         )
     code = hulls[0]
     if not _all_inside(track, _CORE[code]):

--- a/tests/test_airspace_ed318.py
+++ b/tests/test_airspace_ed318.py
@@ -1,0 +1,135 @@
+"""ED-318 GeoJSON-profile parser tests (#452) against the real-shape fixture.
+
+Ireland's published file is a plain GeoJSON FeatureCollection whose
+vertical limits ride in a non-standard ``layer`` member inside each
+feature's geometry, with timed windows in ``limitedApplicability`` and the
+restriction class under ``type`` (with the Z-spelling
+``REQ_AUTHORIZATION`` the ED-269 feeds spell with an S).
+"""
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder.geo.airspace import AirspaceError, SourceInfo
+from dji_metadata_embedder.geo.airspace.ed318 import (
+    ED318_FEEDS,
+    discover_feed_url,
+    parse_ed318,
+)
+
+FIXTURES = Path(__file__).parent.parent / "samples" / "airspace"
+SRC = SourceInfo(
+    feed="test", url="https://example.invalid/zones",
+    fetched="2026-08-14T12:00:00Z",
+    license="test", caveat="informational only",
+)
+
+
+def _ie() -> bytes:
+    return (FIXTURES / "ed318-ie.json").read_bytes()
+
+
+def test_parses_the_ireland_fixture():
+    zones = parse_ed318(_ie(), SRC)
+    assert [z.identifier for z in zones] == ["U901", "T901", "U902", "U903"]
+    z = zones[0]
+    assert z.name == "Example Control Zone - Red Zone"
+    # Mixed datums are the Irish norm: floor AGL, ceiling AMSL, both feet.
+    assert z.lower is not None and z.lower.label() == "0 ft AGL"
+    assert z.upper is not None and z.upper.label() == "2500 ft AMSL"
+    assert z.applicability == []          # no windows -> always applicable
+    assert z.polygons[0][0] == (-8.50, 51.60)
+    assert len(z.holes) == 1              # the inner ring is a hole (#422)
+    assert z.native["properties"]["reason"] == "AIR_TRAFFIC"
+
+
+def test_z_spelling_is_normalized_at_the_provider_boundary():
+    # ED-269 feeds publish REQ_AUTHORISATION; Ireland publishes the
+    # Z-spelling. One concept must render as one label across countries,
+    # while the native block keeps what the feed actually said.
+    zones = parse_ed318(_ie(), SRC)
+    assert zones[0].restriction == "REQ_AUTHORISATION"
+    assert zones[0].native["properties"]["type"] == "REQ_AUTHORIZATION"
+    assert zones[2].restriction == "CONDITIONAL"     # others pass through
+
+
+def test_limited_applicability_windows_are_utc():
+    timed = parse_ed318(_ie(), SRC)[1]
+    assert len(timed.applicability) == 2
+    win = timed.applicability[0]
+    assert win.permanent is False
+    assert win.start == datetime(2026, 8, 5, 11, 0)
+    assert win.end == datetime(2026, 8, 5, 22, 59)
+
+
+def test_missing_layer_means_not_stated_never_zero():
+    unlimited = parse_ed318(_ie(), SRC)[3]
+    assert unlimited.lower is None
+    assert unlimited.upper is None
+
+
+def test_bom_is_tolerated():
+    with_bom = b"\xef\xbb\xbf" + _ie()
+    assert len(parse_ed318(with_bom, SRC)) == 4
+
+
+def test_one_malformed_zone_invalidates_the_whole_document():
+    broken = json.loads(_ie().decode("utf-8"))
+    del broken["features"][0]["properties"]["identifier"]
+    with pytest.raises(AirspaceError, match="zone 0.*identifier"):
+        parse_ed318(json.dumps(broken).encode(), SRC)
+
+
+def test_unexpected_vertical_reference_raises():
+    broken = json.loads(_ie().decode("utf-8"))
+    broken["features"][0]["geometry"]["layer"]["upperReference"] = "FL"
+    with pytest.raises(AirspaceError, match="upperReference"):
+        parse_ed318(json.dumps(broken).encode(), SRC)
+
+
+def test_unsupported_geometry_type_raises():
+    broken = json.loads(_ie().decode("utf-8"))
+    broken["features"][0]["geometry"]["type"] = "Point"
+    with pytest.raises(AirspaceError, match="Point"):
+        parse_ed318(json.dumps(broken).encode(), SRC)
+
+
+def test_plain_polygon_geometry_is_accepted():
+    # The live file is all MultiPolygon today; a Polygon sibling must not
+    # invalidate a future revision of the feed.
+    doc = json.loads(_ie().decode("utf-8"))
+    geom = doc["features"][2]["geometry"]
+    geom["type"] = "Polygon"
+    geom["coordinates"] = geom["coordinates"][0]
+    zones = parse_ed318(json.dumps(doc).encode(), SRC)
+    assert zones[2].polygons and not zones[2].holes
+
+
+def test_ie_feed_registry_states_source_and_reference_only_note():
+    feed = ED318_FEEDS["IE"]
+    assert feed.page_url.startswith("https://www.iaa.ie/")
+    assert "Irish Aviation Authority" in feed.license
+    assert "navigation" in (feed.note or "")
+
+
+def test_discover_feed_url_finds_the_dated_file_on_the_page():
+    # The published filename is dated and versioned, so the page is the
+    # stable entry point and the current href is discovered at fetch time.
+    page = (
+        b'<html><a href="/docs/default-source/default-document-library/uas/'
+        b'20260804_uas_zones_ireland_v1.geojson?sfvrsn=f9d5eff3_188&amp;'
+        b'download=true">Download</a></html>'
+    )
+    url = discover_feed_url(page, "https://www.iaa.ie/x/y")
+    assert url == (
+        "https://www.iaa.ie/docs/default-source/default-document-library/"
+        "uas/20260804_uas_zones_ireland_v1.geojson"
+        "?sfvrsn=f9d5eff3_188&download=true"
+    )
+
+
+def test_discover_feed_url_raises_when_the_page_changed_shape():
+    with pytest.raises(AirspaceError, match="zones file"):
+        discover_feed_url(b"<html>redesigned</html>", "https://www.iaa.ie/")

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -181,3 +181,38 @@ def test_switzerland_fetch_applies_the_no_ceiling_sentinel(tmp_path):
     assert (tmp_path / "ed269-CH.json").exists()
     sentinel_zone = next(z for z in data.zones if z.identifier == "CH-GT9990")
     assert sentinel_zone.upper is None  # 99999 m AMSL sentinel, not a ceiling
+
+
+def test_an_irish_flight_discovers_the_dated_file_then_fetches_it(tmp_path):
+    # #452: the IAA filename is dated and versioned, so the fetch is
+    # two-step — zones page first, then the discovered file.
+    page = (
+        b'<a href="/docs/default-source/default-document-library/uas/'
+        b'20260804_uas_zones_ireland_v1.geojson?sfvrsn=1_2&amp;download=true">'
+        b'</a>'
+    )
+    fake = FakeTransport([page, (FIXTURES / "ed318-ie.json").read_bytes()])
+    lines = []
+    data = fetch_zones(_track(53.35, -6.26), tmp_path, transport=fake,
+                       announce=lines.append)
+    assert data.gap_reason is None and len(data.zones) == 4
+    assert fake.urls[0].startswith(
+        "https://www.iaa.ie/general-aviation/drones/uas-geographic-zones")
+    assert "uas_zones_ireland" in fake.urls[1]
+    assert data.source is not None and "Irish Aviation Authority" in data.source.license
+    assert (tmp_path / "ed318-IE.json").exists()
+    assert any("Fetching" in ln and "iaa.ie" in ln for ln in lines)
+
+
+def test_a_cached_irish_body_skips_discovery_entirely(tmp_path):
+    page = (
+        b'<a href="/docs/x/20260804_uas_zones_ireland_v1.geojson'
+        b'?sfvrsn=1_2&amp;download=true"></a>'
+    )
+    fake = FakeTransport([page, (FIXTURES / "ed318-ie.json").read_bytes()])
+    fetch_zones(_track(53.35, -6.26), tmp_path, transport=fake)
+
+    def no_network(req, timeout=None):
+        raise AssertionError("cached run must not touch the network")
+    data = fetch_zones(_track(53.35, -6.26), tmp_path, transport=no_network)
+    assert data.from_cache and len(data.zones) == 4

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -168,3 +168,39 @@ def test_milan_gaps_outside_the_ch_hull():
     r = resolve_jurisdiction(_track((45.46, 9.19)))
     assert r.jurisdiction is None
     assert r.gap_reason is not None and "no supported airspace data" in r.gap_reason
+
+
+# --- Ireland (#452) ---------------------------------------------------------
+# Core/hull edges Nominatim-verified 2026-08-14: the NI border's
+# southernmost reach is ~54.03 (Carlingford Lough) and its westernmost
+# ~-8.18 (Belleek), so the cores stop at 53.85 and -8.4 respectively.
+
+
+def test_a_dublin_flight_resolves_to_ie_with_the_eu_measure():
+    r = resolve_jurisdiction(_track((53.35, -6.26), (53.36, -6.25)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "IE"
+    assert "2019/947" in r.jurisdiction.measure_note
+
+
+def test_a_sligo_flight_resolves_through_the_northwest_core():
+    r = resolve_jurisdiction(_track((54.27, -8.48)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "IE"
+
+
+def test_a_belfast_flight_gaps_instead_of_resolving_ie():
+    r = resolve_jurisdiction(_track((54.60, -5.93)))
+    assert r.jurisdiction is None
+    assert "boundary" in (r.gap_reason or "")
+
+
+def test_a_dundalk_flight_gaps_as_a_border_band():
+    # 15 km from the border: too close to choose from coordinates alone.
+    r = resolve_jurisdiction(_track((54.00, -6.40)))
+    assert r.jurisdiction is None
+    assert "boundary" in (r.gap_reason or "")
+
+
+def test_the_no_provider_message_names_ireland():
+    r = resolve_jurisdiction(_track((48.85, 2.35)))   # Paris
+    assert r.jurisdiction is None
+    assert "Ireland" in (r.gap_reason or "")


### PR DESCRIPTION
Closes #452. First ED-318 provider; permission record and feed analysis posted on the issue.

## What ships

- **`geo/airspace/ed318.py`** — parser for the ED-318 GeoJSON profile: zone fields in `properties` (restriction class under `type`), vertical limits in the non-standard `layer` member **inside the geometry object**, timed windows in `limitedApplicability`. All-or-nothing like the ED-269 parser. The Z-spelled `REQ_AUTHORIZATION` is normalised to the ED-269 S-spelling at the provider boundary so one concept renders as one label across countries; `native` keeps the feed's spelling.
- **Discovery at fetch time** — the published filename is dated and versioned (`20260804_uas_zones_ireland_v1.geojson`), so the registry pins the stable zones page and `discover_feed_url` finds the current href per live fetch. The cache stores the file body: cached runs never touch the network, verified by test.
- **Jurisdiction** — island geometry: two core boxes stop 15+ km short of the Northern Ireland border (southernmost reach ~54.03 at Carlingford Lough, westernmost ~-8.18 at Belleek; every edge Nominatim-verified on 2026-08-14). Donegal and the border counties gap honestly; the hull covers the whole island so an NI flight gaps as a border band rather than "no provider" — the same semantics the CH hull gives Konstanz.
- **Honest strings** — attribution names the Irish Aviation Authority and the source page; the IAA's "reference only — not to be used for navigation" wording rides into the feed note. Docs and the GUI airspace tooltip now name all four national feeds (the tooltip had missed Switzerland too).

## Live E2E (real network, shipped code path)

Dublin track → announce → page discovery → 81 zones parsed (72 mixed-datum AGL-floor/AMSL-ceiling, 5 timed `T*`, 28 holes) → Dublin CTR red/amber/green sub-zone model in the result → second run served from cache offline.

## Tests

TDD red-first: 12 parser/discovery tests on a real-shape fixture (mixed datums, holes, timed windows, missing-layer degradation, BOM, all-or-nothing failures, Z-spelling normalisation), 5 jurisdiction tests (Dublin and Sligo resolve, Belfast and Dundalk gap, the no-provider message names Ireland), 2 fetch tests (two-step discovery, cache skips discovery). Full suite 1270 passed + ruff + mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186pA6oi9yWBVJuLcuJpa6z