### PR TITLE
fix(geo): downscale or embed real DJI DNG previews instead of dropping them (#509)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -481,8 +481,11 @@ one pass (`dji-embed doctor` checks it's installed); the HTML map clusters
 nearby shots into an expandable marker, and clicking a pin shows the EXIF
 thumbnail, filename, timestamp, altitude, and camera settings — plus an
 attribution line when the photo carries `Artist`/`Copyright` metadata (see
-below). Photos with no GPS are skipped and counted in a summary; `-v` lists
-them.
+below). DNGs carry no EXIF thumbnail, so their embedded preview is used
+instead — downscaled to thumbnail size when Pillow is available (the
+`[terrain]` extra; included in the packaged builds), embedded as-is
+otherwise. Photos with no GPS are skipped and counted in a summary; `-v`
+lists them.
 
 With `--link-originals`, a popup's thumbnail and filename become a
 click-through to the full-resolution original (JPGs open inline, DNGs

--- a/src/dji_metadata_embedder/geo/photomap.py
+++ b/src/dji_metadata_embedder/geo/photomap.py
@@ -8,6 +8,7 @@ GeoJSON and KML here, the clustered HTML map in :mod:`.photomap_html`.
 from __future__ import annotations
 
 import base64
+import io
 import json
 import logging
 import os
@@ -76,11 +77,21 @@ _PHOTO_EXTS = ("jpg", "jpeg", "dng")
 # writers may embed it in CDATA/data URIs without further escaping.
 _BASE64_RE = re.compile(r"[A-Za-z0-9+/=\s]+")
 
-# Cap on the PreviewImage fallback so a DNG-heavy archive doesn't blow the
-# ~15-40 KB/photo embed budget (raw previews can be multi-MB). ~225 KB decoded.
-# UNVERIFIED against a real DJI DNG: the JSON shape is assumed identical to
-# ThumbnailImage ("base64:...") — the tag differs, the encoding does not.
-_MAX_PREVIEW_B64_CHARS = 300_000
+# Cap on a raw PreviewImage embed (~450 KB decoded). A real Air 3S preview is
+# ~396 KB binary → ~527k base64 chars (#509), so the cap must clear that; the
+# JSON shape ("base64:..." like ThumbnailImage) is verified against FC9113.
+# Pillow-equipped installs never get near it — oversized previews are
+# downscaled into the normal ~15-40 KB/photo embed budget instead.
+_MAX_PREVIEW_B64_CHARS = 600_000
+
+# Previews at or below this embed as-is even with Pillow present: they are
+# already thumbnail-scale and a re-encode would only cost quality.
+_PREVIEW_DOWNSCALE_MIN_CHARS = 60_000
+
+# Downscale target: popups render at 260 CSS px, so 640 px covers 2x-DPI
+# displays with margin while keeping the re-encoded JPEG in budget.
+_PREVIEW_MAX_EDGE_PX = 640
+_PREVIEW_JPEG_QUALITY = 80
 
 
 @dataclass
@@ -234,17 +245,60 @@ def _thumb_dimensions(thumb_b64: str) -> tuple[int, int] | None:
         return None
 
 
-def _extract_thumbnail_b64(entry: dict) -> str | None:
-    """Pick a preview blob: the small EXIF thumbnail, else a size-capped PreviewImage.
+def _pil_image():
+    """Pillow's ``Image`` module, or ``None`` when Pillow is absent.
 
-    The EXIF thumbnail is always preferred (small, present on JPGs). PreviewImage
-    is the DNG fallback, taken only when it stays under ``_MAX_PREVIEW_B64_CHARS``.
+    Imported lazily, like :mod:`.panoedit`: Pillow ships in the ``[terrain]``
+    extra (and every packaged build), and a bare install must still map DNGs —
+    just with raw rather than downscaled previews.
+    """
+    try:
+        from PIL import Image  # type: ignore[import-untyped]
+    except ImportError:
+        return None
+    return Image
+
+
+def _downscale_preview(preview_b64: str) -> str | None:
+    """Re-encode a large preview to ``_PREVIEW_MAX_EDGE_PX``, ``None`` on failure.
+
+    Failure (no Pillow, undecodable bytes) is not an error: the caller falls
+    back to embedding the raw preview under ``_MAX_PREVIEW_B64_CHARS``.
+    """
+    Image = _pil_image()
+    if Image is None:
+        return None
+    try:
+        with Image.open(io.BytesIO(base64.b64decode(preview_b64))) as im:
+            rgb = im.convert("RGB")
+        rgb.thumbnail((_PREVIEW_MAX_EDGE_PX, _PREVIEW_MAX_EDGE_PX), Image.LANCZOS)
+        buf = io.BytesIO()
+        rgb.save(buf, format="JPEG", quality=_PREVIEW_JPEG_QUALITY)
+    except (OSError, ValueError):
+        return None
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _extract_thumbnail_b64(entry: dict) -> str | None:
+    """Pick a preview blob: the small EXIF thumbnail, else the PreviewImage.
+
+    The EXIF thumbnail is always preferred (small, present on JPGs).
+    PreviewImage is the DNG fallback (#509): small ones embed as-is, large
+    ones are downscaled into the embed budget when Pillow is available, and
+    otherwise embed raw as long as they fit ``_MAX_PREVIEW_B64_CHARS``.
     """
     thumb = _clean_base64(entry.get("ThumbnailImage"))
     if thumb is not None:
         return thumb
     preview = _clean_base64(entry.get("PreviewImage"))
-    if preview is not None and len(preview) <= _MAX_PREVIEW_B64_CHARS:
+    if preview is None:
+        return None
+    if len(preview) <= _PREVIEW_DOWNSCALE_MIN_CHARS:
+        return preview
+    scaled = _downscale_preview(preview)
+    if scaled is not None:
+        return scaled
+    if len(preview) <= _MAX_PREVIEW_B64_CHARS:
         return preview
     return None
 

--- a/tests/test_geo_photomap.py
+++ b/tests/test_geo_photomap.py
@@ -1,9 +1,13 @@
+import base64
+import io
 import json as jsonlib
+import os
 import subprocess
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from dji_metadata_embedder.geo.photomap import (
     PhotoPoint,
@@ -141,6 +145,57 @@ def test_oversized_preview_is_dropped_to_protect_budget():
         "PreviewImage": "base64:" + big,
     }])
     assert points[0].thumbnail_b64 is None
+
+
+def _noise_jpeg_b64(width: int, height: int) -> str:
+    """A real JPEG big enough to overflow the preview cap (noise defeats compression)."""
+    im = Image.frombytes("RGB", (width, height), os.urandom(width * height * 3))
+    buf = io.BytesIO()
+    im.save(buf, format="JPEG", quality=95)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def test_oversized_preview_is_downscaled_when_pillow_available():
+    # Real Air 3S DNG previews (~527k b64 chars, #509) must still yield a popup
+    # image: with Pillow present they are downscaled into the embed budget.
+    from dji_metadata_embedder.geo import photomap as pm
+
+    big = _noise_jpeg_b64(2400, 1200)
+    assert len(big) > pm._MAX_PREVIEW_B64_CHARS
+    points, _ = points_from_exiftool_json([{
+        "SourceFile": "a.dng", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+        "PreviewImage": "base64:" + big,
+    }])
+    thumb = points[0].thumbnail_b64
+    assert thumb is not None and len(thumb) < len(big)
+    dims = pm._thumb_dimensions(thumb)
+    assert dims is not None and max(dims) <= pm._PREVIEW_MAX_EDGE_PX
+    assert dims[0] / dims[1] == pytest.approx(2.0, abs=0.02)  # aspect preserved
+
+
+def test_oversized_preview_embeds_raw_when_pillow_missing(monkeypatch):
+    # Plain pip installs have no Pillow: a real-world-sized preview embeds
+    # as-is under the raised cap rather than silently vanishing.
+    from dji_metadata_embedder.geo import photomap as pm
+
+    monkeypatch.setattr(pm, "_pil_image", lambda: None)
+    big = "A" * 400_000  # over the old 300k cap, under the raised one
+    points, _ = points_from_exiftool_json([{
+        "SourceFile": "a.dng", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+        "PreviewImage": "base64:" + big,
+    }])
+    assert points[0].thumbnail_b64 == big
+
+
+def test_undecodable_oversized_preview_falls_back_to_raw_embed():
+    # Valid base64 that is not a decodable image: the downscale fails, and the
+    # raw bytes still embed as long as they fit the cap.
+    big = "A" * 400_000
+    points, _ = points_from_exiftool_json([{
+        "SourceFile": "a.dng", "GPSLatitude": 1.0, "GPSLongitude": 2.0,
+        "PreviewImage": "base64:" + big,
+    }])
+    assert points[0].thumbnail_b64 == big
 
 
 def test_scan_photos_requests_preview_tag(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #509.

Found validating photomap against real Air 3S DNGs (FC9113): DJI DNGs carry no EXIF ThumbnailImage, and the PreviewImage fallback rejected real previews (~396 KB binary → ~527k base64 chars) because `_MAX_PREVIEW_B64_CHARS` was 300,000 — so DNG popups rendered with no image at all while the JPGs around them got thumbnails.

**Fix (both directions from the issue, combined):**
- With Pillow importable (the `terrain` extra — bundled in the EXE, installer, and macOS builds): oversized previews are downscaled to a 640 px long edge (covers the 260 CSS px popup at 2× DPI) and re-encoded at quality 80, landing in the normal ~15–40 KB/photo embed budget. Small previews (≤60k chars) embed as-is.
- Without Pillow, or when the preview bytes don't decode: the raw preview embeds under a raised 600k-char cap, so a plain pip install still shows the image (at ~0.4 MB/DNG map cost). Only a preview over ~450 KB decoded is dropped.

The cap comment's "UNVERIFIED against a real DJI DNG" note is resolved — the JSON shape matched exactly; only the size estimate was wrong.

**Tests** (TDD, all red first): oversized real JPEG preview is downscaled with aspect preserved and bounded edge; oversized preview embeds raw when Pillow is absent; undecodable oversized preview falls back to raw embed. Existing preview tests (thumbnail preferred, over-cap dropped, base64 hygiene) unchanged and passing.

**Verification:** 1222 unit tests + browser popup pin green, ruff clean, mypy clean. Real-DNG E2E not rerun (the Air 3S DNGs aren't currently staged in WSL); the ExifTool JSON shape was verified against FC9113 during the #509 triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J677oX7MdjT3MutrZq8AJT