### PR TITLE
test(gui): headless captures for the 360° views mode and a Setup-selected setup shot

### DIFF
--- a/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/ScreenshotCaptureTests.cs
@@ -489,7 +489,13 @@ public class ScreenshotCaptureTests
         verify.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Verify);
         CaptureMode(verify, Png("mode-verify"));
 
+        var pano = NewVm();
+        pano.SelectedFolder = @"C:\Users\demo\Photos\panoramas";
+        pano.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        CaptureMode(pano, Png("mode-360-views"));
+
         var setup = NewVm();
+        setup.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.Setup);
         setup.Step = FlowStep.Done;
         setup.AllGood = true;
         setup.SetupItems.Add(new SetupItem(


### PR DESCRIPTION
Two additions to the opt-in screenshot tooling, feeding the website's mode pages:

- `mode-360-views`: the seventh mode's default state (folder picked, mode selected, hint + CLI line visible).
- The setup capture now actually selects Setup in the mode strip — the old `mode-setup.png` showed Flight map highlighted (the parked follow-up from the site's content batch 2).

GUI suite: 561 passed, 16 skipped locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U4PWi5zbarxwJmjk6yAif