### PR TITLE
docs: catch the overview docs up with v2.11 (airspace, map, panoedit, 360° views)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,9 +120,11 @@ extending the desktop app. Design specs are local-only working notes since
 [`docs/superpowers/specs/2026-07-18-gui-full-workspace-design.md` (permalink)](https://github.com/CallMarcus/dji-drone-metadata-embedder/blob/e51ab2a/docs/superpowers/specs/2026-07-18-gui-full-workspace-design.md). It amends the
 original 2026-07-14 design: a single window, split into a source/mode/action
 column on the left and a preview pane on the right, replaces the three
-task-flow pages. The mode strip tops out at six modes (Embed, Flight map,
-Photo map, Convert, Verify, Setup); M1 wires up four (Flight map, Photo map,
-Embed, Setup), with Convert and Verify joining in M4. Options stay curated,
+task-flow pages. The spec's mode strip topped out at six modes (Embed,
+Flight map, Photo map, Convert, Verify, Setup); M1 wired up four (Flight
+map, Photo map, Embed, Setup), with Convert and Verify joining in M4, and
+a seventh mode — 360° views, fronting the `panoedit` opening-view
+editor — was added after the 2.0 arc (#440). Options stay curated,
 not exhaustive: they arrive in M3+, one *Advanced* expander per mode for the
 long tail, exotic flags remain CLI-only. As of M4a, the SOURCE door also
 accepts a single telemetry file (`.SRT`/`.MP4`/`.MOV`), not just a folder,

--- a/HELP.md
+++ b/HELP.md
@@ -25,7 +25,15 @@ Free, open-source (MIT) tool for DJI drone footage. Everything runs locally.
 - **Map your footage** — `photomap` pins every GPS-tagged photo (JPG/JPEG/
   DNG) on an interactive HTML map with thumbnails; 360° panoramas get their
   own orange pins and an in-page viewer. `flightmap` draws every flight in
-  a folder of `.SRT` logs on one map.
+  a folder of `.SRT` logs on one map. `map` combines both: photos,
+  panoramas and flight tracks on a single map, subfolders included.
+- **Airspace awareness** — `flightmap --airspace` overlays official drone
+  zones (FAA UAS Facility Maps in the US, the national feeds in Europe)
+  on the flat or 3D flight map; `flightmap -f record` writes a printable
+  flight record listing the zones each flight crossed. Covered so far:
+  US, UK, Ireland, Switzerland, Luxembourg, Denmark, Sweden, Finland,
+  Estonia. The map states facts about published zones; it never rules on
+  whether a flight was legal.
 - **Convert telemetry** — SRT to GPX, CSV, GeoJSON, KML, CoT, or an HTML
   map, for use in other apps (Google Earth, GIS tools, video editors).
 - **Privacy controls** — `--redact fuzz` coarsens locations to ~100 m;
@@ -35,10 +43,13 @@ Two ways to use it — same engine:
 
 1. **Desktop app** ("DJI Metadata Embedder", Windows and macOS): install, open, drop a folder,
    pick a mode (*Flight map*, *Photo map*, *Embed telemetry*,
-   *Convert telemetry*, *Verify footage*, *Setup*), and press the action
-   button; finished maps render right in the app's preview pane, with an
-   *Open in browser* pop-out. The Flight map mode has a *3D terrain map*
-   toggle for a MapLibre terrain view (`flightmap-3d.html`). No terminal.
+   *Convert telemetry*, *Verify footage*, *360° views*, *Setup*), and
+   press the action button; finished maps render right in the app's
+   preview pane, with an *Open in browser* pop-out. The Flight map mode
+   has a *3D terrain map* toggle for a MapLibre terrain view
+   (`flightmap-3d.html`) and an *Airspace* toggle for the official-zones
+   overlay. The *360° views* mode opens a local editor for setting each
+   panorama's opening view. No terminal.
    The workspace also accepts a
    single telemetry file (`.SRT`/`.MP4`/`.MOV`) as the source, and
    *Convert telemetry* turns it (or a folder) into GPX, CSV, GeoJSON, KML,
@@ -74,12 +85,15 @@ upgrade the same Python that owns the `dji-embed` command).
 
 ```
 dji-embed embed <folder>        Embed SRT telemetry into the MP4s (pairs by filename)
+dji-embed map <folder>          One HTML map of everything: photos, panoramas, flights
 dji-embed photomap <folder>     HTML map of GPS-tagged photos (-r = subfolders too)
-dji-embed flightmap <folder>    HTML map of all flights from the .SRT logs
+dji-embed flightmap <folder>    HTML map of all flights (--airspace, --3d, -f record)
 dji-embed convert <fmt> <file>  SRT → gpx | csv | geojson | kml | cot | html
 dji-embed check <folder>        What metadata do these files already carry?
 dji-embed validate <folder>     Are SRT and MP4 in sync? (drift report)
 dji-embed serve <folder>        Serve an existing map locally (enables the 360° viewer)
+dji-embed panoedit <folder>     Local editor: set each 360° panorama's opening view
+dji-embed fetch-log <file.TXT>  Decrypt DJI TXT flight records via Flight Reader (opt-in)
 dji-embed doctor                Diagnostics: versions, FFmpeg/ExifTool present?
 dji-embed verify-sun <file>     Sun position over a clip (shadow plausibility)
 ```
@@ -89,8 +103,19 @@ Every command accepts `--help` for its options.
 ## Recipes the user will most likely ask about
 
 - **"Map everything in this folder, including subfolders":**
-  `dji-embed photomap D:\Photos -r` → writes `photomap.html` into the
-  folder; open it in a browser. Videos' flights: `dji-embed flightmap D:\Footage`.
+  `dji-embed map D:\Drone` → one `map.html` with photos, panoramas and
+  flight tracks together (subfolders always included; add `--serve` for
+  the 360° viewer). For just photos with more options:
+  `dji-embed photomap D:\Photos -r`; just flights:
+  `dji-embed flightmap D:\Footage`.
+- **"Show official drone zones around my flights":**
+  `dji-embed flightmap D:\Footage --airspace` — overlays published zones
+  on the map (works with `--3d` too); `-f record` writes a printable
+  flight record including the zones crossed. Covered: US, UK, Ireland,
+  Switzerland, Luxembourg, Denmark, Sweden, Finland, Estonia; flights
+  elsewhere simply get no overlay. Zone data is fetched from the
+  official feeds and cached beside the map (`--airspace-refresh` forces
+  a refetch). Needs exact positions, so it refuses `--redact fuzz`.
 - **"My 360° panoramas won't open / black viewer":** browsers block the 360°
   viewer on maps opened straight from disk (`file://`). Rebuild with
   `dji-embed photomap <folder> --serve`, or serve an existing map with
@@ -130,6 +155,12 @@ Every command accepts `--help` for its options.
   for **any** GPS-tagged photos, not just DJI's.
 - The desktop app is a front end over the same CLI: anything the app does,
   the `dji-embed` command can do with more options.
+- Nothing is ever uploaded, with one opt-in exception: `fetch-log` sends
+  encrypted DJI `.TXT` flight records (never footage) to flightreader.com
+  for decoding, using the user's own Flight Reader API key, after an
+  explicit consent prompt. The decoded CSV feeds
+  `flightmap --flight-log`, which upgrades the 3D map's estimated camera
+  footprints to measured gimbal data.
 - Photo-map pins open their popup on click/tap; thumbnail previews on hover
   are **off by default** — a "Hover previews" toggle in the map's top-right
   corner (mouse devices only; the browser remembers the choice) turns them
@@ -146,4 +177,4 @@ Every command accepts `--help` for its options.
    <https://github.com/CallMarcus/dji-drone-metadata-embedder/issues>
 
 *This document ships with the project and is updated alongside it; it
-describes v2.0+ behavior.*
+describes v2.11+ behavior.*

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ it's a handful of copy-paste commands. For a guided tour see
   telemetry lines up.
 - **Flight records** — `dji-embed flightmap -f record` writes a printable
   logbook with airspace facts (FAA / ED-269) and honestly-labelled heights,
-  and `--airspace` overlays the same zones on the interactive maps — as translucent ceiling-height volumes in the 3D view.
+  and `--airspace` overlays the same zones on the interactive maps — as
+  translucent ceiling-height volumes in the 3D view. Covered so far: the
+  US, UK, Ireland, Switzerland, Luxembourg, Denmark, Sweden, Finland and
+  Estonia; everywhere else the record states the gap honestly.
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
   folder of stills on one clustered map, thumbnails included; 360° panoramas
   get their own marker color and toggle, and open in an interactive viewer.
@@ -234,6 +237,7 @@ maps there's also `dji-embed photomap <folder> --serve`.
 | See all my flights on one map | `dji-embed flightmap /path/to/footage` |
 | See my photos on a map | `dji-embed photomap /path/to/photos` |
 | Map a mixed folder (photos + flights) | `dji-embed map /path/to/folder` |
+| See official drone zones along my flights | `dji-embed flightmap /path/to/footage --airspace` |
 | Map one flight in detail | `dji-embed convert html DJI_0001.SRT` |
 | Make videos searchable by location | `dji-embed embed /path/to/footage` |
 | Get a GPX track for Google Earth | `dji-embed convert gpx DJI_0001.SRT` |

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -17,6 +17,9 @@ This guide helps you choose the right command and approach for your specific use
 | **Map a whole folder of flights** | `dji-embed flightmap` | You want every flight's track on one combined map |
 | **Map your still photos** | `dji-embed photomap` | You shot geotagged photos and want them on a map |
 | **Map a mixed folder of photos and videos** | `dji-embed map` | You want photos, panoramas, and flight tracks together on one map |
+| **See official drone zones along your flights** | `dji-embed flightmap --airspace` | Overlays published airspace zones on the flight map — nine countries covered, see [Flight records](how-to/flight-record.md) |
+| **A printable flight record / logbook** | `dji-embed flightmap -f record` | One page per flight with airspace facts and honestly-labelled heights |
+| **Set a 360° panorama's opening view** | `dji-embed panoedit` | Drag-and-save editor for the view a panorama opens with (also the app's *360° views* mode) |
 | **No terminal at all** | drag the folder onto `dji-embed.exe` | Maps the folder's flight logs and photos, then opens the result in your browser (same as `dji-embed <folder>`) |
 
 ---

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -26,7 +26,7 @@ and drag the app to Applications. FFmpeg and ExifTool come from Homebrew
 (`brew install ffmpeg exiftool`) — the Setup screen confirms the app
 found them. Full details in [Installation](installation.md#macos).
 
-## The six modes
+## The seven modes
 
 Drop a folder (or a single `.SRT`/`.MP4` file) into **Source** and the
 likely mode is picked for you. The **Mode** strip offers:
@@ -48,6 +48,10 @@ likely mode is picked for you. The **Mode** strip offers:
   tools.
 - **Verify** — checks embedded metadata, video/log pairing drift, or
   cross-checks the recorded time and place against the sun's position.
+- **360° views** — opens the panorama opening-view editor
+  (`dji-embed panoedit`) on the folder: drag each 360° panorama to the
+  view it should open with, and Save writes the GPano tags the photo
+  map and Google Photos honour.
 - **Setup** — confirms FFmpeg and ExifTool are ready, and can install
   what's missing.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # DJI Drone Metadata Embedder
 
-Welcome to the documentation for **DJI Drone Metadata Embedder**. This project embeds telemetry from DJI drone SRT files into videos, maps flights and GPS-tagged photos as interactive HTML maps, and converts telemetry to other formats — all locally on your machine, via a desktop app (Windows and macOS) or the `dji-embed` command line.
+Welcome to the documentation for **DJI Drone Metadata Embedder**. This project embeds telemetry from DJI drone SRT files into videos, maps flights and GPS-tagged photos as interactive HTML maps, overlays official airspace zones and writes printable flight records, and converts telemetry to other formats — all locally on your machine, via a desktop app (Windows and macOS) or the `dji-embed` command line.
 
 Use the guides in this site to embed GPS data in your footage, map where you've flown, redact sensitive information and generate GPX tracks.
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -23,6 +23,11 @@ folder onto `dji-embed.exe`**:
 dji-embed /path/to/footage    # -> flightmap.html (and photomap.html) open in the browser
 ```
 
+For one combined map instead — photos, panoramas and flight tracks
+together — use `dji-embed map <folder>`; airspace overlays, flight
+records and the panorama tools are covered in
+[Maps & Panoramas](geospatial.md).
+
 ## 3D terrain view
 
 `dji-embed flightmap <folder> --3d` writes a second map, `flightmap-3d.html`,
@@ -82,7 +87,8 @@ For detailed how-to guides such as creating Windows bundles or redacting locatio
 
 ## Scripting and frontends
 
-`photomap`, `flightmap`, `embed`, `check`, and `doctor` accept `--progress jsonl`,
+`map`, `photomap`, `flightmap`, `embed`, `check`, `doctor`, `convert`,
+`validate`, `verify-sun`, and `fetch-log` accept `--progress jsonl`,
 which switches stdout to machine-readable progress events (one JSON object
 per line) for scripts and GUI frontends. The event contract is documented
 in [Progress Events (JSONL)](PROGRESS_JSONL.md).


### PR DESCRIPTION
HELP.md hadn't moved since the v2.5.0 macOS sweep (#445), and a sweep found the same drift across the overview layer. The deep pages (geospatial.md, how-to/flight-record.md, PROGRESS_JSONL.md, troubleshooting.md) were already current — they shipped with their feature PRs.

## HELP.md (the AI-priming doc)
- Airspace bullet in *What the tool does* and a dedicated recipe: `--airspace`, `-f record`, caching / `--airspace-refresh`, the nine covered countries, and the refuses-`--redact fuzz` rule.
- `map`, `panoedit` and `fetch-log` added to the command table; `flightmap` line now hints at `--airspace` / `--3d` / `-f record`.
- The *map everything* recipe leads with `dji-embed map`.
- Desktop app paragraph lists all seven modes incl. *360° views*, plus the Airspace toggle.
- New fact reconciling privacy with `fetch-log`: the one opt-in upload (encrypted .TXT flight records, never footage, user's own Flight Reader key, consent prompt).
- Footer bumped from v2.0+ to v2.11+.

## Overview docs
- **README**: airspace features bullet now names the nine covered countries; airspace row in the *Which command do I need?* table.
- **docs/desktop-app.md**: *The six modes* → seven, with a *360° views* bullet.
- **docs/user_guide.md**: pointer to `dji-embed map` and geospatial.md from the drag-and-drop section; the `--progress jsonl` command list aligned with PROGRESS_JSONL.md (was five commands, is ten).
- **docs/decision-table.md**: rows for airspace overlay, printable flight record, and panoedit.
- **docs/index.md**: blurb mentions airspace overlays and flight records.
- **AGENTS.md**: GUI mode-strip history updated to note the seventh mode.

Every claim was checked against `cli.py` help text / option wiring and `WorkspaceMode.cs`, including the flag-combination rules (`--airspace` rejects redaction and non-HTML formats, works flat or 3D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eRu4EdPs1RVuJP1dSWaWF