### PR TITLE
chore(types): drop types-click 7.1.8 — click-7 stubs mask a real click-8 signature mismatch (#519)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dev = [
     "black==26.5.1",
     "ruff==0.15.20",
     "mypy==2.1.0",
-    "types-click==7.1.8",
     "jsonschema==4.26.0",
     "pillow==12.3.0",
 ]

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -165,7 +165,7 @@ class DragDropGroup(click.Group):
 
     def resolve_command(
         self, ctx: click.Context, args: list[str]
-    ) -> tuple[str, click.Command, list[str]]:
+    ) -> tuple[str | None, click.Command | None, list[str]]:
         try:
             return super().resolve_command(ctx, args)
         except click.UsageError:

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "types-click" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -520,7 +519,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
     { name = "setuptools", marker = "extra == 'build'", specifier = ">=65.0.0" },
     { name = "twine", marker = "extra == 'build'", specifier = "==6.2.0" },
-    { name = "types-click", marker = "extra == 'dev'", specifier = "==7.1.8" },
     { name = "wheel", marker = "extra == 'build'", specifier = ">=0.38.0" },
 ]
 provides-extras = ["browser", "build", "dev", "docs", "terrain"]
@@ -2191,15 +2189,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
-]
-
-[[package]]
-name = "types-click"
-version = "7.1.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/ff/0e6a56108d45c80c61cdd4743312d0304d8192482aea4cce96c554aaa90d/types-click-7.1.8.tar.gz", hash = "sha256:b6604968be6401dc516311ca50708a0a28baa7a0cb840efd7412f0dbbff4e092", size = 10015, upload-time = "2021-11-23T12:28:01.701Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ad/607454a5f991c5b3e14693a7113926758f889138371058a5f72f567fa131/types_click-7.1.8-py3-none-any.whl", hash = "sha256:8cb030a669e2e927461be9827375f83c16b8178c365852c060a34e24871e7e81", size = 12929, upload-time = "2021-11-23T12:27:59.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #519.

A fresh venv without the dev extra failed `mypy src` at `cli.py:170` while dev environments passed: `types-click==7.1.8` (a 2021, click-7-era stub-only package) made mypy prefer stale stubs over click 8.4.2's real inline annotations. Those declare `Group.resolve_command -> tuple[str | None, Command | None, list[str]]` (the `None` case serves resilient parsing during shell completion), and our `DragDropGroup.resolve_command` override narrowed that illegally while passing `super()`'s result straight through.

Two changes:
- remove `types-click` from the dev extra (click 8 is fully typed inline)
- widen the override's return annotation to click 8's actual signature

No runtime behaviour change — annotations only. Verified red→green: with the stubs removed, mypy reported exactly the one predicted error, then passed after the signature fix. Full suite: 1303 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R66PgAV6rad1NrRgVSBEex