### PR TITLE
polish(geo): collapse the combined map's legend at scale, drop the hover toggle on photo-less maps (#515)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -686,7 +686,11 @@ subfolders; photos cluster and toggle exactly as in `photomap`, flights
 draw and play back exactly as in `flightmap`, and recordings split at the
 4 GB limit are chained back into single flights the same way. A tree with
 no photos never touches ExifTool, so a tracks-only archive maps on a
-machine that doesn't have it installed.
+machine that doesn't have it installed (and, having nothing to preview,
+gets no hover-previews toggle). One layer control covers the photo and
+panorama rows plus one row per flight; it stays open for a handful of
+rows and collapses to its icon (open on hover) past ten, so a 20-flight
+archive doesn't wall off the map.
 
 Panoramas that already have a saved opening view (see [Setting the opening
 view](#setting-the-opening-view)) render their popup thumbnail as a square

--- a/src/dji_metadata_embedder/geo/map_html.py
+++ b/src/dji_metadata_embedder/geo/map_html.py
@@ -192,10 +192,22 @@ if (panoMarkers.length) {
     panoCluster;
 }
 Object.assign(allOverlays, overlays);
-if (Object.keys(allOverlays).length > 1) {
-  L.control.layers(null, allOverlays, { collapsed: false }).addTo(map);
+// Expanded is the legend rule, but one row per flight grows without
+// bound: a 24-flight folder measured 529 px tall on a 768 px viewport
+// (#515 field check). Past this many rows the control collapses to its
+// icon and expands on hover, like flightmap's own.
+const LAYER_CONTROL_EXPANDED_MAX = 10;
+const overlayCount = Object.keys(allOverlays).length;
+if (overlayCount > 1) {
+  L.control.layers(null, allOverlays, {
+    collapsed: overlayCount > LAYER_CONTROL_EXPANDED_MAX
+  }).addTo(map);
 }
+// No photo or panorama pins, no hover-previews toggle (#515): a
+// tracks-only folder has nothing for it to preview.
+if (allMarkers.length) {
 __HOVER_CONTROL__
+}
 
 const bounds = photoLatLngs.concat(allLatLngs);
 if (bounds.length > 1) {

--- a/tests/browser/test_map_combined.py
+++ b/tests/browser/test_map_combined.py
@@ -8,6 +8,7 @@ playback control must actually advance the clock.
 
 import base64
 import io
+import re
 from datetime import datetime, timedelta
 
 import pytest
@@ -75,3 +76,47 @@ def test_photo_popup_track_and_playback_share_one_page(serve_map, page):
     page.locator("#pb-play").click()
     page.wait_for_function(
         "() => Number(document.getElementById('pb-slider').value) > 0")
+
+
+def _flight(i: int) -> Track:
+    return Track(name=f"DJI_{i:04d}", points=[
+        TrackPoint(lat=34.0570 + i * 0.002 + k * 0.0005,
+                   lon=-84.1230 + k * 0.0001, alt=5.0 + k,
+                   timestamp=f"00:00:{k:02d},000",
+                   utc=_T0 + timedelta(seconds=30 * k))
+        for k in range(3)
+    ])
+
+
+LAYERS = ".leaflet-control-layers:not(.hover-control)"
+
+
+def test_layer_control_stays_expanded_for_a_few_flights_and_collapses_at_scale(
+        serve_map, page):
+    # #515 field check: the expanded legend is right for a handful of
+    # rows (photomap's rule) and a 529 px wall at 24 flights. Leaflet
+    # marks the open state with -expanded; a collapsed control shows its
+    # icon and opens on hover.
+    # (Regex: the class list's order differs between an initially-expanded
+    # control and one expanded on hover.)
+    expanded = re.compile(r"\bleaflet-control-layers-expanded\b")
+    serve_map(mixed_to_html(POINTS, [_flight(i) for i in range(4)], title="few"))
+    expect(page.locator(LAYERS)).to_have_class(expanded)
+    # 1 photo row + 12 flight rows = 13 > 10.
+    serve_map(mixed_to_html(POINTS, [_flight(i) for i in range(12)], title="many"))
+    control = page.locator(LAYERS)
+    expect(control).to_be_visible()
+    expect(control).not_to_have_class(expanded)
+    control.hover()
+    expect(control).to_have_class(expanded)
+    expect(control).to_contain_text("DJI_0011")
+
+
+def test_tracks_only_folder_has_no_hover_previews_toggle(serve_map, page):
+    # #515: nothing to preview, so the control is not emitted at all —
+    # unlike a folder with photos, where it sits beside the layer list.
+    serve_map(mixed_to_html([], TRACKS, title="tracks only"))
+    expect(page.locator("path.leaflet-interactive").first).to_be_visible()
+    expect(page.locator("#hover-toggle")).to_have_count(0)
+    serve_map(HTML)
+    expect(page.locator("#hover-toggle")).to_have_count(1)

--- a/tests/test_geo_map_html.py
+++ b/tests/test_geo_map_html.py
@@ -117,6 +117,25 @@ def test_html_renders_single_type_folders():
     assert "pb-play" in mixed_to_html([], TRACKS, title="t")
 
 
+def test_html_collapses_the_layer_control_past_ten_rows():
+    # #515 field check: 24 flights = a 529 px legend on a 768 px viewport.
+    # The threshold is a runtime count (photo/pano rows + one per flight);
+    # the browser test exercises both sides of it.
+    html = mixed_to_html(POINTS, TRACKS, title="t")
+    assert "const LAYER_CONTROL_EXPANDED_MAX = 10;" in html
+    assert "collapsed: overlayCount > LAYER_CONTROL_EXPANDED_MAX" in html
+    assert "{ collapsed: false }" not in html
+
+
+def test_html_gates_the_hover_toggle_on_photo_or_pano_pins():
+    # #515: a tracks-only folder has nothing to preview, so the toggle
+    # must not be emitted; allMarkers holds both photo and pano markers.
+    html = mixed_to_html(POINTS, TRACKS, title="t")
+    gate = html.index("if (allMarkers.length) {")
+    assert gate < html.index("id=\"hover-toggle\"")
+    assert gate > html.index("L.control.layers(null, allOverlays")
+
+
 def test_html_substitutions_are_complete():
     # A leftover placeholder is a JS SyntaxError that kills the whole page
     # while every substring assertion above stays green.


### PR DESCRIPTION
## Field check (real footage, headless Chromium measurements)
| folder | rows | layer control | hover toggle |
|---|---|---|---|
| staged archive: 4 flights + 8 photos/panos | 5 | 324×119 px, expanded — fine | present (photos) |
| stress: 24 real flights (25 SRT copies) + 3 photos | 25 | 159×**529 px** on a 768 px viewport — confirmed unwieldy | present |
| tracks-only (2 SRTs, chained to 1 flight) | — | not emitted (single overlay) | **present with zero pins** — confirmed clutter |

## Fixes (both in `geo/map_html.py` app JS)
- `collapsed: overlayCount > LAYER_CONTROL_EXPANDED_MAX` with the max at 10 rows: photomap's expanded-legend rule for a handful of rows, flightmap's collapsed-icon-opens-on-hover past that.
- `HOVER_CONTROL_JS` emitted inside `if (allMarkers.length)` — `allMarkers` holds both photo and pano markers, so a tracks-only map gets no toggle.

## Tests
- Static pins in `test_geo_map_html.py` (constant, runtime expression, gate ordering).
- Browser: 4 flights → expanded; 12 flights + photo row (13 > 10) → collapsed, expands on hover and lists the last flight; tracks-only → no `#hover-toggle`, photo folder → one.
- `ruff`, `mypy`, full non-browser suite 1327 passed; browser combined-map file green locally.

The `--serve` + real-panorama half of the checklist was exercised E2E on 2026-08-15 (panoedit real-pano pass, same viewer); no change needed there.

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t