### PR TITLE
fix(gui): let --airspace through with the 3D toggle (#530)

### DIFF
--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -36,9 +36,10 @@ likely mode is picked for you. The **Mode** strip offers:
   terrain map** toggle renders the flights draped over real terrain
   instead (writes `flightmap-3d.html`, so the flat map is never
   overwritten). An **Airspace zones** option overlays official zone
-  data on the flat map (US FAA, plus ED-269 feeds where a country
+  data on either map (US FAA, plus ED-269 feeds where a country
   publishes one), fetched from the official sources and cached beside
-  the map for reuse.
+  the map for reuse; on the 3D map, published ceilings become
+  translucent volumes.
 - **Photo map** — your still photos pinned on a map, including a full
   360° panorama viewer for drone panoramas.
 - **Embed telemetry** — writes each flight log's GPS track into the video

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -137,11 +137,12 @@ public class CommandBuilderTests
             CommandBuilder.FlightMap("/x", opts));
     }
 
-    // #427: --airspace overlays official zone data on the flat map. The CLI
-    // rejects it with --3d (a 3D zone overlay is #424) and with --redact
-    // fuzz (zones checked against coarsened coordinates would mislead), so
-    // the builder suppresses it in both cases — every argv stays legal by
-    // construction, same as the --format all suppression.
+    // #427: --airspace overlays official zone data on the map, flat or --3d
+    // (#424 made the 3D pairing legal; the GUI caught up in #530). The CLI
+    // still rejects it with --redact fuzz (zones checked against coarsened
+    // coordinates would mislead), so the builder suppresses it there —
+    // every argv stays legal by construction, same as the --format all
+    // suppression.
     [Fact]
     public void Airspace_adds_the_flag()
     {
@@ -163,14 +164,14 @@ public class CommandBuilderTests
     }
 
     [Fact]
-    public void Airspace_with_three_d_is_suppressed()
+    public void Airspace_with_three_d_keeps_the_flag()
     {
         var opts = FlightMapOptions.Defaults with
         {
             Airspace = true,
             ThreeD = true,
         };
-        Assert.Equal(["flightmap", "/x", "-r", "--3d"],
+        Assert.Equal(["flightmap", "/x", "-r", "--3d", "--airspace"],
             CommandBuilder.FlightMap("/x", opts));
     }
 
@@ -186,6 +187,7 @@ public class CommandBuilderTests
             CommandBuilder.FlightMap("/x", opts));
     }
 
+    // Fuzz is the suppression that survives #530: it wins even in 3D.
     [Fact]
     public void Airspace_with_three_d_and_fuzz_keeps_only_their_flags()
     {

--- a/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
@@ -105,10 +105,10 @@ public class FlightMapOptionsViewModelTests
 
     // #427: the airspace overlay is suppressed under fuzz (the CLI rejects
     // the pair), so a note must say so exactly while the checkbox is ticked
-    // but the flag stays out of the argv. Under 3D the 3D note already
-    // names the suppression, so this one stays quiet there.
+    // but the flag stays out of the argv — flat or 3D alike, since #530
+    // made Fuzz the only suppression left.
     [Fact]
-    public void Airspace_fuzz_note_needs_airspace_and_fuzz_on_the_flat_map()
+    public void Airspace_fuzz_note_needs_airspace_and_fuzz()
     {
         var vm = new FlightMapOptionsViewModel();
         Assert.False(vm.ShowsAirspaceFuzzNote);   // defaults: nothing on
@@ -121,11 +121,11 @@ public class FlightMapOptionsViewModelTests
         Assert.True(vm.ShowsAirspaceFuzzNote);    // airspace + Fuzz
 
         vm.ThreeD = true;
-        Assert.False(vm.ShowsAirspaceFuzzNote);   // the 3D note covers it
+        Assert.True(vm.ShowsAirspaceFuzzNote);    // 3D changes nothing (#530)
     }
 
     [Fact]
-    public void Airspace_fuzz_note_notifies_on_each_of_its_three_inputs()
+    public void Airspace_fuzz_note_notifies_on_each_of_its_two_inputs()
     {
         var vm = new FlightMapOptionsViewModel();
         var raised = 0;
@@ -140,13 +140,13 @@ public class FlightMapOptionsViewModelTests
         vm.Airspace = true;
         vm.SelectedPrivacy = vm.PrivacyOptions.Single(
             p => p.Value == MapPrivacy.Fuzz);
-        vm.ThreeD = true;
-        Assert.Equal(3, raised);
+        vm.ThreeD = true;   // no longer an input (#530)
+        Assert.Equal(2, raised);
     }
 
     // #431 review: the network note must mirror the argv exactly — visible
     // only while --airspace is actually emitted, so it never claims a fetch
-    // for a run that makes none (ticked + 3D, ticked + Fuzz).
+    // for a run that makes none (ticked + Fuzz; 3D emits since #530).
     [Fact]
     public void Airspace_network_note_shows_exactly_while_the_flag_is_emitted()
     {
@@ -157,7 +157,7 @@ public class FlightMapOptionsViewModelTests
         Assert.True(vm.ShowsAirspaceNote);        // ticked, Keep, flat map
 
         vm.ThreeD = true;
-        Assert.False(vm.ShowsAirspaceNote);       // suppressed under 3D
+        Assert.True(vm.ShowsAirspaceNote);        // still emitted in 3D (#530)
 
         vm.ThreeD = false;
         vm.SelectedPrivacy = vm.PrivacyOptions.Single(
@@ -166,7 +166,7 @@ public class FlightMapOptionsViewModelTests
     }
 
     [Fact]
-    public void Airspace_network_note_notifies_on_each_of_its_three_inputs()
+    public void Airspace_network_note_notifies_on_each_of_its_two_inputs()
     {
         var vm = new FlightMapOptionsViewModel();
         var raised = 0;
@@ -181,8 +181,8 @@ public class FlightMapOptionsViewModelTests
         vm.Airspace = true;
         vm.SelectedPrivacy = vm.PrivacyOptions.Single(
             p => p.Value == MapPrivacy.Fuzz);
-        vm.ThreeD = true;
-        Assert.Equal(3, raised);
+        vm.ThreeD = true;   // no longer an input (#530)
+        Assert.Equal(2, raised);
     }
 
     // #431 review: the flight record itself fetches airspace and terrain

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -636,7 +636,8 @@ public class WorkspaceScreenTests
 
     // #366: the 3D toggle binds to the options VM, surfaces --3d in the
     // strip, and greys the two controls whose flags the builder suppresses
-    // (Map style: CLI-ignored; export all: CLI UsageError). Choices made
+    // (Map style: CLI-ignored; export all: CLI UsageError). Airspace stays
+    // enabled — the pair has been legal since #424 (#530). Choices made
     // before entering 3D must come back when it is unchecked.
     [AvaloniaFact]
     public void Three_d_toggle_binds_and_greys_the_flat_map_options()
@@ -663,7 +664,7 @@ public class WorkspaceScreenTests
 
         var airspace = window.GetVisualDescendants().OfType<CheckBox>()
             .Single(c => c.Name == "FlightAirspaceCheck");
-        Assert.False(airspace.IsEnabled);
+        Assert.True(airspace.IsEnabled);
 
         var advanced = window.GetVisualDescendants().OfType<Expander>()
             .Single(e => e.Name == "FlightAdvanced");
@@ -686,8 +687,8 @@ public class WorkspaceScreenTests
     // #431 review: every airspace note must mirror the emitted argv — the
     // network disclosure only while --airspace is actually in the command,
     // the fuzz note exactly while the checkbox is ticked but Fuzz keeps the
-    // flag out, and both quiet under 3D where the 3D note names the
-    // suppression.
+    // flag out. 3D no longer suppresses the flag (#530), so both notes
+    // carry straight through it.
     [AvaloniaFact]
     public void Flight_map_airspace_notes_mirror_the_emitted_argv()
     {
@@ -721,8 +722,17 @@ public class WorkspaceScreenTests
         vm.FlightOptions.ThreeD = true;
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();
-        Assert.False(check.IsEnabled);
+        Assert.True(check.IsEnabled);
         Assert.False(note.IsVisible);
+        Assert.True(fuzzNote.IsEffectivelyVisible);
+
+        vm.FlightOptions.SelectedPrivacy = vm.FlightOptions.PrivacyOptions
+            .Single(p => p.Value == MapPrivacy.Keep);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.Contains("--airspace", vm.CommandPreview);
+        Assert.Contains("--3d", vm.CommandPreview);
+        Assert.True(note.IsEffectivelyVisible);
         Assert.False(fuzzNote.IsVisible);
     }
 

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -38,12 +38,11 @@ public static class CommandBuilder
     /// M3b). Flags are omitted at their defaults so an untouched run reads
     /// <c>flightmap &lt;folder&gt; -r</c>, exactly like M3a. Order is fixed for
     /// golden tests. No <c>--progress</c>: the runner appends that.
-    /// When <paramref name="opts"/>.ThreeD is set, <c>--tile-style</c>,
-    /// <c>--airspace</c> and <c>--format all</c> are suppressed — the CLI
-    /// ignores the first and rejects the others with <c>--3d</c> — and Fuzz
-    /// privacy suppresses <c>--airspace</c> too (the CLI rejects the pair),
-    /// so every argv this method returns is legal by construction
-    /// (#366, #427).
+    /// When <paramref name="opts"/>.ThreeD is set, <c>--tile-style</c> and
+    /// <c>--format all</c> are suppressed — the CLI ignores the first and
+    /// rejects the second with <c>--3d</c> — and Fuzz privacy suppresses
+    /// <c>--airspace</c> (the CLI rejects the pair), so every argv this
+    /// method returns is legal by construction (#366, #427, #530).
     /// </summary>
     public static string[] FlightMap(string folder, FlightMapOptions opts)
     {
@@ -68,10 +67,11 @@ public static class CommandBuilder
             args.Add("--tile-style");
             args.Add(opts.TileStyle);
         }
-        if (opts.Airspace && !opts.ThreeD && opts.Privacy != MapPrivacy.Fuzz)
+        if (opts.Airspace && opts.Privacy != MapPrivacy.Fuzz)
         {
-            // The CLI rejects --airspace with --3d (#424 will lift that)
-            // and with --redact fuzz, so both suppress it here (#427).
+            // Legal flat or 3D since #424 (in 3D, published ceilings become
+            // translucent volumes). The CLI still rejects the pairing with
+            // --redact fuzz, so Fuzz suppresses it here (#427, #530).
             args.Add("--airspace");
         }
         if (opts.Privacy == MapPrivacy.Fuzz)

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
@@ -21,10 +21,11 @@ public enum MapPrivacy
 /// <param name="TileStyle">A <c>tiles.py</c> key: <c>osm</c> (default),
 /// <c>osm-hot</c>, <c>opentopomap</c>, or <c>cyclosm</c>.</param>
 /// <param name="Airspace">Overlay official airspace zones
-/// (<c>--airspace</c>, #427). The CLI rejects the flag with <c>--3d</c>
-/// (a 3D zone overlay is #424) and with <c>--redact fuzz</c> (zones
-/// checked against coarsened coordinates would mislead), so the builder
-/// suppresses it in both cases.</param>
+/// (<c>--airspace</c>, #427), flat or 3D — since #424 the 3D map renders
+/// published ceilings as translucent volumes (#530). The CLI still
+/// rejects the flag with <c>--redact fuzz</c> (zones checked against
+/// coarsened coordinates would mislead), so the builder suppresses it
+/// there.</param>
 /// <param name="JoinGap">Seconds to chain size-split recordings; 15 = the CLI
 /// default, 0 = don't join.</param>
 /// <param name="LinkOriginals">Embed links to each flight's source videos

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
@@ -78,21 +78,23 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
     /// <summary>
     /// True exactly while <c>--airspace</c> is in the emitted argv, so the
     /// network-disclosure note never claims a fetch for a run that makes
-    /// none (#427, tightened by the #431 review). A real property so it is
+    /// none (#427, tightened by the #431 review). 3D stopped mattering when
+    /// the builder let the pair through (#530). A real property so it is
     /// assertable headless.
     /// </summary>
     public bool ShowsAirspaceNote =>
-        Airspace && !ThreeD && SelectedPrivacy.Value != MapPrivacy.Fuzz;
+        Airspace && SelectedPrivacy.Value != MapPrivacy.Fuzz;
 
     /// <summary>
     /// True when the airspace checkbox is ticked but the builder keeps
     /// <c>--airspace</c> out of the argv because Fuzz privacy is on (the
     /// CLI rejects the pair — zones checked against coarsened coordinates
-    /// would mislead). Quiet under 3D, where the 3D note already names the
-    /// suppression (#427). A real property so it is assertable headless.
+    /// would mislead). Flat or 3D alike, now that Fuzz is the only
+    /// suppression left (#427, #530). A real property so it is assertable
+    /// headless.
     /// </summary>
     public bool ShowsAirspaceFuzzNote =>
-        Airspace && !ThreeD && SelectedPrivacy.Value == MapPrivacy.Fuzz;
+        Airspace && SelectedPrivacy.Value == MapPrivacy.Fuzz;
 
     /// <summary>
     /// True exactly while "Export all" will write the flight record — which
@@ -116,8 +118,6 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
     partial void OnThreeDChanged(bool value)
     {
         OnPropertyChanged(nameof(ShowsFuzzCaveat));
-        OnPropertyChanged(nameof(ShowsAirspaceNote));
-        OnPropertyChanged(nameof(ShowsAirspaceFuzzNote));
         OnPropertyChanged(nameof(ShowsRecordNetworkNote));
         OnPropertyChanged(nameof(ShowsRecordSkipNote));
     }

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -275,7 +275,7 @@
                                                        VerticalAlignment="Center" />
                                         </DockPanel>
                                         <TextBlock Name="FlightThreeDNote"
-                                                   Text="Map style, airspace zones and KML/GeoJSON export don't apply to the 3D map."
+                                                   Text="Map style and KML/GeoJSON export don't apply to the 3D map. Airspace zones do — published ceilings become translucent volumes."
                                                    IsVisible="{Binding FlightOptions.ThreeD}"
                                                    TextWrapping="Wrap"
                                                    Opacity="0.5" FontSize="11" />
@@ -325,14 +325,13 @@
                                     </StackPanel>
 
                                     <StackPanel Spacing="4">
-                                        <!-- Two affordances for one "flag suppressed" state, on
-                                             purpose: 3D greys the checkbox (a toggle right above
-                                             it), while Fuzz keeps it enabled and explains in a
-                                             note — greying on a combo set elsewhere in the panel
-                                             would be action at a distance. -->
+                                        <!-- Fuzz suppresses the flag but keeps the checkbox
+                                             enabled and explains in a note — greying on a combo
+                                             set elsewhere in the panel would be action at a
+                                             distance. (3D used to grey it too, until #424 made
+                                             the pair legal — #530.) -->
                                         <CheckBox Name="FlightAirspaceCheck"
                                                   IsChecked="{Binding FlightOptions.Airspace}"
-                                                  IsEnabled="{Binding !FlightOptions.ThreeD}"
                                                   Content="Airspace zones" />
                                         <TextBlock Name="FlightAirspaceNote"
                                                    Text="Draws official airspace zones on the map — US FAA, plus national UAS-zone feeds where a country publishes one (currently Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark, Sweden and Estonia). Zone data is fetched from those feeds and cached next to the map (airspace-cache/); later runs reuse the cache."


### PR DESCRIPTION
## What

Ticking **Airspace zones** together with **3D terrain map** silently dropped `--airspace` from the argv — a leftover from before #424 made the pair legal CLI-side. Desktop users can now get the 3D airspace volumes the CLI already renders.

## Changes

- `CommandBuilder.FlightMap()` no longer gates `--airspace` on `!ThreeD`; Fuzz remains the only suppression (the CLI still rejects `--airspace` with `--redact fuzz`), so every argv stays legal by construction.
- The airspace checkbox stays enabled under 3D; the 3D note now reads "Map style and KML/GeoJSON export don't apply to the 3D map. Airspace zones do — published ceilings become translucent volumes."
- `ShowsAirspaceNote` / `ShowsAirspaceFuzzNote` dropped their `!ThreeD` condition, keeping the #427/#431 invariant: the network-disclosure note is true exactly while `--airspace` is in the argv, and the fuzz note exactly while Fuzz keeps it out — flat or 3D alike. `OnThreeDChanged` no longer notifies them.
- Golden argv tests, note-property tests (ThreeD is no longer an input, notify counts 3 → 2), and headless screen tests updated; the notes test now also walks back from 3D+Fuzz to 3D+Keep and sees `--airspace --3d` emitted together.
- `docs/desktop-app.md` Flight map bullet: "on the flat map" → "on either map", with the volumes mentioned.

## Testing

`dotnet test DjiEmbed.Gui.Tests`: 561 passed, 0 failed (16 skipped screenshot captures, as always headless).

Closes #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t