### PR TITLE
fix(geo): Denmark tz-aware zone windows crashed evaluate on timestamped flights (#520)

### DIFF
--- a/src/dji_metadata_embedder/geo/airspace/dronezoner.py
+++ b/src/dji_metadata_embedder/geo/airspace/dronezoner.py
@@ -211,8 +211,10 @@ def _applicability(props: dict, where: str) -> list[Applicability]:
             raise AirspaceError(
                 f"{where}: unparseable {label} {raw!r}"
             ) from exc
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
+        # Naive UTC, like ed269._utc: Track.utc is naive, and the
+        # evaluator's window comparison must never mix awareness (#520).
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
         return parsed
 
     return [

--- a/tests/test_airspace_dronezoner.py
+++ b/tests/test_airspace_dronezoner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import math
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -137,8 +137,10 @@ class TestParsing:
         assert len(z.applicability) == 1
         win = z.applicability[0]
         assert not win.permanent
-        assert win.start == datetime(2026, 9, 7, 6, 0, tzinfo=timezone.utc)
-        assert win.end == datetime(2026, 9, 11, 18, 0, tzinfo=timezone.utc)
+        # Naive UTC, matching ed269._utc and Track.utc (#520): tz-aware
+        # windows crashed the evaluator on any timestamped flight.
+        assert win.start == datetime(2026, 9, 7, 6, 0)
+        assert win.end == datetime(2026, 9, 11, 18, 0)
 
     def test_permanent_zones_have_no_applicability_entries(self):
         assert zone(fixture_zones(), "DK-2").applicability == []
@@ -210,3 +212,31 @@ class TestAllOrNothing:
         )
         with pytest.raises(AirspaceError, match="OBJECTID"):
             parse_dronezoner(body, SOURCE)
+
+
+class TestEvaluateIntegration:
+    def test_windowed_zone_evaluates_against_a_timestamped_track(self):
+        # #520 regression: zone windows must be naive UTC like every other
+        # provider's (ed269._utc semantics) — Track.utc is naive, and a
+        # tz-aware window made evaluate() die with a TypeError instead of
+        # an AirspaceError on any normal timestamped Danish flight.
+        from dji_metadata_embedder.geo.airspace.evaluate import evaluate
+        from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+        z = zone(fixture_zones(), "DK-6")
+        lon, lat = z.polygons[0][0]
+        pts = [TrackPoint(lat=lat, lon=lon, alt=50, timestamp="c",
+                          utc=datetime(2026, 9, 8, 12, 0), rel_alt=20)]
+        report = evaluate(Track(name="dk", points=pts), [z])
+        assert z not in report.not_applicable
+
+    def test_windowed_zone_outside_its_window_is_not_applicable(self):
+        from dji_metadata_embedder.geo.airspace.evaluate import evaluate
+        from dji_metadata_embedder.geo.track import Track, TrackPoint
+
+        z = zone(fixture_zones(), "DK-6")
+        lon, lat = z.polygons[0][0]
+        pts = [TrackPoint(lat=lat, lon=lon, alt=50, timestamp="c",
+                          utc=datetime(2026, 10, 1, 12, 0), rel_alt=20)]
+        report = evaluate(Track(name="dk", points=pts), [z])
+        assert z in report.not_applicable


### PR DESCRIPTION
Closes #520. Found by #511's whole-branch review exercising the shared evaluator against the live Danish feed.

`dronezoner._applicability` attached `timezone.utc` to parsed windows while every other provider strips tzinfo (`ed269._utc`) and `Track.utc` is naive — so `evaluate._applies` raised a bare `TypeError` (outside the `AirspaceError` never-raises contract) on any Danish flight with complete timestamps. 26 of the 986 live zones carry such windows. Unreleased regression from #508; no released version affected.

Fix: convert aware datetimes to UTC and strip tzinfo, matching ed269 semantics; the existing window test (which had enshrined the aware datetimes) now pins naive UTC, and two new evaluator-integration regression tests cover the class the parser-only tests missed — one timestamped flight inside a zone's window, one outside. Live E2E: fetch + evaluate over the real feed completes, zero tz-aware windows, the 26 windowed zones filter correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YnYQZrCKXHCUEHkGWme6j