### PR TITLE
polish(gui/panoedit/photomap): the v2.9.0 field-tester round (#532)

### DIFF
--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -52,7 +52,11 @@ likely mode is picked for you. The **Mode** strip offers:
 - **360° views** — opens the panorama opening-view editor
   (`dji-embed panoedit`) on the folder: drag each 360° panorama to the
   view it should open with, and Save writes the GPano tags the photo
-  map and Google Photos honour.
+  map and Google Photos honour. By default oversized panoramas are
+  shown downscaled so older graphics cards can display them (the files
+  and the saved view are identical either way); an **Edit at full
+  resolution** option turns that off for machines with a capable
+  graphics card.
 - **Setup** — confirms FFmpeg and ExifTool are ready, and can install
   what's missing.
 

--- a/gui/DjiEmbed.Gui.Tests/AppVersionTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/AppVersionTests.cs
@@ -1,0 +1,47 @@
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+// #532: the main window title carries the stamped version so any field
+// report screenshot names the build it came from. Dev builds (the SDK's
+// default 1.0.0) show the bare name — a made-up number would mislead
+// exactly the reports the title exists for.
+public class AppVersionTests
+{
+    [Theory]
+    [InlineData("2.11.0", "2.11.0")]
+    [InlineData("2.11.0+abc1234", "2.11.0")]  // SourceLink build metadata
+    [InlineData("2.12.0-rc.1", "2.12.0-rc.1")]
+    public void Stamped_versions_survive_with_metadata_stripped(
+        string informational, string expected)
+    {
+        Assert.Equal(expected, AppVersion.Normalize(informational));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("1.0.0")]
+    [InlineData("1.0.0+abc1234")]
+    public void Unstamped_builds_normalize_to_null(string? informational)
+    {
+        Assert.Null(AppVersion.Normalize(informational));
+    }
+
+    [Fact]
+    public void Title_carries_the_version_only_when_there_is_one()
+    {
+        Assert.Equal("DJI Metadata Embedder v2.11.0",
+            AppVersion.TitleFor("2.11.0"));
+        Assert.Equal("DJI Metadata Embedder", AppVersion.TitleFor(null));
+    }
+
+    [Fact]
+    public void Window_title_is_always_presentable()
+    {
+        // The test host itself is an unstamped build, so this exercises
+        // the real assembly-attribute path end to end.
+        Assert.StartsWith("DJI Metadata Embedder", AppVersion.WindowTitle);
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -43,6 +43,17 @@ public class CommandBuilderTests
         Assert.Equal(expected, CommandBuilder.Build(WorkspaceModeKind.PanoEdit, "/x"));
     }
 
+    // #532: the one 360° views option — full resolution maps to
+    // --max-width 0 (serve-width downscale off), omitted at its default.
+    [Fact]
+    public void Pano_edit_full_resolution_adds_max_width_zero()
+    {
+        Assert.Equal(["panoedit", "/x", "--max-width", "0"],
+            CommandBuilder.PanoEdit("/x", fullResolution: true));
+        Assert.Equal(["panoedit", "/x"],
+            CommandBuilder.PanoEdit("/x", fullResolution: false));
+    }
+
     [Fact]
     public void No_mode_ever_includes_the_progress_flag()
     {

--- a/gui/DjiEmbed.Gui.Tests/FakeMapServer.cs
+++ b/gui/DjiEmbed.Gui.Tests/FakeMapServer.cs
@@ -13,6 +13,8 @@ internal sealed class FakeMapServer(string? url) : IMapServer
 
     public List<string> EditorRequests { get; } = [];
 
+    public List<bool> EditorFullResolutions { get; } = [];
+
     public Task<string?> GetUrlAsync(
         string cliPath, string htmlPath, CancellationToken cancellationToken)
     {
@@ -21,9 +23,11 @@ internal sealed class FakeMapServer(string? url) : IMapServer
     }
 
     public Task<string?> GetEditorUrlAsync(
-        string cliPath, string folder, CancellationToken cancellationToken)
+        string cliPath, string folder, bool fullResolution,
+        CancellationToken cancellationToken)
     {
         EditorRequests.Add(folder);
+        EditorFullResolutions.Add(fullResolution);
         return Task.FromResult(url);
     }
 }

--- a/gui/DjiEmbed.Gui.Tests/MapServerTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/MapServerTests.cs
@@ -135,6 +135,27 @@ public class MapServerTests : IDisposable
             cli, MapFile(), CancellationToken.None));
     }
 
+    // #532: the full-resolution option must reach the editor child's argv
+    // as --max-width 0, and only when asked for.
+    [Fact]
+    public async Task Editor_full_resolution_reaches_the_child_argv()
+    {
+        using var server = new MapServer(LogPath());
+        var argsFile = Path.Combine(_dir, "editor-args");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile,
+            ["http://127.0.0.1:54321/"]);
+        Assert.NotNull(await server.GetEditorUrlAsync(
+            cli, _dir, fullResolution: true, CancellationToken.None));
+        var argv = string.Join(' ', File.ReadAllLines(argsFile));
+        Assert.Contains("--max-width 0", argv);
+
+        File.Delete(argsFile);
+        Assert.NotNull(await server.GetEditorUrlAsync(
+            cli, _dir, fullResolution: false, CancellationToken.None));
+        Assert.DoesNotContain("--max-width",
+            string.Join(' ', File.ReadAllLines(argsFile)));
+    }
+
     // #531: the drained helper output used to be discarded — which threw
     // away exactly the per-save timing lines a field report needs. It now
     // lands in a timestamped helper log.

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -1622,6 +1622,35 @@ public class WorkspaceScreenTests
         Assert.False(advanced.IsExpanded);
     }
 
+    // #532: the 360° views panel's one option — full-resolution serving —
+    // binds through to the CLI strip as --max-width 0.
+    [AvaloniaFact]
+    public void Pano_edit_full_resolution_checkbox_drives_the_strip()
+    {
+        var window = ShowWorkspace();
+        var vm = (WorkspaceViewModel)((WorkspaceView)window.Content!).DataContext!;
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+
+        var panel = window.GetVisualDescendants().OfType<Border>()
+            .Single(b => b.Name == "PanoEditOptionsPanel");
+        Assert.True(panel.IsEffectivelyVisible);
+        var check = window.GetVisualDescendants().OfType<CheckBox>()
+            .Single(c => c.Name == "PanoFullResolutionCheck");
+        Assert.False(check.IsChecked);
+        Assert.DoesNotContain("--max-width", vm.CommandPreview);
+
+        check.IsChecked = true;
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(vm.PanoOptions.FullResolution);
+        Assert.Contains("--max-width 0", vm.CommandPreview);
+
+        check.IsChecked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.DoesNotContain("--max-width", vm.CommandPreview);
+    }
+
     [AvaloniaFact]
     public void Non_convert_mode_hides_the_convert_options_panel()
     {

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -2173,7 +2173,26 @@ public class WorkspaceViewModelTests : IDisposable
         vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
         await vm.RunCommand.ExecuteAsync(null);
         Assert.Equal([folder], fake.EditorRequests);
+        Assert.Equal([false], fake.EditorFullResolutions);
         Assert.Equal("http://127.0.0.1:9/", vm.PreviewUrl);
+        Assert.Equal(FlowStep.Done, vm.Step);
+    }
+
+    // #532: the full-resolution opt-out of the serve-width downscale must
+    // reach the editor child, not just the preview strip.
+    [Fact]
+    public async Task Pano_edit_full_resolution_reaches_the_editor_launch()
+    {
+        var cli = Path.Combine(_dir, "dji-embed-fake");
+        File.WriteAllText(cli, "");
+        var folder = MakeFolder(photos: true);
+        var fake = new FakeMapServer("http://127.0.0.1:9/");
+        var vm = Vm(cli, mapServer: fake, previewAvailable: static () => true);
+        await vm.SetFolderAsync(folder);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        vm.PanoOptions.FullResolution = true;
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.Equal([true], fake.EditorFullResolutions);
         Assert.Equal(FlowStep.Done, vm.Step);
     }
 
@@ -2200,6 +2219,18 @@ public class WorkspaceViewModelTests : IDisposable
         Assert.Equal("dji-embed panoedit <folder>", vm.CommandPreview);
     }
 
+    [Fact]
+    public void Pano_edit_full_resolution_shows_in_the_preview()
+    {
+        var vm = Vm(null);
+        vm.SelectedMode = WorkspaceMode.Of(WorkspaceModeKind.PanoEdit);
+        vm.PanoOptions.FullResolution = true;
+        Assert.Equal("dji-embed panoedit <folder> --max-width 0",
+            vm.CommandPreview);
+        vm.PanoOptions.FullResolution = false;
+        Assert.Equal("dji-embed panoedit <folder>", vm.CommandPreview);
+    }
+
     private sealed class ThrowingMapServer : IMapServer
     {
         public Task<string?> GetUrlAsync(
@@ -2207,7 +2238,8 @@ public class WorkspaceViewModelTests : IDisposable
             throw new InvalidOperationException("server exploded");
 
         public Task<string?> GetEditorUrlAsync(
-            string cliPath, string folder, CancellationToken cancellationToken) =>
+            string cliPath, string folder, bool fullResolution,
+            CancellationToken cancellationToken) =>
             throw new InvalidOperationException("server exploded");
     }
 
@@ -2218,7 +2250,8 @@ public class WorkspaceViewModelTests : IDisposable
             throw new OperationCanceledException();
 
         public Task<string?> GetEditorUrlAsync(
-            string cliPath, string folder, CancellationToken cancellationToken) =>
+            string cliPath, string folder, bool fullResolution,
+            CancellationToken cancellationToken) =>
             throw new OperationCanceledException();
     }
 

--- a/gui/DjiEmbed.Gui/Services/AppVersion.cs
+++ b/gui/DjiEmbed.Gui/Services/AppVersion.cs
@@ -1,0 +1,39 @@
+using System.Reflection;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// The version the running build was stamped with (release workflows pass
+/// <c>-p:Version=X.Y.Z</c> at publish). Shown in the main window title so
+/// a field report can name its version from any screenshot — a tester
+/// spent three messages unable to say which build he was running (#532).
+/// </summary>
+public static class AppVersion
+{
+    public static string WindowTitle => TitleFor(Current);
+
+    public static string TitleFor(string? version) => version is null
+        ? "DJI Metadata Embedder"
+        : "DJI Metadata Embedder v" + version;
+
+    /// <summary>The stamped version, or null for an unstamped dev build —
+    /// where showing the SDK's default would mislead exactly the reports
+    /// the title exists for.</summary>
+    public static string? Current => Normalize(
+        Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion);
+
+    /// <summary>"2.11.0+abc123" → "2.11.0" (SourceLink appends the commit
+    /// as build metadata); blank or the SDK default "1.0.0" → null.</summary>
+    public static string? Normalize(string? informational)
+    {
+        if (string.IsNullOrWhiteSpace(informational))
+        {
+            return null;
+        }
+        var plus = informational.IndexOf('+');
+        var version = plus >= 0 ? informational[..plus] : informational;
+        return version == "1.0.0" ? null : version;
+    }
+}

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -354,7 +354,14 @@ public static class CommandBuilder
     /// <c>panoedit &lt;folder&gt;</c>; MapServer appends
     /// <c>--no-browser --url-only --exit-with-stdin</c> at launch, the
     /// same split the serve child uses.</summary>
-    public static string[] PanoEdit(string folder) => ["panoedit", folder];
+    /// <summary>The 360° views argv (#440). <paramref name="fullResolution"/>
+    /// maps to <c>--max-width 0</c>: serve panoramas at full size instead of
+    /// the CLI's default downscale of oversized ones, which is calibrated
+    /// for old low-memory graphics cards (#471, #532).</summary>
+    public static string[] PanoEdit(string folder, bool fullResolution = false)
+        => fullResolution
+            ? ["panoedit", folder, "--max-width", "0"]
+            : ["panoedit", folder];
 
     /// <summary>
     /// The <c>--popup-fields</c> value, or <c>null</c> to omit the flag.

--- a/gui/DjiEmbed.Gui/Services/IMapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/IMapServer.cs
@@ -19,7 +19,11 @@ public interface IMapServer
     /// <summary>Launches (or reuses) a <c>dji-embed panoedit</c> child for
     /// <paramref name="folder"/> and returns its editor URL (#440). Null
     /// when the editor could not start (no panoramas, no CLI);
-    /// cancellation surfaces as OperationCanceledException.</summary>
+    /// cancellation surfaces as OperationCanceledException.
+    /// <paramref name="fullResolution"/> serves panoramas full-size
+    /// (<c>--max-width 0</c>, #532); children with different resolution
+    /// modes never share a server.</summary>
     Task<string?> GetEditorUrlAsync(
-        string cliPath, string folder, CancellationToken cancellationToken);
+        string cliPath, string folder, bool fullResolution,
+        CancellationToken cancellationToken);
 }

--- a/gui/DjiEmbed.Gui/Services/MapServer.cs
+++ b/gui/DjiEmbed.Gui/Services/MapServer.cs
@@ -76,17 +76,23 @@ public sealed class MapServer : IMapServer, IDisposable
     }
 
     public Task<string?> GetEditorUrlAsync(
-        string cliPath, string folder, CancellationToken cancellationToken)
+        string cliPath, string folder, bool fullResolution,
+        CancellationToken cancellationToken)
     {
         var dir = Path.GetFullPath(folder);
         // The key prefix keeps a served map folder and an edited pano
-        // folder from colliding in the reuse table; the editor's URL is
-        // its base URL (the child prints "http://127.0.0.1:PORT/").
+        // folder from colliding in the reuse table — and carries the
+        // resolution mode, so toggling it launches a fresh child instead
+        // of reusing one serving the other size (#532). The editor's URL
+        // is its base URL (the child prints "http://127.0.0.1:PORT/").
+        string[] args = fullResolution
+            ? ["panoedit", dir, "--max-width", "0", "--no-browser",
+               "--url-only", "--exit-with-stdin"]
+            : ["panoedit", dir, "--no-browser", "--url-only",
+               "--exit-with-stdin"];
         return LaunchAsync(
-            cliPath, "panoedit:" + dir,
-            ["panoedit", dir, "--no-browser", "--url-only",
-             "--exit-with-stdin"],
-            cancellationToken);
+            cliPath, "panoedit:" + (fullResolution ? "full:" : "") + dir,
+            args, cancellationToken);
     }
 
     /// <summary>One child per <paramref name="key"/>: reuses a live one,

--- a/gui/DjiEmbed.Gui/ViewModels/PanoEditOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/PanoEditOptionsViewModel.cs
@@ -1,0 +1,17 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DjiEmbed.Gui.ViewModels;
+
+/// <summary>
+/// Observable control state for the 360° views options panel (#532). One
+/// curated option: whether panoramas are served at full resolution
+/// (<c>--max-width 0</c>) instead of the CLI's default downscale for
+/// oversized ones — the default was calibrated for a 2 GB graphics card
+/// (#471), and a tester with a modern card reasonably wants full-resolution
+/// editing. In-memory only, like the other option panels.
+/// </summary>
+public partial class PanoEditOptionsViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    public partial bool FullResolution { get; set; }
+}

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -59,6 +59,8 @@ public partial class WorkspaceViewModel : FlowViewModel
             OnPropertyChanged(nameof(CommandPreview));
             OnPropertyChanged(nameof(ActionVerb));
         };
+        PanoOptions.PropertyChanged += (_, _) =>
+            OnPropertyChanged(nameof(CommandPreview));
         Warnings.CollectionChanged += (_, _) =>
             OnPropertyChanged(nameof(ShowDoneWarnings));
         VerifyCards.CollectionChanged += (_, _) =>
@@ -102,6 +104,11 @@ public partial class WorkspaceViewModel : FlowViewModel
     /// the run and the CLI strip; any change re-raises <see cref="CommandPreview"/>
     /// and the sub-action-shaped <see cref="ActionVerb"/>.</summary>
     public VerifyOptionsViewModel VerifyOptions { get; } = new();
+
+    /// <summary>Curated option state for the 360° views mode (#532). Feeds
+    /// both the editor launch and the CLI strip; any change re-raises
+    /// <see cref="CommandPreview"/>.</summary>
+    public PanoEditOptionsViewModel PanoOptions { get; } = new();
 
     public IReadOnlyList<WorkspaceMode> Modes => WorkspaceMode.All;
 
@@ -388,7 +395,7 @@ public partial class WorkspaceViewModel : FlowViewModel
                         SelectedFile ?? SelectedFolder ?? "<source>",
                         VerifyOptions.ToOptions()),
                 WorkspaceModeKind.PanoEdit =>
-                    CommandBuilder.PanoEdit(folder!),
+                    CommandBuilder.PanoEdit(folder!, PanoOptions.FullResolution),
                 _ => CommandBuilder.Build(SelectedMode.Kind, folder),
             };
             return CommandLine.Format("dji-embed", argv);
@@ -824,7 +831,8 @@ public partial class WorkspaceViewModel : FlowViewModel
             await ExecuteFlowAsync(async () =>
             {
                 var url = await _mapServer.GetEditorUrlAsync(
-                    CliPath!, panoFolder, FlowToken);
+                    CliPath!, panoFolder, PanoOptions.FullResolution,
+                    FlowToken);
                 if (url is null)
                 {
                     Fail("The 360° view editor could not be started — "

--- a/gui/DjiEmbed.Gui/Views/MainWindow.axaml.cs
+++ b/gui/DjiEmbed.Gui/Views/MainWindow.axaml.cs
@@ -23,6 +23,10 @@ public partial class MainWindow : Window
     public MainWindow(GuiStateStore? store)
     {
         InitializeComponent();
+        // Release builds carry their stamped version in the title so any
+        // screenshot names the build it came from (#532); dev builds keep
+        // the bare name.
+        Title = AppVersion.WindowTitle;
         _store = store;
         if (store?.State.Window is { } b
             && GuiState.RestorableOn(b, ScreenRects()))

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -926,10 +926,19 @@
                         <StackPanel>
                             <TextBlock Classes="zone" Text="OPTIONS" />
                             <suki:GlassCard Padding="14">
-                                <TextBlock Name="PanoEditHint"
-                                           TextWrapping="Wrap" Opacity="0.7"
-                                           FontSize="12"
-                                           Text="Pick the folder with your 360° panoramas. Drag each one to its best opening view, then Save — the view is written into the photo itself (a backup is kept beside it) and the photo map opens it that way." />
+                                <StackPanel Spacing="10">
+                                    <TextBlock Name="PanoEditHint"
+                                               TextWrapping="Wrap" Opacity="0.7"
+                                               FontSize="12"
+                                               Text="Pick the folder with your 360° panoramas. Drag each one to its best opening view, then Save — the view is written into the photo itself (a backup is kept beside it) and the photo map opens it that way." />
+                                    <CheckBox Name="PanoFullResolutionCheck"
+                                              IsChecked="{Binding PanoOptions.FullResolution}"
+                                              Content="Edit at full resolution" />
+                                    <TextBlock Name="PanoFullResolutionNote"
+                                               TextWrapping="Wrap" Opacity="0.5"
+                                               FontSize="11"
+                                               Text="By default, panoramas wider than 6000 px are shown downscaled so older graphics cards can display them — the saved view is identical either way, and the files are never modified. Full resolution needs a graphics card with enough memory for the whole image." />
+                                </StackPanel>
                             </suki:GlassCard>
                         </StackPanel>
                     </Border>

--- a/src/dji_metadata_embedder/geo/panoedit_html.py
+++ b/src/dji_metadata_embedder/geo/panoedit_html.py
@@ -51,9 +51,13 @@ _PAGE = """<!DOCTYPE html>
   #status.err {{ color: #ff7b6b; }}
   #strip {{ position: fixed; left: 0; right: 0; bottom: 0; height: 96px;
     background: #1b1b1b; display: flex; align-items: center; gap: 6px;
-    overflow-x: auto; padding: 0 12px; box-sizing: border-box; }}
+    overflow-x: auto; padding: 0 48px; box-sizing: border-box;
+    scroll-behavior: smooth; }}
+  /* Long filenames meant only a couple of chips fit (#532): cap and
+     ellipsize — the full name is the chip's title and the readout. */
   .chip {{ flex: 0 0 auto; padding: 6px 10px; border-radius: 5px;
-    background: #2a2a2a; cursor: pointer; white-space: nowrap; }}
+    background: #2a2a2a; cursor: pointer; white-space: nowrap;
+    max-width: 17ch; overflow: hidden; text-overflow: ellipsis; }}
   .chip.active {{ outline: 2px solid #2a81cb; }}
   .chip .dot {{ display: inline-block; width: 8px; height: 8px;
     border-radius: 50%; background: #666; margin-right: 6px; }}
@@ -73,6 +77,14 @@ _PAGE = """<!DOCTYPE html>
   #panoerr > div {{ max-width: 36em; line-height: 1.6; text-align: center; }}
   #panoerr b {{ color: #ff7b6b; }}
   #panoerr code {{ color: #ffd24d; }}
+  /* Big flanking arrows for the film strip — a field tester found the
+     bare scrollbar too fiddly with 200+ panoramas (#532). */
+  .stripnav {{ position: fixed; bottom: 0; height: 96px; width: 40px;
+    z-index: 11; border: 0; background: #262626; color: #ddd;
+    font-size: 26px; cursor: pointer; }}
+  .stripnav:hover {{ background: #333; }}
+  #stripback {{ left: 0; }}
+  #stripfwd {{ right: 0; }}
 </style>
 </head>
 <body>
@@ -92,6 +104,12 @@ _PAGE = """<!DOCTYPE html>
 <div id="note">{backup_note} N/P: next/previous. Esc: back to the opening
 view. C: compare with the saved one.</div>
 <div id="strip"></div>
+<button id="stripback" class="stripnav" type="button"
+  title="Scroll the file strip back" aria-label="Scroll the file strip back"
+  >&#8249;</button>
+<button id="stripfwd" class="stripnav" type="button"
+  title="Scroll the file strip forward"
+  aria-label="Scroll the file strip forward">&#8250;</button>
 <script src="https://unpkg.com/pannellum@{pannellum}/build/pannellum.js"
         integrity="{pannellum_js_sri}" crossorigin=""></script>
 <script>
@@ -258,17 +276,25 @@ function dropCompare() {{
 function renderStrip() {{
   const strip = $("strip");
   strip.textContent = "";
+  let active = null;
   files.forEach((f, i) => {{
     const chip = document.createElement("div");
     chip.className = "chip" + (i === idx ? " active" : "")
       + (f.hasView ? " hasview" : "");
+    // Chips ellipsize long names (#532); the title carries the full one.
+    chip.title = f.name;
     const dot = document.createElement("span");
     dot.className = "dot";
     chip.appendChild(dot);
     chip.appendChild(document.createTextNode(f.name));
     chip.addEventListener("click", () => navigate(i));
     strip.appendChild(chip);
+    if (i === idx) active = chip;
   }});
+  // Keep the current file in sight: with hundreds of panoramas and
+  // save/auto-advance, the strip otherwise scrolls away from where the
+  // work is (#532). block: "nearest" so the page itself never jumps.
+  if (active) active.scrollIntoView({{ inline: "center", block: "nearest" }});
   $("counter").textContent = (idx + 1) + " / " + files.length;
 }}
 
@@ -410,6 +436,26 @@ async function save() {{
 $("save").addEventListener("click", save);
 $("reset").addEventListener("click", resetView);
 $("compare").addEventListener("click", toggleCompare);
+// A page-width jump per press: coarse on purpose, the chips themselves are
+// the fine control (#532).
+$("stripback").addEventListener("click", () => {{
+  $("strip").scrollLeft -= $("strip").clientWidth * 0.8;
+}});
+$("stripfwd").addEventListener("click", () => {{
+  $("strip").scrollLeft += $("strip").clientWidth * 0.8;
+}});
+// Half of Pannellum's ~5° per wheel notch, which a field tester found
+// landed twice as far as intended (#532). Capture phase with the event
+// stopped, so this replaces Pannellum's own wheel handler rather than
+// stacking on it; instant (no ease) so repeated notches stay predictable.
+const WHEEL_HFOV_STEP = 2.5;
+$("viewer").addEventListener("wheel", (e) => {{
+  e.preventDefault();
+  e.stopPropagation();
+  if (!viewer || !e.deltaY) return;
+  viewer.setHfov(viewer.getHfov() + (e.deltaY > 0 ? 1 : -1) * WHEEL_HFOV_STEP,
+    false);
+}}, {{ capture: true, passive: false }});
 document.addEventListener("keydown", (e) => {{
   if (e.key === "Enter") {{ e.preventDefault(); save(); }}
   else if (e.key === "Escape") {{ e.preventDefault(); resetView(); }}

--- a/src/dji_metadata_embedder/geo/photomap_js.py
+++ b/src/dji_metadata_embedder/geo/photomap_js.py
@@ -138,11 +138,15 @@ function openPano(a) {
   // and the file is fine — say so, and point at the link that still works.
   panoViewer.on('error', msg => {
     if (panoViewer) { panoViewer.destroy(); panoViewer = null; }
+    // Blame the right thing: a field tester read the old wording as a
+    // product limit and asked for it to be "raised" (#532). It is the
+    // graphics card running out of memory, not a size the map enforces.
     panoContainer.innerHTML = '<div class="pano-blocked">' +
-      esc(msg) + '<br><br>Very large panoramas (8000\\u00a0px and wider) ' +
-      'can exceed what older graphics hardware can display, even when the ' +
-      'file itself is fine. The "open original" link in the popup shows ' +
-      'the image itself.</div>';
+      esc(msg) + '<br><br>Your graphics card could not display this ' +
+      'panorama - typical for images 8000\\u00a0px and wider on older ' +
+      'graphics hardware, even when the file itself is fine. The map ' +
+      'has no size limit of its own. The "open original" link in the ' +
+      'popup shows the image itself.</div>';
   });
 }
 function closePano() {
@@ -218,8 +222,12 @@ function buildPopup(f) {
   if (p.thumb) {
     // Honest thumbnails (#441): a square opening-view crop and the full
     // 2:1 strip look nothing alike — the title says which one this is.
-    const kind = p.vthumb ? 'Opening view of the panorama'
+    // When the thumbnail is a link into the 360° viewer, the title also
+    // says so: a field tester went the long way round via the filename
+    // because nothing announced the shortcut (#532).
+    let kind = p.vthumb ? 'Opening view of the panorama'
       : (p.pano ? 'Full 360° panorama' : '');
+    if (kind && p.link) kind += ' - click to open the 360° viewer';
     inner += `<img src="data:image/jpeg;base64,${esc(p.thumb)}" alt=""` +
       imgDims(p) + (kind ? ` title="${kind}"` : '') + `>`;
   }
@@ -282,10 +290,13 @@ const writeHoverPref = on => {
   try { localStorage.setItem(HOVER_KEY, on ? '1' : '0'); } catch (e) {}
 };
 const allMarkers = [];
+let hoverPreviewsOn = false;
+const TOOLTIP_OPTS = { sticky: true, direction: 'top' };
 function setHoverPreviews(on) {
+  hoverPreviewsOn = on;
   for (const [marker, f] of allMarkers) {
     if (on) {
-      marker.bindTooltip(() => buildTooltip(f), { sticky: true, direction: 'top' });
+      marker.bindTooltip(() => buildTooltip(f), TOOLTIP_OPTS);
     } else {
       marker.unbindTooltip();
     }
@@ -314,6 +325,23 @@ map.on('popupopen', e => {
   if (img && !img.complete) {
     img.addEventListener('load', () => e.popup.update(), { once: true });
   }
+  // #532: with hover previews on, the sticky tooltip lingered under the
+  // click popup (it only closes on mouseout, and the pointer is still on
+  // the pin). Unbinding, not just closing — a closed-but-bound sticky
+  // tooltip reopens on the very next mousemove.
+  const src = e.popup._source;
+  if (src && src.getTooltip && src.getTooltip()) {
+    src.closeTooltip();
+    src.unbindTooltip();
+  }
+});
+map.on('popupclose', e => {
+  const src = e.popup && e.popup._source;
+  // Rebind exactly the marker popupopen unbound: with previews on, every
+  // other marker still has its tooltip.
+  if (!hoverPreviewsOn || !src || !src.getTooltip || src.getTooltip()) return;
+  const entry = allMarkers.find(pair => pair[0] === src);
+  if (entry) src.bindTooltip(() => buildTooltip(entry[1]), TOOLTIP_OPTS);
 });"""
 
 # Mouse-only hover-previews control (issue #345). Reads TOUCH, allMarkers, and

--- a/tests/browser/test_panoedit_editor.py
+++ b/tests/browser/test_panoedit_editor.py
@@ -350,3 +350,58 @@ def test_no_backup_save_leaves_no_original_copy(tmp_path, page, monkeypatch):
         ["exiftool", "-n", "-XMP-GPano:InitialViewHeadingDegrees",
          str(tmp_path / "a.jpg")], capture_output=True, text=True, check=True)
     assert "Initial View Heading" in out.stdout   # the write still landed
+
+
+@needs_exiftool
+def test_wheel_zoom_moves_half_a_pannellum_step(editor, page):
+    # #532: Pannellum's own wheel handler moved ~5 degrees of FOV per
+    # notch, which a field tester found landed twice as far as intended.
+    # The page's capture-phase handler replaces it with exact 2.5-degree
+    # steps.
+    url, _ = editor
+    page.goto(url)
+    page.wait_for_function("window.__panoReady === true")
+    before = page.evaluate("window.__viewer.getHfov()")
+    box = page.locator("#viewer").bounding_box()
+    page.mouse.move(box["x"] + box["width"] / 2,
+                    box["y"] + box["height"] / 2)
+    page.mouse.wheel(0, 120)            # one notch out
+    page.wait_for_function(
+        f"Math.abs(window.__viewer.getHfov() - {before + 2.5}) < 0.01")
+    page.mouse.wheel(0, -120)           # one notch back in
+    page.wait_for_function(
+        f"Math.abs(window.__viewer.getHfov() - {before}) < 0.01")
+
+
+@needs_exiftool
+def test_strip_arrows_page_through_many_panoramas(tmp_path, page, monkeypatch):
+    # #532: with hundreds of panoramas only a couple of chips fit, and the
+    # bare scrollbar was the only way through. The flanking arrows page the
+    # strip, and the active chip keeps itself scrolled into sight.
+    monkeypatch.delenv("DJIEMBED_EXIFTOOL_PATH", raising=False)
+    for i in range(40):
+        _make_pano(tmp_path / f"Goose Lake Rd_{i:04d}.jpg", pose=0.0)
+    httpd, url = _serve(tmp_path, page)
+    try:
+        page.goto(url)
+        page.wait_for_function("window.__panoReady === true")
+        strip = page.locator("#strip")
+        assert page.locator(".chip").count() == 40
+        start = strip.evaluate("el => el.scrollLeft")
+        page.locator("#stripfwd").click()
+        page.wait_for_function(
+            f"document.getElementById('strip').scrollLeft > {start}")
+        page.locator("#stripback").click()
+        page.wait_for_function(
+            f"document.getElementById('strip').scrollLeft <= {start}")
+        # Jumping to the last file drags its chip into the viewport.
+        page.evaluate("navigate(39)")
+        page.wait_for_function("window.__panoReady === true")
+        page.wait_for_function(
+            "() => { const s = document.getElementById('strip');"
+            " const c = document.querySelector('.chip.active');"
+            " const sr = s.getBoundingClientRect();"
+            " const cr = c.getBoundingClientRect();"
+            " return cr.left >= sr.left && cr.right <= sr.right; }")
+    finally:
+        httpd.shutdown()

--- a/tests/browser/test_photomap_hover.py
+++ b/tests/browser/test_photomap_hover.py
@@ -53,6 +53,33 @@ def test_choice_is_remembered_across_reload(serve_map, page):
     expect(page.locator("#hover-toggle")).not_to_be_checked()
 
 
+def test_tooltip_never_lingers_under_the_click_popup(serve_map, page):
+    # #532, reproduced on a field tester's hosted map: with hover previews
+    # on, clicking a pin opened the popup but the sticky tooltip stayed
+    # visible beneath it until the pointer moved. The popup must have the
+    # stage to itself — and the tooltip must come back afterwards.
+    serve_map(HTML)
+    page.check("#hover-toggle")
+    pin = page.locator(PIN).first
+    pin.hover()
+    expect(page.locator(TOOLTIP)).to_have_count(1)
+
+    pin.click()
+    expect(page.locator(".leaflet-popup")).to_be_visible()
+    expect(page.locator(TOOLTIP)).to_have_count(0)
+    # The pointer is still on the pin: a close without the unbind would
+    # reopen the tooltip on the next mousemove.
+    box = pin.bounding_box()
+    page.mouse.move(box["x"] + 2, box["y"] + 2)
+    page.wait_for_timeout(200)
+    expect(page.locator(TOOLTIP)).to_have_count(0)
+
+    page.locator(".leaflet-popup-close-button").click()
+    page.mouse.move(10, 10)             # leave and re-enter the pin
+    pin.hover()
+    expect(page.locator(TOOLTIP)).to_have_count(1)
+
+
 def test_touch_devices_get_no_toggle_at_all(serve_map, browser, playwright):
     # #295 parity: touch never had hover tooltips and must not gain a dead
     # toggle. A mobile descriptor flips the (hover/pointer) media queries

--- a/tests/test_geo_panoedit_html.py
+++ b/tests/test_geo_panoedit_html.py
@@ -140,3 +140,26 @@ def test_page_note_tells_the_truth_about_backups():
     no_backup = build_editor_page("tok123", backup=False)
     assert "keeps a backup" not in no_backup
     assert "no backup" in no_backup
+
+
+def test_page_film_strip_is_navigable_at_scale():
+    # #532: a field tester with 200+ long-named panoramas could see only a
+    # couple of chips and found the bare scrollbar too fiddly. Chips
+    # ellipsize (full name in the title), the active chip keeps itself in
+    # sight, and big flanking arrows page the strip.
+    html = build_editor_page("tok123")
+    assert "text-overflow: ellipsis" in html
+    assert "chip.title = f.name" in html
+    assert "active.scrollIntoView" in html
+    assert 'id="stripback"' in html and 'id="stripfwd"' in html
+    assert "Scroll the file strip" in html
+
+
+def test_page_wheel_zoom_replaces_pannellums_step():
+    # #532: Pannellum's ~5° per notch landed twice as far as intended.
+    # The page's own capture-phase handler halves it — and must stop the
+    # event, or Pannellum's handler would stack on top.
+    html = build_editor_page("tok123")
+    assert "const WHEEL_HFOV_STEP = 2.5;" in html
+    assert "e.stopPropagation();" in html
+    assert "capture: true" in html

--- a/tests/test_geo_photomap_html.py
+++ b/tests/test_geo_photomap_html.py
@@ -122,12 +122,16 @@ def test_html_hover_previews_are_off_by_default():
     # popup's details and link. Markers now bind only the click popup at
     # creation; the tooltip binding lives solely in the opt-in toggle path.
     html = photos_to_html(POINTS, title="t")
-    # The dot keeps `unbindTooltip(` from matching as a substring.
-    assert html.count(".bindTooltip(") == 1
+    # Exactly two binding sites, both behind the opt-in: the toggle path,
+    # and the popupclose rebind of the one marker popupopen unbound (#532)
+    # — which is guarded by the toggle's own state flag. The dot keeps
+    # `unbindTooltip(` from matching as a substring.
+    assert html.count(".bindTooltip(") == 2
     match = re.search(
         r"function setHoverPreviews\(on\) \{(.*?)\n\}", html, re.DOTALL)
     assert match, "setHoverPreviews function not found"
     assert ".bindTooltip(" in match.group(1)
+    assert "if (!hoverPreviewsOn" in html   # the rebind's guard
 
 
 def test_html_hover_toggle_binds_and_unbinds():
@@ -139,7 +143,10 @@ def test_html_hover_toggle_binds_and_unbinds():
     assert match
     body = match.group(1)
     assert "bindTooltip(" in body
-    assert "sticky: true" in body
+    # The options moved into a shared const (#532) so the popupclose
+    # rebind can never drift from the toggle's binding.
+    assert "TOOLTIP_OPTS" in body
+    assert "sticky: true" in html
     assert "unbindTooltip(" in body
 
 
@@ -260,6 +267,29 @@ def test_html_pano_load_failure_explains_the_likely_cause():
     assert "panoViewer.on('error'" in html
     assert "older graphics hardware" in html
     assert "open original" in html
+    # #532: a field tester read the old wording as a raisable product limit
+    # ("raise it to 9000") — the text must blame the graphics card and say
+    # the map itself imposes nothing.
+    assert "Your graphics card could not display" in html
+    assert "no size limit of its own" in html
+
+
+def test_html_suppresses_the_hover_tooltip_under_the_popup():
+    # #532: with hover previews on, the sticky tooltip lingered under the
+    # click popup (it only closes on mouseout, and the pointer is still on
+    # the pin). The popup handlers unbind it for the popup's lifetime; a
+    # close alone would be undone by the next mousemove.
+    html = photos_to_html(PANO_POINTS, title="t", link_base="")
+    assert "src.unbindTooltip()" in html
+    assert "map.on('popupclose'" in html
+
+
+def test_html_pano_thumbnail_title_announces_the_viewer_shortcut():
+    # #532: the popup thumbnail has opened the 360° viewer for a long time,
+    # but nothing said so — a field tester went the long way round via the
+    # filename link.
+    html = photos_to_html(PANO_POINTS, title="t", link_base="")
+    assert "click to open the 360° viewer" in html
 
 
 def test_html_pano_container_reset_on_every_open():


### PR DESCRIPTION
## What

All seven items from the #532 field-tester batch (same tester as #490/#531), in his priority order:

1. **Version in the title bar.** New `AppVersion` service reads the `AssemblyInformationalVersion` the release workflows stamp via `-p:Version=X.Y.Z` (SourceLink `+commit` metadata stripped) and sets the main window title to e.g. `DJI Metadata Embedder v2.11.0`. Unstamped dev builds (the SDK's default 1.0.0) keep the bare name — a made-up number would mislead exactly the reports the title exists for.

2. **Lingering hover tooltip.** With hover previews on, the sticky tooltip stayed visible under the click popup (it only closes on mouseout, and the pointer is still on the pin). `popupopen` now closes *and unbinds* the clicked marker's tooltip — a close alone is undone by the next mousemove — and `popupclose` rebinds it via the shared `TOOLTIP_OPTS`, guarded by the toggle's state. Browser E2E pins the full sequence, including pointer-still-on-pin and tooltip-comes-back.

3. **Marker → photosphere.** Investigation found the popup thumbnail has opened the 360° viewer all along (`a.pano-open` wraps thumbnail + name); the tester went the long way round via the filename because nothing said so and the lingering tooltip covered it. The thumbnail title now announces "click to open the 360° viewer", and item 2 clears the path.

4. **Film strip at scale.** Save/auto-advance already ships (#440). Added: chips ellipsize long names at 17ch (full name in the chip title), the active chip keeps itself scrolled into sight — the strip used to drift away from the work with 200+ panos — and large flanking ◂ ▸ buttons page the strip. Browser test drives a 40-pano folder through arrows and end-jump.

5. **Wheel zoom.** The editor page now owns wheel zoom at exactly 2.5° of FOV per notch, half Pannellum's step, applied in capture phase with the event stopped so the two handlers never stack. Browser test asserts the exact delta in both directions.

6. **Serve-width in the GUI.** The 360° views panel gains **Edit at full resolution** (a new one-property `PanoEditOptionsViewModel`, following the per-mode options pattern), mapping to `--max-width 0` in both the CLI strip and the actual editor launch (`IMapServer.GetEditorUrlAsync` gained the flag). The resolution mode is part of the editor-server reuse key, so toggling launches a fresh child instead of reusing one serving the other size. The 6000 px default stays — it was calibrated for a 2 GB card (#471) and remains the safe default.

7. **8000 px wording.** The photomap's large-panorama failure text now reads "Your graphics card could not display this panorama… The map has no size limit of its own" — the tester read the old phrasing as a raisable product cap.

## Testing

- Python: 1456 passed including the full browser suite (3 new browser tests: tooltip-under-popup, wheel step, strip arrows; 5 new/extended static pins), ruff and mypy clean.
- GUI: 580 passed (19 new: `AppVersionTests`, PanoEdit golden argv, full-resolution VM/flow/screen tests, editor-argv MapServer test).

Closes #532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t