### PR TITLE
feat(geo): state the AIRAC cycle date in the UK airspace source line (#502)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -447,7 +447,11 @@ zone's published message).
 Zones draw in one neutral
 style; clicking one shows the published facts: restriction class, vertical
 limits (or "not stated"), applicability windows, and the feed, license and
-fetch time. Zones the
+fetch time. Where the dataset is published per edition (the UK's 28-day
+AIRAC cycle, dated in the filename), the popup and the corner note also
+state the edition's effective date, so a cached copy that has outlived its
+cycle is visible as such: "fetched" is when the copy was downloaded,
+"effective" is which cycle it reflects. Zones the
 flight entered get a slightly stronger outline plus the entry/exit times and
 maximum heights in the popup. The map states facts and makes no
 determination.

--- a/src/dji_metadata_embedder/geo/airspace/aixm51.py
+++ b/src/dji_metadata_embedder/geo/airspace/aixm51.py
@@ -99,8 +99,11 @@ _ZIP_HREF_RE = re.compile(
 )
 
 
-def discover_feed_url(page: bytes, page_url: str, *, today: date) -> str:
-    """The currently-effective dataset zip URL from the datasets page.
+def discover_feed_url(
+    page: bytes, page_url: str, *, today: date
+) -> tuple[str, str]:
+    """The currently-effective dataset zip URL from the datasets page,
+    with the cycle's effective date as ISO ``YYYY-MM-DD`` (#502).
 
     A cycle takes effect at 00:00 UTC on its filename date, so the
     newest listed date that is not in the future wins; a page listing
@@ -120,8 +123,8 @@ def discover_feed_url(page: bytes, page_url: str, *, today: date) -> str:
             f"NATS page ({page_url}) — the page layout may have changed"
         )
     current = [(d, h) for d, h in dated if d <= today]
-    _, href = max(current) if current else min(dated)
-    return urljoin(page_url, href)
+    effective, href = max(current) if current else min(dated)
+    return urljoin(page_url, href), effective.isoformat()
 
 
 _XML_MEMBER_RE = re.compile(r"EG_UAS_FR_DS_AREA1_FULL_\d{8}\.xml$")

--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -56,24 +56,40 @@ def _bbox(track: Track) -> tuple[float, float, float, float]:
     return min(lons), min(lats), max(lons), max(lats)
 
 
-def _read_cache(body_path: Path) -> tuple[bytes, str] | None:
+def _read_cache(body_path: Path) -> tuple[bytes, str, str | None] | None:
+    """``(body, fetched, effective)`` — ``effective`` is the dataset's own
+    edition date when the sidecar recorded one (#502); sidecars written
+    before that, or for undated feeds, yield None and the record simply
+    omits the line."""
     meta_path = body_path.with_name(body_path.name + ".meta.json")
     if not (body_path.exists() and meta_path.exists()):
         return None
     try:
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
-        return body_path.read_bytes(), str(meta.get("fetched", "unknown time"))
-    except (OSError, ValueError):
-        # A corrupt cache (bad JSON, bad encoding, unreadable file) is a
-        # cache miss, not a crash — the caller will refetch.
+        effective = meta.get("effective")
+        return (
+            body_path.read_bytes(),
+            str(meta.get("fetched", "unknown time")),
+            str(effective) if effective is not None else None,
+        )
+    except (OSError, ValueError, AttributeError):
+        # A corrupt cache (bad JSON, bad encoding, unreadable file, or a
+        # sidecar that is not an object) is a cache miss, not a crash —
+        # the caller will refetch.
         return None
 
 
-def _write_cache(body_path: Path, body: bytes, url: str, fetched: str) -> None:
+def _write_cache(
+    body_path: Path, body: bytes, url: str, fetched: str,
+    effective: str | None,
+) -> None:
     body_path.parent.mkdir(parents=True, exist_ok=True)
     body_path.write_bytes(body)
+    meta: dict[str, str] = {"url": url, "fetched": fetched}
+    if effective is not None:
+        meta["effective"] = effective
     body_path.with_name(body_path.name + ".meta.json").write_text(
-        json.dumps({"url": url, "fetched": fetched}), encoding="utf-8"
+        json.dumps(meta), encoding="utf-8"
     )
 
 
@@ -189,9 +205,10 @@ def fetch_zones(
         return parse_aixm51(body, source)
 
     cached = None if refresh else _read_cache(body_path)
+    effective: str | None = None
     try:
         if cached is not None:
-            body, fetched = cached
+            body, fetched, effective = cached
             from_cache = True
         else:
             host = url.split("/")[2]
@@ -218,7 +235,7 @@ def fetch_zones(
                 body = _fetch_url(url, transport)
             else:
                 page = _fetch_url(url, transport)
-                zip_url = discover_aixm_url(
+                zip_url, effective = discover_aixm_url(
                     page, url, today=datetime.now(timezone.utc).date()
                 )
                 body = extract_xml(_fetch_url(zip_url, transport))
@@ -228,6 +245,7 @@ def fetch_zones(
         source = SourceInfo(
             feed=feed_name, url=url, fetched=fetched,
             license=license_line, caveat=caveat, note=note,
+            effective=effective,
         )
         zones = parse_body(body, source)
         if from_cache:
@@ -240,14 +258,15 @@ def fetch_zones(
             # Cache only what parsed (#518): a maintenance page served
             # with HTTP 200 must never become the body every later run
             # trusts.
-            _write_cache(body_path, body, url, fetched)
+            _write_cache(body_path, body, url, fetched, effective)
     except AirspaceError as exc:
         stale = _read_cache(body_path) if refresh else None
         if stale is not None:
-            body, fetched = stale
+            body, fetched, effective = stale
             source = SourceInfo(
                 feed=feed_name, url=url, fetched=fetched,
                 license=license_line, caveat=caveat, note=note,
+                effective=effective,
             )
             try:
                 zones = parse_body(body, source)

--- a/src/dji_metadata_embedder/geo/airspace/model.py
+++ b/src/dji_metadata_embedder/geo/airspace/model.py
@@ -60,6 +60,12 @@ class SourceInfo:
     license: str   # license line, printed verbatim
     caveat: str    # the feed's own informational-only wording
     note: str | None = None  # e.g. Finland's established-zones-only limit
+    # ISO date the dataset itself took effect, when the product states
+    # one (the UK AIRAC cycle date in the zip filename, #502). ``fetched``
+    # is when this copy was downloaded; this is which edition it is — a
+    # cached copy keeps serving a superseded cycle, and the record must
+    # let the reader see that. None when the feed publishes no date.
+    effective: str | None = None
 
 
 @dataclass

--- a/src/dji_metadata_embedder/geo/airspace/overlay.py
+++ b/src/dji_metadata_embedder/geo/airspace/overlay.py
@@ -77,7 +77,10 @@ def zones_to_overlay_json(
             continue
         covered = True
         if data.source is not None:
-            line = f"Airspace: {data.source.feed}, fetched {data.source.fetched}"
+            line = f"Airspace: {data.source.feed}, "
+            if data.source.effective:
+                line += f"effective {data.source.effective}, "
+            line += f"fetched {data.source.fetched}"
             if line not in notes:
                 notes.append(line)
             if data.source.note:
@@ -106,6 +109,8 @@ def zones_to_overlay_json(
                         "feed": zone.source.feed,
                         "license": zone.source.license,
                         "fetched": zone.source.fetched,
+                        **({"effective": zone.source.effective}
+                           if zone.source.effective else {}),
                     },
                     "entered": [],
                 }

--- a/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
@@ -41,8 +41,9 @@ function zonePopupHtml(z) {
       html += `<br>max altitude in zone: ${e.max_amsl_m} m (as logged)`;
     if (e.time_note) html += `<br><i>${esc(e.time_note)}</i>`;
   }
-  html += `<hr>${esc(z.source.feed)} — ${esc(z.source.license)}` +
-          `<br>fetched ${esc(z.source.fetched)}`;
+  html += `<hr>${esc(z.source.feed)} — ${esc(z.source.license)}`;
+  if (z.source.effective) html += `<br>effective ${esc(z.source.effective)}`;
+  html += `<br>fetched ${esc(z.source.fetched)}`;
   html += '</div>';
   return html;
 }

--- a/src/dji_metadata_embedder/geo/record_html.py
+++ b/src/dji_metadata_embedder/geo/record_html.py
@@ -303,6 +303,12 @@ def _source_dl(source, terrain_source: str | None, version: str) -> str:
             ("Feed", source.feed),
             ("URL", source.url),
             ("Fetched", source.fetched),
+        ]
+        if source.effective:
+            # The dataset's own edition date (#502) — "Fetched" is only
+            # when this copy was downloaded.
+            items.append(("Effective", source.effective))
+        items += [
             ("License", source.license),
             ("Caveat", source.caveat),
         ]

--- a/tests/test_airspace_aixm51.py
+++ b/tests/test_airspace_aixm51.py
@@ -41,19 +41,22 @@ BASE = "https://nats-uk.ead-it.com/cms-nats/opencms/en/Publications/digital-data
 def test_discovery_picks_the_effective_cycle_not_the_next_one():
     # Both the current and the NEXT AIRAC cycle are on the page; a cycle
     # takes effect at 00:00 UTC on its filename date.
-    url = discover_feed_url(PAGE, BASE, today=date(2026, 8, 15))
+    url, effective = discover_feed_url(PAGE, BASE, today=date(2026, 8, 15))
     assert url.endswith("EG_UAS_FR_DS_AREA1_FULL_20260806_XML.zip")
     assert url.startswith("https://nats-uk.ead-it.com/x/")
+    # #502: the cycle's effective date travels with the URL so the record
+    # can state which cycle the zones reflect, not just when we fetched.
+    assert effective == "2026-08-06"
 
 
 def test_discovery_rolls_over_on_the_cycle_date():
-    url = discover_feed_url(PAGE, BASE, today=date(2026, 9, 3))
-    assert "20260903_XML" in url
+    url, effective = discover_feed_url(PAGE, BASE, today=date(2026, 9, 3))
+    assert "20260903_XML" in url and effective == "2026-09-03"
 
 
 def test_discovery_falls_back_to_the_oldest_when_all_dates_are_future():
-    url = discover_feed_url(PAGE, BASE, today=date(2026, 8, 1))
-    assert "20260806_XML" in url
+    url, effective = discover_feed_url(PAGE, BASE, today=date(2026, 8, 1))
+    assert "20260806_XML" in url and effective == "2026-08-06"
 
 
 def test_discovery_never_picks_the_kml_product():

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -1,6 +1,7 @@
 """Fetch orchestration tests (#413): consent lines, cache, honest gaps."""
 import hashlib
 import io
+import json
 import zipfile
 from datetime import datetime
 from pathlib import Path
@@ -42,6 +43,13 @@ def test_luxembourg_fetch_parses_caches_and_announces(tmp_path):
     assert any("Fetching" in ln and "geoportail.lu" in ln for ln in lines)
     assert (tmp_path / "ed269-LU.json").exists()
     assert (tmp_path / "ed269-LU.json.meta.json").exists()
+    # No dated product here: nothing is claimed and the sidecar stays as
+    # it was (#502 only adds the key when a feed states a date).
+    assert data.source.effective is None
+    meta = json.loads(
+        (tmp_path / "ed269-LU.json.meta.json").read_text(encoding="utf-8")
+    )
+    assert "effective" not in meta
 
 
 def test_second_run_uses_the_cache_offline(tmp_path):
@@ -256,6 +264,13 @@ def test_a_uk_flight_discovers_the_cycle_zip_and_caches_the_xml(tmp_path):
     assert (tmp_path / "aixm-GB.xml").read_bytes().startswith(b"<?xml")
     assert any("Fetching" in ln and "nats-uk.ead-it.com" in ln
                for ln in lines)
+    # #502: the AIRAC cycle date from the zip filename reaches the
+    # source line and the cache sidecar, so a cached run can state it.
+    assert data.source.effective == "2020-01-01"
+    meta = json.loads(
+        (tmp_path / "aixm-GB.xml.meta.json").read_text(encoding="utf-8")
+    )
+    assert meta["effective"] == "2020-01-01"
 
 
 def test_a_cached_uk_body_skips_discovery_and_the_network(tmp_path):
@@ -266,6 +281,25 @@ def test_a_cached_uk_body_skips_discovery_and_the_network(tmp_path):
         raise AssertionError("cached run must not touch the network")
     data = fetch_zones(_track(51.50, -0.12), tmp_path, transport=no_network)
     assert data.from_cache and len(data.zones) == 6
+    assert data.source is not None and data.source.effective == "2020-01-01"
+
+
+def test_a_cache_sidecar_without_a_cycle_date_states_none(tmp_path):
+    # Sidecars written before #502 (or by feeds with no dated product)
+    # carry no "effective" key: the record simply omits the line rather
+    # than inventing a date or refusing the cache.
+    fetch_zones(_track(51.50, -0.12), tmp_path,
+                transport=FakeTransport([GB_PAGE, _gb_zip()]))
+    meta_path = tmp_path / "aixm-GB.xml.meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    del meta["effective"]
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    def no_network(req, timeout=None):
+        raise AssertionError("cached run must not touch the network")
+    data = fetch_zones(_track(51.50, -0.12), tmp_path, transport=no_network)
+    assert data.from_cache and data.source is not None
+    assert data.source.effective is None
 
 
 def _gb_zip_bad_sha() -> bytes:

--- a/tests/test_airspace_overlay.py
+++ b/tests/test_airspace_overlay.py
@@ -119,6 +119,32 @@ def test_notes_provenance_line_once_and_gap_lines():
     assert any(n.startswith("Airspace, B:") for n in out["notes"])
 
 
+def test_a_dated_product_states_its_effective_date_everywhere():
+    # #502: a feed published per cycle (the UK AIRAC dataset) states the
+    # cycle's effective date beside the fetch time — in the corner note
+    # and in every zone's popup source block — so a reader can tell which
+    # cycle the zones reflect, not just when this copy was downloaded.
+    zones, source = _lu_zones()
+    dated = SourceInfo(
+        feed=source.feed, url=source.url, fetched=source.fetched,
+        license=source.license, caveat=source.caveat, note=source.note,
+        effective="2026-08-06",
+    )
+    for z in zones:
+        z.source = dated
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(zones=zones, source=dated)]
+    )
+    assert (f"Airspace: {dated.feed}, effective 2026-08-06, "
+            f"fetched {dated.fetched}") in out["notes"]
+    assert all(z["source"]["effective"] == "2026-08-06" for z in out["zones"])
+    # Undated feeds keep the old shape: no key invented.
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(zones=_lu_zones()[0], source=source)]
+    )
+    assert all("effective" not in z["source"] for z in out["zones"])
+
+
 def test_source_note_reaches_the_map_notes_once():
     # #510 I3: the schedule/reference-only disclosures that ride in
     # SourceInfo.note must reach the overlay, not just the record.

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -240,6 +240,15 @@ def test_airspace_json_embeds_block_layer_and_note():
     assert "zonePopupHtml" in html
 
 
+def test_airspace_popup_states_the_edition_date_only_when_published():
+    # #502: the popup JS renders "effective <date>" from the zone's
+    # source block when present and nothing when the feed is undated.
+    from dji_metadata_embedder.geo.flightmap_html import flights_to_html
+    html = flights_to_html([_mini_track()], "t", airspace_json=_OVERLAY)
+    assert "if (z.source.effective) html += `<br>effective " in html
+    assert "`<br>fetched ${esc(z.source.fetched)}`" in html
+
+
 def test_airspace_json_escapes_script_breakout():
     from dji_metadata_embedder.geo.flightmap_html import flights_to_html
     evil = dict(_OVERLAY)

--- a/tests/test_geo_record_html.py
+++ b/tests/test_geo_record_html.py
@@ -67,6 +67,22 @@ def test_sources_caveats_and_footer_identify_the_record():
     assert "factual record, not a determination" in html
 
 
+def test_a_dated_source_shows_its_effective_date_beside_the_fetch_time():
+    # #502: "Fetched" is when this copy was downloaded; "Effective" is the
+    # date the dataset itself took effect (the UK AIRAC cycle). Undated
+    # feeds render no such row.
+    from dataclasses import replace
+
+    dated = replace(SRC, effective="2026-08-06")
+    rec = _record()
+    rec.airspace.source = dated
+    html = record_to_html([rec], "t", "2.4.0")
+    assert "<dt>Effective</dt><dd>2026-08-06</dd>" in html
+    assert html.index("<dt>Fetched</dt>") < html.index("<dt>Effective</dt>")
+    plain = record_to_html([_record()], "t", "2.4.0")
+    assert "<dt>Effective</dt>" not in plain
+
+
 def test_record_carries_the_generator_comment():
     from dji_metadata_embedder.geo.provenance import generator_comment
 


### PR DESCRIPTION
## Summary
- `SourceInfo.effective` (ISO date, `None` for undated feeds): the dataset's own edition date, distinct from `fetched` (when this copy was downloaded).
- UK AIXM discovery already parsed the cycle date from the zip filename to pick the effective cycle; it now returns it alongside the URL, and `fetch.py` carries it into `SourceInfo` and the cache sidecar (`"effective"` key, written only when known). Pre-existing sidecars and undated feeds read back as `None` and the line is simply omitted — never a refetch, never an invented date.
- Rendered beside the fetch time at every source site: the flight record's source block (`Effective` row after `Fetched`), the overlay corner note (`Airspace: …, effective 2026-08-06, fetched …`), and each zone's popup source block (2D and 3D share the popup JS).
- `docs/geospatial.md` explains the fetched-vs-effective distinction.

## Tests
- AIXM discovery tests assert the returned date; fetch tests cover the fresh UK fetch (source + sidecar), the cached run, a sidecar with the key removed, and the undated LU path (no key written, `None` stated).
- Overlay, record HTML and flightmap HTML pins for the three render sites.
- `ruff`, `mypy`, full non-browser suite: 1329 passed.

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t