### PR TITLE
feat(geo): Estonia UAS geographical zones via EANS's uas.geojson (#511)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -437,9 +437,13 @@ rides into the map — the UK via the NATS AIS AIXM 5.1 dataset, whose
 activation hours and temporary restrictions live in the AIP and NOTAMs,
 not in the file — that caveat rides along too — Denmark via
 Trafikstyrelsen's drone-zone dataset, which likewise leaves NOTAM-driven
-temporaries to the AIP, and Sweden via LFV's ED-318 file, where a few
+temporaries to the AIP, Sweden via LFV's ED-318 file, where a few
 zones apply only during scheduled hours within their published windows —
-the schedule stays in the zone's published data and is not evaluated).
+the schedule stays in the zone's published data and is not evaluated,
+and Estonia via EANS's published zones file, which reflects the rules
+at the time of download rather than the time of the flight — that
+caveat rides along, and NOTAM activation hours stay as text in the
+zone's published message).
 Zones draw in one neutral
 style; clicking one shows the published facts: restriction class, vertical
 limits (or "not stated"), applicability windows, and the feed, license and

--- a/docs/how-to/flight-record.md
+++ b/docs/how-to/flight-record.md
@@ -34,7 +34,7 @@ takeoff-referenced height, which is aircraft-reported. The
 surface-referenced height is the exception — it needs a fetch from
 Mapterhorn's terrain tiles (see "The `[terrain]` extra" below).
 
-Five feeds are used:
+Six feeds are used:
 
 - **US flights** query the FAA's UAS Facility Map (keyless ArcGIS). The
   bounding box sent to the endpoint is padded and snapped outward to a
@@ -55,6 +55,13 @@ Five feeds are used:
   (the file behind droneregler.dk), once more with no location sent.
   NOTAM-driven temporary restrictions are not part of that dataset
   either; the record says so.
+- **Estonia** flights fetch EANS's whole UAS geographical-zone file
+  (attributed to Estonian Air Navigation Services, confirmed in writing
+  as public data), again with no location sent. The file reflects the
+  rules at the time of download rather than the time of the flight, and
+  NOTAM activation hours live only as text in the zone's published
+  message, not a machine-readable field; the record says so on both
+  counts.
 - **Every flight**, regardless of jurisdiction, fetches surface-height
   tiles from Mapterhorn (`tiles.mapterhorn.com`) for the surface-referenced
   height estimate, when the `[terrain]` extra is installed.
@@ -69,12 +76,13 @@ nothing without `-f record`; terrain tiles are unaffected by this flag).
 dji-embed flightmap ./flights -f record --airspace-refresh
 ```
 
-## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark, Sweden — and an honest gap everywhere else
+## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark, Sweden, Estonia — and an honest gap everywhere else
 
 Airspace lookup only resolves for flights that sit clearly inside the
 United States, Luxembourg, Finland, Switzerland, Ireland, the UK,
-Denmark, or Sweden. Everywhere else the record states the gap instead
-of guessing: *"no supported airspace data source for this location."*
+Denmark, Sweden, or Estonia. Everywhere else the record states the gap
+instead of guessing: *"no supported airspace data source for this
+location."*
 A flight near a jurisdiction boundary gaps the same way, deliberately,
 rather than borrowing a neighbouring country's rules from coordinates
 alone. The logbook half of the record (times, distances, heights) is

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -335,7 +335,7 @@
                                                   IsEnabled="{Binding !FlightOptions.ThreeD}"
                                                   Content="Airspace zones" />
                                         <TextBlock Name="FlightAirspaceNote"
-                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark and Sweden). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
+                                                   Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark, Sweden and Estonia). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."
                                                    IsVisible="{Binding FlightOptions.ShowsAirspaceNote}"
                                                    TextWrapping="Wrap"
                                                    Opacity="0.5" FontSize="11" />

--- a/samples/airspace/README.md
+++ b/samples/airspace/README.md
@@ -27,9 +27,17 @@ verified on issue #413 (2026-07-29). Public data, no privacy concern.
   LFV's condition that the zone content not be modified — a trimmed extract
   of the live file would have breached that, so this fixture pastes no live
   LFV zone data at all. Don't "fix" it by swapping in real zones.
+- `eans-ee.json` — **synthetic**, not a trimmed copy. Invented zones in the
+  real EANS `uas.geojson` shape (issue #511, 2026-08-19), covering both
+  viewer-furniture masks the parser must skip — a `hidden` feature and the
+  world-spanning `EERZout` "Outside Estonia" prohibition — so the fixture
+  pins the skip contract instead of just the happy path. Attribution:
+  "Estonian Air Navigation Services", public data confirmed in writing by
+  EANS UTM development.
 
 The manual E2E step before merge re-fetches each live endpoint and confirms
-these shapes still match; `ed318-se.json` is synthetic, so there is nothing
-to byte-match — but the LFV endpoint is still re-fetched and the fixture's
-shape confirmed against it (it is the one fixture with no tie to the live
-file, which makes it the most prone to drifting from reality unnoticed).
+these shapes still match; `ed318-se.json` and `eans-ee.json` are synthetic,
+so there is nothing to byte-match for them — but their live endpoints are
+still re-fetched and each fixture's shape confirmed against it (these are
+the fixtures with no tie to a live file, which makes them the most prone to
+drifting from reality unnoticed).

--- a/samples/airspace/eans-ee.json
+++ b/samples/airspace/eans-ee.json
@@ -1,0 +1,207 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                    [25.00, 58.80], [25.10, 58.80], [25.10, 58.85],
+                    [25.00, 58.85], [25.00, 58.80]
+                ]]
+            },
+            "properties": {
+                "identifier": "EE901",
+                "country": "EST",
+                "name": "Example aerodrome zone",
+                "type": "COMMON",
+                "restriction": "REQ_AUTHORISATION",
+                "restrictionConditions": "",
+                "reason": "Air traffic",
+                "message": "You must have a permission from the example authority.",
+                "extendedProperties": {},
+                "geometry": {
+                    "uomDimensions": "M",
+                    "lowerLimit": 0,
+                    "lowerVerticalReference": "AGL",
+                    "upperLimit": 120,
+                    "upperVerticalReference": "AGL"
+                },
+                "applicability": [{"permanent": "YES", "schedule": []}],
+                "zoneAuthority": [{"name": "EANS", "contactName": "EANS", "siteURL": "https://example.invalid/zone", "email": "", "purpose": "AUTHORIZATION"}],
+                "metaData": {"creationDateTime": "2024-04-08T07:32:17.571Z", "updateDateTime": "2026-08-07T07:12:14.948Z", "author": "Lennuliiklusteeninduse AS"},
+                "airspacetype": "other",
+                "airspaceclass": "EEGZ901",
+                "lower": "SFC",
+                "lowerMeters": 0,
+                "upper": "120 M AGL",
+                "upperMeters": 120,
+                "hidden": false
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [26.00, 58.50], [26.20, 58.50], [26.20, 58.60],
+                        [26.00, 58.60], [26.00, 58.50]
+                    ],
+                    [
+                        [26.08, 58.54], [26.12, 58.54], [26.12, 58.56],
+                        [26.08, 58.56], [26.08, 58.54]
+                    ]
+                ]
+            },
+            "properties": {
+                "identifier": "EE902",
+                "country": "EST",
+                "name": "Example bird sanctuary",
+                "type": "COMMON",
+                "restriction": "NO_RESTRICTION",
+                "restrictionConditions": "",
+                "reason": "Nature",
+                "message": "Please avoid disturbing nesting birds.",
+                "extendedProperties": {},
+                "geometry": {
+                    "uomDimensions": "FT",
+                    "lowerLimit": 0,
+                    "lowerVerticalReference": "AGL",
+                    "upperLimit": 6000,
+                    "upperVerticalReference": "AGL"
+                },
+                "applicability": [{"permanent": "NO", "startDateTime": "2026-04-01T00:00:00.000Z", "endDateTime": "2026-11-30T00:00:00.000Z", "schedule": []}],
+                "zoneAuthority": [{"name": "EANS", "contactName": "EANS", "siteURL": "", "email": "", "purpose": "AUTHORIZATION"}],
+                "metaData": {"creationDateTime": "2024-04-08T07:32:17.571Z", "updateDateTime": "2026-08-07T07:12:14.948Z", "author": "Lennuliiklusteeninduse AS"},
+                "airspacetype": "other",
+                "airspaceclass": "EER901FAUNA",
+                "lower": "SFC",
+                "lowerMeters": 0,
+                "upper": "6000 FT AGL",
+                "upperMeters": 1800,
+                "hidden": false
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                    [24.40, 58.30], [24.50, 58.30], [24.50, 58.35],
+                    [24.40, 58.35], [24.40, 58.30]
+                ]]
+            },
+            "properties": {
+                "identifier": "A990126",
+                "country": "EST",
+                "name": "A9901/26",
+                "type": "COMMON",
+                "restriction": "NO_RESTRICTION",
+                "restrictionConditions": "",
+                "reason": "Air traffic",
+                "message": "DANGER AREA EXAMPLE ACTIVATED. [Schedule: 18-19 0500-1659]",
+                "extendedProperties": {},
+                "geometry": {
+                    "uomDimensions": "FT",
+                    "lowerLimit": 0,
+                    "lowerVerticalReference": "AGL",
+                    "upperLimit": 2200,
+                    "upperVerticalReference": "AGL"
+                },
+                "applicability": [{"permanent": "NO", "startDateTime": "2026-08-18T05:00:00.000Z", "endDateTime": "2026-08-20T13:59:00.000Z", "schedule": []}],
+                "zoneAuthority": [{"name": "EANS", "contactName": "EANS", "siteURL": "", "email": "", "purpose": "AUTHORIZATION"}],
+                "metaData": {"creationDateTime": "2026-08-17T10:00:00.000Z", "updateDateTime": "2026-08-17T10:00:00.000Z", "author": "Lennuliiklusteeninduse AS"},
+                "airspacetype": "other",
+                "airspaceclass": "A9901/26",
+                "lower": "SFC",
+                "lowerMeters": 0,
+                "upper": "2200 FT AGL",
+                "upperMeters": 671,
+                "hidden": false
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                    [21.0, 57.0], [29.0, 57.0], [29.0, 60.0],
+                    [21.0, 60.0], [21.0, 57.0]
+                ]]
+            },
+            "properties": {
+                "identifier": "EEGZS9",
+                "country": "EST",
+                "name": "",
+                "type": "COMMON",
+                "restriction": "PROHIBITED",
+                "restrictionConditions": "",
+                "reason": "Other",
+                "message": "",
+                "extendedProperties": {},
+                "geometry": {
+                    "uomDimensions": "M",
+                    "lowerLimit": 121,
+                    "lowerVerticalReference": "AGL",
+                    "upperLimit": 9999,
+                    "upperVerticalReference": "AGL"
+                },
+                "applicability": [{"permanent": "YES", "schedule": []}],
+                "zoneAuthority": [{"name": "EANS", "contactName": "EANS", "siteURL": "", "email": "", "purpose": "AUTHORIZATION"}],
+                "metaData": {"creationDateTime": "2024-04-08T07:32:17.571Z", "updateDateTime": "2026-08-07T07:12:14.948Z", "author": "Lennuliiklusteeninduse AS"},
+                "airspacetype": "other",
+                "airspaceclass": "",
+                "lower": "121 M AGL",
+                "lowerMeters": 121,
+                "upper": "UNL",
+                "upperMeters": 9999,
+                "hidden": true
+            }
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [-180.0, -90.0], [180.0, -90.0], [180.0, 90.0],
+                        [-180.0, 90.0], [-180.0, -90.0]
+                    ],
+                    [
+                        [22.0, 57.5], [28.0, 57.5], [28.0, 59.7],
+                        [22.0, 59.7], [22.0, 57.5]
+                    ]
+                ]
+            },
+            "properties": {
+                "identifier": "EERZout",
+                "country": "EST",
+                "name": "Outside Estonia",
+                "type": "COMMON",
+                "restriction": "PROHIBITED",
+                "restrictionConditions": "",
+                "reason": "Foreign territory",
+                "message": "",
+                "extendedProperties": {},
+                "geometry": {
+                    "uomDimensions": "M",
+                    "lowerLimit": 0,
+                    "lowerVerticalReference": "AGL",
+                    "upperLimit": 5000,
+                    "upperVerticalReference": "AGL"
+                },
+                "applicability": [{"permanent": "YES", "schedule": []}],
+                "zoneAuthority": [{"name": "EANS", "contactName": "EANS", "siteURL": "", "email": "", "purpose": "AUTHORIZATION"}],
+                "metaData": {"creationDateTime": "2024-04-08T07:32:17.571Z", "updateDateTime": "2026-08-07T07:12:14.948Z", "author": "Lennuliiklusteeninduse AS"},
+                "airspacetype": "other",
+                "airspaceclass": "Outside Estonia",
+                "lower": "SFC",
+                "lowerMeters": 0,
+                "upper": "5000 M AGL",
+                "upperMeters": 5000,
+                "hidden": false
+            }
+        }
+    ]
+}

--- a/src/dji_metadata_embedder/geo/airspace/eans.py
+++ b/src/dji_metadata_embedder/geo/airspace/eans.py
@@ -15,7 +15,9 @@ skipped by contract rather than parsed: any feature flagged ``hidden``
 ("Outside Estonia"), a world-spanning PROHIBITED mask with Estonia as
 its hole — rendering it would paint the entire planet as an Estonian
 prohibition. Everything else malformed still raises; all-or-nothing
-like the other providers.
+like the other providers. The skip is disclosed in the feed note (see
+``EANS_FEEDS["EE"].note``) so the omission is visible to the user
+rather than silent.
 
 Permission record (issue #511): EANS's UTM development manager confirmed
 in writing on 2026-08-19 that the file is public data intended for use
@@ -63,7 +65,10 @@ EANS_FEEDS: dict[str, EansFeed] = {
             "The file reflects the airspace rules at the time of "
             "download, not necessarily at the time of the flight (EANS). "
             "NOTAM-area activation hours appear as text in the zone's "
-            "published message and are not evaluated here."
+            "published message and are not evaluated here. Two "
+            "presentation-layer features published in the file — a "
+            "hidden above-120 m shade and an \"Outside Estonia\" "
+            "world-covering mask — are omitted from the zones shown."
         ),
     ),
 }
@@ -149,11 +154,12 @@ def parse_eans(raw: bytes, source: SourceInfo) -> list[Zone]:
                 raise AirspaceError(
                     f"{where} ({ident}): properties.geometry is not an object"
                 )
-            unit = (
-                "ft"
-                if str(volume.get("uomDimensions", "M")).upper() == "FT"
-                else "m"
-            )
+            uom = str(volume.get("uomDimensions", "M")).upper()
+            if uom not in ("M", "FT"):
+                raise AirspaceError(
+                    f"{where} ({ident}): uomDimensions {uom!r} is not M or FT"
+                )
+            unit = "ft" if uom == "FT" else "m"
             lower = _limit(volume, "lower", unit, f"{where} ({ident})")
             upper = _limit(volume, "upper", unit, f"{where} ({ident})")
         applicability: list[Applicability] = []

--- a/src/dji_metadata_embedder/geo/airspace/eans.py
+++ b/src/dji_metadata_embedder/geo/airspace/eans.py
@@ -1,0 +1,203 @@
+"""Estonia UAS geographical-zone parser (EANS uas.geojson, #511).
+
+EANS's UTM system publishes the national zones as a plain GeoJSON
+FeatureCollection whose feature properties embed one ED-269-style
+volume: vertical limits live in ``properties.geometry`` under ED-269's
+field names (``uomDimensions``/``lowerLimit``/``lowerVerticalReference``/…),
+the applicability list uses ED-269 semantics (``permanent: "YES"`` means
+always applicable, so no window materializes), and restrictions arrive
+natively S-spelled. The display strings (``lower``/``upper``), metre
+conversions and per-zone update timestamps ride in ``native`` untouched.
+
+Two features are the publisher's viewer furniture, not zones, and are
+skipped by contract rather than parsed: any feature flagged ``hidden``
+(live: EEGZS1, the Droonikaart app's above-120 m shade) and ``EERZout``
+("Outside Estonia"), a world-spanning PROHIBITED mask with Estonia as
+its hole — rendering it would paint the entire planet as an Estonian
+prohibition. Everything else malformed still raises; all-or-nothing
+like the other providers.
+
+Permission record (issue #511): EANS's UTM development manager confirmed
+in writing on 2026-08-19 that the file is public data intended for use
+in ground-control and planning tools; attribution to "Estonian Air
+Navigation Services". Their own caveat — the file reflects the rules at
+download time, not necessarily at flight time — ships in the feed note.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from .ed269 import _utc
+from .model import Applicability, AirspaceError, SourceInfo, VerticalLimit, Zone
+
+
+@dataclass(frozen=True)
+class EansFeed:
+    code: str
+    url: str
+    feed_name: str
+    license: str
+    caveat: str
+    note: str | None = None
+
+
+_CAVEAT = (
+    "UAS geographical-zone data is informational and is not an "
+    "authorization to fly."
+)
+
+EANS_FEEDS: dict[str, EansFeed] = {
+    "EE": EansFeed(
+        code="EE",
+        url="https://utm.eans.ee/avm/utm/uas.geojson",
+        feed_name="Estonia UAS geographical zones (EANS)",
+        license=(
+            "© Estonian Air Navigation Services — public data intended "
+            "for use in ground-control and planning tools (confirmed in "
+            "writing by EANS UTM development, 2026-08-19)"
+        ),
+        caveat=_CAVEAT,
+        note=(
+            "The file reflects the airspace rules at the time of "
+            "download, not necessarily at the time of the flight (EANS). "
+            "NOTAM-area activation hours appear as text in the zone's "
+            "published message and are not evaluated here."
+        ),
+    ),
+}
+
+# The publisher's viewer furniture: EERZout is a world-spanning
+# "Outside Estonia" mask with Estonia as its hole.
+_MASK_IDENTIFIERS = frozenset({"EERZout"})
+
+
+def _limit(volume: dict, side: str, unit: str, where: str) -> VerticalLimit | None:
+    value = volume.get(f"{side}Limit")
+    if value is None:
+        return None  # "not stated" — never 0
+    ref = volume.get(f"{side}VerticalReference")
+    if ref not in ("AGL", "AMSL"):
+        raise AirspaceError(
+            f"{where}: {side}VerticalReference is {ref!r}, expected AGL/AMSL"
+        )
+    if not isinstance(value, (int, float)):
+        raise AirspaceError(f"{where}: {side}Limit {value!r} is not a number")
+    return VerticalLimit(float(value), unit, ref)
+
+
+def _rings(
+    geometry: dict, ident: str, where: str
+) -> tuple[list[list[tuple[float, float]]], list[list[tuple[float, float]]]]:
+    gtype = geometry.get("type")
+    if gtype != "Polygon":
+        raise AirspaceError(
+            f"{where} ({ident}): geometry type {gtype!r} is not supported"
+        )
+    polygons: list[list[tuple[float, float]]] = []
+    holes: list[list[tuple[float, float]]] = []
+    for ring_index, ring in enumerate(geometry.get("coordinates") or []):
+        try:
+            parsed = [(float(x), float(y)) for x, y in ring]
+        except (TypeError, ValueError) as exc:
+            raise AirspaceError(
+                f"{where} ({ident}): malformed ring coordinates"
+            ) from exc
+        # GeoJSON ring order: 0 is the exterior, the rest are holes —
+        # kept apart so the evaluator subtracts them (#422).
+        (polygons if ring_index == 0 else holes).append(parsed)
+    return polygons, holes
+
+
+def parse_eans(raw: bytes, source: SourceInfo) -> list[Zone]:
+    """Every zone of the EANS uas.geojson as normalized :class:`Zone`s."""
+    try:
+        data = json.loads(raw.decode("utf-8-sig"))
+    except ValueError as exc:
+        raise AirspaceError(f"{source.feed}: feed is not JSON ({exc})") from exc
+    features = data.get("features") if isinstance(data, dict) else None
+    if not isinstance(features, list):
+        raise AirspaceError(
+            f"{source.feed}: not a GeoJSON document (no 'features' list)"
+        )
+    zones: list[Zone] = []
+    for i, feat in enumerate(features):
+        where = f"{source.feed}: zone {i}"
+        if not isinstance(feat, dict):
+            raise AirspaceError(f"{where}: not an object")
+        props = feat.get("properties")
+        if not isinstance(props, dict):
+            raise AirspaceError(f"{where}: missing properties")
+        ident = props.get("identifier")
+        if not isinstance(ident, str) or not ident:
+            raise AirspaceError(f"{where}: missing identifier")
+        if props.get("hidden") or ident in _MASK_IDENTIFIERS:
+            continue  # publisher viewer masks, by contract (see module doc)
+        restriction = props.get("restriction")
+        if not isinstance(restriction, str) or not restriction:
+            raise AirspaceError(f"{where} ({ident}): missing restriction")
+        name = (
+            str(props.get("name") or "").strip()
+            or str(props.get("airspaceclass") or "").strip()
+            or ident
+        )
+        volume = props.get("geometry")
+        lower = upper = None
+        if volume is not None:
+            if not isinstance(volume, dict):
+                raise AirspaceError(
+                    f"{where} ({ident}): properties.geometry is not an object"
+                )
+            unit = (
+                "ft"
+                if str(volume.get("uomDimensions", "M")).upper() == "FT"
+                else "m"
+            )
+            lower = _limit(volume, "lower", unit, f"{where} ({ident})")
+            upper = _limit(volume, "upper", unit, f"{where} ({ident})")
+        applicability: list[Applicability] = []
+        always_applicable = False
+        windows = props.get("applicability")
+        if windows is not None:
+            if not isinstance(windows, list):
+                raise AirspaceError(
+                    f"{where} ({ident}): applicability is not a list"
+                )
+            for win in windows:
+                if str(win.get("permanent", "")).upper() == "YES":
+                    always_applicable = True
+                    continue
+                start = win.get("startDateTime")
+                end = win.get("endDateTime")
+                applicability.append(
+                    Applicability(
+                        start=_utc(start, f"{where}: startDateTime")
+                        if start else None,
+                        end=_utc(end, f"{where}: endDateTime") if end else None,
+                        permanent=False,
+                    )
+                )
+        if always_applicable:
+            applicability = []
+        geometry = feat.get("geometry")
+        if not isinstance(geometry, dict):
+            raise AirspaceError(f"{where} ({ident}): missing geometry")
+        polygons, holes = _rings(geometry, ident, where)
+        if not polygons:
+            raise AirspaceError(f"{where} ({ident}): no polygon geometry")
+        zones.append(
+            Zone(
+                identifier=ident,
+                name=name,
+                restriction=restriction,
+                lower=lower,
+                upper=upper,
+                applicability=applicability,
+                polygons=polygons,
+                holes=holes,
+                source=source,
+                native=feat,
+            )
+        )
+    return zones

--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -29,6 +29,7 @@ from .dronezoner import (
     discover_feed_url as discover_dronezoner_url,
     parse_dronezoner,
 )
+from .eans import EANS_FEEDS, parse_eans
 from .ed269 import ED269_FEEDS, parse_ed269
 from .ed318 import ED318_FEEDS, discover_feed_url, parse_ed318
 from .jurisdiction import resolve_jurisdiction
@@ -155,6 +156,15 @@ def fetch_zones(
         # item href is discovered per fetch.
         url = feed_dz.page_url
         note = feed_dz.note
+    elif code in EANS_FEEDS:
+        feed_ee = EANS_FEEDS[code]
+        body_path = cache_dir / f"eans-{code}.json"
+        feed_name = feed_ee.feed_name
+        license_line, caveat = feed_ee.license, feed_ee.caveat
+        # The UTM system's file URL is the stable published address —
+        # fetched and cited directly, like Sweden's ED-318 file.
+        url = feed_ee.url
+        note = feed_ee.note
     else:
         feed_aixm = AIXM_FEEDS[code]
         body_path = cache_dir / f"aixm-{code}.xml"
@@ -192,6 +202,8 @@ def fetch_zones(
                 body = _fetch_url(
                     discover_dronezoner_url(page, url), transport
                 )
+            elif code in EANS_FEEDS:
+                body = _fetch_url(url, transport)
             else:
                 page = _fetch_url(url, transport)
                 zip_url = discover_aixm_url(
@@ -217,6 +229,8 @@ def fetch_zones(
             zones = parse_ed318(body, source)
         elif code in DRONEZONER_FEEDS:
             zones = parse_dronezoner(body, source)
+        elif code in EANS_FEEDS:
+            zones = parse_eans(body, source)
         else:
             zones = parse_aixm51(body, source)
         if from_cache:
@@ -246,6 +260,8 @@ def fetch_zones(
                     zones = parse_ed318(body, source)
                 elif code in DRONEZONER_FEEDS:
                     zones = parse_dronezoner(body, source)
+                elif code in EANS_FEEDS:
+                    zones = parse_eans(body, source)
                 else:
                     zones = parse_aixm51(body, source)
             except AirspaceError as exc2:

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -165,14 +165,19 @@ _CORE: dict[str, list[Box]] = {
     # Nominatim-verified 2026-08-19: Tallinn/Kunda/Haapsalu/Pärnu/Tartu/
     # Kohtla-Järve/Kuressaare/Sõrve/Kärdla and the interiors resolve EE
     # inside the cores; Ivangorod RU, Valka LV and Cape Kolka LV sit
-    # outside them. Deliberate gaps, each an honest border band: Valga
-    # (its Latvian twin Valka is 1.2 km away), Narva and the river strip,
-    # Setomaa, the Peipus shore, the southern border strip (Mõisaküla,
-    # Häädemeeste) and the small outer islands (Ruhnu, Vormsi, Kihnu).
+    # outside them. The cores are inset rectangles, not a hand-traced
+    # border, so the gaps are wider than the border bands that motivate
+    # them: alongside the true border bands (Valga, whose Latvian twin
+    # Valka is 1.2 km away; Narva and the river strip; Setomaa; the
+    # Peipus shore; the southern border strip), the coastal salients
+    # that reach past the rectangles (the Kõpu peninsula with Ristna,
+    # Vilsandi, the Lahemaa headlands) and the southern interior
+    # (Otepää, Võru) gap too, even though no border sits nearby.
+    # Recovering the salients is tracked in #521.
     "EE": [
         (23.4, 58.75, 26.6, 59.6),    # N + NW mainland (Tallinn, Haapsalu)
-        (23.5, 58.2, 25.6, 58.85),    # SW mainland (Pärnu; LV border >=13 km)
-        (25.6, 58.2, 26.9, 59.3),     # centre-east (Tartu; Peipus >=30 km)
+        (23.5, 58.2, 25.6, 58.85),    # SW mainland (Pärnu; LV border >=12 km)
+        (25.6, 58.2, 26.9, 59.3),     # centre-east (Tartu; edge at the Peipus shore, mid-lake border beyond)
         (26.6, 59.1, 27.75, 59.47),   # NE (Kohtla-Järve; Narva river >=17 km)
         (21.9, 57.9, 23.45, 58.65),   # Saaremaa + Muhu (Kolka LV >=17 km S)
         (22.35, 58.68, 23.1, 59.1),   # Hiiumaa

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -160,6 +160,23 @@ _CORE: dict[str, list[Box]] = {
         (18.9, 65.95, 22.4, 67.5),     # Jokkmokk/Gällivare (Torne border >=40 km E)
         (19.6, 67.5, 21.6, 68.0),      # Kiruna
     ],
+    # Land borders with Latvia (south) and Russia (east: the Narva river
+    # and the lakes), sea north and west. All 20 edge probes
+    # Nominatim-verified 2026-08-19: Tallinn/Kunda/Haapsalu/Pärnu/Tartu/
+    # Kohtla-Järve/Kuressaare/Sõrve/Kärdla and the interiors resolve EE
+    # inside the cores; Ivangorod RU, Valka LV and Cape Kolka LV sit
+    # outside them. Deliberate gaps, each an honest border band: Valga
+    # (its Latvian twin Valka is 1.2 km away), Narva and the river strip,
+    # Setomaa, the Peipus shore, the southern border strip (Mõisaküla,
+    # Häädemeeste) and the small outer islands (Ruhnu, Vormsi, Kihnu).
+    "EE": [
+        (23.4, 58.75, 26.6, 59.6),    # N + NW mainland (Tallinn, Haapsalu)
+        (23.5, 58.2, 25.6, 58.85),    # SW mainland (Pärnu; LV border >=13 km)
+        (25.6, 58.2, 26.9, 59.3),     # centre-east (Tartu; Peipus >=30 km)
+        (26.6, 59.1, 27.75, 59.47),   # NE (Kohtla-Järve; Narva river >=17 km)
+        (21.9, 57.9, 23.45, 58.65),   # Saaremaa + Muhu (Kolka LV >=17 km S)
+        (22.35, 58.68, 23.1, 59.1),   # Hiiumaa
+    ],
 }
 _HULL: dict[str, list[Box]] = {
     "US": [
@@ -202,12 +219,18 @@ _HULL: dict[str, list[Box]] = {
         (13.4, 61.0, 24.3, 66.4),      # Norrland + the Bothnian sea
         (16.3, 66.4, 24.2, 69.3),      # Lapland up to Treriksröset
     ],
+    # Valka, Ivangorod and the Latvian coast strip sit inside the hull
+    # deliberately (border-band semantics); Riga and Helsinki stay
+    # outside. Overlaps the FI hull over the Gulf of Finland on purpose:
+    # cores break the tie (#499).
+    "EE": [(21.5, 57.45, 28.45, 59.9)],
 }
 # CH takes the EU measure: Regulation (EU) 2019/947 applies in Switzerland
 # since 2023-01-01 under the CH-EU air transport agreement.
 _MEASURE = {
     "US": MEASURE_US, "LU": MEASURE_EU, "FI": MEASURE_EU, "CH": MEASURE_EU,
     "IE": MEASURE_EU, "GB": MEASURE_UK, "DK": MEASURE_EU, "SE": MEASURE_EU,
+    "EE": MEASURE_EU,
 }
 
 
@@ -239,7 +262,7 @@ def resolve_jurisdiction(track: Track) -> Resolution:
             None,
             "no supported airspace data source for this location "
             "(covered: the US, Luxembourg, Finland, Switzerland, "
-            "Ireland, the UK, Denmark and Sweden)",
+            "Ireland, the UK, Denmark, Sweden and Estonia)",
         )
     cores = [code for code in hulls if _all_inside(track, _CORE[code])]
     if len(cores) != 1:

--- a/tests/test_airspace_eans.py
+++ b/tests/test_airspace_eans.py
@@ -112,6 +112,13 @@ def test_bom_is_tolerated():
     assert len(parse_eans(with_bom, SRC)) == 3
 
 
+def test_unknown_dimension_unit_raises():
+    broken = json.loads(_ee().decode("utf-8"))
+    broken["features"][0]["properties"]["geometry"]["uomDimensions"] = "SM"
+    with pytest.raises(AirspaceError, match="uomDimensions"):
+        parse_eans(json.dumps(broken).encode(), SRC)
+
+
 def test_ee_feed_registry_states_the_eans_terms():
     feed = EANS_FEEDS["EE"]
     assert feed.url == "https://utm.eans.ee/avm/utm/uas.geojson"
@@ -119,3 +126,4 @@ def test_ee_feed_registry_states_the_eans_terms():
     assert "2026-08-19" in feed.license
     assert "time of download" in (feed.note or "")
     assert "not evaluated" in (feed.note or "")
+    assert "omitted" in (feed.note or "")

--- a/tests/test_airspace_eans.py
+++ b/tests/test_airspace_eans.py
@@ -1,0 +1,121 @@
+"""EANS Estonia uas.geojson parser tests (#511) against the synthetic fixture.
+
+The live file is GeoJSON features whose properties embed one ED-269-style
+volume dict (ED-269 field names, S-spelled restrictions, permanent-YES
+applicability semantics). Two publisher viewer masks are skipped by
+contract; everything else malformed raises.
+"""
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder.geo.airspace import AirspaceError, SourceInfo
+from dji_metadata_embedder.geo.airspace.eans import EANS_FEEDS, parse_eans
+
+FIXTURES = Path(__file__).parent.parent / "samples" / "airspace"
+SRC = SourceInfo(
+    feed="test", url="https://example.invalid/uas.geojson",
+    fetched="2026-08-19T12:00:00Z",
+    license="test", caveat="informational only",
+)
+
+
+def _ee() -> bytes:
+    return (FIXTURES / "eans-ee.json").read_bytes()
+
+
+def test_parses_the_fixture_and_skips_exactly_the_two_masks():
+    zones = parse_eans(_ee(), SRC)
+    # 5 features in, 3 zones out: the hidden shade and EERZout are the
+    # publisher's viewer furniture, skipped by contract — never silently.
+    assert [z.identifier for z in zones] == ["EE901", "EE902", "A990126"]
+    assert all(z.identifier != "EERZout" for z in zones)
+
+
+def test_metric_zone_limits_and_permanent_applicability():
+    z = parse_eans(_ee(), SRC)[0]
+    assert z.name == "Example aerodrome zone"
+    assert z.restriction == "REQ_AUTHORISATION"   # natively S-spelled
+    assert z.lower is not None and z.lower.label() == "0 m AGL"
+    assert z.upper is not None and z.upper.label() == "120 m AGL"
+    assert z.applicability == []                  # permanent YES -> always
+    assert z.native["properties"]["upper"] == "120 M AGL"
+
+
+def test_feet_zone_with_hole_and_seasonal_window():
+    z = parse_eans(_ee(), SRC)[1]
+    assert z.upper is not None and z.upper.label() == "6000 ft AGL"
+    assert len(z.polygons) == 1 and len(z.holes) == 1   # inner ring (#422)
+    assert len(z.applicability) == 1
+    win = z.applicability[0]
+    assert win.permanent is False
+    assert win.start == datetime(2026, 4, 1, 0, 0)
+    assert win.end == datetime(2026, 11, 30, 0, 0)
+
+
+def test_notam_zone_keeps_schedule_text_in_native_only():
+    z = parse_eans(_ee(), SRC)[2]
+    assert z.name == "A9901/26"                   # display name, with slash
+    assert z.applicability[0].start == datetime(2026, 8, 18, 5, 0)
+    assert "[Schedule:" in z.native["properties"]["message"]
+
+
+def test_empty_name_falls_back_to_airspaceclass_then_identifier():
+    doc = json.loads(_ee().decode("utf-8"))
+    doc["features"][0]["properties"]["name"] = ""
+    zones = parse_eans(json.dumps(doc).encode(), SRC)
+    assert zones[0].name == "EEGZ901"             # airspaceclass fallback
+    doc["features"][0]["properties"]["airspaceclass"] = ""
+    zones = parse_eans(json.dumps(doc).encode(), SRC)
+    assert zones[0].name == "EE901"               # identifier fallback
+
+
+def test_a_new_hidden_feature_still_skips():
+    doc = json.loads(_ee().decode("utf-8"))
+    doc["features"][1]["properties"]["hidden"] = True
+    zones = parse_eans(json.dumps(doc).encode(), SRC)
+    assert [z.identifier for z in zones] == ["EE901", "A990126"]
+
+
+def test_one_malformed_zone_invalidates_the_whole_document():
+    broken = json.loads(_ee().decode("utf-8"))
+    del broken["features"][0]["properties"]["identifier"]
+    with pytest.raises(AirspaceError, match="zone 0.*identifier"):
+        parse_eans(json.dumps(broken).encode(), SRC)
+
+
+def test_unexpected_vertical_reference_raises():
+    broken = json.loads(_ee().decode("utf-8"))
+    broken["features"][0]["properties"]["geometry"]["upperVerticalReference"] = "STD"
+    with pytest.raises(AirspaceError, match="upperVerticalReference"):
+        parse_eans(json.dumps(broken).encode(), SRC)
+
+
+def test_non_polygon_geometry_raises():
+    broken = json.loads(_ee().decode("utf-8"))
+    broken["features"][0]["geometry"]["type"] = "Point"
+    with pytest.raises(AirspaceError, match="Point"):
+        parse_eans(json.dumps(broken).encode(), SRC)
+
+
+def test_missing_volume_dict_means_not_stated_never_zero():
+    doc = json.loads(_ee().decode("utf-8"))
+    del doc["features"][0]["properties"]["geometry"]
+    zones = parse_eans(json.dumps(doc).encode(), SRC)
+    assert zones[0].lower is None and zones[0].upper is None
+
+
+def test_bom_is_tolerated():
+    with_bom = b"\xef\xbb\xbf" + _ee()
+    assert len(parse_eans(with_bom, SRC)) == 3
+
+
+def test_ee_feed_registry_states_the_eans_terms():
+    feed = EANS_FEEDS["EE"]
+    assert feed.url == "https://utm.eans.ee/avm/utm/uas.geojson"
+    assert "Estonian Air Navigation Services" in feed.license
+    assert "2026-08-19" in feed.license
+    assert "time of download" in (feed.note or "")
+    assert "not evaluated" in (feed.note or "")

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -366,3 +366,29 @@ def test_a_cached_swedish_body_never_touches_the_network(tmp_path):
     data = fetch_zones(_track(59.33, 18.07), tmp_path, transport=no_network)
     assert data.from_cache and len(data.zones) == 3
 
+
+def test_an_estonian_flight_fetches_the_eans_file_directly(tmp_path):
+    # #511: EANS's URL is stable — one fetch, no discovery, the record
+    # cites the file URL itself.
+    fake = FakeTransport([(FIXTURES / "eans-ee.json").read_bytes()])
+    lines = []
+    data = fetch_zones(_track(59.44, 24.75), tmp_path, transport=fake,
+                       announce=lines.append)
+    assert data.gap_reason is None and len(data.zones) == 3
+    assert fake.urls == ["https://utm.eans.ee/avm/utm/uas.geojson"]
+    assert data.source is not None
+    assert "Estonian Air Navigation Services" in data.source.license
+    assert "time of download" in (data.source.note or "")
+    assert (tmp_path / "eans-EE.json").exists()
+    assert any("Fetching" in ln and "utm.eans.ee" in ln for ln in lines)
+
+
+def test_a_cached_estonian_body_never_touches_the_network(tmp_path):
+    fake = FakeTransport([(FIXTURES / "eans-ee.json").read_bytes()])
+    fetch_zones(_track(59.44, 24.75), tmp_path, transport=fake)
+
+    def no_network(req, timeout=None):
+        raise AssertionError("cached run must not touch the network")
+    data = fetch_zones(_track(59.44, 24.75), tmp_path, transport=no_network)
+    assert data.from_cache and len(data.zones) == 3
+

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -425,3 +425,66 @@ def test_transtrand_resolves_se_now_the_hull_reaches_the_whole_core():
     r = resolve_jurisdiction(_track((61.2, 13.7)))
     assert r.jurisdiction is not None and r.jurisdiction.code == "SE"
 
+
+
+def test_a_tallinn_flight_resolves_to_ee_with_the_eu_measure():
+    r = resolve_jurisdiction(_track((59.44, 24.75)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
+    assert "2019/947" in r.jurisdiction.measure_note
+
+
+def test_tartu_resolves_to_ee():
+    r = resolve_jurisdiction(_track((58.38, 26.72)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
+
+
+def test_parnu_resolves_to_ee():
+    r = resolve_jurisdiction(_track((58.39, 24.50)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
+
+
+def test_kuressaare_and_sorve_resolve_through_the_saaremaa_core():
+    r = resolve_jurisdiction(_track((58.25, 22.48), (57.92, 22.04)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
+
+
+def test_kardla_hiiumaa_resolves_to_ee():
+    r = resolve_jurisdiction(_track((59.00, 22.75)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
+
+
+def test_valga_gaps_as_a_border_band():
+    # Its Latvian twin Valka is 1.2 km away — no coordinate box can
+    # honestly split the twin towns.
+    r = resolve_jurisdiction(_track((57.78, 26.03)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "boundary" in r.gap_reason
+
+
+def test_narva_gaps_as_a_border_band():
+    r = resolve_jurisdiction(_track((59.38, 28.20)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "boundary" in r.gap_reason
+
+
+def test_valka_latvia_gaps_inside_the_hull_only():
+    r = resolve_jurisdiction(_track((57.77, 26.02)))
+    assert r.jurisdiction is None
+
+
+def test_riga_stays_outside_the_ee_hull_entirely():
+    r = resolve_jurisdiction(_track((56.95, 24.10)))
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "Estonia" in r.gap_reason
+
+
+def test_helsinki_still_resolves_fi_with_the_ee_hull_nearby():
+    r = resolve_jurisdiction(_track((60.25, 24.95)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "FI"
+
+
+def test_the_gulf_coast_overlap_band_resolves_ee_via_its_core():
+    # Kunda (59.50, 26.50) sits inside BOTH the FI hull (lat >= 59.5) and
+    # the EE hull; only the EE core contains it (#499 tie-break).
+    r = resolve_jurisdiction(_track((59.50, 26.50)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "EE"


### PR DESCRIPTION
Closes #511.

Ninth airspace country. EANS confirmed reuse in writing on 2026-08-19 (permission record on the issue): public data intended for ground-control and planning tools, attribution to "Estonian Air Navigation Services".

- New `eans.py` provider: the file is GeoJSON features each embedding one ED-269-style volume dict (ED-269 field names, natively S-spelled restrictions, permanent-YES applicability semantics) — neither the ED-318 profile nor an ED-269 document, so it gets its own small parser. All-or-nothing, with one explicit, tested exception: two publisher viewer-mask features (a `hidden` above-120 m shade and the world-covering "Outside Estonia" polygon) are skipped by contract, and the feed note discloses the omission on the record and both maps.
- The feed note also carries EANS's own caveat verbatim in spirit: the file reflects the rules at the time of download, not necessarily at the time of the flight.
- Direct stable URL (no discovery), cache `eans-EE.json`, stale-cache fallback wired.
- EE jurisdiction cores/hull, 20 edge probes Nominatim-verified 2026-08-19; Valga (twin town with Latvian Valka, 1.2 km apart), Narva and Setomaa gap as border bands; the FI-hull overlap over the Gulf of Finland resolves via the #499 core tie-break. Coastal-salient recovery (Kõpu/Ristna, Lahemaa) tracked in #521.
- Coverage updated on all four surfaces (docs ×2, GUI tooltip, jurisdiction gap message); unknown vertical units now raise instead of silently reading as metres.
- Live E2E against the real feed: 239 features → 237 zones (208 NO_RESTRICTION + 29 REQ_AUTHORISATION, 62 time-bounded), masks absent, note verified on the record, the flat map and the 3D map.

Review side-catches filed separately: #520 (Denmark tz-aware windows crash evaluate — unreleased master regression, fix PR to follow) and #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YnYQZrCKXHCUEHkGWme6j