### PR TITLE
feat(geo): render UK activation status and schedule text in zone popups (#503)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -433,9 +433,12 @@ for the flight area on the HTML maps — the flat map and the 3D terrain view
 geographical-zone feeds where a country publishes one (currently
 Luxembourg, Finland and Switzerland via ED-269, Ireland via the IAA's
 published ED-318 file, which the IAA labels reference-only — that caveat
-rides into the map — the UK via the NATS AIS AIXM 5.1 dataset, whose
-activation hours and temporary restrictions live in the AIP and NOTAMs,
-not in the file — that caveat rides along too — Denmark via
+rides into the map — the UK via the NATS AIS AIXM 5.1 dataset, where a
+part-time danger area's activation status and schedule text ("available
+for activation — Mon-Sat SR to SS") show in its popup exactly as published
+and labelled as not evaluated; the authoritative hours and temporary
+restrictions live in the AIP and NOTAMs, not in the file — that caveat
+rides along too — Denmark via
 Trafikstyrelsen's drone-zone dataset, which likewise leaves NOTAM-driven
 temporaries to the AIP, Sweden via LFV's ED-318 file, where a few
 zones apply only during scheduled hours within their published windows —

--- a/src/dji_metadata_embedder/geo/airspace/aixm51.py
+++ b/src/dji_metadata_embedder/geo/airspace/aixm51.py
@@ -83,10 +83,11 @@ AIXM_FEEDS: dict[str, Aixm51Feed] = {
         ),
         caveat=_CAVEAT,
         note=(
-            "Activation hours are not in the dataset and are not "
-            "evaluated here (many danger areas are part-time; the AIP "
-            "and NOTAM service hold the hours). Temporary restrictions "
-            "live in NOTAMs and AIP Supplements, not in this record."
+            "Activation status and schedule text are shown as published "
+            "and are not evaluated here (many danger areas are part-time; "
+            "the AIP and NOTAM service hold the authoritative hours). "
+            "Temporary restrictions live in NOTAMs and AIP Supplements, "
+            "not in this record."
         ),
     ),
 }
@@ -515,6 +516,33 @@ def _limit(
     return VerticalLimit(value, _LIMIT_UNITS[uom], _LIMIT_REFS[ref_raw])
 
 
+# AIXM 5.1 CodeStatusAirspaceType values seen or expected in the UK
+# product, in plain words; anything else passes through as published.
+_ACTIVATION_STATUS = {
+    "ACTIVE": "active",
+    "AVBL_FOR_ACTIVATION": "available for activation",
+    "INACTIVE": "inactive",
+    "INTERMITTENT": "intermittent",
+    "IN_USE": "in use",
+}
+
+
+def _activation_lines(activations: list[dict]) -> list[str]:
+    """Reader-facing lines for the activation blocks (#503): the status
+    code in plain words, then the published notes joined — exactly what
+    the dataset says, never an evaluation."""
+    lines = []
+    for act in activations:
+        status = act.get("status")
+        words = _ACTIVATION_STATUS.get(status, status) if status else None
+        notes = "; ".join(act.get("notes") or [])
+        if words and notes:
+            lines.append(f"{words} — {notes}")
+        elif words or notes:
+            lines.append(words or notes)
+    return lines
+
+
 def _native(
     ts: ElementTree.Element, type_code: str, local_type: str
 ) -> dict:
@@ -630,6 +658,7 @@ def parse_aixm51(raw: bytes, source: SourceInfo) -> list[Zone]:
                     (lon, lat)
                     for lat, lon in _ring_points(inner, borders, where)
                 ])
+        native = _native(ts, type_code, local_type)
         zones.append(
             Zone(
                 identifier=designator,
@@ -641,7 +670,8 @@ def parse_aixm51(raw: bytes, source: SourceInfo) -> list[Zone]:
                 polygons=[[(lon, lat) for lat, lon in ring]],
                 holes=holes,
                 source=source,
-                native=_native(ts, type_code, local_type),
+                native=native,
+                activation=_activation_lines(native["activation"]),
             )
         )
     if not zones:

--- a/src/dji_metadata_embedder/geo/airspace/model.py
+++ b/src/dji_metadata_embedder/geo/airspace/model.py
@@ -86,3 +86,9 @@ class Zone:
     source: SourceInfo
     holes: list[list[tuple[float, float]]] = field(default_factory=list)
     native: dict = field(default_factory=dict)
+    # Published activation status/schedule text, one line per activation
+    # block, rendered verbatim and labelled as not evaluated (#503). The
+    # UK dataset carries these for part-time danger areas ("available for
+    # activation — Mon-Sat SR to SS."). Never an applicability window:
+    # the evaluator must keep treating such zones as applicable.
+    activation: list[str] = field(default_factory=list)

--- a/src/dji_metadata_embedder/geo/airspace/overlay.py
+++ b/src/dji_metadata_embedder/geo/airspace/overlay.py
@@ -102,6 +102,10 @@ def zones_to_overlay_json(
                     ],
                     "polygons": zone.polygons,
                     "holes": zone.holes,
+                    # Published, unevaluated text (#503) — only when the
+                    # zone carries any, so undated/plain feeds keep shape.
+                    **({"activation": list(zone.activation)}
+                       if zone.activation else {}),
                     "source": {
                         "feed": zone.source.feed,
                         "license": zone.source.license,

--- a/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
@@ -30,6 +30,12 @@ function zonePopupHtml(z) {
   html += z.applicability.length
     ? `<br>applies: ${z.applicability.map(esc).join('; ')}`
     : '<br>applies: permanently';
+  // #503: activation status/schedule as the feed published it. The
+  // evaluator never read these (they are not machine-evaluable), and the
+  // label says so — a part-time danger area still counts as entered.
+  if (z.activation && z.activation.length)
+    html += `<br><i>activation (published, not evaluated): ` +
+            `${z.activation.map(esc).join('; ')}</i>`;
   for (const e of z.entered) {
     html += `<hr><b>${esc(e.flight)}</b> was inside this zone`;
     html += e.entry_utc

--- a/src/dji_metadata_embedder/geo/record_html.py
+++ b/src/dji_metadata_embedder/geo/record_html.py
@@ -153,8 +153,16 @@ def _zone_row(f: ZoneFinding) -> str:
             )
         else:
             compare = "limit datum not recognized"
+    name_cell = f"{_esc(z.name)}<br><small>{_esc(z.identifier)}</small>"
+    if z.activation:
+        # #503: the feed's own activation status/schedule text, verbatim
+        # and labelled — the record never evaluated it.
+        name_cell += (
+            "<br><small>activation (published, not evaluated): "
+            f"{_esc('; '.join(z.activation))}</small>"
+        )
     return (
-        f"<tr><td>{_esc(z.name)}<br><small>{_esc(z.identifier)}</small></td>"
+        f"<tr><td>{name_cell}</td>"
         f"<td>{_esc(z.restriction)}</td><td>{_esc(limit)}</td>"
         f"<td>{_esc(status)}</td><td>{_esc(compare)}</td></tr>"
     )

--- a/tests/test_airspace_aixm51.py
+++ b/tests/test_airspace_aixm51.py
@@ -100,7 +100,8 @@ def test_gb_feed_registry_states_source_rights_and_honesty_note():
     assert "NATS" in feed.license and "ISO 19115" in feed.license
     assert "not for resale" in feed.license
     note = feed.note or ""
-    assert "Activation hours" in note and "Temporary restrictions" in note
+    assert "Activation status" in note and "not evaluated" in note
+    assert "Temporary restrictions" in note
 
 
 def _gb() -> bytes:
@@ -156,6 +157,38 @@ def test_activation_rides_in_native_and_never_becomes_applicability():
                     "notes": ["Mon-Sat SR to SS."]}]
     assert zones[0].native["type"] == "R"
     assert zones[0].native["localType"] == "RPZ"
+
+
+def test_activation_is_also_rendered_as_published_text_lines():
+    # #503: the same blocks become reader-facing lines — the status code
+    # in plain words plus the prose schedule, exactly as published — so a
+    # part-time danger area can say so in the popup and the record.
+    # Still no applicability (the evaluator never sees these).
+    zones = parse_aixm51(_gb(), SRC)
+    assert zones[0].activation == [
+        "available for activation — Mon-Sat SR to SS."
+    ]
+    assert all(z.activation == [] for z in zones[1:])
+    assert all(z.applicability == [] for z in zones)
+
+
+def test_activation_status_codes_read_as_words_and_unknowns_pass_through():
+    from dji_metadata_embedder.geo.airspace.aixm51 import _activation_lines
+
+    assert _activation_lines([
+        {"status": "ACTIVE", "notes": ["H24."]},
+        {"status": "AVBL_FOR_ACTIVATION", "notes": []},
+        {"status": "INTERMITTENT", "notes": ["a", "b"]},
+        {"status": None, "notes": ["schedule only"]},
+        {"status": "SOME_NEW_CODE", "notes": []},
+        {"status": None, "notes": []},
+    ]) == [
+        "active — H24.",
+        "available for activation",
+        "intermittent — a; b",
+        "schedule only",
+        "SOME_NEW_CODE",
+    ]
 
 
 def test_coordinates_come_out_lon_lat_and_rings_close():

--- a/tests/test_airspace_overlay.py
+++ b/tests/test_airspace_overlay.py
@@ -76,6 +76,22 @@ def test_entered_zone_carries_facts_and_dedupe_merges_tracks():
     assert e["time_note"] is None
 
 
+def test_published_activation_text_reaches_the_popup_data_only_when_present():
+    # #503: zones carrying activation text (UK part-time danger areas)
+    # get an "activation" list in their popup data; every other zone keeps
+    # the pinned shape (no key invented).
+    zones, source = _lu_zones()
+    zones[0].activation = ["available for activation — Mon-Sat SR to SS."]
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(zones=zones, source=source)]
+    )
+    by_id = {z["id"]: z for z in out["zones"]}
+    assert by_id[zones[0].identifier]["activation"] == [
+        "available for activation — Mon-Sat SR to SS."
+    ]
+    assert all("activation" not in by_id[z.identifier] for z in zones[1:])
+
+
 def test_zone_dict_shape_and_source_footer():
     zones, source = _lu_zones()
     out = zones_to_overlay_json(

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -231,6 +231,17 @@ def test_no_airspace_json_means_no_airspace_bytes():
     assert "airspace" not in html.lower()
 
 
+def test_airspace_popup_renders_activation_text_as_published_not_evaluated():
+    # #503: the popup shows a zone's activation status/schedule text
+    # verbatim, labelled as published information the record did not
+    # evaluate — and nothing at all for zones without it.
+    from dji_metadata_embedder.geo.flightmap_html import flights_to_html
+    html = flights_to_html([_mini_track()], "t", airspace_json=_OVERLAY)
+    assert "if (z.activation && z.activation.length)" in html
+    assert "activation (published, not evaluated): " in html
+    assert "z.activation.map(esc).join('; ')" in html
+
+
 def test_airspace_json_embeds_block_layer_and_note():
     from dji_metadata_embedder.geo.flightmap_html import flights_to_html
     html = flights_to_html([_mini_track()], "t", airspace_json=_OVERLAY)

--- a/tests/test_geo_record_html.py
+++ b/tests/test_geo_record_html.py
@@ -74,6 +74,24 @@ def test_record_carries_the_generator_comment():
     assert html.startswith("<!DOCTYPE html>\n" + generator_comment())
 
 
+def test_zone_row_carries_published_activation_text_when_present():
+    # #503: a part-time zone's published activation status/schedule shows
+    # under its name in the zone table, framed as published and not
+    # evaluated; zones without it render exactly as before.
+    from dataclasses import replace
+
+    part_time = replace(
+        ZONE, activation=["available for activation — Mon-Sat SR to SS."]
+    )
+    rec = _record()
+    rec.airspace.findings[0].zone = part_time
+    html = record_to_html([rec], "t", "2.4.0")
+    assert ("<small>activation (published, not evaluated): "
+            "available for activation — Mon-Sat SR to SS.</small>") in html
+    plain = record_to_html([_record()], "t", "2.4.0")
+    assert "activation (published" not in plain
+
+
 def test_no_verdict_vocabulary_ever():
     html = record_to_html([_record()], "t", "2.4.0").lower()
     for word in ("legal", "illegal", "compliant", "violation"):


### PR DESCRIPTION
## Summary
- `Zone.activation: list[str]` — published activation status/schedule text as reader-facing lines; never an applicability window, so the evaluator keeps treating these zones as applicable (a part-time danger area still counts as entered).
- The AIXM 5.1 parser fills it from the same blocks it already preserves in `native`: status code in plain words (`ACTIVE`/`AVBL_FOR_ACTIVATION`/`INACTIVE`/`INTERMITTENT`/`IN_USE`), then the notes verbatim — `available for activation — Mon-Sat SR to SS.`; unknown codes pass through as published.
- Popup data carries an `activation` list only for zones that have any; the shared 2D/3D popup JS and the record's zone table render it as *activation (published, not evaluated): …*.
- GB feed note reworded: it claimed activation hours were "not in the dataset", but 62 zones carry schedule text; it now says the text is shown as published and not evaluated, and the AIP/NOTAM service holds the authoritative hours. `docs/geospatial.md` updated to match.

## Tests
- Parser: activation lines for the fixture, status-word mapping incl. unknown/None/empty cases, applicability still empty.
- Overlay shape (key only when present), flightmap popup JS pin, record zone-row pin (and absence for plain zones).
- `ruff`, `mypy`, full non-browser suite: 1330 passed.

Independent of #536 (#502); touches adjacent but distinct regions.

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t