### PR TITLE
feat(geo): Denmark UAS drone zones via Trafikstyrelsen's Dronezoner dataset (#507)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -433,9 +433,11 @@ for the flight area on the HTML maps — the flat map and the 3D terrain view
 geographical-zone feeds where a country publishes one (currently
 Luxembourg, Finland and Switzerland via ED-269, Ireland via the IAA's
 published ED-318 file, which the IAA labels reference-only — that caveat
-rides into the map — and the UK via the NATS AIS AIXM 5.1 dataset, whose
+rides into the map — the UK via the NATS AIS AIXM 5.1 dataset, whose
 activation hours and temporary restrictions live in the AIP and NOTAMs,
-not in the file; that caveat rides along too). Zones draw in one neutral
+not in the file — that caveat rides along too — and Denmark via
+Trafikstyrelsen's drone-zone dataset, which likewise leaves NOTAM-driven
+temporaries to the AIP). Zones draw in one neutral
 style; clicking one shows the published facts: restriction class, vertical
 limits (or "not stated"), applicability windows, and the feed, license and
 fetch time. Zones the

--- a/docs/how-to/flight-record.md
+++ b/docs/how-to/flight-record.md
@@ -34,7 +34,7 @@ takeoff-referenced height, which is aircraft-reported. The
 surface-referenced height is the exception — it needs a fetch from
 Mapterhorn's terrain tiles (see "The `[terrain]` extra" below).
 
-Four feeds are used:
+Five feeds are used:
 
 - **US flights** query the FAA's UAS Facility Map (keyless ArcGIS). The
   bounding box sent to the endpoint is padded and snapped outward to a
@@ -49,6 +49,10 @@ Four feeds are used:
   (AIXM 5.1, refreshed each 28-day AIRAC cycle), again with no location
   sent. Activation hours are not in the dataset and temporary
   restrictions live in NOTAMs; the record says so rather than guessing.
+- **Denmark** flights fetch Trafikstyrelsen's whole drone-zone dataset
+  (the file behind droneregler.dk), once more with no location sent.
+  NOTAM-driven temporary restrictions are not part of that dataset
+  either; the record says so.
 - **Every flight**, regardless of jurisdiction, fetches surface-height
   tiles from Mapterhorn (`tiles.mapterhorn.com`) for the surface-referenced
   height estimate, when the `[terrain]` extra is installed.
@@ -63,10 +67,11 @@ nothing without `-f record`; terrain tiles are unaffected by this flag).
 dji-embed flightmap ./flights -f record --airspace-refresh
 ```
 
-## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK — and an honest gap everywhere else
+## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark — and an honest gap everywhere else
 
 Airspace lookup only resolves for flights that sit clearly inside the
-United States, Luxembourg, Finland, Switzerland, Ireland, or the UK.
+United States, Luxembourg, Finland, Switzerland, Ireland, the UK, or
+Denmark.
 Everywhere else — including Sweden — the record states the gap instead of
 guessing: *"no supported
 airspace data source for this location."* A flight near a jurisdiction

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -335,7 +335,7 @@
                                                   IsEnabled="{Binding !FlightOptions.ThreeD}"
                                                   Content="Airspace zones" />
                                         <TextBlock Name="FlightAirspaceNote"
-                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland, Ireland and the UK). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
+                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland, Ireland, the UK and Denmark). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
                                                    IsVisible="{Binding FlightOptions.ShowsAirspaceNote}"
                                                    TextWrapping="Wrap"
                                                    Opacity="0.5" FontSize="11" />

--- a/samples/airspace/dronezoner-dk.json
+++ b/samples/airspace/dronezoner-dk.json
@@ -1,0 +1,431 @@
+{
+  "type": "FeatureCollection",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "EPSG:4326"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              12.5,
+              55.6,
+              0
+            ],
+            [
+              12.56,
+              55.6,
+              0
+            ],
+            [
+              12.56,
+              55.64,
+              0
+            ],
+            [
+              12.5,
+              55.64,
+              0
+            ],
+            [
+              12.5,
+              55.6,
+              0
+            ]
+          ]
+        ]
+      },
+      "properties": {
+        "OBJECTID": 1,
+        "typeId": "Civil Lufthavn",
+        "title": "Testlufthavn",
+        "Farve": "1",
+        "Bufferzone": "5 km",
+        "Type": "2",
+        "Lovkrav": 5,
+        "Enhed": "1",
+        "Elevation_fod": 17,
+        "Elevation_meter": 5.1816,
+        "ICAO": "EKTS",
+        "Version": "1"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.53,
+          55.62,
+          0
+        ]
+      },
+      "properties": {
+        "OBJECTID": 101,
+        "typeId": "Civil Lufthavn",
+        "title": "Testlufthavn",
+        "Farve": "1",
+        "Bufferzone": "5 km",
+        "Type": "2",
+        "Lovkrav": 5,
+        "Enhed": "1",
+        "Elevation_fod": 17,
+        "Elevation_meter": 5.1816,
+        "ICAO": "EKTS",
+        "Version": "1"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [
+            [
+              [
+                12.3,
+                55.7
+              ],
+              [
+                12.34,
+                55.7
+              ],
+              [
+                12.34,
+                55.73
+              ],
+              [
+                12.3,
+                55.73
+              ],
+              [
+                12.3,
+                55.7
+              ]
+            ],
+            [
+              [
+                12.31,
+                55.71
+              ],
+              [
+                12.32,
+                55.71
+              ],
+              [
+                12.32,
+                55.72
+              ],
+              [
+                12.31,
+                55.72
+              ],
+              [
+                12.31,
+                55.71
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                12.36,
+                55.7
+              ],
+              [
+                12.38,
+                55.7
+              ],
+              [
+                12.38,
+                55.72
+              ],
+              [
+                12.36,
+                55.72
+              ],
+              [
+                12.36,
+                55.7
+              ]
+            ]
+          ]
+        ]
+      },
+      "properties": {
+        "OBJECTID": 2,
+        "typeId": "Militær",
+        "title": "Kasernen Test",
+        "Farve": "4",
+        "Bufferzone": "150 m",
+        "Type": "10",
+        "Lovkrav": 150,
+        "Enhed": "1000",
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null,
+        "Aktiv": "JA",
+        "zoneKategori": "Permanent",
+        "datoTidSTART": null,
+        "datoTidSLUT": null
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.2,
+          55.5
+        ]
+      },
+      "properties": {
+        "OBJECTID": 3,
+        "typeId": "Politi",
+        "title": "Politistation Test",
+        "Farve": "4",
+        "Bufferzone": "150",
+        "Lovkrav": 150,
+        "Enhed": "1000",
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null,
+        "Aktiv": "JA",
+        "zoneKategori": "Permanent"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.1,
+          55.45
+        ]
+      },
+      "properties": {
+        "OBJECTID": 4,
+        "typeId": "Modelflyveplads",
+        "title": "Modelflyveplads Test",
+        "Farve": "5",
+        "Bufferzone": "2 km",
+        "Lovkrav": null,
+        "Enhed": null,
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.0,
+          55.4
+        ]
+      },
+      "properties": {
+        "OBJECTID": 7,
+        "typeId": "Privat flyveplads 3km",
+        "title": "Testflyveplads Privat",
+        "Farve": "5",
+        "Bufferzone": "3 km",
+        "Lovkrav": 3,
+        "Enhed": "1",
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              12.4,
+              55.3
+            ],
+            [
+              12.44,
+              55.3
+            ],
+            [
+              12.44,
+              55.33
+            ],
+            [
+              12.4,
+              55.33
+            ],
+            [
+              12.4,
+              55.3
+            ]
+          ]
+        ]
+      },
+      "properties": {
+        "OBJECTID": 5,
+        "typeId": "Sikringskritisk område",
+        "title": "Gammelt event",
+        "Farve": "4",
+        "Bufferzone": null,
+        "Lovkrav": null,
+        "Enhed": null,
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null,
+        "Aktiv": "NEJ",
+        "zoneKategori": "Midlertidig",
+        "datoTidSTART": "Wed, 10 Jun 2026 05:00:00 GMT",
+        "datoTidSLUT": "Sun, 14 Jun 2026 10:00:00 GMT"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              12.6,
+              55.3
+            ],
+            [
+              12.64,
+              55.3
+            ],
+            [
+              12.64,
+              55.33
+            ],
+            [
+              12.6,
+              55.33
+            ],
+            [
+              12.6,
+              55.3
+            ]
+          ]
+        ]
+      },
+      "properties": {
+        "OBJECTID": 6,
+        "typeId": "Sikringskritisk område",
+        "title": "Sikringskritisk område - Testevent",
+        "Farve": "4",
+        "Bufferzone": null,
+        "Lovkrav": null,
+        "Enhed": null,
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null,
+        "Aktiv": "JA",
+        "zoneKategori": "Midlertidig",
+        "datoTidSTART": "Mon, 07 Sep 2026 06:00:00 GMT",
+        "datoTidSLUT": "Fri, 11 Sep 2026 18:00:00 GMT"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              12.58,
+              55.7
+            ],
+            [
+              12.6,
+              55.7
+            ],
+            [
+              12.6,
+              55.72
+            ],
+            [
+              12.58,
+              55.72
+            ],
+            [
+              12.58,
+              55.7
+            ]
+          ]
+        ]
+      },
+      "properties": {
+        "OBJECTID": 8,
+        "typeId": "Restvæsen",
+        "title": "Landsret Test",
+        "Farve": "4",
+        "Bufferzone": null,
+        "Lovkrav": null,
+        "Enhed": null,
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null,
+        "Aktiv": "JA",
+        "zoneKategori": "Permanent"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.59,
+          55.71
+        ]
+      },
+      "properties": {
+        "OBJECTID": 108,
+        "typeId": "Retsvæsen",
+        "title": "Landsret Test",
+        "Farve": "4",
+        "Bufferzone": null,
+        "Lovkrav": null,
+        "Enhed": null,
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null,
+        "Aktiv": "JA",
+        "zoneKategori": "Permanent"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.5,
+          55.3
+        ]
+      },
+      "properties": {
+        "OBJECTID": 9,
+        "typeId": "Modelflyveplads",
+        "title": "Klub nr: 999 - Test Modelflyveklub",
+        "Farve": "5",
+        "Bufferzone": null,
+        "Lovkrav": null,
+        "Enhed": null,
+        "Elevation_fod": null,
+        "Elevation_meter": null,
+        "ICAO": null,
+        "Kommentar": "Pladsen er godkendt til flyvning med stormodel"
+      }
+    }
+  ]
+}

--- a/src/dji_metadata_embedder/geo/airspace/dronezoner.py
+++ b/src/dji_metadata_embedder/geo/airspace/dronezoner.py
@@ -1,0 +1,309 @@
+"""Denmark drone-zone parser (Trafikstyrelsen Dronezoner GeoJSON).
+
+The official dataset behind droneregler.dk: a GeoJSON FeatureCollection
+whose zones come in three colour classes named by the KMZ export's own
+layers — RØD (flight-safety-critical: airports, HEMS, military air
+stations), BLÅ (security-critical: police, military, embassies, prisons)
+and ORANGE (awareness: recreational airfields). All-or-nothing like the
+other providers: any malformed feature raises rather than silently
+thinning the set.
+
+Two dataset quirks are contract, both probed on the live file 2026-08-15:
+
+- Most zones appear twice — once as the buffered Polygon and once as a
+  Point map marker (the "Signatur" KMZ layers). Points that duplicate a
+  polygon feature are dropped — matched on (title, colour) only, because
+  ``typeId`` spelling churns between the twins ("Retsvæsen" point vs
+  "Restvæsen" polygon in the live file). Orphan points (police stations,
+  HEMS sites published as centre + buffer only) become densified circles
+  from their published buffer distance; awareness-class (ORANGE) orphans
+  with no buffer at all — model-club and parachute site markers, 84 in
+  the live file — are dimensionless site markers, not crossable zones,
+  and are skipped. A bufferless orphan in either restrictive class still
+  raises: those all carry buffers today, and losing them would be a
+  regression worth failing loudly on.
+- ``Elevation_fod``/``Elevation_meter`` is the aerodrome site elevation,
+  not a zone limit, and no vertical limits are published at all — zones
+  render "not stated", never an invented 0.
+
+The download page's ArcGIS item IDs churn (an ``_old``-suffixed item and
+a dead KML ID were both observed), so the stable droneregler.dk page is
+what the registry pins and the record cites; the current GeoJSON href is
+discovered from it per fetch. The page says "exclusively for personal
+use", but the dataset's own embedded metadata grants "Data kan frit
+anvendes med kildeangivelse" (free use with attribution) — the
+NATS/BAZL pattern of the licence living inside the data.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import timezone
+from email.utils import parsedate_to_datetime
+from urllib.parse import urljoin
+
+from .aixm51 import _CIRCLE_POINTS, _destination
+from .model import Applicability, AirspaceError, SourceInfo, Zone
+
+
+@dataclass(frozen=True)
+class DronezonerFeed:
+    code: str
+    page_url: str
+    feed_name: str
+    license: str
+    caveat: str
+    note: str | None = None
+
+
+_CAVEAT = (
+    "UAS geographical-zone data is informational and is not an "
+    "authorization to fly."
+)
+
+DRONEZONER_FEEDS: dict[str, DronezonerFeed] = {
+    "DK": DronezonerFeed(
+        code="DK",
+        # The Danish-language twin of this page 404s; the English page is
+        # the canonical, stable entry point.
+        page_url=(
+            "https://www.en.droneregler.dk/uas-geographical-zones/"
+            "data-for-download"
+        ),
+        feed_name="Denmark drone zones (Trafikstyrelsen)",
+        license=(
+            "© Trafikstyrelsen — \"Data kan frit anvendes med "
+            "kildeangivelse\" (free use with attribution, stated in the "
+            "dataset metadata)"
+        ),
+        caveat=_CAVEAT,
+        note=(
+            "Static zones only — NOTAM-driven temporary restrictions are "
+            "not part of this dataset."
+        ),
+    ),
+}
+
+# The page links five export formats as ArcGIS item /data URLs; only the
+# link whose anchor text says GeoJson is wanted. Item IDs churn, so the
+# href itself is never pinned.
+_GEOJSON_LINK_RE = re.compile(
+    r'href="(https://trafikstyrelsen\.maps\.arcgis\.com/sharing/rest/'
+    r'content/items/[0-9a-f]+/data)"[^>]*>\s*(?:<[^>]+>\s*)*GeoJson',
+    re.IGNORECASE,
+)
+
+# The official colour classes, named after the dataset's own KMZ layers.
+_RESTRICTION_BY_FARVE = {
+    "1": "Flight-safety-critical (RØD)",
+    "4": "Security-critical (BLÅ)",
+    "5": "Awareness (ORANGE)",
+}
+
+# Bare numbers in the Bufferzone fallback: every observed pairing with
+# Lovkrav/Enhed reads small numbers as kilometres ("3" ↔ "3 km") and
+# large ones as metres ("150" ↔ "150 m").
+_KM_THRESHOLD = 10.0
+
+
+def discover_feed_url(page: bytes, page_url: str) -> str:
+    """The current GeoJSON item URL from the droneregler.dk page's HTML."""
+    match = _GEOJSON_LINK_RE.search(page.decode("utf-8", errors="replace"))
+    if not match:
+        raise AirspaceError(
+            "could not find the GeoJson download on the droneregler.dk "
+            f"page ({page_url}) — the page layout may have changed"
+        )
+    return urljoin(page_url, match.group(1))
+
+
+def _dedup_key(props: dict) -> tuple[str, str]:
+    # typeId is deliberately absent: the live file spells it differently
+    # between a zone's point marker and its polygon ("Retsvæsen" vs
+    # "Restvæsen"), while title and colour agree.
+    return (
+        str(props.get("title") or "").strip(),
+        str(props.get("Farve") or "").strip(),
+    )
+
+
+def _buffer_m(props: dict, where: str) -> float | None:
+    """The published buffer distance of a point-only zone, in metres.
+
+    ``None`` for an awareness-class point with no distance anywhere —
+    a site marker, not a zone. Restrictive classes must carry one."""
+    lovkrav = props.get("Lovkrav")
+    enhed = str(props.get("Enhed") or "").strip()
+    if isinstance(lovkrav, (int, float)) and lovkrav > 0 and enhed in (
+        "1", "1000"
+    ):
+        # Enhed "1" pairs with kilometre distances, "1000" with metres —
+        # probed against the human-readable Bufferzone strings.
+        return float(lovkrav) * (1000.0 if enhed == "1" else 1.0)
+    text = str(props.get("Bufferzone") or "").strip().lower()
+    match = re.match(r"^(\d+(?:[.,]\d+)?)\s*(km|m(?:eter)?)?$", text)
+    if match:
+        value = float(match.group(1).replace(",", "."))
+        unit = match.group(2)
+        if unit == "km":
+            return value * 1000.0
+        if unit is not None:
+            return value
+        return value * 1000.0 if value <= _KM_THRESHOLD else value
+    if str(props.get("Farve") or "").strip() == "5":
+        return None
+    raise AirspaceError(
+        f"{where}: point zone has no usable buffer distance "
+        f"(Lovkrav={lovkrav!r}, Enhed={enhed!r}, Bufferzone={text!r})"
+    )
+
+
+def _circle_ring(
+    lon: float, lat: float, radius_m: float
+) -> list[tuple[float, float]]:
+    step = 360.0 / _CIRCLE_POINTS
+    ring = []
+    for k in range(_CIRCLE_POINTS + 1):
+        p_lat, p_lon = _destination((lat, lon), k * step, radius_m)
+        ring.append((p_lon, p_lat))
+    return ring
+
+
+def _position(pos, where: str) -> tuple[float, float]:
+    # Positions are [lon, lat] or [lon, lat, z]; only the first two count.
+    try:
+        return float(pos[0]), float(pos[1])
+    except (TypeError, ValueError, IndexError) as exc:
+        raise AirspaceError(f"{where}: malformed position {pos!r}") from exc
+
+
+def _rings(
+    geometry: dict, where: str
+) -> tuple[list[list[tuple[float, float]]], list[list[tuple[float, float]]]]:
+    gtype = geometry.get("type")
+    coords = geometry.get("coordinates") or []
+    polys = [coords] if gtype == "Polygon" else coords
+    polygons: list[list[tuple[float, float]]] = []
+    holes: list[list[tuple[float, float]]] = []
+    for poly in polys:
+        for ring_index, ring in enumerate(poly):
+            parsed = [_position(pos, where) for pos in ring]
+            # GeoJSON ring order: 0 is an exterior, the rest are holes —
+            # kept apart so the evaluator subtracts them (#422).
+            (polygons if ring_index == 0 else holes).append(parsed)
+    return polygons, holes
+
+
+def _applicability(props: dict, where: str) -> list[Applicability]:
+    start_raw = props.get("datoTidSTART")
+    end_raw = props.get("datoTidSLUT")
+    if not start_raw and not end_raw:
+        return []
+
+    def parse(raw, label):
+        if not raw:
+            return None
+        try:
+            parsed = parsedate_to_datetime(str(raw))
+        except (TypeError, ValueError) as exc:
+            raise AirspaceError(
+                f"{where}: unparseable {label} {raw!r}"
+            ) from exc
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+
+    return [
+        Applicability(
+            start=parse(start_raw, "datoTidSTART"),
+            end=parse(end_raw, "datoTidSLUT"),
+            permanent=False,
+        )
+    ]
+
+
+def parse_dronezoner(raw: bytes, source: SourceInfo) -> list[Zone]:
+    """Every zone of the Danish Dronezoner GeoJSON as normalized Zones."""
+    try:
+        data = json.loads(raw.decode("utf-8-sig"))
+    except ValueError as exc:
+        raise AirspaceError(f"{source.feed}: feed is not JSON ({exc})") from exc
+    features = data.get("features") if isinstance(data, dict) else None
+    if not isinstance(features, list):
+        raise AirspaceError(
+            f"{source.feed}: not a Dronezoner document (no 'features' list)"
+        )
+
+    polygon_keys = {
+        _dedup_key(feat.get("properties") or {})
+        for feat in features
+        if isinstance(feat, dict)
+        and isinstance(feat.get("geometry"), dict)
+        and feat["geometry"].get("type") in ("Polygon", "MultiPolygon")
+    }
+
+    zones: list[Zone] = []
+    for i, feat in enumerate(features):
+        where = f"{source.feed}: feature {i}"
+        if not isinstance(feat, dict):
+            raise AirspaceError(f"{where}: not an object")
+        props = feat.get("properties")
+        if not isinstance(props, dict):
+            raise AirspaceError(f"{where}: missing properties")
+        title = str(props.get("title") or "").strip()
+        where = f"{where} ({title or 'untitled'})"
+        # The authority's own inactive flag (e.g. a finished event zone).
+        if str(props.get("Aktiv") or "").strip().upper() == "NEJ":
+            continue
+        farve = str(props.get("Farve") or "").strip()
+        restriction = _RESTRICTION_BY_FARVE.get(farve)
+        if restriction is None:
+            raise AirspaceError(
+                f"{where}: unknown zone colour class Farve={farve!r}"
+            )
+        geometry = feat.get("geometry")
+        if not isinstance(geometry, dict):
+            raise AirspaceError(f"{where}: missing geometry")
+        gtype = geometry.get("type")
+        if gtype in ("Polygon", "MultiPolygon"):
+            polygons, holes = _rings(geometry, where)
+            if not polygons:
+                raise AirspaceError(f"{where}: no polygon geometry")
+        elif gtype == "Point":
+            # A point duplicating a polygon feature is that zone's map
+            # marker; a point with no polygon twin IS the zone, published
+            # as centre + buffer distance.
+            if _dedup_key(props) in polygon_keys:
+                continue
+            radius_m = _buffer_m(props, where)
+            if radius_m is None:
+                continue  # an extent-less site marker, not a zone
+            lon, lat = _position(geometry.get("coordinates"), where)
+            polygons = [_circle_ring(lon, lat, radius_m)]
+            holes = []
+        else:
+            raise AirspaceError(
+                f"{where}: geometry type {gtype!r} is not supported"
+            )
+        object_id = props.get("OBJECTID")
+        if not isinstance(object_id, int):
+            raise AirspaceError(f"{where}: missing OBJECTID")
+        zones.append(
+            Zone(
+                identifier=f"DK-{object_id}",
+                name=title or f"DK-{object_id}",
+                restriction=restriction,
+                # The dataset publishes no vertical limits; Elevation_* is
+                # the aerodrome site elevation and stays in `native`.
+                lower=None,
+                upper=None,
+                applicability=_applicability(props, where),
+                polygons=polygons,
+                holes=holes,
+                source=source,
+                native=feat,
+            )
+        )
+    return zones

--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -24,6 +24,11 @@ from .aixm51 import (
     parse_aixm51,
 )
 from .arcgis_faa import FAA_FEED, FAA_QUERY_URL, fetch_faa_pages, parse_faa, snap_bbox
+from .dronezoner import (
+    DRONEZONER_FEEDS,
+    discover_feed_url as discover_dronezoner_url,
+    parse_dronezoner,
+)
 from .ed269 import ED269_FEEDS, parse_ed269
 from .ed318 import ED318_FEEDS, discover_feed_url, parse_ed318
 from .jurisdiction import resolve_jurisdiction
@@ -139,6 +144,16 @@ def fetch_zones(
         # record cites. The current file href is discovered per fetch.
         url = feed318.page_url
         note = feed318.note
+    elif code in DRONEZONER_FEEDS:
+        feed_dz = DRONEZONER_FEEDS[code]
+        body_path = cache_dir / f"dronezoner-{code}.json"
+        feed_name = feed_dz.feed_name
+        license_line, caveat = feed_dz.license, feed_dz.caveat
+        # Same churning-link pattern as ED-318: the droneregler.dk page
+        # is the stable entry point the record cites; the current ArcGIS
+        # item href is discovered per fetch.
+        url = feed_dz.page_url
+        note = feed_dz.note
     else:
         feed_aixm = AIXM_FEEDS[code]
         body_path = cache_dir / f"aixm-{code}.xml"
@@ -168,6 +183,11 @@ def fetch_zones(
             elif code in ED318_FEEDS:
                 page = _fetch_url(url, transport)
                 body = _fetch_url(discover_feed_url(page, url), transport)
+            elif code in DRONEZONER_FEEDS:
+                page = _fetch_url(url, transport)
+                body = _fetch_url(
+                    discover_dronezoner_url(page, url), transport
+                )
             else:
                 page = _fetch_url(url, transport)
                 zip_url = discover_aixm_url(
@@ -191,6 +211,8 @@ def fetch_zones(
             )
         elif code in ED318_FEEDS:
             zones = parse_ed318(body, source)
+        elif code in DRONEZONER_FEEDS:
+            zones = parse_dronezoner(body, source)
         else:
             zones = parse_aixm51(body, source)
         if from_cache:
@@ -218,6 +240,8 @@ def fetch_zones(
                     )
                 elif code in ED318_FEEDS:
                     zones = parse_ed318(body, source)
+                elif code in DRONEZONER_FEEDS:
+                    zones = parse_dronezoner(body, source)
                 else:
                     zones = parse_aixm51(body, source)
             except AirspaceError as exc2:

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -111,6 +111,25 @@ _CORE: dict[str, list[Box]] = {
         (-1.85, 59.75, -0.65, 60.9),   # Shetland
         (-6.55, 54.42, -5.43, 55.25),  # Northern Ireland (Belfast, Coleraine)
     ],
+    # Sea margins on three sides, one land border (Germany, ~54.8-54.95N
+    # across Jutland). Every edge point Nominatim-verified 2026-08-15:
+    # Kastrup and the Zealand core's Øresund edge both resolve DK (the
+    # Swedish coast starts by 12.90 → >=13 km margin), Rønne/Skagen/Læsø
+    # DK inside their cores, Helsingborg/Flensburg/Puttgarden foreign and
+    # inside the hull only. Deliberate gaps, each an honest border band:
+    # the German border strip south of 55.1 (Sønderborg, Ærø), Helsingør
+    # (the 4.5 km strait), Gedser, Anholt-to-Sweden seas.
+    "DK": [
+        (8.0, 55.1, 10.9, 57.73),      # Jutland (Skagen in; Sweden >=35 km E)
+        (9.6, 55.0, 10.85, 55.1),      # south Funen (Svendborg)
+        (11.05, 54.95, 12.68, 55.9),   # Zealand incl. Copenhagen/Kastrup
+        (11.3, 55.9, 12.4, 56.1),      # N Zealand, cut back from the strait
+        (11.9, 54.85, 12.56, 54.97),   # Møn (German coast >=40 km)
+        (11.0, 54.63, 12.3, 54.95),    # Lolland-Falster (Fehmarn >=11 km)
+        (14.67, 54.98, 15.17, 55.32),  # Bornholm (Sweden >=60 km)
+        (10.85, 57.1, 11.25, 57.35),   # Læsø
+        (11.38, 56.6, 11.78, 56.78),   # Anholt
+    ],
 }
 _HULL: dict[str, list[Box]] = {
     "US": [
@@ -136,12 +155,20 @@ _HULL: dict[str, list[Box]] = {
         (-8.0, 55.55, -5.9, 61.0),     # Hebridean seas
         (-8.2, 54.0, -5.35, 55.4),     # Northern Ireland
     ],
+    # Flensburg, Helsingborg and Fehmarn's north tip sit inside the hull
+    # deliberately (the CH-Konstanz semantics: a border band, not "no
+    # provider"); Malmö stays outside entirely.
+    "DK": [
+        (7.5, 54.68, 11.0, 57.9),      # Jutland + Funen
+        (11.0, 54.5, 12.78, 57.4),     # Zealand / Lolland-Falster / Øresund
+        (14.6, 54.9, 15.35, 55.38),    # Bornholm
+    ],
 }
 # CH takes the EU measure: Regulation (EU) 2019/947 applies in Switzerland
 # since 2023-01-01 under the CH-EU air transport agreement.
 _MEASURE = {
     "US": MEASURE_US, "LU": MEASURE_EU, "FI": MEASURE_EU, "CH": MEASURE_EU,
-    "IE": MEASURE_EU, "GB": MEASURE_UK,
+    "IE": MEASURE_EU, "GB": MEASURE_UK, "DK": MEASURE_EU,
 }
 
 
@@ -173,7 +200,7 @@ def resolve_jurisdiction(track: Track) -> Resolution:
             None,
             "no supported airspace data source for this location "
             "(covered: the US, Luxembourg, Finland, Switzerland, "
-            "Ireland and the UK)",
+            "Ireland, the UK and Denmark)",
         )
     cores = [code for code in hulls if _all_inside(track, _CORE[code])]
     if len(cores) != 1:

--- a/tests/test_airspace_dronezoner.py
+++ b/tests/test_airspace_dronezoner.py
@@ -1,0 +1,212 @@
+"""Denmark Dronezoner provider (Trafikstyrelsen GeoJSON)."""
+
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder.geo.airspace.dronezoner import (
+    DRONEZONER_FEEDS,
+    discover_feed_url,
+    parse_dronezoner,
+)
+from dji_metadata_embedder.geo.airspace.model import AirspaceError, SourceInfo
+
+FIXTURE = (
+    Path(__file__).parent.parent / "samples" / "airspace" / "dronezoner-dk.json"
+)
+
+SOURCE = SourceInfo(
+    feed="Denmark drone zones (Trafikstyrelsen)",
+    url="https://example.test/page",
+    fetched="2026-08-15T12:00:00Z",
+    license="test",
+    caveat="test",
+)
+
+PAGE = b"""
+<html><body>
+<a href="https://trafikstyrelsen.maps.arcgis.com/sharing/rest/content/items/1a629c73da354790b7501091354a3943/data">GeoPackage</a>
+<a href="https://trafikstyrelsen.maps.arcgis.com/sharing/rest/content/items/f049a65ae2f34bd1b747895d555dac71/data">GeoJson</a>
+<a href="https://trafikstyrelsen.maps.arcgis.com/sharing/rest/content/items/c92fcd162f9346ae818858b1640a565f/data">KML</a>
+</body></html>
+"""
+
+
+def fixture_zones():
+    return parse_dronezoner(FIXTURE.read_bytes(), SOURCE)
+
+
+def zone(zones, ident):
+    return next(z for z in zones if z.identifier == ident)
+
+
+def dist_m(a, b):
+    # Small-angle equirectangular distance, plenty for circle radii.
+    lat = math.radians((a[1] + b[1]) / 2)
+    dx = math.radians(b[0] - a[0]) * math.cos(lat) * 6371000
+    dy = math.radians(b[1] - a[1]) * 6371000
+    return math.hypot(dx, dy)
+
+
+class TestDiscovery:
+    def test_picks_the_geojson_link_among_the_five_formats(self):
+        url = discover_feed_url(PAGE, DRONEZONER_FEEDS["DK"].page_url)
+        assert url == (
+            "https://trafikstyrelsen.maps.arcgis.com/sharing/rest/content/"
+            "items/f049a65ae2f34bd1b747895d555dac71/data"
+        )
+
+    def test_page_without_a_geojson_link_raises(self):
+        with pytest.raises(AirspaceError, match="droneregler.dk"):
+            discover_feed_url(b"<html>redesigned</html>", "https://x.test/")
+
+
+class TestParsing:
+    def test_marker_points_and_inactive_zones_are_dropped(self):
+        zones = fixture_zones()
+        # 11 features: the polygon-twin Point markers (one via the
+        # live file's Retsvæsen/Restvæsen typeId typo — dedup must not
+        # look at typeId), the Aktiv NEJ feature and the bufferless
+        # awareness-class site marker all drop; the rest are zones.
+        assert len(zones) == 7
+        assert {z.identifier for z in zones} == {
+            "DK-1", "DK-2", "DK-3", "DK-4", "DK-6", "DK-7", "DK-8"
+        }
+
+    def test_a_typo_divergent_typeid_still_dedups_the_marker(self):
+        # The point twin spells "Retsvæsen", the polygon "Restvæsen":
+        # the polygon zone survives, the buffer-less point drops as its
+        # marker instead of raising.
+        zones = fixture_zones()
+        z = zone(zones, "DK-8")
+        assert z.native["properties"]["typeId"] == "Restvæsen"
+
+    def test_a_bufferless_awareness_site_marker_is_skipped(self):
+        # Model-club markers carry no extent at all in the live file —
+        # a dimensionless point cannot be crossed, so it is not a zone.
+        zones = fixture_zones()
+        assert not any("Test Modelflyveklub" in z.name for z in zones)
+
+    def test_colour_classes_map_to_the_official_layer_names(self):
+        zones = fixture_zones()
+        assert zone(zones, "DK-1").restriction == "Flight-safety-critical (RØD)"
+        assert zone(zones, "DK-2").restriction == "Security-critical (BLÅ)"
+        assert zone(zones, "DK-4").restriction == "Awareness (ORANGE)"
+
+    def test_three_element_positions_lose_only_the_z(self):
+        z = zone(fixture_zones(), "DK-1")
+        assert z.polygons[0][0] == (12.50, 55.60)
+
+    def test_multipolygon_keeps_parts_and_holes_apart(self):
+        z = zone(fixture_zones(), "DK-2")
+        assert len(z.polygons) == 2
+        assert len(z.holes) == 1
+        assert z.holes[0][0] == (12.31, 55.71)
+
+    def test_orphan_point_with_metre_units_becomes_a_150_m_circle(self):
+        z = zone(fixture_zones(), "DK-3")
+        ring = z.polygons[0]
+        assert len(ring) == 129  # 128 steps + closure
+        assert ring[0] == ring[-1]
+        for pos in ring[:8]:
+            assert dist_m((12.20, 55.50), pos) == pytest.approx(150, rel=0.01)
+
+    def test_orphan_point_with_km_lovkrav_becomes_a_3_km_circle(self):
+        z = zone(fixture_zones(), "DK-7")
+        assert dist_m((12.00, 55.40), z.polygons[0][0]) == pytest.approx(
+            3000, rel=0.01
+        )
+
+    def test_orphan_point_falls_back_to_the_bufferzone_string(self):
+        z = zone(fixture_zones(), "DK-4")
+        assert dist_m((12.10, 55.45), z.polygons[0][0]) == pytest.approx(
+            2000, rel=0.01
+        )
+
+    def test_no_vertical_limits_are_ever_invented(self):
+        for z in fixture_zones():
+            assert z.lower is None and z.upper is None
+
+    def test_temporary_zone_carries_its_window(self):
+        z = zone(fixture_zones(), "DK-6")
+        assert len(z.applicability) == 1
+        win = z.applicability[0]
+        assert not win.permanent
+        assert win.start == datetime(2026, 9, 7, 6, 0, tzinfo=timezone.utc)
+        assert win.end == datetime(2026, 9, 11, 18, 0, tzinfo=timezone.utc)
+
+    def test_permanent_zones_have_no_applicability_entries(self):
+        assert zone(fixture_zones(), "DK-2").applicability == []
+
+    def test_native_keeps_the_full_feature(self):
+        z = zone(fixture_zones(), "DK-1")
+        assert z.native["properties"]["ICAO"] == "EKTS"
+        assert z.native["properties"]["Elevation_fod"] == 17
+
+
+def _one_feature(props, geometry):
+    return json.dumps(
+        {"type": "FeatureCollection",
+         "features": [{"type": "Feature", "geometry": geometry,
+                       "properties": props}]}
+    ).encode()
+
+
+class TestAllOrNothing:
+    def test_not_json_raises(self):
+        with pytest.raises(AirspaceError, match="not JSON"):
+            parse_dronezoner(b"<html>", SOURCE)
+
+    def test_no_features_list_raises(self):
+        with pytest.raises(AirspaceError, match="features"):
+            parse_dronezoner(b"{}", SOURCE)
+
+    def test_unknown_colour_class_raises(self):
+        body = _one_feature(
+            {"OBJECTID": 9, "title": "X", "typeId": "Y", "Farve": "2"},
+            {"type": "Point", "coordinates": [12.0, 55.0]},
+        )
+        with pytest.raises(AirspaceError, match="Farve='2'"):
+            parse_dronezoner(body, SOURCE)
+
+    def test_point_without_any_buffer_raises(self):
+        body = _one_feature(
+            {"OBJECTID": 9, "title": "X", "typeId": "Politi", "Farve": "4"},
+            {"type": "Point", "coordinates": [12.0, 55.0]},
+        )
+        with pytest.raises(AirspaceError, match="buffer distance"):
+            parse_dronezoner(body, SOURCE)
+
+    def test_unparseable_window_raises(self):
+        body = _one_feature(
+            {"OBJECTID": 9, "title": "X", "typeId": "MGZ", "Farve": "4",
+             "datoTidSTART": "next Tuesday-ish"},
+            {"type": "Polygon", "coordinates": [
+                [[12.0, 55.0], [12.1, 55.0], [12.1, 55.1], [12.0, 55.0]]
+            ]},
+        )
+        with pytest.raises(AirspaceError, match="datoTidSTART"):
+            parse_dronezoner(body, SOURCE)
+
+    def test_unsupported_geometry_raises(self):
+        body = _one_feature(
+            {"OBJECTID": 9, "title": "X", "typeId": "Y", "Farve": "4"},
+            {"type": "LineString", "coordinates": [[12.0, 55.0], [12.1, 55.1]]},
+        )
+        with pytest.raises(AirspaceError, match="LineString"):
+            parse_dronezoner(body, SOURCE)
+
+    def test_missing_objectid_raises(self):
+        body = _one_feature(
+            {"title": "X", "typeId": "Y", "Farve": "4"},
+            {"type": "Polygon", "coordinates": [
+                [[12.0, 55.0], [12.1, 55.0], [12.1, 55.1], [12.0, 55.0]]
+            ]},
+        )
+        with pytest.raises(AirspaceError, match="OBJECTID"):
+            parse_dronezoner(body, SOURCE)

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -287,3 +287,51 @@ def test_a_uk_sha_mismatch_is_a_stated_gap(tmp_path):
     data = fetch_zones(_track(51.50, -0.12), tmp_path,
                        transport=FakeTransport([GB_PAGE, _gb_zip_bad_sha()]))
     assert data.gap_reason is not None and "SHA-256" in data.gap_reason
+
+
+DK_PAGE = (
+    b'<a href="https://trafikstyrelsen.maps.arcgis.com/sharing/rest/'
+    b'content/items/f049a65ae2f34bd1b747895d555dac71/data">GeoJson</a>'
+)
+
+
+def test_a_danish_flight_discovers_the_geojson_and_caches_it(tmp_path):
+    fake = FakeTransport(
+        [DK_PAGE, (FIXTURES / "dronezoner-dk.json").read_bytes()]
+    )
+    lines = []
+    data = fetch_zones(_track(55.68, 12.57), tmp_path, transport=fake,
+                       announce=lines.append)
+    assert data.gap_reason is None and len(data.zones) == 7
+    assert fake.urls[0].startswith("https://www.en.droneregler.dk/")
+    assert fake.urls[1].endswith(
+        "items/f049a65ae2f34bd1b747895d555dac71/data"
+    )
+    assert data.source is not None
+    assert "kildeangivelse" in data.source.license
+    assert (tmp_path / "dronezoner-DK.json").exists()
+    assert any("Fetching" in ln and "www.en.droneregler.dk" in ln
+               for ln in lines)
+
+
+def test_a_cached_danish_body_skips_discovery_and_the_network(tmp_path):
+    fetch_zones(
+        _track(55.68, 12.57), tmp_path,
+        transport=FakeTransport(
+            [DK_PAGE, (FIXTURES / "dronezoner-dk.json").read_bytes()]
+        ),
+    )
+
+    def no_network(req, timeout=None):
+        raise AssertionError("cached run must not touch the network")
+    data = fetch_zones(_track(55.68, 12.57), tmp_path, transport=no_network)
+    assert data.from_cache and len(data.zones) == 7
+
+
+def test_a_redesigned_danish_page_is_a_stated_gap(tmp_path):
+    data = fetch_zones(_track(55.68, 12.57), tmp_path,
+                       transport=FakeTransport([b"<html>redesigned</html>"]))
+    assert not data.zones
+    assert data.gap_reason is not None
+    assert "droneregler.dk" in data.gap_reason
+

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -282,3 +282,74 @@ def test_calais_gaps_instead_of_resolving_gb():
 def test_the_no_provider_message_names_the_uk():
     r = resolve_jurisdiction(_track((48.85, 2.35)))   # Paris
     assert "the UK" in (r.gap_reason or "")
+
+
+# --- Denmark (Trafikstyrelsen Dronezoner) ---
+
+
+def test_a_copenhagen_flight_resolves_to_dk_with_the_eu_measure():
+    r = resolve_jurisdiction(_track((55.68, 12.57), (55.66, 12.6)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "DK"
+    assert "2019/947" in r.jurisdiction.measure_note
+
+
+def test_kastrup_airport_resolves_to_dk():
+    # Amager sits 2 km from the core's Øresund edge; the Swedish coast
+    # is >=13 km further east (Nominatim-verified 2026-08-15).
+    r = resolve_jurisdiction(_track((55.62, 12.65)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "DK"
+
+
+def test_aarhus_and_odense_resolve_to_dk():
+    for lat, lon in ((56.16, 10.21), (55.40, 10.39)):
+        r = resolve_jurisdiction(_track((lat, lon)))
+        assert r.jurisdiction is not None and r.jurisdiction.code == "DK"
+
+
+def test_the_danish_islands_resolve_to_dk():
+    # Bornholm (Rønne), Læsø, Skagen at Jutland's tip.
+    for lat, lon in ((55.10, 14.70), (57.26, 11.00), (57.72, 10.58)):
+        r = resolve_jurisdiction(_track((lat, lon)))
+        assert r.jurisdiction is not None and r.jurisdiction.code == "DK"
+
+
+def test_sonderborg_gaps_as_a_border_band():
+    # Danish, but <10 km from the German border: inside the hull,
+    # outside every core.
+    r = resolve_jurisdiction(_track((54.91, 9.79)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "boundary" in r.gap_reason
+
+
+def test_helsingor_gaps_as_a_border_band():
+    # The strait to Helsingborg is ~4.5 km wide; coordinates alone
+    # cannot pick a side confidently.
+    r = resolve_jurisdiction(_track((56.03, 12.61)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "boundary" in r.gap_reason
+
+
+def test_helsingborg_sweden_gaps_instead_of_resolving_dk():
+    # Inside the DK hull on purpose (CH-Konstanz semantics) but never
+    # inside a core.
+    r = resolve_jurisdiction(_track((56.05, 12.69)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "boundary" in r.gap_reason
+
+
+def test_malmo_is_an_honest_no_provider_gap():
+    r = resolve_jurisdiction(_track((55.60, 13.00)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "no supported airspace data" in r.gap_reason
+
+
+def test_flensburg_germany_gaps_instead_of_resolving_dk():
+    r = resolve_jurisdiction(_track((54.79, 9.43)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "boundary" in r.gap_reason
+
+
+def test_the_no_provider_message_names_denmark():
+    r = resolve_jurisdiction(_track((48.85, 2.35)))  # Paris
+    assert r.gap_reason is not None and "Denmark" in r.gap_reason
+


### PR DESCRIPTION
Closes #507. Seventh airspace country, from today's feed survey (GREEN, probe-verified).

## Source
- Stable entry point: the droneregler.dk **data-for-download page** (English page; the Danish twin 404s). The five ArcGIS export links churn item IDs — the survey's KML ID died within hours — so the GeoJSON href is **discovered from the page per fetch**, ED-318 style, and the page is what the record cites.
- Licence: the dataset's own embedded metadata grants **"Data kan frit anvendes med kildeangivelse"** (free use with attribution), overriding the page's personal-use line — the NATS/BAZL licence-inside-the-data pattern. Quoted verbatim in the licence line.

## Provider (`dronezoner.py`)
- The three official colour classes, named after the dataset's own KMZ layers (decoded empirically): **Flight-safety-critical (RØD)** airports/HEMS/military air stations, **Security-critical (BLÅ)** police/military/embassies/prisons, **Awareness (ORANGE)** recreational airfields. Unknown class → error (all-or-nothing).
- Most zones ship twice (buffered polygon + point map marker): markers dedup on **(title, colour)** — deliberately not typeId, which the live file spells differently between twins ("Retsvæsen" point vs "Restvæsen" polygon; found by live E2E). Orphan points with a published buffer (127 live) densify to 129-point geodesic circles via the AIXM helpers; the 84 buffer-less awareness-class club markers are dimensionless site markers, skipped — a bufferless orphan in a restrictive class still raises as a regression guard.
- `Aktiv == NEJ` features drop (the authority's own inactive flag); `Midlertidig` windows (RFC-1123 timestamps) become non-permanent Applicability.
- **No vertical limits are published** → zones render "not stated", never an invented 0; `Elevation_*` is aerodrome site elevation and stays in `native`. Feed note: NOTAM-driven temporaries are not in the dataset.

## Jurisdiction
DK cores/hull with GB-style sea margins, every edge Nominatim-verified today: Copenhagen/Kastrup resolve (Swedish coast ≥13 km beyond the core's Øresund edge), Aarhus/Odense/Bornholm/Læsø/Skagen resolve; Sønderborg, Helsingør (4.5 km strait) and Gedser gap as border bands; Flensburg, Helsingborg and Fehmarn's north tip sit inside the hull on the CH-Konstanz precedent; Malmö stays a no-provider gap. EU 2019/947 measure.

## Verification
- 35 new tests (provider 23, fetch 3, jurisdiction 10 incl. the gap-string rename); full gate **1356 passed / 3 skipped + mypy + ruff**.
- **Live E2E PASS** against the real feed: 986 zones (876 polygons + 127 circles − 17 inactive — the arithmetic checks out), all three classes present, EKCH Kastrup zones found, 26 time-bounded zones, offline cache re-parse clean.

Docs (`geospatial.md`, `flight-record.md` five-feeds/coverage) and the GUI airspace note updated to name Denmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U4PWi5zbarxwJmjk6yAif