### PR TITLE
fix(geo): recover the Kõpu/Ristna and Lahemaa coastal salients into the EE cores (#521)

### DIFF
--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -165,22 +165,23 @@ _CORE: dict[str, list[Box]] = {
     # Nominatim-verified 2026-08-19: Tallinn/Kunda/Haapsalu/Pärnu/Tartu/
     # Kohtla-Järve/Kuressaare/Sõrve/Kärdla and the interiors resolve EE
     # inside the cores; Ivangorod RU, Valka LV and Cape Kolka LV sit
-    # outside them. The cores are inset rectangles, not a hand-traced
-    # border, so the gaps are wider than the border bands that motivate
-    # them: alongside the true border bands (Valga, whose Latvian twin
-    # Valka is 1.2 km away; Narva and the river strip; Setomaa; the
-    # Peipus shore; the southern border strip), the coastal salients
-    # that reach past the rectangles (the Kõpu peninsula with Ristna,
-    # Vilsandi, the Lahemaa headlands) and the southern interior
-    # (Otepää, Võru) gap too, even though no border sits nearby.
-    # Recovering the salients is tracked in #521.
+    # outside them. The Kõpu peninsula (Ristna) and the Lahemaa
+    # headlands (Käsmu) recovered via #521, probes 2026-08-20; the N
+    # core top stays 0.15° under the FI core floor (Hanko 59.82).
+    # The cores are inset rectangles, not a hand-traced border, so the
+    # gaps are wider than the border bands that motivate them: alongside
+    # the true border bands (Valga, whose Latvian twin Valka is 1.2 km
+    # away; Narva and the river strip; Setomaa; the Peipus shore; the
+    # southern border strip), Vilsandi (west of the Saaremaa core) and
+    # the southern interior (Otepää, Võru) gap too, even though no
+    # border sits nearby.
     "EE": [
-        (23.4, 58.75, 26.6, 59.6),    # N + NW mainland (Tallinn, Haapsalu)
+        (23.4, 58.75, 26.6, 59.65),   # N + NW mainland (Tallinn; Käsmu in, Purekkari cape 59.66 gaps)
         (23.5, 58.2, 25.6, 58.85),    # SW mainland (Pärnu; LV border >=12 km)
         (25.6, 58.2, 26.9, 59.3),     # centre-east (Tartu; edge at the Peipus shore, mid-lake border beyond)
         (26.6, 59.1, 27.75, 59.47),   # NE (Kohtla-Järve; Narva river >=17 km)
         (21.9, 57.9, 23.45, 58.65),   # Saaremaa + Muhu (Kolka LV >=17 km S)
-        (22.35, 58.68, 23.1, 59.1),   # Hiiumaa
+        (22.0, 58.68, 23.1, 59.1),    # Hiiumaa incl. Kõpu/Ristna
     ],
 }
 _HULL: dict[str, list[Box]] = {

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -453,6 +453,27 @@ def test_kardla_hiiumaa_resolves_to_ee():
     assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
 
 
+def test_kopu_and_ristna_resolve_through_the_hiiumaa_core():
+    # #521: the Kõpu peninsula sits ~90 km from the nearest foreign
+    # territory — a gap there was an inset-rectangle artefact, not a
+    # border band.
+    r = resolve_jurisdiction(_track((58.916, 22.200), (58.939, 22.057)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
+
+
+def test_kasmu_lahemaa_resolves_to_ee():
+    # #521: Käsmu missed the N-core top by ~390 m.
+    r = resolve_jurisdiction(_track((59.6035, 25.928)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
+
+
+def test_hanko_still_resolves_fi_above_the_raised_ee_core():
+    # The FI core floor is 59.8; the raised EE core top (59.65) must
+    # not capture Finland's south coast.
+    r = resolve_jurisdiction(_track((59.823, 22.97)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "FI"
+
+
 def test_valga_gaps_as_a_border_band():
     # Its Latvian twin Valka is 1.2 km away — no coordinate box can
     # honestly split the twin towns.


### PR DESCRIPTION
Closes #521.

The Estonian jurisdiction cores are inset rectangles, so two coastal salients far from any border gapped as if they were border bands: the Kõpu peninsula on Hiiumaa with the Kõpu and Ristna lighthouses (~90 km from the nearest foreign territory), and the Lahemaa headlands, where Käsmu missed the N-core top by ~390 m.

Two box edits, exactly the extension #511's review pre-checked as structurally safe:
- Hiiumaa core west edge 22.35 → **22.0** (recovers Kõpu/Ristna)
- N-mainland core top 59.6 → **59.65** (recovers Käsmu, Viinistu, Juminda; Purekkari cape at 59.66 still gaps deliberately — it stays a sea-margin band)

Per the boxes-are-probe-verified-finals rule, the extension got its own Nominatim pass (2026-08-20): Ristna lighthouse, Kõpu lighthouse, Käsmu, Viinistu and Juminda all reverse-geocode to Estonia inside the new strips, and Hanko resolves Finland at 59.82 — confirming the Finnish coast sits above the FI core floor (59.8) and the raised EE top keeps ~19 km of clearance.

Vilsandi, also named in the issue body, sits west of the *Saaremaa* core and is not covered by the pre-checked extension; it still gaps (inside the hull, so it gets the border-band message, not "no provider").

TDD: three new jurisdiction tests (Kõpu/Ristna, Käsmu, and a Hanko-stays-FI guard), watched red first. Full suite 1306 passed, mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R66PgAV6rad1NrRgVSBEex