### PR TITLE
feat(geo): UK UAS flight restrictions via the NATS AIS AIXM 5.1 dataset (#499)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -431,11 +431,14 @@ already reports.
 for the flight area on the HTML maps — the flat map and the 3D terrain view
 (`--3d`) — FAA UAS Facility Maps in the US, and national UAS
 geographical-zone feeds where a country publishes one (currently
-Luxembourg, Finland and Switzerland via ED-269, and Ireland via the IAA's
+Luxembourg, Finland and Switzerland via ED-269, Ireland via the IAA's
 published ED-318 file, which the IAA labels reference-only — that caveat
-rides into the map). Zones draw in one neutral style; clicking one shows
-the published facts: restriction class, vertical limits (or "not stated"),
-applicability windows, and the feed, license and fetch time. Zones the
+rides into the map — and the UK via the NATS AIS AIXM 5.1 dataset, whose
+activation hours and temporary restrictions live in the AIP and NOTAMs,
+not in the file; that caveat rides along too). Zones draw in one neutral
+style; clicking one shows the published facts: restriction class, vertical
+limits (or "not stated"), applicability windows, and the feed, license and
+fetch time. Zones the
 flight entered get a slightly stronger outline plus the entry/exit times and
 maximum heights in the popup. The map states facts and makes no
 determination.

--- a/docs/how-to/flight-record.md
+++ b/docs/how-to/flight-record.md
@@ -34,17 +34,21 @@ takeoff-referenced height, which is aircraft-reported. The
 surface-referenced height is the exception — it needs a fetch from
 Mapterhorn's terrain tiles (see "The `[terrain]` extra" below).
 
-Three feeds are used:
+Four feeds are used:
 
 - **US flights** query the FAA's UAS Facility Map (keyless ArcGIS). The
   bounding box sent to the endpoint is padded and snapped outward to a
   0.1° grid before it goes on the wire, so the endpoint learns no more
   about where you flew than a map-tile fetch already would.
 - **Luxembourg, Finland and Switzerland** flights fetch the country's
-  whole ED-269
-  geographical-zone document — the feed has no query parameter for a
-  location at all, so nothing about the flight is sent; the entire country's
-  zones come back regardless of where the flight was.
+  whole ED-269 geographical-zone document, and **Ireland** the IAA's
+  published ED-318 file — the feeds have no query parameter for a
+  location at all, so nothing about the flight is sent; the entire
+  country's zones come back regardless of where the flight was.
+- **UK** flights fetch NATS AIS's whole UAS flight-restrictions dataset
+  (AIXM 5.1, refreshed each 28-day AIRAC cycle), again with no location
+  sent. Activation hours are not in the dataset and temporary
+  restrictions live in NOTAMs; the record says so rather than guessing.
 - **Every flight**, regardless of jurisdiction, fetches surface-height
   tiles from Mapterhorn (`tiles.mapterhorn.com`) for the surface-referenced
   height estimate, when the `[terrain]` extra is installed.
@@ -59,17 +63,19 @@ nothing without `-f record`; terrain tiles are unaffected by this flag).
 dji-embed flightmap ./flights -f record --airspace-refresh
 ```
 
-## Coverage: US, Luxembourg, Finland, Switzerland — and an honest gap everywhere else
+## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK — and an honest gap everywhere else
 
 Airspace lookup only resolves for flights that sit clearly inside the
-United States, Luxembourg, Finland, or Switzerland. Everywhere else —
-including
-Sweden — the record states the gap instead of guessing: *"no supported
+United States, Luxembourg, Finland, Switzerland, Ireland, or the UK.
+Everywhere else — including Sweden — the record states the gap instead of
+guessing: *"no supported
 airspace data source for this location."* A flight near a jurisdiction
 boundary gaps the same way, deliberately, rather than borrowing a
 neighbouring country's rules from coordinates alone. The logbook half of
 the record (times, distances, heights) is unaffected — a gapped airspace
-section never blocks the rest.
+section never blocks the rest. Northern Ireland resolves to the UK
+dataset; flights close to the Irish land border still gap deliberately,
+from both sides.
 
 Widening coverage means adding and verifying another feed; it will grow,
 but a wrong jurisdiction guessed from coordinates would be worse than no

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -335,7 +335,7 @@
                                                   IsEnabled="{Binding !FlightOptions.ThreeD}"
                                                   Content="Airspace zones" />
                                         <TextBlock Name="FlightAirspaceNote"
-                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland and Ireland). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
+                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland, Ireland and the UK). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
                                                    IsVisible="{Binding FlightOptions.ShowsAirspaceNote}"
                                                    TextWrapping="Wrap"
                                                    Opacity="0.5" FontSize="11" />

--- a/samples/airspace/aixm51-gb.xml
+++ b/samples/airspace/aixm51-gb.xml
@@ -272,6 +272,63 @@
     </aixm:Airspace>
   </message:hasMember>
   <message:hasMember>
+    <aixm:Airspace gml:id="a6">
+      <gml:identifier codeSpace="urn:uuid:">66666666-6666-6666-6666-666666666666</gml:identifier>
+      <aixm:timeSlice>
+        <aixm:AirspaceTimeSlice gml:id="a6ts">
+          <aixm:type>D</aixm:type>
+          <aixm:designator>EGD904</aixm:designator>
+          <aixm:name>TEST ARC FLIP</aixm:name>
+          <aixm:geometryComponent>
+            <aixm:AirspaceGeometryComponent gml:id="a6gc">
+              <aixm:theAirspaceVolume>
+                <aixm:AirspaceVolume gml:id="a6v">
+                  <aixm:upperLimit uom="FT">3000</aixm:upperLimit>
+                  <aixm:upperLimitReference>MSL</aixm:upperLimitReference>
+                  <aixm:lowerLimit uom="FT">0</aixm:lowerLimit>
+                  <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
+                  <aixm:horizontalProjection>
+                    <aixm:Surface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="a6s">
+                      <gml:patches>
+                        <gml:PolygonPatch>
+                          <gml:exterior>
+                            <gml:Ring>
+                              <gml:curveMember>
+                                <gml:Curve gml:id="a6c">
+                                  <gml:segments>
+                                    <gml:GeodesicString interpolation="geodesic">
+                                      <gml:pointProperty><aixm:Point gml:id="a6p1"><gml:pos>53.014 -2.0195349</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a6p2"><gml:pos>53.0117516 -2.0195349</gml:pos></aixm:Point></gml:pointProperty>
+                                    </gml:GeodesicString>
+                                    <gml:ArcByCenterPoint interpolation="circularArcCenterPointWithRadius" numArc="1">
+                                      <gml:pointProperty><aixm:Point gml:id="a6p3"><gml:pos>53.0 -2.0</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:radius uom="[nmi_i]">1</gml:radius>
+                                      <gml:startAngle uom="deg">315</gml:startAngle>
+                                      <gml:endAngle uom="deg">45</gml:endAngle>
+                                    </gml:ArcByCenterPoint>
+                                    <gml:GeodesicString interpolation="geodesic">
+                                      <gml:pointProperty><aixm:Point gml:id="a6p4"><gml:pos>53.0117516 -1.9804651</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a6p5"><gml:pos>53.014 -1.9804651</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a6p6"><gml:pos>53.014 -2.0195349</gml:pos></aixm:Point></gml:pointProperty>
+                                    </gml:GeodesicString>
+                                  </gml:segments>
+                                </gml:Curve>
+                              </gml:curveMember>
+                            </gml:Ring>
+                          </gml:exterior>
+                        </gml:PolygonPatch>
+                      </gml:patches>
+                    </aixm:Surface>
+                  </aixm:horizontalProjection>
+                </aixm:AirspaceVolume>
+              </aixm:theAirspaceVolume>
+            </aixm:AirspaceGeometryComponent>
+          </aixm:geometryComponent>
+        </aixm:AirspaceTimeSlice>
+      </aixm:timeSlice>
+    </aixm:Airspace>
+  </message:hasMember>
+  <message:hasMember>
     <aixm:GeoBorder gml:id="g1">
       <gml:identifier codeSpace="urn:uuid:">99999999-9999-9999-9999-999999999999</gml:identifier>
       <aixm:timeSlice>

--- a/samples/airspace/aixm51-gb.xml
+++ b/samples/airspace/aixm51-gb.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<message:AIXMBasicMessage
+    xmlns:aixm="http://www.aixm.aero/schema/5.1"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:message="http://www.aixm.aero/schema/5.1/message"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    gml:id="m1">
+  <message:hasMember>
+    <aixm:Airspace gml:id="a1">
+      <gml:identifier codeSpace="urn:uuid:">11111111-1111-1111-1111-111111111111</gml:identifier>
+      <aixm:timeSlice>
+        <aixm:AirspaceTimeSlice gml:id="a1ts">
+          <aixm:type>R</aixm:type>
+          <aixm:designator>EGTEST1</aixm:designator>
+          <aixm:localType>RPZ</aixm:localType>
+          <aixm:name>TESTFIELD RWY 09</aixm:name>
+          <aixm:activation>
+            <aixm:AirspaceActivation gml:id="a1act">
+              <aixm:annotation>
+                <aixm:Note gml:id="a1n1">
+                  <aixm:purpose>REMARK</aixm:purpose>
+                  <aixm:translatedNote>
+                    <aixm:LinguisticNote gml:id="a1n2">
+                      <aixm:note lang="eng">Mon-Sat SR to SS.</aixm:note>
+                    </aixm:LinguisticNote>
+                  </aixm:translatedNote>
+                </aixm:Note>
+              </aixm:annotation>
+              <aixm:status>AVBL_FOR_ACTIVATION</aixm:status>
+            </aixm:AirspaceActivation>
+          </aixm:activation>
+          <aixm:geometryComponent>
+            <aixm:AirspaceGeometryComponent gml:id="a1gc">
+              <aixm:theAirspaceVolume>
+                <aixm:AirspaceVolume gml:id="a1v">
+                  <aixm:upperLimit uom="FT">2000</aixm:upperLimit>
+                  <aixm:upperLimitReference>SFC</aixm:upperLimitReference>
+                  <aixm:lowerLimit uom="FT">0</aixm:lowerLimit>
+                  <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
+                  <aixm:horizontalProjection>
+                    <aixm:Surface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="a1s">
+                      <gml:patches>
+                        <gml:PolygonPatch>
+                          <gml:exterior>
+                            <gml:Ring>
+                              <gml:curveMember>
+                                <gml:Curve gml:id="a1c">
+                                  <gml:segments>
+                                    <gml:GeodesicString interpolation="geodesic">
+                                      <gml:pointProperty><aixm:Point gml:id="a1p1"><gml:pos>50.99 -1.03</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a1p2"><gml:pos>51.0166253 -1.0</gml:pos></aixm:Point></gml:pointProperty>
+                                    </gml:GeodesicString>
+                                    <gml:ArcByCenterPoint interpolation="circularArcCenterPointWithRadius" numArc="1">
+                                      <gml:pointProperty><aixm:Point gml:id="a1p3"><gml:pos>51.0 -1.0</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:radius uom="[nmi_i]">1</gml:radius>
+                                      <gml:startAngle uom="deg">0</gml:startAngle>
+                                      <gml:endAngle uom="deg">90</gml:endAngle>
+                                    </gml:ArcByCenterPoint>
+                                    <gml:LineStringSegment>
+                                      <gml:pointProperty><aixm:Point gml:id="a1p4"><gml:pos>50.9999970 -0.9735822</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a1p5"><gml:pos>50.99 -1.03</gml:pos></aixm:Point></gml:pointProperty>
+                                    </gml:LineStringSegment>
+                                  </gml:segments>
+                                </gml:Curve>
+                              </gml:curveMember>
+                            </gml:Ring>
+                          </gml:exterior>
+                        </gml:PolygonPatch>
+                      </gml:patches>
+                    </aixm:Surface>
+                  </aixm:horizontalProjection>
+                </aixm:AirspaceVolume>
+              </aixm:theAirspaceVolume>
+            </aixm:AirspaceGeometryComponent>
+          </aixm:geometryComponent>
+        </aixm:AirspaceTimeSlice>
+      </aixm:timeSlice>
+    </aixm:Airspace>
+  </message:hasMember>
+  <message:hasMember>
+    <aixm:Airspace gml:id="a2">
+      <gml:identifier codeSpace="urn:uuid:">22222222-2222-2222-2222-222222222222</gml:identifier>
+      <aixm:timeSlice>
+        <aixm:AirspaceTimeSlice gml:id="a2ts">
+          <aixm:type>D</aixm:type>
+          <aixm:designator>EGD901</aixm:designator>
+          <aixm:name>TEST DANGER</aixm:name>
+          <aixm:geometryComponent>
+            <aixm:AirspaceGeometryComponent gml:id="a2gc">
+              <aixm:theAirspaceVolume>
+                <aixm:AirspaceVolume gml:id="a2v">
+                  <aixm:upperLimit uom="FL">999</aixm:upperLimit>
+                  <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                  <aixm:lowerLimit uom="FL">50</aixm:lowerLimit>
+                  <aixm:lowerLimitReference>STD</aixm:lowerLimitReference>
+                  <aixm:horizontalProjection>
+                    <aixm:Surface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="a2s">
+                      <gml:patches>
+                        <gml:PolygonPatch>
+                          <gml:exterior>
+                            <gml:Ring>
+                              <gml:curveMember>
+                                <gml:Curve gml:id="a2c">
+                                  <gml:segments>
+                                    <gml:CircleByCenterPoint interpolation="circularArcCenterPointWithRadius" numArc="1">
+                                      <gml:pointProperty><aixm:Point gml:id="a2p1"><gml:pos>51.2 -1.5</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:radius uom="[nmi_i]">2</gml:radius>
+                                    </gml:CircleByCenterPoint>
+                                  </gml:segments>
+                                </gml:Curve>
+                              </gml:curveMember>
+                            </gml:Ring>
+                          </gml:exterior>
+                        </gml:PolygonPatch>
+                      </gml:patches>
+                    </aixm:Surface>
+                  </aixm:horizontalProjection>
+                </aixm:AirspaceVolume>
+              </aixm:theAirspaceVolume>
+            </aixm:AirspaceGeometryComponent>
+          </aixm:geometryComponent>
+        </aixm:AirspaceTimeSlice>
+      </aixm:timeSlice>
+    </aixm:Airspace>
+  </message:hasMember>
+  <message:hasMember>
+    <aixm:Airspace gml:id="a3">
+      <gml:identifier codeSpace="urn:uuid:">33333333-3333-3333-3333-333333333333</gml:identifier>
+      <aixm:timeSlice>
+        <aixm:AirspaceTimeSlice gml:id="a3ts">
+          <aixm:type>P</aixm:type>
+          <aixm:designator>EGP901</aixm:designator>
+          <aixm:name>TEST PROHIB</aixm:name>
+          <aixm:geometryComponent>
+            <aixm:AirspaceGeometryComponent gml:id="a3gc">
+              <aixm:theAirspaceVolume>
+                <aixm:AirspaceVolume gml:id="a3v">
+                  <aixm:upperLimit uom="FT">2000</aixm:upperLimit>
+                  <aixm:upperLimitReference>MSL</aixm:upperLimitReference>
+                  <aixm:lowerLimit uom="FT">0</aixm:lowerLimit>
+                  <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
+                  <aixm:horizontalProjection>
+                    <aixm:Surface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="a3s">
+                      <gml:patches>
+                        <gml:PolygonPatch>
+                          <gml:exterior>
+                            <gml:Ring>
+                              <gml:curveMember>
+                                <gml:Curve gml:id="a3c">
+                                  <gml:segments>
+                                    <gml:GeodesicString interpolation="geodesic">
+                                      <gml:pointProperty><aixm:Point gml:id="a3p1"><gml:pos>51.5 -0.5</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a3p2"><gml:pos>51.5 -0.48</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a3p3"><gml:pos>51.48 -0.48</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a3p4"><gml:pos>51.48 -0.5</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a3p5"><gml:pos>51.5 -0.5</gml:pos></aixm:Point></gml:pointProperty>
+                                    </gml:GeodesicString>
+                                  </gml:segments>
+                                </gml:Curve>
+                              </gml:curveMember>
+                            </gml:Ring>
+                          </gml:exterior>
+                        </gml:PolygonPatch>
+                      </gml:patches>
+                    </aixm:Surface>
+                  </aixm:horizontalProjection>
+                </aixm:AirspaceVolume>
+              </aixm:theAirspaceVolume>
+            </aixm:AirspaceGeometryComponent>
+          </aixm:geometryComponent>
+        </aixm:AirspaceTimeSlice>
+      </aixm:timeSlice>
+    </aixm:Airspace>
+  </message:hasMember>
+  <message:hasMember>
+    <aixm:Airspace gml:id="a4">
+      <gml:identifier codeSpace="urn:uuid:">44444444-4444-4444-4444-444444444444</gml:identifier>
+      <aixm:timeSlice>
+        <aixm:AirspaceTimeSlice gml:id="a4ts">
+          <aixm:type>D</aixm:type>
+          <aixm:designator>EGD902</aixm:designator>
+          <aixm:name>TEST COAST FOLLOW</aixm:name>
+          <aixm:geometryComponent>
+            <aixm:AirspaceGeometryComponent gml:id="a4gc">
+              <aixm:theAirspaceVolume>
+                <aixm:AirspaceVolume gml:id="a4v">
+                  <aixm:upperLimit uom="FT">5000</aixm:upperLimit>
+                  <aixm:upperLimitReference>MSL</aixm:upperLimitReference>
+                  <aixm:lowerLimit uom="FT">0</aixm:lowerLimit>
+                  <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
+                  <aixm:horizontalProjection>
+                    <aixm:Surface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="a4s">
+                      <gml:patches>
+                        <gml:PolygonPatch>
+                          <gml:exterior>
+                            <gml:Ring>
+                              <gml:curveMember xlink:href="urn:uuid:99999999-9999-9999-9999-999999999999"/>
+                              <gml:curveMember>
+                                <gml:Curve gml:id="a4c">
+                                  <gml:segments>
+                                    <gml:GeodesicString interpolation="geodesic">
+                                      <gml:pointProperty><aixm:Point gml:id="a4p1"><gml:pos>52.02 0.0</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a4p2"><gml:pos>52.02 -0.01</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a4p3"><gml:pos>52.0 -0.01</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a4p4"><gml:pos>52.0 0.0</gml:pos></aixm:Point></gml:pointProperty>
+                                    </gml:GeodesicString>
+                                  </gml:segments>
+                                </gml:Curve>
+                              </gml:curveMember>
+                            </gml:Ring>
+                          </gml:exterior>
+                        </gml:PolygonPatch>
+                      </gml:patches>
+                    </aixm:Surface>
+                  </aixm:horizontalProjection>
+                </aixm:AirspaceVolume>
+              </aixm:theAirspaceVolume>
+            </aixm:AirspaceGeometryComponent>
+          </aixm:geometryComponent>
+        </aixm:AirspaceTimeSlice>
+      </aixm:timeSlice>
+    </aixm:Airspace>
+  </message:hasMember>
+  <message:hasMember>
+    <aixm:Airspace gml:id="a5">
+      <gml:identifier codeSpace="urn:uuid:">55555555-5555-5555-5555-555555555555</gml:identifier>
+      <aixm:timeSlice>
+        <aixm:AirspaceTimeSlice gml:id="a5ts">
+          <aixm:type>D</aixm:type>
+          <aixm:designator>EGD903</aixm:designator>
+          <aixm:name>TEST COAST REVERSED</aixm:name>
+          <aixm:geometryComponent>
+            <aixm:AirspaceGeometryComponent gml:id="a5gc">
+              <aixm:theAirspaceVolume>
+                <aixm:AirspaceVolume gml:id="a5v">
+                  <aixm:upperLimit uom="FL">100</aixm:upperLimit>
+                  <aixm:upperLimitReference>STD</aixm:upperLimitReference>
+                  <aixm:lowerLimit uom="FT">0</aixm:lowerLimit>
+                  <aixm:lowerLimitReference>SFC</aixm:lowerLimitReference>
+                  <aixm:horizontalProjection>
+                    <aixm:Surface srsName="urn:ogc:def:crs:EPSG::4326" gml:id="a5s">
+                      <gml:patches>
+                        <gml:PolygonPatch>
+                          <gml:exterior>
+                            <gml:Ring>
+                              <gml:curveMember>
+                                <gml:Curve gml:id="a5c">
+                                  <gml:segments>
+                                    <gml:GeodesicString interpolation="geodesic">
+                                      <gml:pointProperty><aixm:Point gml:id="a5p1"><gml:pos>52.0 0.0</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a5p2"><gml:pos>52.0 0.02</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a5p3"><gml:pos>52.02 0.02</gml:pos></aixm:Point></gml:pointProperty>
+                                      <gml:pointProperty><aixm:Point gml:id="a5p4"><gml:pos>52.02 0.0</gml:pos></aixm:Point></gml:pointProperty>
+                                    </gml:GeodesicString>
+                                  </gml:segments>
+                                </gml:Curve>
+                              </gml:curveMember>
+                              <gml:curveMember xlink:href="urn:uuid:99999999-9999-9999-9999-999999999999"/>
+                            </gml:Ring>
+                          </gml:exterior>
+                        </gml:PolygonPatch>
+                      </gml:patches>
+                    </aixm:Surface>
+                  </aixm:horizontalProjection>
+                </aixm:AirspaceVolume>
+              </aixm:theAirspaceVolume>
+            </aixm:AirspaceGeometryComponent>
+          </aixm:geometryComponent>
+        </aixm:AirspaceTimeSlice>
+      </aixm:timeSlice>
+    </aixm:Airspace>
+  </message:hasMember>
+  <message:hasMember>
+    <aixm:GeoBorder gml:id="g1">
+      <gml:identifier codeSpace="urn:uuid:">99999999-9999-9999-9999-999999999999</gml:identifier>
+      <aixm:timeSlice>
+        <aixm:GeoBorderTimeSlice gml:id="g1ts">
+          <aixm:name>TEST COASTLINE</aixm:name>
+          <aixm:type>COAST</aixm:type>
+          <aixm:border>
+            <aixm:Curve srsName="urn:ogc:def:crs:EPSG::4326" gml:id="g1c">
+              <gml:segments>
+                <gml:GeodesicString interpolation="geodesic">
+                  <gml:pointProperty><aixm:Point gml:id="g1p1"><gml:pos>52.0 0.0</gml:pos></aixm:Point></gml:pointProperty>
+                  <gml:pointProperty><aixm:Point gml:id="g1p2"><gml:pos>52.01 0.005</gml:pos></aixm:Point></gml:pointProperty>
+                  <gml:pointProperty><aixm:Point gml:id="g1p3"><gml:pos>52.02 0.0</gml:pos></aixm:Point></gml:pointProperty>
+                </gml:GeodesicString>
+              </gml:segments>
+            </aixm:Curve>
+          </aixm:border>
+        </aixm:GeoBorderTimeSlice>
+      </aixm:timeSlice>
+    </aixm:GeoBorder>
+  </message:hasMember>
+</message:AIXMBasicMessage>

--- a/samples/airspace/aixm51-gb.xml
+++ b/samples/airspace/aixm51-gb.xml
@@ -285,6 +285,7 @@
                   <gml:pointProperty><aixm:Point gml:id="g1p1"><gml:pos>52.0 0.0</gml:pos></aixm:Point></gml:pointProperty>
                   <gml:pointProperty><aixm:Point gml:id="g1p2"><gml:pos>52.01 0.005</gml:pos></aixm:Point></gml:pointProperty>
                   <gml:pointProperty><aixm:Point gml:id="g1p3"><gml:pos>52.02 0.0</gml:pos></aixm:Point></gml:pointProperty>
+                  <gml:pointProperty><aixm:Point gml:id="g1p4"><gml:pos>52.03 -0.01</gml:pos></aixm:Point></gml:pointProperty>
                 </gml:GeodesicString>
               </gml:segments>
             </aixm:Curve>

--- a/src/dji_metadata_embedder/geo/airspace/aixm51.py
+++ b/src/dji_metadata_embedder/geo/airspace/aixm51.py
@@ -1,0 +1,151 @@
+"""AIXM 5.1 UAS-restriction parser (#499): the UK NATS AIS dataset.
+
+The authoritative product is an AIXM 5.1 BasicMessage: one
+``aixm:Airspace`` per zone (single time slice, single volume), geometry
+as GML curve segments — geodesic/line point runs, arcs and circles by
+centre point, plus xlink references to in-document ``aixm:GeoBorder``
+curves for coast/river-following boundaries. Arcs and circles are
+densified here, deliberately: the sibling KML product ships pre-densified
+with visual gaps between abutting volumes, the exact flaw a consistent
+in-house densification avoids.
+
+Arc sweep direction is untrustworthy in the wild (the 20260806 cycle
+mixes clockwise and anticlockwise arcs), so each arc defaults to its
+shorter sweep and the assembled ring is checked for self-intersection;
+on failure every direction combination is tried until a simple ring
+emerges (probe 2026-08-15: 543 of 548 arc-bearing zones take the shorter
+sweep, 5 need the search, none unsolved).
+
+Vertical limits arrive in feet and flight levels against SFC/MSL/STD
+datums. An upper limit of FL 999 is the UK "unlimited" convention — a
+sentinel mapped to "not stated", never rendered as a number (the Swiss
+99999 lesson). Activation blocks (NOTAM-activated danger areas, prose
+schedules) ride in ``native`` but never become applicability windows:
+the evaluator treats a window's presence as machine-evaluable
+time-bounding, and these are not.
+
+Rights (issue #499): the dataset's own ISO 19115 metadata states
+"Unrestricted" access and usage (not for resale; for aviation use only),
+which governs over the site's copyright boilerplate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import zipfile
+from dataclasses import dataclass
+from datetime import date, datetime
+from urllib.parse import urljoin
+
+from .model import AirspaceError
+
+_AIXM = "{http://www.aixm.aero/schema/5.1}"
+_GML = "{http://www.opengis.net/gml/3.2}"
+_XLINK = "{http://www.w3.org/1999/xlink}"
+_XSI = "{http://www.w3.org/2001/XMLSchema-instance}"
+
+
+@dataclass(frozen=True)
+class Aixm51Feed:
+    code: str
+    page_url: str
+    feed_name: str
+    license: str
+    caveat: str
+    note: str | None = None
+
+
+_CAVEAT = (
+    "UAS flight-restriction data is informational and is not an "
+    "authorization to fly."
+)
+
+AIXM_FEEDS: dict[str, Aixm51Feed] = {
+    "GB": Aixm51Feed(
+        code="GB",
+        page_url=(
+            "https://nats-uk.ead-it.com/cms-nats/opencms/en/Publications/"
+            "digital-datasets/"
+        ),
+        feed_name="UK UAS flight restrictions (AIXM 5.1, NATS AIS)",
+        license=(
+            "© NATS Limited — UK UAS Flight Restrictions dataset; usage "
+            "unrestricted per the product's ISO 19115 metadata (not for "
+            "resale; for aviation use only)"
+        ),
+        caveat=_CAVEAT,
+        note=(
+            "Activation hours are not in the dataset and are not "
+            "evaluated here (many danger areas are part-time; the AIP "
+            "and NOTAM service hold the hours). Temporary restrictions "
+            "live in NOTAMs and AIP Supplements, not in this record."
+        ),
+    ),
+}
+
+# The page lists the current AND next AIRAC cycle as dated zips; only
+# the XML product is authoritative (the KML sibling is visualisation).
+_ZIP_HREF_RE = re.compile(
+    r'href="([^"]*UAS_AREA_1/EG_UAS_FR_DS_AREA1_FULL_(\d{8})_XML\.zip)"',
+    re.IGNORECASE,
+)
+
+
+def discover_feed_url(page: bytes, page_url: str, *, today: date) -> str:
+    """The currently-effective dataset zip URL from the datasets page.
+
+    A cycle takes effect at 00:00 UTC on its filename date, so the
+    newest listed date that is not in the future wins; a page listing
+    only future cycles falls back to the oldest one."""
+    dated: list[tuple[date, str]] = []
+    for href, ymd in _ZIP_HREF_RE.findall(
+        page.decode("utf-8", errors="replace")
+    ):
+        try:
+            effective = datetime.strptime(ymd, "%Y%m%d").date()
+        except ValueError:
+            continue
+        dated.append((effective, href.replace("&amp;", "&")))
+    if not dated:
+        raise AirspaceError(
+            "could not find the UAS flight-restrictions dataset on the "
+            f"NATS page ({page_url}) — the page layout may have changed"
+        )
+    current = [(d, h) for d, h in dated if d <= today]
+    _, href = max(current) if current else min(dated)
+    return urljoin(page_url, href)
+
+
+_XML_MEMBER_RE = re.compile(r"EG_UAS_FR_DS_AREA1_FULL_\d{8}\.xml$")
+
+
+def extract_xml(zip_bytes: bytes) -> bytes:
+    """The dataset XML out of the downloaded archive, verified against
+    the archive's own SHA-256 sidecar."""
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        raise AirspaceError(f"dataset archive is not a zip ({exc})") from exc
+    with archive:
+        names = archive.namelist()
+        xml_names = [n for n in names if _XML_MEMBER_RE.search(n)]
+        if len(xml_names) != 1:
+            raise AirspaceError(
+                f"expected one dataset XML in the archive, found "
+                f"{len(xml_names)}"
+            )
+        body = archive.read(xml_names[0])
+        sha_names = [n for n in names if n.endswith(".sha256")]
+        if len(sha_names) != 1:
+            raise AirspaceError(
+                "no SHA-256 sidecar in the dataset archive"
+            )
+        sidecar = archive.read(sha_names[0]).decode("ascii", "replace")
+        expected = sidecar.split()[0].lower() if sidecar.split() else ""
+    if hashlib.sha256(body).hexdigest() != expected:
+        raise AirspaceError(
+            "dataset XML failed the archive's own SHA-256 integrity check"
+        )
+    return body

--- a/src/dji_metadata_embedder/geo/airspace/aixm51.py
+++ b/src/dji_metadata_embedder/geo/airspace/aixm51.py
@@ -146,7 +146,8 @@ def extract_xml(zip_bytes: bytes) -> bytes:
         sha_names = [n for n in names if n.endswith(".sha256")]
         if len(sha_names) != 1:
             raise AirspaceError(
-                "no SHA-256 sidecar in the dataset archive"
+                "expected one SHA-256 sidecar in the dataset archive, "
+                f"found {len(sha_names)}"
             )
         sidecar = archive.read(sha_names[0]).decode("ascii", "replace")
         expected = sidecar.split()[0].lower() if sidecar.split() else ""
@@ -176,6 +177,12 @@ _CIRCLE_POINTS = 128
 # arc endpoints sit up to ~77 m from the neighbouring published vertices
 # (data imprecision); a gap beyond this is a broken ring.
 _JUNCTION_M = 160.0
+
+# Implied GML Ring closure is honest only at coastline resolution: the
+# live file's largest real closure remainder (EGD012's coast-to-corner
+# gap) is ~967 m. Beyond this cap a "closure" is a truncated ring, and
+# rendering it silently would bridge the tear — gap instead.
+_CLOSURE_M = 5000.0
 
 # Bounds the simple-ring search over arc directions (2^8 assemblies);
 # the live file's worst zone has 5 arcs.
@@ -408,10 +415,16 @@ def _assemble(
         pts.extend(run)
     if len(pts) < 3:
         raise AirspaceError(f"{where}: ring has too few points")
-    if _dist_m(pts[0], pts[-1]) <= _JUNCTION_M:
+    gap = _dist_m(pts[0], pts[-1])
+    if gap <= _JUNCTION_M:
         pts[-1] = pts[0]
-    else:
+    elif gap <= _CLOSURE_M:
         pts.append(pts[0])  # GML Ring closure may be implied
+    else:
+        raise AirspaceError(
+            f"{where}: ring closure gap is {gap:.0f} m — the ring looks "
+            "truncated"
+        )
     return pts
 
 
@@ -525,6 +538,12 @@ def _native(
 
 def parse_aixm51(raw: bytes, source: SourceInfo) -> list[Zone]:
     """Every airspace of an AIXM 5.1 message as normalized :class:`Zone`s."""
+    # The scan below is byte-wise; a UTF-16/32 body would slip past it.
+    # The dataset is UTF-8, so any BOM or NUL in the prologue is refused.
+    if raw[:1] in (b"\xff", b"\xfe") or b"\x00" in raw[:4096]:
+        raise AirspaceError(
+            f"{source.feed}: refusing non-UTF-8 XML encoding"
+        )
     # The dataset never declares a DTD; refusing them up front closes
     # the stdlib parser's entity-expansion/XXE surface without a
     # defusedxml dependency (whose core defence is exactly this).

--- a/src/dji_metadata_embedder/geo/airspace/aixm51.py
+++ b/src/dji_metadata_embedder/geo/airspace/aixm51.py
@@ -33,13 +33,16 @@ from __future__ import annotations
 
 import hashlib
 import io
+import itertools
+import math
 import re
 import zipfile
 from dataclasses import dataclass
 from datetime import date, datetime
 from urllib.parse import urljoin
+from xml.etree import ElementTree
 
-from .model import AirspaceError
+from .model import AirspaceError, SourceInfo, VerticalLimit, Zone
 
 _AIXM = "{http://www.aixm.aero/schema/5.1}"
 _GML = "{http://www.opengis.net/gml/3.2}"
@@ -149,3 +152,439 @@ def extract_xml(zip_bytes: bytes) -> bytes:
             "dataset XML failed the archive's own SHA-256 integrity check"
         )
     return body
+
+
+# --- geometry -------------------------------------------------------------
+
+# WGS84
+_A = 6378137.0
+_F = 1 / 298.257223563
+_E2 = _F * (2 - _F)
+
+# Radius unit spellings are UCUM (probe-verified: [nmi_i], m, [ft_i]).
+_RADIUS_M = {"[nmi_i]": 1852.0, "m": 1.0, "[ft_i]": 0.3048}
+
+# Points per full circle: chord sagitta ~1 m at the 2-2.5 NM norm and
+# ~14 m at the file's single 27 NM outlier — under the dataset's own
+# stated 30 m horizontal accuracy.
+_CIRCLE_POINTS = 128
+
+# Junction tolerance between consecutive ring segments: the live file's
+# arc endpoints sit up to ~77 m from the neighbouring published vertices
+# (data imprecision); a gap beyond this is a broken ring.
+_JUNCTION_M = 160.0
+
+# Bounds the simple-ring search over arc directions (2^8 assemblies);
+# the live file's worst zone has 5 arcs.
+_MAX_ARC_SEARCH = 8
+
+LatLon = tuple[float, float]
+
+
+def _gaussian_radius_m(lat_deg: float) -> float:
+    """Radius of the sphere that locally best fits the ellipsoid, keeping
+    densification error ~0.05% of the arc radius."""
+    s = math.sin(math.radians(lat_deg))
+    d = 1 - _E2 * s * s
+    meridional = _A * (1 - _E2) / d**1.5
+    normal = _A / math.sqrt(d)
+    return math.sqrt(meridional * normal)
+
+
+def _destination(origin: LatLon, bearing_deg: float, dist_m: float) -> LatLon:
+    lat1 = math.radians(origin[0])
+    lon1 = math.radians(origin[1])
+    d = dist_m / _gaussian_radius_m(origin[0])
+    br = math.radians(bearing_deg)
+    lat2 = math.asin(
+        math.sin(lat1) * math.cos(d)
+        + math.cos(lat1) * math.sin(d) * math.cos(br)
+    )
+    lon2 = lon1 + math.atan2(
+        math.sin(br) * math.sin(d) * math.cos(lat1),
+        math.cos(d) - math.sin(lat1) * math.sin(lat2),
+    )
+    return math.degrees(lat2), math.degrees(lon2)
+
+
+def _dist_m(p: LatLon, q: LatLon) -> float:
+    return math.hypot(
+        (p[0] - q[0]) * 111_320,
+        (p[1] - q[1]) * 111_320 * math.cos(math.radians(p[0])),
+    )
+
+
+def _pos(el: ElementTree.Element, where: str) -> LatLon:
+    parts = (el.text or "").split()
+    if len(parts) != 2:
+        raise AirspaceError(f"{where}: malformed gml:pos {el.text!r}")
+    try:
+        lat, lon = (float(p) for p in parts)
+    except ValueError as exc:
+        raise AirspaceError(
+            f"{where}: malformed gml:pos {el.text!r}"
+        ) from exc
+    return lat, lon  # EPSG::4326 URN axis order: latitude first
+
+
+def _point_run(seg: ElementTree.Element, where: str) -> list[LatLon]:
+    return [_pos(p, where) for p in seg.iter(f"{_GML}pos")]
+
+
+def _centre_radius(
+    seg: ElementTree.Element, where: str
+) -> tuple[LatLon, float]:
+    pos = seg.find(f"{_GML}pointProperty/{_AIXM}Point/{_GML}pos")
+    if pos is None:
+        raise AirspaceError(f"{where}: arc/circle has no centre point")
+    radius = seg.find(f"{_GML}radius")
+    uom = radius.get("uom") if radius is not None else None
+    if radius is None or uom not in _RADIUS_M:
+        raise AirspaceError(f"{where}: unsupported radius unit {uom!r}")
+    try:
+        r = float(radius.text or "") * _RADIUS_M[uom]
+    except ValueError as exc:
+        raise AirspaceError(f"{where}: malformed radius") from exc
+    return _pos(pos, where), r
+
+
+def _angle(seg: ElementTree.Element, name: str, where: str) -> float:
+    el = seg.find(f"{_GML}{name}")
+    if el is None:
+        raise AirspaceError(f"{where}: arc has no {name}")
+    try:
+        return float(el.text or "")
+    except ValueError as exc:
+        raise AirspaceError(f"{where}: malformed {name}") from exc
+
+
+def _circle(seg: ElementTree.Element, where: str) -> list[LatLon]:
+    centre, r = _centre_radius(seg, where)
+    step = 360.0 / _CIRCLE_POINTS
+    return [
+        _destination(centre, k * step, r)
+        for k in range(_CIRCLE_POINTS + 1)
+    ]
+
+
+def _arc(
+    seg: ElementTree.Element, clockwise: bool, where: str
+) -> list[LatLon]:
+    centre, r = _centre_radius(seg, where)
+    start = _angle(seg, "startAngle", where)
+    end = _angle(seg, "endAngle", where)
+    sweep = (end - start) % 360 if clockwise else (start - end) % 360
+    n = max(2, math.ceil(_CIRCLE_POINTS * sweep / 360))
+    step = sweep / n if clockwise else -sweep / n
+    return [_destination(centre, start + k * step, r) for k in range(n + 1)]
+
+
+# A ring is a sequence of pieces: fixed point runs (geodesic/line
+# strings, circles, GeoBorder splices) and arcs whose sweep direction is
+# chosen at assembly time.
+_Piece = tuple[str, object]
+
+
+def _ring_pieces(
+    ring: ElementTree.Element, borders: dict[str, list[LatLon]], where: str
+) -> list[_Piece]:
+    pieces: list[_Piece] = []
+    members = ring.findall(f"{_GML}curveMember")
+    if not members:
+        raise AirspaceError(f"{where}: ring has no curve members")
+    for member in members:
+        href = member.get(f"{_XLINK}href")
+        if href is not None:
+            uuid = href.removeprefix("urn:uuid:")
+            if uuid not in borders:
+                raise AirspaceError(
+                    f"{where}: unresolvable GeoBorder reference {href}"
+                )
+            pieces.append(("border", borders[uuid]))
+            continue
+        segments = member.find(f"{_GML}Curve/{_GML}segments")
+        if segments is None:
+            raise AirspaceError(f"{where}: curve member has no segments")
+        for seg in segments:
+            if seg.tag in (
+                f"{_GML}GeodesicString", f"{_GML}LineStringSegment"
+            ):
+                pieces.append(("fixed", _point_run(seg, where)))
+            elif seg.tag == f"{_GML}CircleByCenterPoint":
+                pieces.append(("fixed", _circle(seg, where)))
+            elif seg.tag == f"{_GML}ArcByCenterPoint":
+                pieces.append(("arc", seg))
+            else:
+                raise AirspaceError(
+                    f"{where}: unsupported curve segment "
+                    f"{seg.tag.rpartition('}')[2]}"
+                )
+    return pieces
+
+
+def _leading_point(piece: _Piece, where: str) -> LatLon:
+    kind, payload = piece
+    if kind == "arc":
+        assert isinstance(payload, ElementTree.Element)
+        centre, r = _centre_radius(payload, where)
+        # An arc's start point is the same for both sweep directions.
+        return _destination(centre, _angle(payload, "startAngle", where), r)
+    assert isinstance(payload, list)
+    return payload[0]
+
+
+def _assemble(
+    pieces: list[_Piece], arc_dirs: list[bool], where: str
+) -> list[LatLon]:
+    pts: list[LatLon] = []
+    arc_i = 0
+    for i, (kind, payload) in enumerate(pieces):
+        if kind == "arc":
+            assert isinstance(payload, ElementTree.Element)
+            run = _arc(payload, arc_dirs[arc_i], where)
+            arc_i += 1
+        elif kind == "border":
+            assert isinstance(payload, list)
+            run = list(payload)
+            # Splice orientation is continuity-driven: a border's two
+            # orientations have different endpoints (unlike an arc's).
+            if pts:
+                if _dist_m(run[-1], pts[-1]) < _dist_m(run[0], pts[-1]):
+                    run.reverse()
+            else:
+                nxt = _leading_point(pieces[(i + 1) % len(pieces)], where)
+                if _dist_m(run[0], nxt) < _dist_m(run[-1], nxt):
+                    run.reverse()
+        else:
+            assert isinstance(payload, list)
+            run = list(payload)
+        if pts:
+            gap = _dist_m(pts[-1], run[0])
+            if gap > _JUNCTION_M:
+                raise AirspaceError(
+                    f"{where}: ring is discontinuous ({gap:.0f} m gap)"
+                )
+            run = run[1:]  # snap the junction
+        pts.extend(run)
+    if len(pts) < 3:
+        raise AirspaceError(f"{where}: ring has too few points")
+    if _dist_m(pts[0], pts[-1]) <= _JUNCTION_M:
+        pts[-1] = pts[0]
+    else:
+        pts.append(pts[0])  # GML Ring closure may be implied
+    return pts
+
+
+def _crosses(p1: LatLon, p2: LatLon, p3: LatLon, p4: LatLon) -> bool:
+    def ccw(a: LatLon, b: LatLon, c: LatLon) -> bool:
+        return (c[1] - a[1]) * (b[0] - a[0]) > (b[1] - a[1]) * (c[0] - a[0])
+
+    return ccw(p1, p3, p4) != ccw(p2, p3, p4) and ccw(p1, p2, p3) != ccw(
+        p1, p2, p4
+    )
+
+
+def _self_intersects(ring: list[LatLon]) -> bool:
+    n = len(ring)
+    for i in range(n - 1):
+        for j in range(i + 2, n - 1):
+            if i == 0 and j == n - 2:
+                continue
+            if _crosses(ring[i], ring[i + 1], ring[j], ring[j + 1]):
+                return True
+    return False
+
+
+def _ring_points(
+    ring: ElementTree.Element, borders: dict[str, list[LatLon]], where: str
+) -> list[LatLon]:
+    pieces = _ring_pieces(ring, borders, where)
+    arc_segs = [seg for kind, seg in pieces if kind == "arc"]
+    # Per-arc default: the shorter way round. Continuity cannot pick the
+    # direction (both sweeps share endpoints) and no uniform convention
+    # fits the live file, but the shorter sweep + a simplicity check
+    # covers it: 543/548 arc-bearing zones directly, 5 via the search.
+    dirs: list[bool] = []
+    for seg in arc_segs:
+        assert isinstance(seg, ElementTree.Element)
+        start = _angle(seg, "startAngle", where)
+        end = _angle(seg, "endAngle", where)
+        dirs.append((end - start) % 360 <= 180)
+    pts = _assemble(pieces, dirs, where)
+    if not arc_segs or not _self_intersects(pts):
+        return pts
+    if len(arc_segs) > _MAX_ARC_SEARCH:
+        raise AirspaceError(f"{where}: too many arcs to disambiguate")
+    for combo in itertools.product((True, False), repeat=len(arc_segs)):
+        pts = _assemble(pieces, list(combo), where)
+        if not _self_intersects(pts):
+            return pts
+    raise AirspaceError(
+        f"{where}: no arc interpretation yields a simple ring"
+    )
+
+
+# --- zones ----------------------------------------------------------------
+
+_TYPES = {"P": "PROHIBITED", "R": "RESTRICTED", "D": "DANGER"}
+_LIMIT_REFS = {"SFC": "AGL", "MSL": "AMSL", "STD": "STD"}
+_LIMIT_UNITS = {"FT": "ft", "M": "m", "FL": "FL"}
+
+
+def _limit(
+    vol: ElementTree.Element, side: str, where: str
+) -> VerticalLimit | None:
+    el = vol.find(f"{_AIXM}{side}Limit")
+    if (
+        el is None
+        or el.get(f"{_XSI}nil") == "true"
+        or not (el.text or "").strip()
+    ):
+        return None  # "not stated" — never 0
+    uom = (el.get("uom") or "").upper()
+    if uom not in _LIMIT_UNITS:
+        raise AirspaceError(
+            f"{where}: unsupported {side} limit unit {uom!r}"
+        )
+    ref_el = vol.find(f"{_AIXM}{side}LimitReference")
+    ref_raw = (ref_el.text or "").strip() if ref_el is not None else ""
+    if ref_raw not in _LIMIT_REFS:
+        raise AirspaceError(
+            f"{where}: {side} limit reference {ref_raw!r} is not "
+            "SFC/MSL/STD"
+        )
+    if (uom == "FL") != (ref_raw == "STD"):
+        raise AirspaceError(f"{where}: {side} limit pairs {uom} with {ref_raw}")
+    try:
+        value = float(el.text or "")
+    except ValueError as exc:
+        raise AirspaceError(f"{where}: malformed {side} limit") from exc
+    return VerticalLimit(value, _LIMIT_UNITS[uom], _LIMIT_REFS[ref_raw])
+
+
+def _native(
+    ts: ElementTree.Element, type_code: str, local_type: str
+) -> dict:
+    activations = []
+    for act in ts.findall(f"{_AIXM}activation/{_AIXM}AirspaceActivation"):
+        notes = [
+            (n.text or "").strip()
+            for n in act.iter(f"{_AIXM}note")
+            if (n.text or "").strip()
+        ]
+        activations.append({
+            "status": (act.findtext(f"{_AIXM}status") or "").strip() or None,
+            "notes": notes,
+        })
+    return {
+        "type": type_code,
+        "localType": local_type or None,
+        "activation": activations,
+    }
+
+
+def parse_aixm51(raw: bytes, source: SourceInfo) -> list[Zone]:
+    """Every airspace of an AIXM 5.1 message as normalized :class:`Zone`s."""
+    # The dataset never declares a DTD; refusing them up front closes
+    # the stdlib parser's entity-expansion/XXE surface without a
+    # defusedxml dependency (whose core defence is exactly this).
+    if b"<!DOCTYPE" in raw or b"<!ENTITY" in raw:
+        raise AirspaceError(
+            f"{source.feed}: document declares a DTD; refusing to parse"
+        )
+    try:
+        root = ElementTree.fromstring(raw)
+    except ElementTree.ParseError as exc:
+        raise AirspaceError(
+            f"{source.feed}: feed is not XML ({exc})"
+        ) from exc
+    borders: dict[str, list[LatLon]] = {}
+    for gb in root.iter(f"{_AIXM}GeoBorder"):
+        ident = (gb.findtext(f"{_GML}identifier") or "").strip()
+        if not ident:
+            raise AirspaceError(
+                f"{source.feed}: GeoBorder without identifier"
+            )
+        borders[ident] = [
+            _pos(p, f"{source.feed}: GeoBorder {ident}")
+            for p in gb.iter(f"{_GML}pos")
+        ]
+    zones: list[Zone] = []
+    for i, asp in enumerate(root.iter(f"{_AIXM}Airspace")):
+        where = f"{source.feed}: zone {i}"
+        slices = asp.findall(f"{_AIXM}timeSlice/{_AIXM}AirspaceTimeSlice")
+        if len(slices) != 1:
+            raise AirspaceError(
+                f"{where}: expected one time slice, found {len(slices)}"
+            )
+        ts = slices[0]
+        designator = (ts.findtext(f"{_AIXM}designator") or "").strip()
+        if not designator:
+            raise AirspaceError(f"{where}: missing designator")
+        where = f"{where} ({designator})"
+        type_code = (ts.findtext(f"{_AIXM}type") or "").strip()
+        if type_code not in _TYPES:
+            raise AirspaceError(
+                f"{where}: airspace type {type_code!r} is not P/R/D"
+            )
+        name = (ts.findtext(f"{_AIXM}name") or "").strip() or designator
+        local_type = (ts.findtext(f"{_AIXM}localType") or "").strip()
+        if local_type in ("FRZ", "RPZ"):
+            # The most drone-meaningful classification in the dataset.
+            name = f"{name} ({local_type})"
+        components = ts.findall(
+            f"{_AIXM}geometryComponent/{_AIXM}AirspaceGeometryComponent"
+        )
+        if len(components) != 1:
+            raise AirspaceError(
+                f"{where}: expected one geometry component, found "
+                f"{len(components)}"
+            )
+        vol = components[0].find(
+            f"{_AIXM}theAirspaceVolume/{_AIXM}AirspaceVolume"
+        )
+        if vol is None:
+            raise AirspaceError(f"{where}: missing airspace volume")
+        lower = _limit(vol, "lower", where)
+        upper = _limit(vol, "upper", where)
+        if upper is not None and upper.unit == "FL" and upper.value >= 999:
+            # FL 999 is the UK "unlimited" convention — a sentinel,
+            # never a number to render (the Swiss 99999 lesson).
+            upper = None
+        patches = vol.findall(
+            f"{_AIXM}horizontalProjection/{_AIXM}Surface/"
+            f"{_GML}patches/{_GML}PolygonPatch"
+        )
+        if len(patches) != 1:
+            raise AirspaceError(
+                f"{where}: expected one polygon patch, found {len(patches)}"
+            )
+        exterior = patches[0].find(f"{_GML}exterior/{_GML}Ring")
+        if exterior is None:
+            raise AirspaceError(f"{where}: patch has no exterior ring")
+        ring = _ring_points(exterior, borders, where)
+        holes: list[list[tuple[float, float]]] = []
+        for interior in patches[0].findall(f"{_GML}interior"):
+            inner = interior.find(f"{_GML}Ring")
+            if inner is not None:
+                holes.append([
+                    (lon, lat)
+                    for lat, lon in _ring_points(inner, borders, where)
+                ])
+        zones.append(
+            Zone(
+                identifier=designator,
+                name=name,
+                restriction=_TYPES[type_code],
+                lower=lower,
+                upper=upper,
+                applicability=[],
+                polygons=[[(lon, lat) for lat, lon in ring]],
+                holes=holes,
+                source=source,
+                native=_native(ts, type_code, local_type),
+            )
+        )
+    if not zones:
+        raise AirspaceError(f"{source.feed}: no airspace features found")
+    return zones

--- a/src/dji_metadata_embedder/geo/airspace/aixm51.py
+++ b/src/dji_metadata_embedder/geo/airspace/aixm51.py
@@ -4,7 +4,10 @@ The authoritative product is an AIXM 5.1 BasicMessage: one
 ``aixm:Airspace`` per zone (single time slice, single volume), geometry
 as GML curve segments — geodesic/line point runs, arcs and circles by
 centre point, plus xlink references to in-document ``aixm:GeoBorder``
-curves for coast/river-following boundaries. Arcs and circles are
+curves for coast/river-following boundaries. A GeoBorder curve is the
+full coastline polyline; a ring's reference to it is trimmed to the
+sub-path between its neighbouring segments' endpoints, not spliced
+whole. Arcs and circles are
 densified here, deliberately: the sibling KML product ships pre-densified
 with visual gaps between abutting volumes, the exact flaw a consistent
 in-house densification avoids.
@@ -309,7 +312,17 @@ def _ring_pieces(
             if seg.tag in (
                 f"{_GML}GeodesicString", f"{_GML}LineStringSegment"
             ):
-                pieces.append(("fixed", _point_run(seg, where)))
+                points = _point_run(seg, where)
+                if len(set(points)) <= 1:
+                    # A zero-length "closing" segment: some real zones
+                    # (e.g. EGD012) end their ring with a curve whose
+                    # points all repeat the ring's own start coordinate
+                    # instead of an actual closing edge. It contributes
+                    # no geometry, so it is dropped rather than forced
+                    # through the junction check — the ring's own
+                    # closure step (which never errors) finishes it off.
+                    continue
+                pieces.append(("fixed", points))
             elif seg.tag == f"{_GML}CircleByCenterPoint":
                 pieces.append(("fixed", _circle(seg, where)))
             elif seg.tag == f"{_GML}ArcByCenterPoint":
@@ -333,6 +346,17 @@ def _leading_point(piece: _Piece, where: str) -> LatLon:
     return payload[0]
 
 
+def _trailing_point(piece: _Piece, where: str) -> LatLon:
+    kind, payload = piece
+    if kind == "arc":
+        assert isinstance(payload, ElementTree.Element)
+        centre, r = _centre_radius(payload, where)
+        # An arc's end point is the same for both sweep directions.
+        return _destination(centre, _angle(payload, "endAngle", where), r)
+    assert isinstance(payload, list)
+    return payload[-1]
+
+
 def _assemble(
     pieces: list[_Piece], arc_dirs: list[bool], where: str
 ) -> list[LatLon]:
@@ -345,16 +369,32 @@ def _assemble(
             arc_i += 1
         elif kind == "border":
             assert isinstance(payload, list)
-            run = list(payload)
-            # Splice orientation is continuity-driven: a border's two
-            # orientations have different endpoints (unlike an arc's).
-            if pts:
-                if _dist_m(run[-1], pts[-1]) < _dist_m(run[0], pts[-1]):
-                    run.reverse()
+            border = payload
+            if len(pieces) == 1:
+                # A border-only ring: keep the whole polyline as-is.
+                run = list(border)
             else:
-                nxt = _leading_point(pieces[(i + 1) % len(pieces)], where)
-                if _dist_m(run[0], nxt) < _dist_m(run[-1], nxt):
-                    run.reverse()
+                # A GeoBorder curve is the full coastline/river polyline;
+                # a ring only follows the stretch BETWEEN its neighbouring
+                # segments' endpoints, not the whole thing.
+                prev_pt = _trailing_point(
+                    pieces[(i - 1) % len(pieces)], where
+                )
+                next_pt = _leading_point(
+                    pieces[(i + 1) % len(pieces)], where
+                )
+                start_idx = min(
+                    range(len(border)),
+                    key=lambda j: _dist_m(border[j], prev_pt),
+                )
+                end_idx = min(
+                    range(len(border)),
+                    key=lambda j: _dist_m(border[j], next_pt),
+                )
+                if start_idx <= end_idx:
+                    run = list(border[start_idx : end_idx + 1])
+                else:
+                    run = list(reversed(border[end_idx : start_idx + 1]))
         else:
             assert isinstance(payload, list)
             run = list(payload)

--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -17,6 +17,12 @@ from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 from ..track import Track
+from .aixm51 import (
+    AIXM_FEEDS,
+    discover_feed_url as discover_aixm_url,
+    extract_xml,
+    parse_aixm51,
+)
 from .arcgis_faa import FAA_FEED, FAA_QUERY_URL, fetch_faa_pages, parse_faa, snap_bbox
 from .ed269 import ED269_FEEDS, parse_ed269
 from .ed318 import ED318_FEEDS, discover_feed_url, parse_ed318
@@ -87,7 +93,7 @@ def _faa_pages_from_doc(doc: dict) -> list[bytes]:
     return [json.dumps(p).encode("utf-8") for p in pages]
 
 
-def _fetch_ed269(url: str, transport) -> bytes:
+def _fetch_url(url: str, transport) -> bytes:
     req = Request(url, headers={"User-Agent": "dji-embed"})
     try:
         with transport(req, timeout=_TIMEOUT_S) as resp:
@@ -123,7 +129,7 @@ def fetch_zones(
         feed_name, license_line, caveat = feed.feed_name, feed.license, feed.caveat
         url = feed.url
         note = feed.note
-    else:
+    elif code in ED318_FEEDS:
         feed318 = ED318_FEEDS[code]
         body_path = cache_dir / f"ed318-{code}.json"
         feed_name = feed318.feed_name
@@ -133,6 +139,16 @@ def fetch_zones(
         # record cites. The current file href is discovered per fetch.
         url = feed318.page_url
         note = feed318.note
+    else:
+        feed_aixm = AIXM_FEEDS[code]
+        body_path = cache_dir / f"aixm-{code}.xml"
+        feed_name = feed_aixm.feed_name
+        license_line, caveat = feed_aixm.license, feed_aixm.caveat
+        # Same dated-filename pattern as ED-318, with a zip around the
+        # XML; the cache holds the extracted, sha-verified XML so cached
+        # and fresh bodies parse identically.
+        url = feed_aixm.page_url
+        note = feed_aixm.note
 
     cached = None if refresh else _read_cache(body_path)
     try:
@@ -148,12 +164,16 @@ def fetch_zones(
                     {"pages": [json.loads(p) for p in pages]}
                 ).encode("utf-8")
             elif code in ED269_FEEDS:
-                body = _fetch_ed269(url, transport)
+                body = _fetch_url(url, transport)
+            elif code in ED318_FEEDS:
+                page = _fetch_url(url, transport)
+                body = _fetch_url(discover_feed_url(page, url), transport)
             else:
-                page = _fetch_ed269(url, transport)
-                body = _fetch_ed269(
-                    discover_feed_url(page, url), transport
+                page = _fetch_url(url, transport)
+                zip_url = discover_aixm_url(
+                    page, url, today=datetime.now(timezone.utc).date()
                 )
+                body = extract_xml(_fetch_url(zip_url, transport))
             fetched = _write_cache(body_path, body, url)
             from_cache = False
 
@@ -169,8 +189,10 @@ def fetch_zones(
             zones = parse_ed269(
                 body, source, no_ceiling_m=feed.no_ceiling_m
             )
-        else:
+        elif code in ED318_FEEDS:
             zones = parse_ed318(body, source)
+        else:
+            zones = parse_aixm51(body, source)
         if from_cache:
             # Only claim the cache was usable once it has actually
             # parsed — an announce made before this point could be a lie.
@@ -194,8 +216,10 @@ def fetch_zones(
                     zones = parse_ed269(
                         body, source, no_ceiling_m=feed.no_ceiling_m
                     )
-                else:
+                elif code in ED318_FEEDS:
                     zones = parse_ed318(body, source)
+                else:
+                    zones = parse_aixm51(body, source)
             except AirspaceError as exc2:
                 return AirspaceData(
                     gap_reason=f"airspace data unavailable: {exc2}"

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -5,6 +5,9 @@ Never a user setting: one flight, one jurisdiction, chosen from the data
 jurisdiction: a track entirely inside a hull AND its core resolves; inside
 a hull but outside the core sits too close to a land border to decide from
 coordinates alone and gaps honestly; anywhere else is the no-provider gap.
+When a track sits inside more than one hull (#499: the GB and IE hulls
+overlap over Northern Ireland), cores break the tie — exactly one
+jurisdiction's core must contain the track, or it gaps as a border band.
 The boxes are deliberately coarse v1 constants — the failure mode they
 must exclude is borrowing another jurisdiction's framing, not coverage.
 """
@@ -29,6 +32,13 @@ MEASURE_EU = (
     "of the surface of the earth, with obstacle exceptions that telemetry "
     "cannot evaluate. This record states measurements and their datums; "
     "it makes no determination."
+)
+MEASURE_UK = (
+    "Where this flight took place, assimilated Regulation (EU) 2019/947 "
+    "(UK law, UAS.OPEN.010(2)) requires staying within 120 m of the "
+    "closest point of the surface of the earth, with obstacle exceptions "
+    "that telemetry cannot evaluate. This record states measurements and "
+    "their datums; it makes no determination."
 )
 
 _CORE: dict[str, list[Box]] = {
@@ -78,6 +88,29 @@ _CORE: dict[str, list[Box]] = {
         (-10.5, 51.45, -5.99, 53.85),  # south + centre (Cork/Dublin/Galway)
         (-10.2, 53.85, -8.4, 54.4),    # northwest coast (Mayo, Sligo)
     ],
+    # An island needs sea margins, not land-border margins (#499): the
+    # only land border is the IE/NI one, handled by the NI core edges
+    # mirroring the IE cores from the other side (border extremes:
+    # Carlingford ~54.03, Belleek ~-8.18). Verified 2026-08-15: Nominatim
+    # confirms (54.42,-6.5), (54.45,-6.55) and (55.2,-6.5) as UK, right at
+    # the core's south/west edges; Kent's SE corner clears Cap Gris-Nez by
+    # ~12 km, the GB hull's south edge clears Alderney by ~14.5 km, and the
+    # Hebrides core's south edge clears Malin Head/Inishtrahull by
+    # ~30/~30 km — all >=10 km.
+    # Deliberate gaps, each an honest border band: Isle of Man, Scilly,
+    # Kintyre, the IE border counties from the NI side.
+    "GB": [
+        (-5.75, 49.93, -2.2, 53.4),    # SW England + Wales (Lizard 49.95 in)
+        (-2.2, 50.45, 0.9, 51.6),      # southern England incl. London
+        (0.9, 50.88, 1.42, 51.45),     # Kent; Cap Gris-Nez stays >=10 km off
+        (-0.2, 51.6, 1.77, 53.3),      # East Anglia (Lowestoft 1.76 in)
+        (-3.65, 53.4, -0.2, 55.3),     # N England (IoM stays >=40 km west)
+        (-5.0, 55.3, -1.5, 58.7),      # Scotland mainland (Kintyre gaps)
+        (-7.6, 55.7, -4.95, 58.55),    # Hebrides; Malin Head >=30 km south
+        (-3.5, 58.85, -2.3, 59.45),    # Orkney
+        (-1.85, 59.75, -0.65, 60.9),   # Shetland
+        (-6.55, 54.42, -5.43, 55.25),  # Northern Ireland (Belfast, Coleraine)
+    ],
 }
 _HULL: dict[str, list[Box]] = {
     "US": [
@@ -92,12 +125,23 @@ _HULL: dict[str, list[Box]] = {
     # flight then gaps as a border band instead of "no provider", the same
     # semantics the CH hull gives Konstanz.
     "IE": [(-11.0, 51.3, -5.3, 55.6)],
+    # Covers Great Britain, its islands and Northern Ireland; the Isle
+    # of Man sits inside deliberately with no core (its own AIP, no
+    # Ronaldsway FRZ in the dataset) and the Channel Islands stay
+    # outside entirely (zero zones in the dataset). The NI box overlaps
+    # the IE hull on purpose: cores break the tie (#499).
+    "GB": [
+        (-5.9, 49.85, 1.9, 61.0),      # Great Britain + Northern Isles
+        (-6.6, 49.75, -5.9, 50.3),     # Scilly approaches
+        (-8.0, 55.55, -5.9, 61.0),     # Hebridean seas
+        (-8.2, 54.0, -5.35, 55.4),     # Northern Ireland
+    ],
 }
 # CH takes the EU measure: Regulation (EU) 2019/947 applies in Switzerland
 # since 2023-01-01 under the CH-EU air transport agreement.
 _MEASURE = {
     "US": MEASURE_US, "LU": MEASURE_EU, "FI": MEASURE_EU, "CH": MEASURE_EU,
-    "IE": MEASURE_EU,
+    "IE": MEASURE_EU, "GB": MEASURE_UK,
 }
 
 
@@ -124,19 +168,19 @@ def resolve_jurisdiction(track: Track) -> Resolution:
     if not track.points:
         return Resolution(None, "the track has no GPS points")
     hulls = [code for code, boxes in _HULL.items() if _all_inside(track, boxes)]
-    if len(hulls) != 1:
+    if not hulls:
         return Resolution(
             None,
             "no supported airspace data source for this location "
-            "(covered: the US, Luxembourg, Finland, Switzerland and "
-            "Ireland)",
+            "(covered: the US, Luxembourg, Finland, Switzerland, "
+            "Ireland and the UK)",
         )
-    code = hulls[0]
-    if not _all_inside(track, _CORE[code]):
+    cores = [code for code in hulls if _all_inside(track, _CORE[code])]
+    if len(cores) != 1:
         return Resolution(
             None,
             "the flight sits too close to a jurisdiction boundary to "
             "choose an airspace source from coordinates alone; airspace "
             "lookup skipped",
         )
-    return Resolution(Jurisdiction(code, _MEASURE[code]), None)
+    return Resolution(Jurisdiction(cores[0], _MEASURE[cores[0]]), None)

--- a/src/dji_metadata_embedder/geo/airspace/model.py
+++ b/src/dji_metadata_embedder/geo/airspace/model.py
@@ -27,10 +27,12 @@ class VerticalLimit:
     "not stated" — never 0 (live ED-269 zones omit limits)."""
 
     value: float
-    unit: str        # "m" | "ft", as published
-    reference: str   # "AGL" | "AMSL"
+    unit: str        # "m" | "ft" | "FL", as published
+    reference: str   # "AGL" | "AMSL" | "STD"
 
     def label(self) -> str:
+        if self.unit == "FL":
+            return f"FL {self.value:g}"
         return f"{self.value:g} {self.unit} {self.reference}"
 
 

--- a/src/dji_metadata_embedder/geo/airspace/overlay.py
+++ b/src/dji_metadata_embedder/geo/airspace/overlay.py
@@ -36,8 +36,10 @@ def _upper_numeric(
     limit: VerticalLimit | None,
 ) -> tuple[float | None, str | None]:
     """Published ceiling in metres + datum for the 3D volumes (#424);
-    (None, None) when not stated — the 3D map renders those flat."""
-    if limit is None:
+    (None, None) when not stated — the 3D map renders those flat. A
+    flight level is a pressure datum, not a map height: FL ceilings
+    render flat too rather than faking a conversion."""
+    if limit is None or limit.unit == "FL":
         return None, None
     metres = limit.value * M_PER_FT if limit.unit == "ft" else limit.value
     return metres, limit.reference

--- a/src/dji_metadata_embedder/geo/record_html.py
+++ b/src/dji_metadata_embedder/geo/record_html.py
@@ -104,10 +104,13 @@ def _zone_row(f: ZoneFinding) -> str:
     # "from X"; the FAA's universal 0-ft floor stays out of the way (#422).
     if z.upper is not None and z.lower is not None and z.lower.value > 0:
         if (z.lower.unit, z.lower.reference) == (z.upper.unit, z.upper.reference):
-            limit = (
-                f"{z.lower.value:g}–{z.upper.value:g} "
-                f"{z.upper.unit} {z.upper.reference}"
-            )
+            if z.upper.unit == "FL":
+                limit = f"FL {z.lower.value:g}–{z.upper.value:g}"
+            else:
+                limit = (
+                    f"{z.lower.value:g}–{z.upper.value:g} "
+                    f"{z.upper.unit} {z.upper.reference}"
+                )
         else:
             limit = f"{z.lower.label()} – {z.upper.label()}"
     elif z.upper is not None:
@@ -143,6 +146,11 @@ def _zone_row(f: ZoneFinding) -> str:
                 )
             else:
                 compare = "limit stated in AMSL; no absolute altitude recorded"
+        elif stated.reference == "STD":
+            compare = (
+                "limit stated as a flight level (pressure datum); not "
+                "comparable with telemetry altitudes"
+            )
         else:
             compare = "limit datum not recognized"
     return (

--- a/tests/test_airspace_aixm51.py
+++ b/tests/test_airspace_aixm51.py
@@ -1,0 +1,100 @@
+"""AIXM 5.1 provider tests (#499): UK NATS AIS UAS flight restrictions.
+
+The authoritative product is an AIXM 5.1 BasicMessage inside a zip with
+its own SHA-256 sidecar, published per AIRAC cycle with dated filenames;
+the current AND next cycle are both listed, so discovery is date-aware.
+"""
+import hashlib
+import io
+import zipfile
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder.geo.airspace import AirspaceError, SourceInfo
+from dji_metadata_embedder.geo.airspace.aixm51 import (
+    AIXM_FEEDS,
+    discover_feed_url,
+    extract_xml,
+)
+
+FIXTURES = Path(__file__).parent.parent / "samples" / "airspace"
+SRC = SourceInfo(
+    feed="test", url="https://example.invalid/datasets",
+    fetched="2026-08-15T12:00:00Z",
+    license="test", caveat="informational only",
+)
+
+PAGE = (
+    b'<a href="/x/UAS_AREA_1/EG_UAS_FR_DS_AREA1_FULL_20260806_KML.zip">k</a>'
+    b'<a href="/x/UAS_AREA_1/EG_UAS_FR_DS_AREA1_FULL_20260806_XML.zip">x</a>'
+    b'<a href="/x/UAS_AREA_1/EG_UAS_FR_DS_AREA1_FULL_20260903_KML.zip">k</a>'
+    b'<a href="/x/UAS_AREA_1/EG_UAS_FR_DS_AREA1_FULL_20260903_XML.zip">x</a>'
+)
+BASE = "https://nats-uk.ead-it.com/cms-nats/opencms/en/Publications/digital-datasets/"
+
+
+def test_discovery_picks_the_effective_cycle_not_the_next_one():
+    # Both the current and the NEXT AIRAC cycle are on the page; a cycle
+    # takes effect at 00:00 UTC on its filename date.
+    url = discover_feed_url(PAGE, BASE, today=date(2026, 8, 15))
+    assert url.endswith("EG_UAS_FR_DS_AREA1_FULL_20260806_XML.zip")
+    assert url.startswith("https://nats-uk.ead-it.com/x/")
+
+
+def test_discovery_rolls_over_on_the_cycle_date():
+    url = discover_feed_url(PAGE, BASE, today=date(2026, 9, 3))
+    assert "20260903_XML" in url
+
+
+def test_discovery_falls_back_to_the_oldest_when_all_dates_are_future():
+    url = discover_feed_url(PAGE, BASE, today=date(2026, 8, 1))
+    assert "20260806_XML" in url
+
+
+def test_discovery_never_picks_the_kml_product():
+    kml_only = PAGE.replace(b"_XML.zip", b"_XKL.zip")
+    with pytest.raises(AirspaceError, match="NATS"):
+        discover_feed_url(kml_only, BASE, today=date(2026, 8, 15))
+
+
+def _zip(xml: bytes, *, sha: str | None = None,
+         xml_name: str = "EG_UAS_FR_DS_AREA1_FULL_20260806.xml") -> bytes:
+    digest = sha if sha is not None else hashlib.sha256(xml).hexdigest()
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(xml_name, xml)
+        zf.writestr(
+            "EG_UAS_FR_DS_AREA1_FULL_20260806.sha256",
+            f"{digest} *{xml_name}",
+        )
+    return buf.getvalue()
+
+
+def test_extract_verifies_the_archives_own_sha256():
+    assert extract_xml(_zip(b"<xml/>")) == b"<xml/>"
+
+
+def test_a_sha_mismatch_is_an_error_not_a_silent_accept():
+    with pytest.raises(AirspaceError, match="SHA-256"):
+        extract_xml(_zip(b"<xml/>", sha="0" * 64))
+
+
+def test_an_archive_without_the_dataset_xml_is_an_error():
+    with pytest.raises(AirspaceError, match="dataset XML"):
+        extract_xml(_zip(b"<xml/>", xml_name="export-filter.xml"))
+
+
+def test_a_non_zip_body_is_an_error():
+    with pytest.raises(AirspaceError, match="zip"):
+        extract_xml(b"<html>login wall</html>")
+
+
+def test_gb_feed_registry_states_source_rights_and_honesty_note():
+    feed = AIXM_FEEDS["GB"]
+    assert feed.page_url.startswith("https://nats-uk.ead-it.com/")
+    assert "NATS" in feed.license and "ISO 19115" in feed.license
+    assert "not for resale" in feed.license
+    note = feed.note or ""
+    assert "Activation hours" in note and "Temporary restrictions" in note

--- a/tests/test_airspace_aixm51.py
+++ b/tests/test_airspace_aixm51.py
@@ -6,6 +6,7 @@ the current AND next cycle are both listed, so discovery is date-aware.
 """
 import hashlib
 import io
+import math
 import zipfile
 from datetime import date
 from pathlib import Path
@@ -17,6 +18,7 @@ from dji_metadata_embedder.geo.airspace.aixm51 import (
     AIXM_FEEDS,
     discover_feed_url,
     extract_xml,
+    parse_aixm51,
 )
 
 FIXTURES = Path(__file__).parent.parent / "samples" / "airspace"
@@ -98,3 +100,173 @@ def test_gb_feed_registry_states_source_rights_and_honesty_note():
     assert "not for resale" in feed.license
     note = feed.note or ""
     assert "Activation hours" in note and "Temporary restrictions" in note
+
+
+def _gb() -> bytes:
+    return (FIXTURES / "aixm51-gb.xml").read_bytes()
+
+
+def _dist_m(a: tuple[float, float], b: tuple[float, float]) -> float:
+    # (lon, lat) points, small separations
+    return math.hypot(
+        (a[1] - b[1]) * 111_320,
+        (a[0] - b[0]) * 111_320 * math.cos(math.radians(a[1])),
+    )
+
+
+def test_parses_the_fixture_and_maps_uk_type_codes():
+    zones = parse_aixm51(_gb(), SRC)
+    assert [z.identifier for z in zones] == [
+        "EGTEST1", "EGD901", "EGP901", "EGD902", "EGD903",
+    ]
+    assert [z.restriction for z in zones] == [
+        "RESTRICTED", "DANGER", "PROHIBITED", "DANGER", "DANGER",
+    ]
+    # FRZ/RPZ is the most drone-meaningful bit of the dataset — it rides
+    # in the display name; zones without a localType stay untouched.
+    assert zones[0].name == "TESTFIELD RWY 09 (RPZ)"
+    assert zones[1].name == "TEST DANGER"
+
+
+def test_vertical_limits_map_sfc_msl_std_and_units():
+    zones = parse_aixm51(_gb(), SRC)
+    rpz = zones[0]
+    assert rpz.lower is not None and rpz.lower.label() == "0 ft AGL"
+    assert rpz.upper is not None and rpz.upper.label() == "2000 ft AGL"
+    prohib = zones[2]
+    assert prohib.upper is not None and prohib.upper.label() == "2000 ft AMSL"
+    rev = zones[4]
+    assert rev.upper is not None and rev.upper.label() == "FL 100"
+
+
+def test_fl999_upper_is_the_unlimited_sentinel_never_a_number():
+    danger = parse_aixm51(_gb(), SRC)[1]
+    assert danger.upper is None                # renders "not stated"
+    assert danger.lower is not None and danger.lower.label() == "FL 50"
+
+
+def test_activation_rides_in_native_and_never_becomes_applicability():
+    # An Applicability entry's presence means machine-evaluable
+    # time-bounding to the evaluator; NOTAM activation prose is not that.
+    zones = parse_aixm51(_gb(), SRC)
+    assert all(z.applicability == [] for z in zones)
+    act = zones[0].native["activation"]
+    assert act == [{"status": "AVBL_FOR_ACTIVATION",
+                    "notes": ["Mon-Sat SR to SS."]}]
+    assert zones[0].native["type"] == "R"
+    assert zones[0].native["localType"] == "RPZ"
+
+
+def test_coordinates_come_out_lon_lat_and_rings_close():
+    zones = parse_aixm51(_gb(), SRC)
+    square = zones[2].polygons[0]
+    assert square[0] == (-0.5, 51.5)            # file says "51.5 -0.5"
+    assert square[0] == square[-1]
+    for z in zones:
+        assert z.polygons[0][0] == z.polygons[0][-1]
+        assert not z.holes
+
+
+def test_circles_and_arcs_densify_at_the_published_radius():
+    zones = parse_aixm51(_gb(), SRC)
+    circle = zones[1].polygons[0]
+    assert len(circle) == 129                    # 128 points + closure
+    centre = (-1.5, 51.2)
+    for p in circle:
+        assert abs(_dist_m(p, centre) - 2 * 1852) < 5
+    arc_ring = zones[0].polygons[0]
+    assert len(arc_ring) > 30                    # ~32 arc points + corners
+    arc_centre = (-1.0, 51.0)
+    on_arc = [p for p in arc_ring if abs(_dist_m(p, arc_centre) - 1852) < 5]
+    assert len(on_arc) >= 30
+
+
+def test_a_border_reference_is_spliced_forward_and_reversed():
+    zones = parse_aixm51(_gb(), SRC)
+    mid = (0.005, 52.01)                         # the coast's middle vertex
+    for z in (zones[3], zones[4]):
+        assert any(_dist_m(p, mid) < 1 for p in z.polygons[0])
+        assert z.polygons[0][0] == z.polygons[0][-1]
+
+
+def _mutated(old: str, new: str) -> bytes:
+    text = _gb().decode("utf-8")
+    assert old in text, f"fixture no longer contains {old!r}"
+    return text.replace(old, new).encode("utf-8")
+
+
+def test_an_unknown_airspace_type_invalidates_the_document():
+    with pytest.raises(AirspaceError, match="EGD901.*not P/R/D"):
+        parse_aixm51(_mutated(">D</aixm:type>", ">Q</aixm:type>"), SRC)
+
+
+def test_an_unknown_radius_unit_raises():
+    with pytest.raises(AirspaceError, match="radius unit"):
+        parse_aixm51(_mutated('uom="[nmi_i]">2<', 'uom="KM">2<'), SRC)
+
+
+def test_an_unknown_vertical_reference_raises():
+    with pytest.raises(AirspaceError, match="SFC/MSL/STD"):
+        parse_aixm51(
+            _mutated(">MSL</aixm:upperLimitReference>",
+                     ">W84</aixm:upperLimitReference>"),
+            SRC,
+        )
+
+
+def test_fl_without_std_raises():
+    with pytest.raises(AirspaceError, match="pairs"):
+        parse_aixm51(
+            _mutated('<aixm:lowerLimit uom="FL">50</aixm:lowerLimit>',
+                     '<aixm:lowerLimit uom="FT">50</aixm:lowerLimit>'),
+            SRC,
+        )
+
+
+def test_an_unresolvable_border_reference_raises():
+    with pytest.raises(AirspaceError, match="GeoBorder"):
+        parse_aixm51(
+            _mutated('href="urn:uuid:99999999-9999-9999-9999-999999999999"',
+                     'href="urn:uuid:00000000-0000-0000-0000-000000000000"'),
+            SRC,
+        )
+
+
+def test_a_discontinuous_ring_raises():
+    # Move the straight segment's start ~3 km off the arc's end: junction
+    # tolerance is 160 m.
+    with pytest.raises(AirspaceError, match="EGTEST1"):
+        parse_aixm51(
+            _mutated("50.9999970 -0.9735822", "50.9700000 -0.9735822"), SRC
+        )
+
+
+def test_an_unsupported_segment_type_raises():
+    broken = _mutated(
+        "<gml:LineStringSegment>", "<gml:CubicSpline>"
+    ).replace(b"</gml:LineStringSegment>", b"</gml:CubicSpline>")
+    with pytest.raises(AirspaceError, match="CubicSpline"):
+        parse_aixm51(broken, SRC)
+
+
+def test_a_document_without_airspaces_raises():
+    empty = (
+        b'<?xml version="1.0"?><message:AIXMBasicMessage '
+        b'xmlns:message="http://www.aixm.aero/schema/5.1/message"/>'
+    )
+    with pytest.raises(AirspaceError, match="no airspace"):
+        parse_aixm51(empty, SRC)
+
+
+def test_non_xml_raises():
+    with pytest.raises(AirspaceError, match="not XML"):
+        parse_aixm51(b"{}", SRC)
+
+
+def test_a_dtd_is_refused_before_parsing():
+    # The dataset never declares one; refusing DTDs up front closes the
+    # stdlib parser's entity-expansion surface (defusedxml's own core
+    # defence, without the dependency).
+    evil = b'<?xml version="1.0"?><!DOCTYPE r [<!ENTITY a "b">]><r/>'
+    with pytest.raises(AirspaceError, match="DTD"):
+        parse_aixm51(evil, SRC)

--- a/tests/test_airspace_aixm51.py
+++ b/tests/test_airspace_aixm51.py
@@ -275,3 +275,24 @@ def test_a_dtd_is_refused_before_parsing():
     evil = b'<?xml version="1.0"?><!DOCTYPE r [<!ENTITY a "b">]><r/>'
     with pytest.raises(AirspaceError, match="DTD"):
         parse_aixm51(evil, SRC)
+
+
+def test_a_zero_extent_export_noop_segment_is_dropped():
+    # EGD012 in the live file ends with a GeodesicString whose two
+    # points both duplicate the ring's start — a NATS export no-op.
+    # It must not trip the junction check or distort the ring.
+    anchor = (
+        '<gml:pointProperty><aixm:Point gml:id="a3p5">'
+        '<gml:pos>51.5 -0.5</gml:pos></aixm:Point></gml:pointProperty>'
+    )
+    degenerate = anchor + (
+        '</gml:GeodesicString>'
+        '<gml:GeodesicString interpolation="geodesic">'
+        '<gml:pointProperty><aixm:Point gml:id="a3d1">'
+        '<gml:pos>51.5 -0.5</gml:pos></aixm:Point></gml:pointProperty>'
+        '<gml:pointProperty><aixm:Point gml:id="a3d2">'
+        '<gml:pos>51.5 -0.5</gml:pos></aixm:Point></gml:pointProperty>'
+    )
+    zones = parse_aixm51(_mutated(anchor, degenerate), SRC)
+    baseline = parse_aixm51(_gb(), SRC)
+    assert zones[2].polygons == baseline[2].polygons

--- a/tests/test_airspace_aixm51.py
+++ b/tests/test_airspace_aixm51.py
@@ -7,6 +7,7 @@ the current AND next cycle are both listed, so discovery is date-aware.
 import hashlib
 import io
 import math
+import re
 import zipfile
 from datetime import date
 from pathlib import Path
@@ -117,10 +118,10 @@ def _dist_m(a: tuple[float, float], b: tuple[float, float]) -> float:
 def test_parses_the_fixture_and_maps_uk_type_codes():
     zones = parse_aixm51(_gb(), SRC)
     assert [z.identifier for z in zones] == [
-        "EGTEST1", "EGD901", "EGP901", "EGD902", "EGD903",
+        "EGTEST1", "EGD901", "EGP901", "EGD902", "EGD903", "EGD904",
     ]
     assert [z.restriction for z in zones] == [
-        "RESTRICTED", "DANGER", "PROHIBITED", "DANGER", "DANGER",
+        "RESTRICTED", "DANGER", "PROHIBITED", "DANGER", "DANGER", "DANGER",
     ]
     # FRZ/RPZ is the most drone-meaningful bit of the dataset — it rides
     # in the display name; zones without a localType stay untouched.
@@ -275,6 +276,60 @@ def test_a_dtd_is_refused_before_parsing():
     evil = b'<?xml version="1.0"?><!DOCTYPE r [<!ENTITY a "b">]><r/>'
     with pytest.raises(AirspaceError, match="DTD"):
         parse_aixm51(evil, SRC)
+
+
+def test_the_direction_search_flips_a_wrong_shorter_sweep():
+    # EGD904's arc must bulge south (the longer sweep); the shorter
+    # sweep would rise through the zone's shallow top edge and
+    # self-intersect, so the search has to flip it.
+    zones = parse_aixm51(_gb(), SRC)
+    flip = next(z for z in zones if z.identifier == "EGD904")
+    ring = flip.polygons[0]
+    assert any(lat < 52.99 for _, lat in ring)      # southern bulge chosen
+    assert all(lat < 53.0145 for _, lat in ring)    # never above the top edge
+
+
+def test_multiple_time_slices_invalidate_the_document():
+    text = _gb().decode("utf-8")
+    a2_match = re.search(
+        r'<aixm:Airspace gml:id="a2">.*?</aixm:Airspace>', text, re.S
+    )
+    assert a2_match is not None
+    a2 = a2_match.group(0)
+    ts_match = re.search(r"<aixm:timeSlice>.*?</aixm:timeSlice>", a2, re.S)
+    assert ts_match is not None
+    ts = ts_match.group(0)
+    broken = text.replace(a2, a2.replace(ts, ts + ts))
+    with pytest.raises(AirspaceError, match="one time slice"):
+        parse_aixm51(broken.encode("utf-8"), SRC)
+
+
+def test_a_modest_closure_gap_is_an_implied_closure_not_an_error():
+    # Drop zone a3's explicit closing vertex: the ~2.2 km remainder is
+    # within the closure cap, so the ring closes by appending the start.
+    no_close = _mutated(
+        '<gml:pointProperty><aixm:Point gml:id="a3p5">'
+        '<gml:pos>51.5 -0.5</gml:pos></aixm:Point></gml:pointProperty>',
+        "",
+    )
+    zone = parse_aixm51(no_close, SRC)[2]
+    assert zone.polygons[0][0] == zone.polygons[0][-1]
+
+
+def test_a_truncated_ring_is_an_error_not_a_silent_bridge():
+    torn = _mutated(
+        '<gml:pointProperty><aixm:Point gml:id="a3p5">'
+        '<gml:pos>51.5 -0.5</gml:pos></aixm:Point></gml:pointProperty>',
+        "",
+    ).replace(b">51.48 -0.5<", b">51.9 -0.5<")
+    with pytest.raises(AirspaceError, match="truncated"):
+        parse_aixm51(torn, SRC)
+
+
+def test_a_utf16_document_cannot_slip_past_the_dtd_guard():
+    evil = '<?xml version="1.0"?><!DOCTYPE r [<!ENTITY a "b">]><r/>'
+    with pytest.raises(AirspaceError, match="encoding"):
+        parse_aixm51(evil.encode("utf-16"), SRC)
 
 
 def test_a_zero_extent_export_noop_segment_is_dropped():

--- a/tests/test_airspace_aixm51.py
+++ b/tests/test_airspace_aixm51.py
@@ -184,9 +184,14 @@ def test_circles_and_arcs_densify_at_the_published_radius():
 def test_a_border_reference_is_spliced_forward_and_reversed():
     zones = parse_aixm51(_gb(), SRC)
     mid = (0.005, 52.01)                         # the coast's middle vertex
+    # The GeoBorder polyline has a fourth tail vertex past the ring's far
+    # neighbouring endpoint; a ring must trim to its own stretch, not
+    # splice the whole coastline.
+    tail = (-0.01, 52.03)
     for z in (zones[3], zones[4]):
         assert any(_dist_m(p, mid) < 1 for p in z.polygons[0])
         assert z.polygons[0][0] == z.polygons[0][-1]
+        assert all(_dist_m(p, tail) > 500 for p in z.polygons[0])
 
 
 def _mutated(old: str, new: str) -> bytes:

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -246,7 +246,7 @@ def test_a_uk_flight_discovers_the_cycle_zip_and_caches_the_xml(tmp_path):
     lines = []
     data = fetch_zones(_track(51.50, -0.12), tmp_path, transport=fake,
                        announce=lines.append)
-    assert data.gap_reason is None and len(data.zones) == 5
+    assert data.gap_reason is None and len(data.zones) == 6
     assert fake.urls[0].startswith("https://nats-uk.ead-it.com/")
     assert fake.urls[1].endswith("_XML.zip")
     assert data.source is not None and "NATS" in data.source.license
@@ -263,7 +263,7 @@ def test_a_cached_uk_body_skips_discovery_and_the_network(tmp_path):
     def no_network(req, timeout=None):
         raise AssertionError("cached run must not touch the network")
     data = fetch_zones(_track(51.50, -0.12), tmp_path, transport=no_network)
-    assert data.from_cache and len(data.zones) == 5
+    assert data.from_cache and len(data.zones) == 6
 
 
 def _gb_zip_bad_sha() -> bytes:

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -1,5 +1,7 @@
 """Fetch orchestration tests (#413): consent lines, cache, honest gaps."""
+import hashlib
 import io
+import zipfile
 from datetime import datetime
 from pathlib import Path
 
@@ -216,3 +218,72 @@ def test_a_cached_irish_body_skips_discovery_entirely(tmp_path):
         raise AssertionError("cached run must not touch the network")
     data = fetch_zones(_track(53.35, -6.26), tmp_path, transport=no_network)
     assert data.from_cache and len(data.zones) == 4
+
+
+def _gb_zip() -> bytes:
+    xml = (FIXTURES / "aixm51-gb.xml").read_bytes()
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("EG_UAS_FR_DS_AREA1_FULL_20260806.xml", xml)
+        zf.writestr(
+            "EG_UAS_FR_DS_AREA1_FULL_20260806.sha256",
+            hashlib.sha256(xml).hexdigest()
+            + " *EG_UAS_FR_DS_AREA1_FULL_20260806.xml",
+        )
+    return buf.getvalue()
+
+
+GB_PAGE = (
+    b'<a href="/x/UAS_AREA_1/EG_UAS_FR_DS_AREA1_FULL_20200101_XML.zip">'
+    b"</a>"
+)
+
+
+def test_a_uk_flight_discovers_the_cycle_zip_and_caches_the_xml(tmp_path):
+    # #499: three-step — datasets page, then the dated zip, then the
+    # XML is extracted (sha-verified) and cached as plain XML.
+    fake = FakeTransport([GB_PAGE, _gb_zip()])
+    lines = []
+    data = fetch_zones(_track(51.50, -0.12), tmp_path, transport=fake,
+                       announce=lines.append)
+    assert data.gap_reason is None and len(data.zones) == 5
+    assert fake.urls[0].startswith("https://nats-uk.ead-it.com/")
+    assert fake.urls[1].endswith("_XML.zip")
+    assert data.source is not None and "NATS" in data.source.license
+    assert (tmp_path / "aixm-GB.xml").exists()
+    assert (tmp_path / "aixm-GB.xml").read_bytes().startswith(b"<?xml")
+    assert any("Fetching" in ln and "nats-uk.ead-it.com" in ln
+               for ln in lines)
+
+
+def test_a_cached_uk_body_skips_discovery_and_the_network(tmp_path):
+    fetch_zones(_track(51.50, -0.12), tmp_path,
+                transport=FakeTransport([GB_PAGE, _gb_zip()]))
+
+    def no_network(req, timeout=None):
+        raise AssertionError("cached run must not touch the network")
+    data = fetch_zones(_track(51.50, -0.12), tmp_path, transport=no_network)
+    assert data.from_cache and len(data.zones) == 5
+
+
+def _gb_zip_bad_sha() -> bytes:
+    # The naive byte-replace-in-the-finished-zip trick corrupts the
+    # member's CRC-32 (BadZipFile, not a clean SHA mismatch) because
+    # zipfile validates CRC on read. Build the bad zip explicitly
+    # instead, mirroring `_zip(..., sha=...)` from
+    # tests/test_airspace_aixm51.py.
+    xml = (FIXTURES / "aixm51-gb.xml").read_bytes()
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("EG_UAS_FR_DS_AREA1_FULL_20260806.xml", xml)
+        zf.writestr(
+            "EG_UAS_FR_DS_AREA1_FULL_20260806.sha256",
+            "0" * 64 + " *EG_UAS_FR_DS_AREA1_FULL_20260806.xml",
+        )
+    return buf.getvalue()
+
+
+def test_a_uk_sha_mismatch_is_a_stated_gap(tmp_path):
+    data = fetch_zones(_track(51.50, -0.12), tmp_path,
+                       transport=FakeTransport([GB_PAGE, _gb_zip_bad_sha()]))
+    assert data.gap_reason is not None and "SHA-256" in data.gap_reason

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -249,7 +249,7 @@ def test_a_belfast_flight_now_resolves_to_gb():
     assert r.jurisdiction is not None and r.jurisdiction.code == "GB"
 
 
-def test_dublin_still_resolves_to_ie_despite_the_gb_hull_overlap():
+def test_dublin_still_resolves_to_ie():
     r = resolve_jurisdiction(_track((53.35, -6.26)))
     assert r.jurisdiction is not None and r.jurisdiction.code == "IE"
 

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -187,12 +187,6 @@ def test_a_sligo_flight_resolves_through_the_northwest_core():
     assert r.jurisdiction is not None and r.jurisdiction.code == "IE"
 
 
-def test_a_belfast_flight_gaps_instead_of_resolving_ie():
-    r = resolve_jurisdiction(_track((54.60, -5.93)))
-    assert r.jurisdiction is None
-    assert "boundary" in (r.gap_reason or "")
-
-
 def test_a_dundalk_flight_gaps_as_a_border_band():
     # 15 km from the border: too close to choose from coordinates alone.
     r = resolve_jurisdiction(_track((54.00, -6.40)))
@@ -204,3 +198,87 @@ def test_the_no_provider_message_names_ireland():
     r = resolve_jurisdiction(_track((48.85, 2.35)))   # Paris
     assert r.jurisdiction is None
     assert "Ireland" in (r.gap_reason or "")
+
+
+# --- United Kingdom (#499) --------------------------------------------------
+# Cores break hull ties: NI sits in both the GB and IE hulls, and
+# resolves through the GB NI core. Edges Nominatim/arithmetic-verified
+# at implementation time.
+
+
+def test_a_london_flight_resolves_to_gb_with_the_uk_measure():
+    r = resolve_jurisdiction(_track((51.50, -0.12), (51.51, -0.11)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "GB"
+    assert "assimilated" in r.jurisdiction.measure_note
+    assert "2019/947" in r.jurisdiction.measure_note
+
+
+def test_cardiff_resolves_to_gb():
+    r = resolve_jurisdiction(_track((51.48, -3.18)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "GB"
+
+
+def test_manchester_resolves_to_gb():
+    r = resolve_jurisdiction(_track((53.48, -2.24)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "GB"
+
+
+def test_edinburgh_resolves_to_gb():
+    r = resolve_jurisdiction(_track((55.95, -3.19)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "GB"
+
+
+def test_dover_and_margate_resolve_through_the_kent_core():
+    for lat, lon in ((51.13, 1.31), (51.39, 1.38)):
+        r = resolve_jurisdiction(_track((lat, lon)))
+        assert r.jurisdiction is not None and r.jurisdiction.code == "GB"
+
+
+def test_the_scottish_islands_resolve_to_gb():
+    # Kirkwall and Wick RPZs are in the dataset; Orkney, Shetland and
+    # the Hebrides get cores, not border-band gaps.
+    for lat, lon in ((58.98, -2.96), (60.15, -1.15), (58.21, -6.39)):
+        r = resolve_jurisdiction(_track((lat, lon)))
+        assert r.jurisdiction is not None and r.jurisdiction.code == "GB"
+
+
+def test_a_belfast_flight_now_resolves_to_gb():
+    # The whole point of #499's NI coverage: Belfast sits in both the
+    # GB and IE hulls and only the GB cores contain it.
+    r = resolve_jurisdiction(_track((54.60, -5.93)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "GB"
+
+
+def test_dublin_still_resolves_to_ie_despite_the_gb_hull_overlap():
+    r = resolve_jurisdiction(_track((53.35, -6.26)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "IE"
+
+
+def test_derry_gaps_as_a_border_band():
+    # ~3 km from the IE border: outside the NI core by design.
+    r = resolve_jurisdiction(_track((54.997, -7.32)))
+    assert r.jurisdiction is None
+    assert "boundary" in (r.gap_reason or "")
+
+
+def test_the_isle_of_man_gaps_instead_of_claiming_coverage():
+    # Its own AIP; the dataset has no Ronaldsway FRZ. Hull yes, core no.
+    r = resolve_jurisdiction(_track((54.15, -4.48)))
+    assert r.jurisdiction is None
+    assert "boundary" in (r.gap_reason or "")
+
+
+def test_jersey_is_an_honest_no_provider_gap():
+    r = resolve_jurisdiction(_track((49.21, -2.13)))
+    assert r.jurisdiction is None
+    assert "no supported airspace data" in (r.gap_reason or "")
+
+
+def test_calais_gaps_instead_of_resolving_gb():
+    r = resolve_jurisdiction(_track((50.96, 1.85)))
+    assert r.jurisdiction is None
+
+
+def test_the_no_provider_message_names_the_uk():
+    r = resolve_jurisdiction(_track((48.85, 2.35)))   # Paris
+    assert "the UK" in (r.gap_reason or "")

--- a/tests/test_airspace_model.py
+++ b/tests/test_airspace_model.py
@@ -11,3 +11,10 @@ def test_vertical_limit_labels_value_unit_and_reference():
 def test_vertical_limit_drops_trailing_zeros():
     assert VerticalLimit(45.72, "m", "AMSL").label() == "45.72 m AMSL"
     assert VerticalLimit(100.0, "ft", "AGL").label() == "100 ft AGL"
+
+
+def test_flight_level_limits_render_as_fl_numbers():
+    # UK danger areas publish flight levels (pressure datum STD); the
+    # label is the aviation form, not "100 FL STD".
+    fl = VerticalLimit(100.0, "FL", "STD")
+    assert fl.label() == "FL 100"

--- a/tests/test_airspace_overlay.py
+++ b/tests/test_airspace_overlay.py
@@ -176,3 +176,12 @@ def test_zone_dicts_carry_numeric_ceilings_for_the_3d_map():
     assert by_id["M"]["upper_ref"] == "AMSL"
     assert by_id["NONE"]["upper_m"] is None
     assert by_id["NONE"]["upper_ref"] is None
+
+
+def test_a_flight_level_ceiling_renders_flat_in_3d_not_100_metres():
+    # FL is a pressure datum: converting it to a map height would be
+    # false precision, and the ft-else-metres branch would draw a
+    # 100 m-tall volume for FL 100.
+    from dji_metadata_embedder.geo.airspace.overlay import _upper_numeric
+    from dji_metadata_embedder.geo.airspace.model import VerticalLimit
+    assert _upper_numeric(VerticalLimit(100.0, "FL", "STD")) == (None, None)

--- a/tests/test_geo_record_html.py
+++ b/tests/test_geo_record_html.py
@@ -402,3 +402,40 @@ def test_an_offset_with_unknown_times_stays_unknown():
                   local_offset=timedelta(hours=2))
     cover = _cover(record_to_html([rec], "t", "2.4.0"))
     assert "unknown" in cover
+
+
+# UK danger areas (#499) publish flight levels: a pressure datum, not a
+# height above anything. The record must show them in aviation form and
+# never invent a comparison against telemetry altitudes.
+def test_fl_banded_limits_render_in_aviation_form():
+    # A UK danger area banded FL 50 - FL 100 must not print "50-100 FL STD".
+    fl_band = Zone(
+        identifier="UK-D001", name="Danger area", restriction="PROHIBITED",
+        lower=VerticalLimit(50, "FL", "STD"), upper=VerticalLimit(100, "FL", "STD"),
+        applicability=[], polygons=ZONE.polygons, source=SRC, native={},
+    )
+    rec = _record(airspace=AirspaceReport(
+        findings=[ZoneFinding(
+            zone=fl_band, entered=True,
+            entry_utc=datetime(2026, 7, 30, 12, 1),
+            exit_utc=datetime(2026, 7, 30, 12, 2),
+        )], source=SRC))
+    html = record_to_html([rec], "t", "2.4.0")
+    assert "FL 50–100" in html
+
+
+def test_an_entered_fl_zone_states_the_pressure_datum_gap():
+    fl_ceiling = Zone(
+        identifier="UK-D002", name="Danger area ceiling",
+        restriction="PROHIBITED",
+        lower=None, upper=VerticalLimit(100, "FL", "STD"),
+        applicability=[], polygons=ZONE.polygons, source=SRC, native={},
+    )
+    rec = _record(airspace=AirspaceReport(
+        findings=[ZoneFinding(
+            zone=fl_ceiling, entered=True,
+            entry_utc=datetime(2026, 7, 30, 12, 1),
+            exit_utc=datetime(2026, 7, 30, 12, 2),
+        )], source=SRC))
+    html = record_to_html([rec], "t", "2.4.0")
+    assert "flight level" in html and "pressure datum" in html


### PR DESCRIPTION
Closes #499. Sibling to #452 (Ireland) and #456 (Switzerland).

Adds the UK as an airspace jurisdiction from the NATS AIS UAS Flight
Restrictions digital dataset — the authoritative AIXM 5.1 product, not
the visualisation KML. New ingest class:

- Date-aware discovery on the Digital Datasets page (current AND next
  AIRAC cycle are listed; the newest non-future date wins), zip download,
  XML extracted and verified against the archive's own SHA-256 sidecar.
- AIXM 5.1 parser with in-module geodesic densification of GML arcs and
  circles (128 points per full circle, local Gaussian radius of
  curvature). Arc sweep direction is untrustworthy in the wild: per-arc
  shorter sweep, validated by ring simplicity, with a bounded search
  over direction combinations when it fails (543/548 arc zones take the
  shorter sweep on the live file, 5 need the search, 0 unsolved).
  Coast/river-following zones splice the referenced GeoBorder coastline
  curves, trimmed to the sub-path between the ring's neighbouring
  endpoints (live E2E on EGD012 caught the whole-polyline version).
- Vertical limits: SFC→AGL, MSL→AMSL, and flight levels (STD) as a new
  VerticalLimit unit; FL 999 uppers are the UK "unlimited" sentinel and
  render "not stated", never a number. FL ceilings render flat in the
  3D overlay (pressure datum, not a map height) and get an explicit
  non-comparability line in the record.
- Jurisdiction: cores now break overlapping-hull ties, so Northern
  Ireland (in both the GB and IE hulls) resolves to the UK dataset that
  actually covers it, while IE-border flights keep gapping honestly from
  both sides. Isle of Man and the Channel Islands are deliberately not
  claimed (no aerodrome coverage in the dataset). Orkney, Shetland and
  the Hebrides get cores; all box edges Nominatim/distance-verified.
- Honesty notes in the record: activation hours are not in the dataset
  and are not evaluated; temporary restrictions live in NOTAMs and AIP
  Supplements.
- Hardening from the final review: implied ring closure is capped at
  5 km so a truncated ring gaps instead of silently bridging; the XML
  guard refuses DTDs and non-UTF-8 encodings before parsing (no
  defusedxml dependency needed).

Rights: green per the dataset's own ISO 19115 metadata ("Unrestricted";
not for resale; for aviation use only) — the product metadata governs
over the site footer, same lesson as Switzerland.

Live E2E: London track discovers the 20260806 cycle, verifies the
sidecar hash, parses all 1,073 zones (incl. Belfast NI zones and the
coast-following danger areas), caches the extracted XML, and re-parses
offline from cache. Full gate: 1,321 tests, mypy, ruff, mkdocs --strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U4PWi5zbarxwJmjk6yAif