### PR TITLE
fix(geo): a 200-status error page no longer poisons the airspace feed cache (#518)

### DIFF
--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -69,14 +69,12 @@ def _read_cache(body_path: Path) -> tuple[bytes, str] | None:
         return None
 
 
-def _write_cache(body_path: Path, body: bytes, url: str) -> str:
+def _write_cache(body_path: Path, body: bytes, url: str, fetched: str) -> None:
     body_path.parent.mkdir(parents=True, exist_ok=True)
-    fetched = _now_iso()
     body_path.write_bytes(body)
     body_path.with_name(body_path.name + ".meta.json").write_text(
         json.dumps({"url": url, "fetched": fetched}), encoding="utf-8"
     )
-    return fetched
 
 
 def _load_faa_doc(body: bytes) -> dict:
@@ -176,6 +174,20 @@ def fetch_zones(
         url = feed_aixm.page_url
         note = feed_aixm.note
 
+    def parse_body(body: bytes, source: SourceInfo) -> list[Zone]:
+        if code == "US":
+            doc = _load_faa_doc(body)
+            return parse_faa(_faa_pages_from_doc(doc), source)
+        if code in ED269_FEEDS:
+            return parse_ed269(body, source, no_ceiling_m=feed.no_ceiling_m)
+        if code in ED318_FEEDS:
+            return parse_ed318(body, source)
+        if code in DRONEZONER_FEEDS:
+            return parse_dronezoner(body, source)
+        if code in EANS_FEEDS:
+            return parse_eans(body, source)
+        return parse_aixm51(body, source)
+
     cached = None if refresh else _read_cache(body_path)
     try:
         if cached is not None:
@@ -210,35 +222,25 @@ def fetch_zones(
                     page, url, today=datetime.now(timezone.utc).date()
                 )
                 body = extract_xml(_fetch_url(zip_url, transport))
-            fetched = _write_cache(body_path, body, url)
+            fetched = _now_iso()
             from_cache = False
 
         source = SourceInfo(
             feed=feed_name, url=url, fetched=fetched,
             license=license_line, caveat=caveat, note=note,
         )
-        if code == "US":
-            doc = _load_faa_doc(body)
-            pages_raw = _faa_pages_from_doc(doc)
-            zones = parse_faa(pages_raw, source)
-        elif code in ED269_FEEDS:
-            zones = parse_ed269(
-                body, source, no_ceiling_m=feed.no_ceiling_m
-            )
-        elif code in ED318_FEEDS:
-            zones = parse_ed318(body, source)
-        elif code in DRONEZONER_FEEDS:
-            zones = parse_dronezoner(body, source)
-        elif code in EANS_FEEDS:
-            zones = parse_eans(body, source)
-        else:
-            zones = parse_aixm51(body, source)
+        zones = parse_body(body, source)
         if from_cache:
             # Only claim the cache was usable once it has actually
             # parsed — an announce made before this point could be a lie.
             announce(
                 f"Using cached {feed_name} from {fetched} ({body_path})"
             )
+        else:
+            # Cache only what parsed (#518): a maintenance page served
+            # with HTTP 200 must never become the body every later run
+            # trusts.
+            _write_cache(body_path, body, url, fetched)
     except AirspaceError as exc:
         stale = _read_cache(body_path) if refresh else None
         if stale is not None:
@@ -248,22 +250,7 @@ def fetch_zones(
                 license=license_line, caveat=caveat, note=note,
             )
             try:
-                if code == "US":
-                    doc = _load_faa_doc(body)
-                    pages_raw = _faa_pages_from_doc(doc)
-                    zones = parse_faa(pages_raw, source)
-                elif code in ED269_FEEDS:
-                    zones = parse_ed269(
-                        body, source, no_ceiling_m=feed.no_ceiling_m
-                    )
-                elif code in ED318_FEEDS:
-                    zones = parse_ed318(body, source)
-                elif code in DRONEZONER_FEEDS:
-                    zones = parse_dronezoner(body, source)
-                elif code in EANS_FEEDS:
-                    zones = parse_eans(body, source)
-                else:
-                    zones = parse_aixm51(body, source)
+                zones = parse_body(body, source)
             except AirspaceError as exc2:
                 return AirspaceData(
                     gap_reason=f"airspace data unavailable: {exc2}"
@@ -275,5 +262,15 @@ def fetch_zones(
                 f"from {fetched}"
             )
             return AirspaceData(zones=zones, source=source, from_cache=True)
-        return AirspaceData(gap_reason=f"airspace data unavailable: {exc}")
+        reason = f"airspace data unavailable: {exc}"
+        if cached is not None:
+            # The body that failed came from the cache (poisoned before
+            # the write-after-parse fix, or corrupted on disk) — the live
+            # feed may be fine, so name the way out (#518). A fresh-fetch
+            # failure never gets this hint: refreshing cannot help there.
+            reason += (
+                f" — the cached copy at {body_path} may be bad; rerun "
+                "with --airspace-refresh to refetch"
+            )
+        return AirspaceData(gap_reason=reason)
     return AirspaceData(zones=zones, source=source, from_cache=from_cache)

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -392,3 +392,43 @@ def test_a_cached_estonian_body_never_touches_the_network(tmp_path):
     data = fetch_zones(_track(59.44, 24.75), tmp_path, transport=no_network)
     assert data.from_cache and len(data.zones) == 3
 
+
+
+def test_a_200_error_page_never_reaches_the_cache(tmp_path):
+    # #518: a provider maintenance page served with HTTP 200 must not be
+    # written as the feed body — the next run should refetch, not be
+    # stuck parsing poison until --airspace-refresh.
+    fake = FakeTransport([b"<html>Down for maintenance</html>"])
+    data = fetch_zones(_track(49.62, 6.2), tmp_path, transport=fake)
+    assert data.gap_reason is not None
+    assert not (tmp_path / "ed269-LU.json").exists()
+    assert not (tmp_path / "ed269-LU.json.meta.json").exists()
+
+    fake2 = FakeTransport([(FIXTURES / "ed269-lu.json").read_bytes()])
+    healed = fetch_zones(_track(49.62, 6.2), tmp_path, transport=fake2)
+    assert healed.gap_reason is None and len(healed.zones) == 2
+    assert fake2.urls
+
+
+def test_an_unparseable_cached_body_names_the_refresh_flag(tmp_path):
+    # #518: caches poisoned before the write-after-parse fix (or corrupted
+    # on disk) still fail — but the gap must tell the user the way out.
+    fake = FakeTransport([(FIXTURES / "ed269-lu.json").read_bytes()])
+    fetch_zones(_track(49.62, 6.2), tmp_path, transport=fake)
+    (tmp_path / "ed269-LU.json").write_bytes(b"<html>Down</html>")
+
+    def no_network(req, timeout=None):
+        raise AssertionError("a corrupted cache hit must not force a live fetch")
+
+    data = fetch_zones(_track(49.62, 6.2), tmp_path, transport=no_network)
+    assert data.gap_reason is not None
+    assert "--airspace-refresh" in data.gap_reason
+
+
+def test_a_fresh_fetch_failure_does_not_name_the_refresh_flag(tmp_path):
+    # Refreshing cannot help when the live feed itself is bad — the hint
+    # belongs to cached-body failures only.
+    fake = FakeTransport([b"<html>Down for maintenance</html>"])
+    data = fetch_zones(_track(49.62, 6.2), tmp_path, transport=fake)
+    assert data.gap_reason is not None
+    assert "--airspace-refresh" not in data.gap_reason


### PR DESCRIPTION
Closes #518.

`fetch.py` wrote the cache before the parser ran. A provider maintenance/error page served with HTTP 200 became the cached feed body; every later run read the cache, failed to parse, and reported "airspace data unavailable: … feed is not JSON" with no hint that `--airspace-refresh` clears it. Shared by every direct-URL feed — ED-269 (LU/FI/CH), ED-318 (SE), dronezoner (DK), EANS (EE), AIXM (GB), FAA (US) — which matters now that the next release adds three of them at once.

Changes:
- **Parse before cache.** The fetched body must parse before `_write_cache` runs, so a bad fetch is a stated gap for that run and the next run refetches cleanly. (The only-cache-after-successful-parse shape from the issue.)
- **Name the way out.** A cached body that fails to parse (poisoned before this fix, or corrupted on disk) still fails closed — no forced live fetch, preserving the existing offline guarantee — but the gap message now names the cached path and `--airspace-refresh`. A fresh-fetch failure never gets the hint, since refreshing can't help a live bad feed.
- The six-way parse dispatch, previously duplicated between the main and stale-fallback paths, is deduped into one closure.

TDD: three new tests (error page never reaches the cache + next run heals; poisoned cache names the flag; fresh failure doesn't), watched red first. Full suite 1306 passed, mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R66PgAV6rad1NrRgVSBEex