### PR TITLE
feat(geo): Sweden UAS geographical zones via LFV's ED-318 file (#510)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -435,9 +435,12 @@ Luxembourg, Finland and Switzerland via ED-269, Ireland via the IAA's
 published ED-318 file, which the IAA labels reference-only — that caveat
 rides into the map — the UK via the NATS AIS AIXM 5.1 dataset, whose
 activation hours and temporary restrictions live in the AIP and NOTAMs,
-not in the file — that caveat rides along too — and Denmark via
+not in the file — that caveat rides along too — Denmark via
 Trafikstyrelsen's drone-zone dataset, which likewise leaves NOTAM-driven
-temporaries to the AIP). Zones draw in one neutral
+temporaries to the AIP, and Sweden via LFV's ED-318 file, where a few
+zones apply only during scheduled hours within their published windows —
+the schedule stays in the zone's published data and is not evaluated).
+Zones draw in one neutral
 style; clicking one shows the published facts: restriction class, vertical
 limits (or "not stated"), applicability windows, and the feed, license and
 fetch time. Zones the

--- a/docs/how-to/flight-record.md
+++ b/docs/how-to/flight-record.md
@@ -41,10 +41,12 @@ Five feeds are used:
   0.1° grid before it goes on the wire, so the endpoint learns no more
   about where you flew than a map-tile fetch already would.
 - **Luxembourg, Finland and Switzerland** flights fetch the country's
-  whole ED-269 geographical-zone document, and **Ireland** the IAA's
-  published ED-318 file — the feeds have no query parameter for a
-  location at all, so nothing about the flight is sent; the entire
-  country's zones come back regardless of where the flight was.
+  whole ED-269 geographical-zone document, and **Ireland** and
+  **Sweden** their published ED-318 files — the IAA's file for
+  Ireland, LFV's dronechart file for Sweden — the feeds have no query
+  parameter for a location at all, so nothing about the flight is
+  sent; the entire country's zones come back regardless of where the
+  flight was.
 - **UK** flights fetch NATS AIS's whole UAS flight-restrictions dataset
   (AIXM 5.1, refreshed each 28-day AIRAC cycle), again with no location
   sent. Activation hours are not in the dataset and temporary
@@ -67,20 +69,18 @@ nothing without `-f record`; terrain tiles are unaffected by this flag).
 dji-embed flightmap ./flights -f record --airspace-refresh
 ```
 
-## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark — and an honest gap everywhere else
+## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark, Sweden — and an honest gap everywhere else
 
 Airspace lookup only resolves for flights that sit clearly inside the
-United States, Luxembourg, Finland, Switzerland, Ireland, the UK, or
-Denmark.
-Everywhere else — including Sweden — the record states the gap instead of
-guessing: *"no supported
-airspace data source for this location."* A flight near a jurisdiction
-boundary gaps the same way, deliberately, rather than borrowing a
-neighbouring country's rules from coordinates alone. The logbook half of
-the record (times, distances, heights) is unaffected — a gapped airspace
-section never blocks the rest. Northern Ireland resolves to the UK
-dataset; flights close to the Irish land border still gap deliberately,
-from both sides.
+United States, Luxembourg, Finland, Switzerland, Ireland, the UK,
+Denmark, or Sweden. Everywhere else the record states the gap instead
+of guessing: *"no supported airspace data source for this location."*
+A flight near a jurisdiction boundary gaps the same way, deliberately,
+rather than borrowing a neighbouring country's rules from coordinates
+alone. The logbook half of the record (times, distances, heights) is
+unaffected — a gapped airspace section never blocks the rest. Northern
+Ireland resolves to the UK dataset; flights close to the Irish land
+border still gap deliberately, from both sides.
 
 Widening coverage means adding and verifying another feed; it will grow,
 but a wrong jurisdiction guessed from coordinates would be worse than no

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -335,7 +335,7 @@
                                                   IsEnabled="{Binding !FlightOptions.ThreeD}"
                                                   Content="Airspace zones" />
                                         <TextBlock Name="FlightAirspaceNote"
-                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland, Ireland, the UK and Denmark). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
+                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark and Sweden). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
                                                    IsVisible="{Binding FlightOptions.ShowsAirspaceNote}"
                                                    TextWrapping="Wrap"
                                                    Opacity="0.5" FontSize="11" />

--- a/samples/airspace/README.md
+++ b/samples/airspace/README.md
@@ -13,6 +13,21 @@ verified on issue #413 (2026-07-29). Public data, no privacy concern.
   verified on issue #456, 2026-08-02). No BOM, like the live feed. Includes
   the `99999 m` no-ceiling sentinel in both its AGL and AMSL forms, and a
   multi-volume zone whose volumes share identical vertical limits.
+- `ed318-ie.json` — Ireland ED-318 document (iaa.ie, "reference only — not
+  to be used for navigation"; live shape verified on issue #452,
+  2026-08-14).
+- `aixm51-gb.xml` — UK AIXM 5.1 UAS flight-restrictions document (NATS AIS;
+  live shape verified on issue #499, 2026-08-15). No location sent to fetch
+  it; the whole dataset comes back regardless of where the flight was.
+- `dronezoner-dk.json` — Denmark drone-zone document (Trafikstyrelsen,
+  "Data kan frit anvendes med kildeangivelse" / free use with attribution;
+  live shape verified on issue #508, 2026-08-15).
+- `ed318-se.json` — **synthetic**, not a trimmed copy. Invented zones in the
+  real LFV file's ED-318 shape (issue #510, 2026-08-19), deliberate under
+  LFV's condition that the zone content not be modified — a trimmed extract
+  of the live file would have breached that, so this fixture pastes no live
+  LFV zone data at all. Don't "fix" it by swapping in real zones.
 
 The manual E2E step before merge re-fetches each live endpoint and confirms
-these shapes still match.
+these shapes still match; `ed318-se.json` is exempt from that step since
+it is not derived from the live feed.

--- a/samples/airspace/README.md
+++ b/samples/airspace/README.md
@@ -17,8 +17,8 @@ verified on issue #413 (2026-07-29). Public data, no privacy concern.
   to be used for navigation"; live shape verified on issue #452,
   2026-08-14).
 - `aixm51-gb.xml` — UK AIXM 5.1 UAS flight-restrictions document (NATS AIS;
-  live shape verified on issue #499, 2026-08-15). No location sent to fetch
-  it; the whole dataset comes back regardless of where the flight was.
+  live shape verified on issue #499, 2026-08-15; usage unrestricted per the
+  product's ISO 19115 metadata — not for resale, for aviation use only).
 - `dronezoner-dk.json` — Denmark drone-zone document (Trafikstyrelsen,
   "Data kan frit anvendes med kildeangivelse" / free use with attribution;
   live shape verified on issue #508, 2026-08-15).
@@ -29,5 +29,7 @@ verified on issue #413 (2026-07-29). Public data, no privacy concern.
   LFV zone data at all. Don't "fix" it by swapping in real zones.
 
 The manual E2E step before merge re-fetches each live endpoint and confirms
-these shapes still match; `ed318-se.json` is exempt from that step since
-it is not derived from the live feed.
+these shapes still match; `ed318-se.json` is synthetic, so there is nothing
+to byte-match — but the LFV endpoint is still re-fetched and the fixture's
+shape confirmed against it (it is the one fixture with no tie to the live
+file, which makes it the most prone to drifting from reality unnoticed).

--- a/samples/airspace/ed318-se.json
+++ b/samples/airspace/ed318-se.json
@@ -1,0 +1,115 @@
+{
+    "type": "FeatureCollection",
+    "metadata": {
+        "provider": [{"lang": "en-GB", "text": "Transportstyrelsen"}],
+        "issued": "2026-08-13T00:00:00Z",
+        "validFrom": "2026-08-13T00:00:00Z"
+    },
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                    [16.00, 59.00], [16.10, 59.00], [16.10, 59.05],
+                    [16.00, 59.05], [16.00, 59.00]
+                ]],
+                "layer": {
+                    "upper": 150, "upperReference": "AGL",
+                    "lower": 0, "lowerReference": "AGL", "uom": "m"
+                }
+            },
+            "properties": {
+                "identifier": "ESU901",
+                "country": "SWE",
+                "name": [
+                    {"text": "Example test range", "lang": "en-GB"},
+                    {"text": "Exempel testområde", "lang": "se-SE"}
+                ],
+                "variant": "COMMON",
+                "reason": ["OTHER"],
+                "type": "REQ_AUTHORIZATION",
+                "restrictionConditions": "AUTHORIZED",
+                "otherReasonInfo": [
+                    {"lang": "en-GB", "text": "Test site"},
+                    {"lang": "se-SE", "text": "Testanläggning"}
+                ],
+                "regulationExemption": "NO",
+                "message": [{"lang": "en-GB", "text": "Example only."}],
+                "limitedApplicability": [
+                    {
+                        "startDateTime": "2026-01-01T00:00Z",
+                        "endDateTime": "2027-12-31T23:59Z"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [15.50, 58.50],
+                "layer": {
+                    "upper": 150, "upperReference": "AGL",
+                    "lower": 0, "lowerReference": "AGL", "uom": "m"
+                },
+                "extent": {"subType": "Circle", "radius": 500.0}
+            },
+            "properties": {
+                "identifier": "ESU902",
+                "country": "SWE",
+                "name": [
+                    {"text": "Example power plant", "lang": "en-GB"},
+                    {"text": "Exempel kraftverk", "lang": "se-SE"}
+                ],
+                "variant": "COMMON",
+                "reason": ["SENSITIVE"],
+                "type": "REQ_AUTHORIZATION",
+                "restrictionConditions": "AUTHORIZED",
+                "otherReasonInfo": [{"lang": "en-GB", "text": "Security"}],
+                "regulationExemption": "NO",
+                "message": [{"lang": "en-GB", "text": "Example only."}],
+                "limitedApplicability": [
+                    {"startDateTime": "2025-10-27T00:00Z"}
+                ]
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [14.90, 58.90],
+                "layer": {
+                    "upper": 1500, "upperReference": "AMSL",
+                    "lower": 0, "lowerReference": "AGL", "uom": "ft"
+                },
+                "extent": {"subType": "Circle", "radius": 1852.0}
+            },
+            "properties": {
+                "identifier": "ESU903",
+                "country": "SWE",
+                "name": [
+                    {"text": "Example heliport", "lang": "en-GB"},
+                    {"text": "Exempel helikopterflygplats", "lang": "se-SE"}
+                ],
+                "variant": "COMMON",
+                "reason": ["AIR_TRAFFIC"],
+                "type": "CONDITIONAL",
+                "restrictionConditions": "AUTHORIZED",
+                "otherReasonInfo": [{"lang": "en-GB", "text": "UAS operations"}],
+                "regulationExemption": "NO",
+                "message": [{"lang": "en-GB", "text": "Example only."}],
+                "limitedApplicability": [
+                    {
+                        "startDateTime": "2026-01-01T00:00Z",
+                        "endDateTime": "2027-08-31T23:59Z",
+                        "schedule": [
+                            {"day": ["MON"], "startTime": "06:00Z", "endTime": "21:00Z"},
+                            {"day": ["TUE"], "startTime": "06:00Z", "endTime": "21:00Z"}
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/samples/airspace/ed318-se.json
+++ b/samples/airspace/ed318-se.json
@@ -41,7 +41,16 @@
                         "startDateTime": "2026-01-01T00:00Z",
                         "endDateTime": "2027-12-31T23:59Z"
                     }
-                ]
+                ],
+                "zoneAuthority": [
+                    {
+                        "name": [
+                            {"text": "Swedish Transport Agency", "lang": "en-GB"},
+                            {"text": "Transportstyrelsen", "lang": "se-SE"}
+                        ]
+                    }
+                ],
+                "extendedProperties": {"text": "SE: Example extended note"}
             }
         },
         {
@@ -71,6 +80,14 @@
                 "message": [{"lang": "en-GB", "text": "Example only."}],
                 "limitedApplicability": [
                     {"startDateTime": "2025-10-27T00:00Z"}
+                ],
+                "zoneAuthority": [
+                    {
+                        "name": [
+                            {"text": "Swedish Transport Agency", "lang": "en-GB"},
+                            {"text": "Transportstyrelsen", "lang": "se-SE"}
+                        ]
+                    }
                 ]
             }
         },
@@ -106,6 +123,14 @@
                         "schedule": [
                             {"day": ["MON"], "startTime": "06:00Z", "endTime": "21:00Z"},
                             {"day": ["TUE"], "startTime": "06:00Z", "endTime": "21:00Z"}
+                        ]
+                    }
+                ],
+                "zoneAuthority": [
+                    {
+                        "name": [
+                            {"text": "Swedish Transport Agency", "lang": "en-GB"},
+                            {"text": "Transportstyrelsen", "lang": "se-SE"}
                         ]
                     }
                 ]

--- a/src/dji_metadata_embedder/geo/airspace/ed318.py
+++ b/src/dji_metadata_embedder/geo/airspace/ed318.py
@@ -253,7 +253,7 @@ def parse_ed318(raw: bytes, source: SourceInfo) -> list[Zone]:
             upper = _limit(layer, "upper", unit, f"{where} ({ident})")
         if geometry.get("type") == "Point":
             polygons = [_point_circle(geometry, ident, where)]
-            holes = []
+            holes: list[list[tuple[float, float]]] = []
         else:
             polygons, holes = _rings(geometry, ident, where)
         if not polygons:

--- a/src/dji_metadata_embedder/geo/airspace/ed318.py
+++ b/src/dji_metadata_embedder/geo/airspace/ed318.py
@@ -8,8 +8,10 @@ timed windows are ``properties.limitedApplicability``. All-or-nothing like
 the ED-269 parser: any malformed zone raises rather than silently thinning
 the set.
 
-The published filenames are dated and versioned, so the registry pins the
-stable zones *page* and the current file href is discovered at fetch time.
+Ireland's published filename is dated and versioned
+(``20260804_uas_zones_ireland_v1.geojson``), so its registry entry pins the
+stable zones *page* and the current href is discovered at fetch time;
+Sweden's file URL is itself the stable address and is pinned directly.
 
 Permission record (issue #452): the IAA's Airspace & U-space Inspector
 rejected the ArcGIS service and pointed at this published file in reply to

--- a/src/dji_metadata_embedder/geo/airspace/ed318.py
+++ b/src/dji_metadata_embedder/geo/airspace/ed318.py
@@ -25,6 +25,7 @@ import re
 from dataclasses import dataclass
 from urllib.parse import urljoin
 
+from .dronezoner import _circle_ring
 from .ed269 import _utc
 from .model import Applicability, AirspaceError, SourceInfo, VerticalLimit, Zone
 
@@ -160,6 +161,37 @@ def _rings(
     return polygons, holes
 
 
+def _point_circle(
+    geometry: dict, ident: str, where: str
+) -> list[tuple[float, float]]:
+    """A Point zone's densified ring from its ED-318 Circle extent.
+
+    The profile publishes point zones as centre + ``extent`` of
+    ``{"subType": "Circle", "radius": <metres>}`` (the live Swedish file's
+    ESU247 radius is 1852.0 — exactly one nautical mile). Anything else is
+    a shape this parser has never seen live and fails loudly."""
+    extent = geometry.get("extent")
+    if not isinstance(extent, dict) or extent.get("subType") != "Circle":
+        raise AirspaceError(
+            f"{where} ({ident}): Point geometry without a Circle extent "
+            "is not supported"
+        )
+    radius = extent.get("radius")
+    if not isinstance(radius, (int, float)) or radius <= 0:
+        raise AirspaceError(
+            f"{where} ({ident}): Circle radius {radius!r} is not a "
+            "positive number of metres"
+        )
+    coords = geometry.get("coordinates") or []
+    try:
+        lon, lat = float(coords[0]), float(coords[1])
+    except (TypeError, ValueError, IndexError) as exc:
+        raise AirspaceError(
+            f"{where} ({ident}): malformed Point coordinates {coords!r}"
+        ) from exc
+    return _circle_ring(lon, lat, float(radius))
+
+
 def parse_ed318(raw: bytes, source: SourceInfo) -> list[Zone]:
     """Every zone of an ED-318 GeoJSON document as normalized :class:`Zone`s."""
     try:
@@ -219,7 +251,11 @@ def parse_ed318(raw: bytes, source: SourceInfo) -> list[Zone]:
             unit = "ft" if str(layer.get("uom", "M")).upper() == "FT" else "m"
             lower = _limit(layer, "lower", unit, f"{where} ({ident})")
             upper = _limit(layer, "upper", unit, f"{where} ({ident})")
-        polygons, holes = _rings(geometry, ident, where)
+        if geometry.get("type") == "Point":
+            polygons = [_point_circle(geometry, ident, where)]
+            holes = []
+        else:
+            polygons, holes = _rings(geometry, ident, where)
         if not polygons:
             raise AirspaceError(f"{where} ({ident}): no polygon geometry")
         zones.append(

--- a/src/dji_metadata_embedder/geo/airspace/ed318.py
+++ b/src/dji_metadata_embedder/geo/airspace/ed318.py
@@ -16,6 +16,12 @@ rejected the ArcGIS service and pointed at this published file in reply to
 our stated open-source reuse request, 2026-08-11. The page carries no
 formal licence; its "reference only, not to be used for navigation"
 wording is preserved in the feed note.
+
+Sweden's permission record (issue #510): LFV Operations UTM confirmed in
+writing on 2026-08-19 that the ED-318 file is free to download and use —
+cite LFV as source, no logos, do not modify the zone content. The file
+URL is the stable published address (until LFV system changes expected
+around 2027/2028), so the registry pins it directly with no discovery.
 """
 
 from __future__ import annotations
@@ -38,6 +44,9 @@ class Ed318Feed:
     license: str
     caveat: str
     note: str | None = None
+    # A stable direct file URL; when set, fetch skips page discovery and
+    # the record cites this URL (it IS the published address).
+    file_url: str | None = None
 
 
 _CAVEAT = (
@@ -62,6 +71,23 @@ ED318_FEEDS: dict[str, Ed318Feed] = {
         note=(
             "IAA publication note: reference only — not to be used for "
             "navigation."
+        ),
+    ),
+    "SE": Ed318Feed(
+        code="SE",
+        page_url="https://dronechart.lfv.se/",
+        file_url="https://dronechart.lfv.se/data/uas_zones_ED318.json",
+        feed_name="Sweden UAS geographical zones (ED-318, LFV)",
+        license=(
+            "© LFV — free to download and use, cite LFV as source "
+            "(confirmed in writing by LFV Operations UTM, 2026-08-19)"
+        ),
+        caveat=_CAVEAT,
+        note=(
+            "Published by LFV with Transportstyrelsen as data provider. "
+            "Some zones apply only during scheduled hours within their "
+            "validity window; the schedule is in the zone's published "
+            "data and is not evaluated here."
         ),
     ),
 }

--- a/src/dji_metadata_embedder/geo/airspace/ed318.py
+++ b/src/dji_metadata_embedder/geo/airspace/ed318.py
@@ -1,14 +1,14 @@
 """ED-318 GeoJSON-profile UAS geographical-zone parser (#452).
 
-Ireland's official publication (iaa.ie) is a plain GeoJSON
-FeatureCollection in the ED-318 shape: zone fields live in ``properties``
-(restriction class under ``type``), vertical limits ride in a non-standard
-``layer`` member inside each feature's ``geometry``, and timed windows are
-``properties.limitedApplicability``. All-or-nothing like the ED-269
-parser: any malformed zone raises rather than silently thinning the set.
+Ireland's (iaa.ie) and Sweden's (LFV dronechart) official publications are
+plain GeoJSON FeatureCollections in the ED-318 shape: zone fields live in
+``properties`` (restriction class under ``type``), vertical limits ride in
+a non-standard ``layer`` member inside each feature's ``geometry``, and
+timed windows are ``properties.limitedApplicability``. All-or-nothing like
+the ED-269 parser: any malformed zone raises rather than silently thinning
+the set.
 
-The published filename is dated and versioned
-(``20260804_uas_zones_ireland_v1.geojson``), so the registry pins the
+The published filenames are dated and versioned, so the registry pins the
 stable zones *page* and the current file href is discovered at fetch time.
 
 Permission record (issue #452): the IAA's Airspace & U-space Inspector
@@ -97,6 +97,38 @@ def _limit(layer: dict, side: str, unit: str, where: str) -> VerticalLimit | Non
     if not isinstance(value, (int, float)):
         raise AirspaceError(f"{where}: {side} limit {value!r} is not a number")
     return VerticalLimit(float(value), unit, ref)
+
+
+def _zone_name(props: dict, ident: str, where: str) -> str:
+    """The zone's display name; multilingual lists pick the English text.
+
+    The Swedish file publishes ``name`` as a list of ``{text, lang}``
+    entries (en-GB + se-SE); Ireland publishes a plain string. The
+    original list rides untouched in ``native``."""
+    raw = props.get("name")
+    if raw is None or isinstance(raw, str):
+        return str(raw or ident)
+    if isinstance(raw, list):
+        texts = [
+            entry["text"].strip()
+            for entry in raw
+            if isinstance(entry, dict)
+            and isinstance(entry.get("text"), str)
+            and entry["text"].strip()
+        ]
+        english = [
+            entry["text"].strip()
+            for entry in raw
+            if isinstance(entry, dict)
+            and entry.get("lang") == "en-GB"
+            and isinstance(entry.get("text"), str)
+            and entry["text"].strip()
+        ]
+        if english:
+            return english[0]
+        if texts:
+            return texts[0]
+    raise AirspaceError(f"{where} ({ident}): unusable name {raw!r}")
 
 
 def _rings(
@@ -193,7 +225,7 @@ def parse_ed318(raw: bytes, source: SourceInfo) -> list[Zone]:
         zones.append(
             Zone(
                 identifier=ident,
-                name=str(props.get("name") or ident),
+                name=_zone_name(props, ident, where),
                 restriction=restriction,
                 lower=lower,
                 upper=upper,

--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -139,10 +139,11 @@ def fetch_zones(
         body_path = cache_dir / f"ed318-{code}.json"
         feed_name = feed318.feed_name
         license_line, caveat = feed318.license, feed318.caveat
-        # The published filename is dated and churns; the zones page is
-        # the stable, user-checkable entry point, so it is what the
-        # record cites. The current file href is discovered per fetch.
-        url = feed318.page_url
+        # IE's published filename is dated and churns, so its registry
+        # pins the stable zones page and the current href is discovered
+        # per fetch. SE's file URL is itself the stable published
+        # address (LFV, 2026-08-19), fetched and cited directly.
+        url = feed318.file_url or feed318.page_url
         note = feed318.note
     elif code in DRONEZONER_FEEDS:
         feed_dz = DRONEZONER_FEEDS[code]
@@ -181,8 +182,11 @@ def fetch_zones(
             elif code in ED269_FEEDS:
                 body = _fetch_url(url, transport)
             elif code in ED318_FEEDS:
-                page = _fetch_url(url, transport)
-                body = _fetch_url(discover_feed_url(page, url), transport)
+                if feed318.file_url:
+                    body = _fetch_url(url, transport)
+                else:
+                    page = _fetch_url(url, transport)
+                    body = _fetch_url(discover_feed_url(page, url), transport)
             elif code in DRONEZONER_FEEDS:
                 page = _fetch_url(url, transport)
                 body = _fetch_url(

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -135,9 +135,11 @@ _CORE: dict[str, list[Box]] = {
     # 26 edge probes Nominatim-verified 2026-08-19: Swedish markers
     # (Malmö, Vinga, Grisslehamn, Halmstad, Kalix coast, Kiruna, Fårö…)
     # resolve SE inside the cores, foreign markers (Saltholm/Læsø/Anholt
-    # DK, Halden NO, Eckerö and Valsörarna FI) sit outside them. The
-    # Norwegian Trysil-area bulge probes SE at 12.75–12.9E (61.0–61.7N),
-    # so the inland 13.4 west edge keeps >=27 km. Deliberate gaps, each
+    # DK, Halden NO, Eckerö and Valsörarna FI) sit outside them. Probes
+    # at 12.75–12.9E (61.0–61.7N), near the Trysil-area bulge on the
+    # Norwegian side of the border, resolve SE — confirming Norway's
+    # easternmost reach there sits west of 12.9E, so the inland 13.4
+    # west edge keeps >=27 km of margin. Deliberate gaps, each
     # an honest border band: the Öresund shore north of Malmö (Ven,
     # Landskrona, Helsingborg, Kullen/Bjäre), Strömstad and the
     # Norway-border strip, the mountain municipalities (Sälen, Åre),
@@ -154,7 +156,7 @@ _CORE: dict[str, list[Box]] = {
         (13.4, 59.7, 18.9, 61.5),      # north Svealand (Märket FI >=13 km E)
         (14.5, 61.5, 20.6, 63.6),      # lower Norrland (Kvarken FI >=23 km E)
         (17.5, 63.6, 23.2, 65.95),     # upper Norrland coast (Umeå, Luleå, Boden)
-        (18.9, 65.95, 22.4, 67.2),     # Jokkmokk/Gällivare (Torne border >=40 km E)
+        (18.9, 65.95, 22.4, 67.5),     # Jokkmokk/Gällivare (Torne border >=40 km E)
         (19.6, 67.5, 21.6, 68.0),      # Kiruna
     ],
 }
@@ -196,7 +198,7 @@ _HULL: dict[str, list[Box]] = {
     # (Konstanz semantics). Oslo stays outside entirely (west of 10.9).
     "SE": [
         (10.9, 55.05, 19.7, 61.0),     # Götaland + Svealand + approaches
-        (14.0, 61.0, 24.3, 66.4),      # Norrland + the Bothnian sea
+        (13.4, 61.0, 24.3, 66.4),      # Norrland + the Bothnian sea
         (16.3, 66.4, 24.2, 69.3),      # Lapland up to Treriksröset
     ],
 }

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -142,9 +142,10 @@ _CORE: dict[str, list[Box]] = {
     # west edge keeps >=27 km of margin. Deliberate gaps, each
     # an honest border band: the Öresund shore north of Malmö (Ven,
     # Landskrona, Helsingborg, Kullen/Bjäre), Strömstad and the
-    # Norway-border strip, the mountain municipalities (Sälen, Åre),
-    # the Torne valley (Haparanda, Karesuando), and the outer Stockholm
-    # archipelago beyond the Åland margin.
+    # Norway-border strip, the Torne valley (Haparanda, Karesuando),
+    # and the outer Stockholm archipelago beyond the Åland margin.
+    # The mountain municipalities (Sälen, Åre) sit west of the hull
+    # entirely, so they get the no-provider message, not the band one.
     "SE": [
         (12.95, 55.33, 16.05, 56.45),  # Skåne + Blekinge (Saltholm DK >=10 km W)
         (12.0, 56.45, 12.95, 57.15),   # Halland coast (Anholt DK >=21 km W)

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -130,6 +130,33 @@ _CORE: dict[str, list[Box]] = {
         (10.85, 57.1, 11.25, 57.35),   # Læsø
         (11.38, 56.6, 11.78, 56.78),   # Anholt
     ],
+    # Long land borders with Norway (west) and Finland (the Torne/Muonio
+    # valley, northeast), plus the Öresund narrows against Denmark. All
+    # 26 edge probes Nominatim-verified 2026-08-19: Swedish markers
+    # (Malmö, Vinga, Grisslehamn, Halmstad, Kalix coast, Kiruna, Fårö…)
+    # resolve SE inside the cores, foreign markers (Saltholm/Læsø/Anholt
+    # DK, Halden NO, Eckerö and Valsörarna FI) sit outside them. The
+    # Norwegian Trysil-area bulge probes SE at 12.75–12.9E (61.0–61.7N),
+    # so the inland 13.4 west edge keeps >=27 km. Deliberate gaps, each
+    # an honest border band: the Öresund shore north of Malmö (Ven,
+    # Landskrona, Helsingborg, Kullen/Bjäre), Strömstad and the
+    # Norway-border strip, the mountain municipalities (Sälen, Åre),
+    # the Torne valley (Haparanda, Karesuando), and the outer Stockholm
+    # archipelago beyond the Åland margin.
+    "SE": [
+        (12.95, 55.33, 16.05, 56.45),  # Skåne + Blekinge (Saltholm DK >=10 km W)
+        (12.0, 56.45, 12.95, 57.15),   # Halland coast (Anholt DK >=21 km W)
+        (11.55, 57.15, 12.3, 58.55),   # west coast, Gothenburg (Læsø DK >=19 km W)
+        (16.3, 56.15, 17.2, 57.4),     # Öland
+        (17.9, 56.85, 19.4, 58.0),     # Gotland incl. Fårö
+        (12.3, 56.35, 19.2, 58.9),     # Götaland interior + east coast
+        (13.4, 58.9, 19.3, 59.7),      # south Svealand (Stockholm, Karlstad)
+        (13.4, 59.7, 18.9, 61.5),      # north Svealand (Märket FI >=13 km E)
+        (14.5, 61.5, 20.6, 63.6),      # lower Norrland (Kvarken FI >=23 km E)
+        (17.5, 63.6, 23.2, 65.95),     # upper Norrland coast (Umeå, Luleå, Boden)
+        (18.9, 65.95, 22.4, 67.2),     # Jokkmokk/Gällivare (Torne border >=40 km E)
+        (19.6, 67.5, 21.6, 68.0),      # Kiruna
+    ],
 }
 _HULL: dict[str, list[Box]] = {
     "US": [
@@ -163,12 +190,21 @@ _HULL: dict[str, list[Box]] = {
         (11.0, 54.5, 12.78, 57.4),     # Zealand / Lolland-Falster / Øresund
         (14.6, 54.9, 15.35, 55.38),    # Bornholm
     ],
+    # Læsø, Bornholm and the Copenhagen shore sit inside the south hull
+    # deliberately and resolve DK via its cores (#499 tie-break); Halden,
+    # Åland and the Tornio strip sit inside as honest border bands
+    # (Konstanz semantics). Oslo stays outside entirely (west of 10.9).
+    "SE": [
+        (10.9, 55.05, 19.7, 61.0),     # Götaland + Svealand + approaches
+        (14.0, 61.0, 24.3, 66.4),      # Norrland + the Bothnian sea
+        (16.3, 66.4, 24.2, 69.3),      # Lapland up to Treriksröset
+    ],
 }
 # CH takes the EU measure: Regulation (EU) 2019/947 applies in Switzerland
 # since 2023-01-01 under the CH-EU air transport agreement.
 _MEASURE = {
     "US": MEASURE_US, "LU": MEASURE_EU, "FI": MEASURE_EU, "CH": MEASURE_EU,
-    "IE": MEASURE_EU, "GB": MEASURE_UK, "DK": MEASURE_EU,
+    "IE": MEASURE_EU, "GB": MEASURE_UK, "DK": MEASURE_EU, "SE": MEASURE_EU,
 }
 
 
@@ -200,7 +236,7 @@ def resolve_jurisdiction(track: Track) -> Resolution:
             None,
             "no supported airspace data source for this location "
             "(covered: the US, Luxembourg, Finland, Switzerland, "
-            "Ireland, the UK and Denmark)",
+            "Ireland, the UK, Denmark and Sweden)",
         )
     cores = [code for code in hulls if _all_inside(track, _CORE[code])]
     if len(cores) != 1:

--- a/src/dji_metadata_embedder/geo/airspace/overlay.py
+++ b/src/dji_metadata_embedder/geo/airspace/overlay.py
@@ -80,6 +80,10 @@ def zones_to_overlay_json(
             line = f"Airspace: {data.source.feed}, fetched {data.source.fetched}"
             if line not in notes:
                 notes.append(line)
+            if data.source.note:
+                note_line = f"Airspace note: {data.source.note}"
+                if note_line not in notes:
+                    notes.append(note_line)
         report = evaluate(track, data.zones)
         for zone in data.zones:
             key = (zone.source.feed, zone.identifier)

--- a/tests/test_airspace_ed318.py
+++ b/tests/test_airspace_ed318.py
@@ -144,22 +144,15 @@ def _se() -> bytes:
 # --- schedule-carrying windows, minute-precision timestamps.
 
 
-def _se_polygon_only() -> bytes:
-    """Fixture with only the Polygon feature (ESU901) for Task 1 tests."""
-    doc = json.loads(_se().decode("utf-8"))
-    doc["features"] = [doc["features"][0]]  # Keep only ESU901 (Polygon)
-    return json.dumps(doc).encode()
-
-
 def test_multilingual_name_picks_english_and_keeps_swedish_in_native():
-    zones = parse_ed318(_se_polygon_only(), SRC)
+    zones = parse_ed318(_se(), SRC)
     assert zones[0].name == "Example test range"
     native_name = zones[0].native["properties"]["name"]
     assert {"text": "Exempel testområde", "lang": "se-SE"} in native_name
 
 
 def test_multilingual_name_falls_back_to_first_entry_without_english():
-    doc = json.loads(_se_polygon_only().decode("utf-8"))
+    doc = json.loads(_se().decode("utf-8"))
     doc["features"][0]["properties"]["name"] = [
         {"text": "Bara svenska", "lang": "se-SE"}
     ]
@@ -168,14 +161,14 @@ def test_multilingual_name_falls_back_to_first_entry_without_english():
 
 
 def test_name_list_without_usable_text_raises():
-    doc = json.loads(_se_polygon_only().decode("utf-8"))
+    doc = json.loads(_se().decode("utf-8"))
     doc["features"][0]["properties"]["name"] = [{"lang": "en-GB"}]
     with pytest.raises(AirspaceError, match="ESU901.*name"):
         parse_ed318(json.dumps(doc).encode(), SRC)
 
 
 def test_minute_precision_windows_parse():
-    zones = parse_ed318(_se_polygon_only(), SRC)
+    zones = parse_ed318(_se(), SRC)
     win = zones[0].applicability[0]
     assert win.start == datetime(2026, 1, 1, 0, 0)
     assert win.end == datetime(2027, 12, 31, 23, 59)
@@ -186,3 +179,56 @@ def test_start_only_window_is_open_ended():
     win = zones[1].applicability[0]
     assert win.start == datetime(2025, 10, 27, 0, 0)
     assert win.end is None and win.permanent is False
+
+
+def test_point_circle_zones_become_densified_rings():
+    zones = parse_ed318(_se(), SRC)
+    assert [z.identifier for z in zones] == ["ESU901", "ESU902", "ESU903"]
+    circle = zones[1]
+    ring = circle.polygons[0]
+    assert len(ring) >= 32 and ring[0] == ring[-1]
+    # Every ring point sits ~500 m from the published centre.
+    import math
+    for lon, lat in ring[:8]:
+        dy = (lat - 58.50) * 111_320.0
+        dx = (lon - 15.50) * 111_320.0 * math.cos(math.radians(58.50))
+        assert 450.0 < math.hypot(dx, dy) < 550.0
+    assert circle.holes == []
+    assert circle.native["geometry"]["extent"]["radius"] == 500.0
+
+
+def test_mixed_datum_feet_circle_keeps_per_side_references():
+    heliport = parse_ed318(_se(), SRC)[2]
+    assert heliport.lower is not None and heliport.lower.label() == "0 ft AGL"
+    assert heliport.upper is not None and heliport.upper.label() == "1500 ft AMSL"
+
+
+def test_schedule_rides_in_native_and_outer_bounds_drive_the_window():
+    heliport = parse_ed318(_se(), SRC)[2]
+    assert len(heliport.applicability) == 1
+    win = heliport.applicability[0]
+    assert win.start == datetime(2026, 1, 1, 0, 0)
+    assert win.end == datetime(2027, 8, 31, 23, 59)
+    native_window = heliport.native["properties"]["limitedApplicability"][0]
+    assert native_window["schedule"][0]["day"] == ["MON"]
+
+
+def test_point_without_circle_extent_raises():
+    doc = json.loads(_se().decode("utf-8"))
+    del doc["features"][1]["geometry"]["extent"]
+    with pytest.raises(AirspaceError, match="ESU902.*Circle"):
+        parse_ed318(json.dumps(doc).encode(), SRC)
+
+
+def test_non_circle_extent_subtype_raises():
+    doc = json.loads(_se().decode("utf-8"))
+    doc["features"][1]["geometry"]["extent"]["subType"] = "Ellipse"
+    with pytest.raises(AirspaceError, match="ESU902.*Circle"):
+        parse_ed318(json.dumps(doc).encode(), SRC)
+
+
+def test_non_positive_circle_radius_raises():
+    doc = json.loads(_se().decode("utf-8"))
+    doc["features"][1]["geometry"]["extent"]["radius"] = 0
+    with pytest.raises(AirspaceError, match="ESU902.*radius"):
+        parse_ed318(json.dumps(doc).encode(), SRC)

--- a/tests/test_airspace_ed318.py
+++ b/tests/test_airspace_ed318.py
@@ -232,3 +232,15 @@ def test_non_positive_circle_radius_raises():
     doc["features"][1]["geometry"]["extent"]["radius"] = 0
     with pytest.raises(AirspaceError, match="ESU902.*radius"):
         parse_ed318(json.dumps(doc).encode(), SRC)
+
+
+def test_se_feed_registry_states_the_lfv_terms():
+    feed = ED318_FEEDS["SE"]
+    assert feed.file_url == (
+        "https://dronechart.lfv.se/data/uas_zones_ED318.json"
+    )
+    assert "cite LFV as source" in feed.license
+    assert "2026-08-19" in feed.license
+    assert "schedule" in (feed.note or "")
+    # Ireland keeps the discovery path: no direct URL.
+    assert ED318_FEEDS["IE"].file_url is None

--- a/tests/test_airspace_ed318.py
+++ b/tests/test_airspace_ed318.py
@@ -133,3 +133,56 @@ def test_discover_feed_url_finds_the_dated_file_on_the_page():
 def test_discover_feed_url_raises_when_the_page_changed_shape():
     with pytest.raises(AirspaceError, match="zones file"):
         discover_feed_url(b"<html>redesigned</html>", "https://www.iaa.ie/")
+
+
+def _se() -> bytes:
+    return (FIXTURES / "ed318-se.json").read_bytes()
+
+
+# --- Sweden (#510): the LFV file exercises ED-318 shapes Ireland's
+# --- publication does not — multilingual names, Point+Circle extents,
+# --- schedule-carrying windows, minute-precision timestamps.
+
+
+def _se_polygon_only() -> bytes:
+    """Fixture with only the Polygon feature (ESU901) for Task 1 tests."""
+    doc = json.loads(_se().decode("utf-8"))
+    doc["features"] = [doc["features"][0]]  # Keep only ESU901 (Polygon)
+    return json.dumps(doc).encode()
+
+
+def test_multilingual_name_picks_english_and_keeps_swedish_in_native():
+    zones = parse_ed318(_se_polygon_only(), SRC)
+    assert zones[0].name == "Example test range"
+    native_name = zones[0].native["properties"]["name"]
+    assert {"text": "Exempel testområde", "lang": "se-SE"} in native_name
+
+
+def test_multilingual_name_falls_back_to_first_entry_without_english():
+    doc = json.loads(_se_polygon_only().decode("utf-8"))
+    doc["features"][0]["properties"]["name"] = [
+        {"text": "Bara svenska", "lang": "se-SE"}
+    ]
+    zones = parse_ed318(json.dumps(doc).encode(), SRC)
+    assert zones[0].name == "Bara svenska"
+
+
+def test_name_list_without_usable_text_raises():
+    doc = json.loads(_se_polygon_only().decode("utf-8"))
+    doc["features"][0]["properties"]["name"] = [{"lang": "en-GB"}]
+    with pytest.raises(AirspaceError, match="ESU901.*name"):
+        parse_ed318(json.dumps(doc).encode(), SRC)
+
+
+def test_minute_precision_windows_parse():
+    zones = parse_ed318(_se_polygon_only(), SRC)
+    win = zones[0].applicability[0]
+    assert win.start == datetime(2026, 1, 1, 0, 0)
+    assert win.end == datetime(2027, 12, 31, 23, 59)
+
+
+def test_start_only_window_is_open_ended():
+    zones = parse_ed318(_se(), SRC)
+    win = zones[1].applicability[0]
+    assert win.start == datetime(2025, 10, 27, 0, 0)
+    assert win.end is None and win.permanent is False

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -75,11 +75,13 @@ def test_a_us_flight_routes_to_the_faa_provider(tmp_path):
     assert "arcgis" in fake.urls[0]
 
 
-def test_a_swedish_flight_is_a_stated_gap_without_network(tmp_path):
+def test_an_oslo_flight_is_a_stated_gap_without_network(tmp_path):
+    # #510: Sweden now has a provider, so this no-provider-gap example
+    # moves to Oslo (outside every hull, including the new SE one).
     def no_network(req, timeout=None):
         raise AssertionError("gap must not touch the network")
 
-    data = fetch_zones(_track(59.33, 18.07), tmp_path, transport=no_network)
+    data = fetch_zones(_track(59.91, 10.75), tmp_path, transport=no_network)
     assert data.gap_reason is not None and not data.zones
 
 
@@ -334,4 +336,33 @@ def test_a_redesigned_danish_page_is_a_stated_gap(tmp_path):
     assert not data.zones
     assert data.gap_reason is not None
     assert "droneregler.dk" in data.gap_reason
+
+
+def test_a_swedish_flight_fetches_the_lfv_file_directly(tmp_path):
+    # #510: LFV's URL is the stable published address — one fetch, no
+    # page discovery, and the record cites the file URL itself.
+    fake = FakeTransport([(FIXTURES / "ed318-se.json").read_bytes()])
+    lines = []
+    data = fetch_zones(_track(59.33, 18.07), tmp_path, transport=fake,
+                       announce=lines.append)
+    assert data.gap_reason is None and len(data.zones) == 3
+    assert fake.urls == [
+        "https://dronechart.lfv.se/data/uas_zones_ED318.json"
+    ]
+    assert data.source is not None and "cite LFV as source" in data.source.license
+    assert data.source.url.endswith("uas_zones_ED318.json")
+    assert (tmp_path / "ed318-SE.json").exists()
+    assert any("Fetching" in ln and "dronechart.lfv.se" in ln for ln in lines)
+    circle = next(z for z in data.zones if z.identifier == "ESU902")
+    assert len(circle.polygons[0]) >= 32
+
+
+def test_a_cached_swedish_body_never_touches_the_network(tmp_path):
+    fake = FakeTransport([(FIXTURES / "ed318-se.json").read_bytes()])
+    fetch_zones(_track(59.33, 18.07), tmp_path, transport=fake)
+
+    def no_network(req, timeout=None):
+        raise AssertionError("cached run must not touch the network")
+    data = fetch_zones(_track(59.33, 18.07), tmp_path, transport=no_network)
+    assert data.from_cache and len(data.zones) == 3
 

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -409,3 +409,19 @@ def test_oslo_stays_outside_the_se_hull_entirely():
     assert r.jurisdiction is None
     assert r.gap_reason is not None and "Sweden" in r.gap_reason
 
+
+def test_svappavaara_resolves_se_closing_the_67_2_to_67_5_hole():
+    # #510 M2: core 11 used to stop at 67.2N, leaving a band up to core
+    # 12's 67.5N start unreachable even though it's Swedish interior.
+    # Nominatim-verified 2026-08-19 at (67.35, 20.50).
+    r = resolve_jurisdiction(_track((67.35, 20.50)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
+
+
+def test_transtrand_resolves_se_now_the_hull_reaches_the_whole_core():
+    # #510 M3: core 8 topped out at 61.5N but the Norrland hull box
+    # stopped at 14.0E, leaving 13.4-14.0E x 61.0-61.5N inside the core
+    # but outside every hull. Transtrand area, west Dalarna.
+    r = resolve_jurisdiction(_track((61.2, 13.7)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
+

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -27,10 +27,10 @@ def test_a_helsinki_flight_resolves_to_fi():
     assert r.jurisdiction is not None and r.jurisdiction.code == "FI"
 
 
-def test_a_swedish_flight_is_an_honest_gap():
-    r = resolve_jurisdiction(_track((59.33, 18.07)))  # Stockholm
-    assert r.jurisdiction is None
-    assert r.gap_reason is not None and "no supported airspace data" in r.gap_reason
+def test_a_stockholm_flight_resolves_to_se_with_the_eu_measure():
+    r = resolve_jurisdiction(_track((59.33, 18.07)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
+    assert "2019/947" in r.jurisdiction.measure_note
 
 
 def test_a_border_band_flight_gaps_instead_of_guessing():
@@ -337,12 +337,6 @@ def test_helsingborg_sweden_gaps_instead_of_resolving_dk():
     assert r.gap_reason is not None and "boundary" in r.gap_reason
 
 
-def test_malmo_is_an_honest_no_provider_gap():
-    r = resolve_jurisdiction(_track((55.60, 13.00)))
-    assert r.jurisdiction is None
-    assert r.gap_reason is not None and "no supported airspace data" in r.gap_reason
-
-
 def test_flensburg_germany_gaps_instead_of_resolving_dk():
     r = resolve_jurisdiction(_track((54.79, 9.43)))
     assert r.jurisdiction is None
@@ -352,4 +346,66 @@ def test_flensburg_germany_gaps_instead_of_resolving_dk():
 def test_the_no_provider_message_names_denmark():
     r = resolve_jurisdiction(_track((48.85, 2.35)))  # Paris
     assert r.gap_reason is not None and "Denmark" in r.gap_reason
+
+
+# --- Sweden (LFV Dronezoner via ED-318) ---
+
+
+def test_gothenburg_resolves_to_se():
+    r = resolve_jurisdiction(_track((57.71, 11.97)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
+
+
+def test_malmo_resolves_to_se_despite_the_oresund():
+    # Malmö sits ~13 km from Danish Saltholm; the core's 12.95 west edge
+    # keeps it in while the Öresund shore north of it gaps.
+    r = resolve_jurisdiction(_track((55.61, 13.00)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
+
+
+def test_visby_gotland_resolves_to_se():
+    r = resolve_jurisdiction(_track((57.64, 18.30)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
+
+
+def test_kiruna_resolves_to_se():
+    r = resolve_jurisdiction(_track((67.86, 20.22)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
+
+
+def test_umea_and_lulea_resolve_through_the_norrland_coast_core():
+    r = resolve_jurisdiction(_track((63.83, 20.26), (65.58, 22.15)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
+
+
+def test_helsingborg_gaps_as_an_oresund_border_band():
+    # 4.5 km strait to Helsingør: inside the hull, outside every core —
+    # the mirror of Helsingør's cut on the Danish side.
+    r = resolve_jurisdiction(_track((56.05, 12.70)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "boundary" in r.gap_reason
+
+
+def test_halden_norway_gaps_instead_of_resolving_se():
+    r = resolve_jurisdiction(_track((59.12, 11.39)))
+    assert r.jurisdiction is None
+
+
+def test_eckero_aland_still_gaps():
+    # Åland: inside the FI and SE hulls, inside neither's cores.
+    r = resolve_jurisdiction(_track((60.22, 19.55)))
+    assert r.jurisdiction is None
+
+
+def test_copenhagen_still_resolves_dk_with_the_se_hull_overlapping():
+    # Kastrup sits inside the new SE south hull; the DK core breaks the
+    # tie (#499 semantics).
+    r = resolve_jurisdiction(_track((55.63, 12.65)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "DK"
+
+
+def test_oslo_stays_outside_the_se_hull_entirely():
+    r = resolve_jurisdiction(_track((59.91, 10.75)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "Sweden" in r.gap_reason
 

--- a/tests/test_airspace_overlay.py
+++ b/tests/test_airspace_overlay.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from dji_metadata_embedder.geo.airspace.ed269 import ED269_FEEDS, parse_ed269
+from dji_metadata_embedder.geo.airspace.ed318 import ED318_FEEDS, parse_ed318
 from dji_metadata_embedder.geo.airspace.fetch import AirspaceData
 from dji_metadata_embedder.geo.airspace.model import SourceInfo, VerticalLimit, Zone
 from dji_metadata_embedder.geo.airspace.overlay import zones_to_overlay_json
@@ -116,6 +117,33 @@ def test_notes_provenance_line_once_and_gap_lines():
     provenance = [n for n in out["notes"] if source.feed in n]
     assert provenance == [f"Airspace: {source.feed}, fetched {source.fetched}"]
     assert any(n.startswith("Airspace, B:") for n in out["notes"])
+
+
+def test_source_note_reaches_the_map_notes_once():
+    # #510 I3: the schedule/reference-only disclosures that ride in
+    # SourceInfo.note must reach the overlay, not just the record.
+    feed = ED318_FEEDS["SE"]
+    source = SourceInfo(
+        feed=feed.feed_name, url=feed.file_url, fetched="2026-08-19T10:00:00Z",
+        license=feed.license, caveat=feed.caveat, note=feed.note,
+    )
+    zones = parse_ed318((SAMPLES / "ed318-se.json").read_bytes(), source)
+    data = [
+        AirspaceData(zones=zones, source=source),
+        AirspaceData(zones=list(zones), source=source),  # second track, same feed
+    ]
+    out = zones_to_overlay_json([_track_far("A"), _track_far("B")], data)
+    note_lines = [n for n in out["notes"] if n == f"Airspace note: {source.note}"]
+    assert note_lines == [f"Airspace note: {source.note}"]
+
+
+def test_source_without_note_adds_no_note_line():
+    zones, source = _lu_zones()
+    assert source.note is None
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(zones=zones, source=source)]
+    )
+    assert not any(n.startswith("Airspace note:") for n in out["notes"])
 
 
 def test_all_gapped_is_not_covered_but_notes_survive():

--- a/tests/test_geo_record.py
+++ b/tests/test_geo_record.py
@@ -80,9 +80,11 @@ def test_a_gap_jurisdiction_still_yields_the_logbook_half(tmp_path, monkeypatch)
     def no_network(req, timeout=None):
         raise AssertionError("a gap flight must not touch the network")
 
-    pts = [TrackPoint(lat=59.33, lon=18.07, alt=50, timestamp="c",
+    # Oslo: deliberately outside every hull (Sweden's starts at 10.9E), so
+    # this stays a no-provider gap now that Swedish flights resolve (#510).
+    pts = [TrackPoint(lat=59.91, lon=10.75, alt=50, timestamp="c",
                       utc=datetime(2026, 7, 30, 12, 0), rel_alt=20)]
-    rec = build_records([Track(name="SWE", points=pts)], cache_dir=tmp_path,
+    rec = build_records([Track(name="NOR", points=pts)], cache_dir=tmp_path,
                         transport=no_network)[0]
     assert rec.airspace.gap_reason is not None
     assert rec.measure_note is None  # no borrowed framing


### PR DESCRIPTION
Closes #510.

Eighth airspace country. LFV confirmed reuse in writing on 2026-08-19 (permission record on the issue): free to download and use, cite LFV as source, no logos, zone content unmodified.

- Shared ED-318 parser grows three spec-level capabilities the Swedish file exercises (Ireland's fixture parses unchanged): multilingual name lists (en-GB picked, Swedish original in `native`), Point+Circle extents densified via the existing circle helper, and schedule-carrying windows (outer bounds modelled; the schedule rides in `native` and the feed note says so).
- `Ed318Feed.file_url`: LFV's URL is the stable published address, so SE fetches and cites it directly — Ireland keeps page discovery.
- SE jurisdiction cores/hull, 28 edge probes Nominatim-verified 2026-08-19; Öresund/Norway/Torne border bands gap honestly; the overlapping DK/FI hulls resolve via the #499 core tie-break (Copenhagen stays DK, Åland still gaps).
- Feed notes now ride into the map overlay's notes lines (review finding): the Swedish schedule disclosure, Ireland's reference-only wording and the GB/DK NOTAM caveats all reach the map, matching what docs/geospatial.md already claimed.
- Docs and GUI tooltip coverage lists updated; three pre-existing tests that used Swedish coordinates as "no provider" examples re-pointed (Oslo) or removed as superseded (Malmö now resolves SE by design).
- Live E2E against the real feed: 62 zones = 48 polygons + 14 circles, Säve Heliport's mixed-datum limits verified (0 ft AGL → 1500 ft AMSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YnYQZrCKXHCUEHkGWme6j