### PR TITLE
feat(gui): launch update note reusing doctor's opt-in online check (#319)

### DIFF
--- a/docs/PROGRESS_JSONL.md
+++ b/docs/PROGRESS_JSONL.md
@@ -126,8 +126,19 @@ field, never by arrival order.
   appear only when it is present and its version is readable.
 - Missing dependencies are a report, not a crash: `"ok": false` with exit
   code 0 (same reading rule as `embed`).
-- The opt-in online update check **never** runs under `--progress jsonl`;
-  consent for going online stays interactive-only.
+- `summary.update_check` (#319): `{"consent": true|false|null,
+  "hard_disabled": bool, "current": "<this version>", "releases_url":
+  "<GitHub releases page>"}`. Nobody is prompted, and a plain run never
+  goes online: `consent` is only the remembered `doctor --online/--offline`
+  choice (null = never answered). Passing the explicit `--online` flag is
+  the consent — it is persisted exactly as on the interactive path and the
+  check runs, adding `"latest": "<PyPI version>"|null`, `"newer":
+  bool|null` (null when offline/PyPI unreachable — never an error) and,
+  when newer, `"hint"` (the environment-aware upgrade command).
+  `--offline` persists the refusal. `DJIEMBED_NO_UPDATE_CHECK=1` blocks
+  both the network and the persisting. This is how the desktop app offers
+  the one-time question and the launch note without a second consent
+  store.
 
 ### `convert`
 - Single-file mode: `start` carries `total: 1` and one `progress` event

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -82,11 +82,29 @@ instead — nothing is lost.
 ## Privacy and stored state
 
 Everything runs on your computer; nothing is uploaded, and there is no
-telemetry. The app stores exactly two things locally in
+telemetry. The app stores exactly three things locally in
 `%APPDATA%\DjiEmbed\state.json` on Windows
 (`~/Library/Application Support/DjiEmbed/state.json` on macOS): your
-recent folders and the window size/position. Delete that file to reset
-both.
+recent folders, the window size/position, and when it last looked for a
+newer version (below). Delete that file to reset all three.
+
+### Looking for new versions
+
+The one thing the app may do online is ask whether a newer version
+exists, and only if you said yes. The first time it is due, a quiet
+question appears at the bottom of the left column: *Look for new versions
+when the app starts?* That is the same question `dji-embed doctor` asks
+once in a terminal, and the answer is shared: Yes in the app is
+`dji-embed doctor --online`, No is `dji-embed doctor --offline`, and
+either command changes your mind later (there is no settings screen). With
+a yes, at most once a day the app makes one request to pypi.org (the same
+index `pip` uses) for the latest version number, nothing else; nothing
+about you or your files is sent. If a newer version exists, one line
+appears in the same spot, *Version X.Y.Z is available*, with a link to the
+release page. The app never downloads or installs anything itself. No
+network, or pypi.org unreachable, means no line at all, never an error.
+Setting `DJIEMBED_NO_UPDATE_CHECK=1` in the environment switches the
+whole thing off regardless of the stored answer.
 
 Beside it, `helper.log` keeps what the app's map and editor helpers
 printed — the same lines the command line shows in its terminal, such as

--- a/gui/DjiEmbed.Gui.Tests/GuiStateTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/GuiStateTests.cs
@@ -33,6 +33,30 @@ public class GuiStateTests : IDisposable
     }
 
     [Fact]
+    public void Last_update_check_round_trips_and_alone_is_not_Empty()
+    {
+        // #319 spec amendment: the one extra field. A state holding only
+        // the stamp must load as itself, not as the Empty singleton, or
+        // the once-a-day gate would reset on every launch.
+        var when = new DateTimeOffset(2026, 8, 22, 10, 30, 0, TimeSpan.Zero);
+        GuiState.Save(new GuiState(null, [], when), StatePath);
+        var loaded = GuiState.Load(StatePath);
+        Assert.NotSame(GuiState.Empty, loaded);
+        Assert.Equal(when, loaded.LastUpdateCheck);
+        Assert.Contains("\"lastUpdateCheck\"", File.ReadAllText(StatePath));
+    }
+
+    [Fact]
+    public void Garbled_last_update_check_degrades_to_never_and_keeps_the_rest()
+    {
+        File.WriteAllText(StatePath,
+            """{"recentFolders": ["C:\\Drone"], "lastUpdateCheck": "yesterday-ish"}""");
+        var loaded = GuiState.Load(StatePath);
+        Assert.Null(loaded.LastUpdateCheck);
+        Assert.Equal(["C:\\Drone"], loaded.RecentFolders);
+    }
+
+    [Fact]
     public void State_round_trips_through_the_file()
     {
         var state = new GuiState(

--- a/gui/DjiEmbed.Gui.Tests/UpdateCheckTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/UpdateCheckTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using DjiEmbed.Gui.Services;
+
+namespace DjiEmbed.Gui.Tests;
+
+public class UpdateCheckTests
+{
+    private static readonly DateTimeOffset Now =
+        new(2026, 8, 22, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Due_when_never_checked_or_a_day_has_passed()
+    {
+        Assert.True(UpdateCheck.IsDue(null, Now));
+        Assert.True(UpdateCheck.IsDue(Now - TimeSpan.FromHours(24), Now));
+        Assert.True(UpdateCheck.IsDue(Now - TimeSpan.FromDays(30), Now));
+        Assert.False(UpdateCheck.IsDue(Now - TimeSpan.FromHours(23), Now));
+        Assert.False(UpdateCheck.IsDue(Now, Now));
+    }
+
+    [Fact]
+    public void A_stamp_far_in_the_future_does_not_silence_the_check()
+    {
+        // Clock jump or a hand-edited file: a stamp a day past "now" is
+        // due again; one a few minutes ahead is just clock skew.
+        Assert.True(UpdateCheck.IsDue(Now + TimeSpan.FromDays(2), Now));
+        Assert.False(UpdateCheck.IsDue(Now + TimeSpan.FromMinutes(5), Now));
+    }
+
+    private static JsonElement? Summary(string json) =>
+        JsonDocument.Parse(json).RootElement.Clone();
+
+    [Fact]
+    public void Parse_reads_the_block_and_tolerates_nulls()
+    {
+        var s = UpdateCheck.Parse(Summary(
+            """{"tools": {}, "update_check": {"consent": null, "hard_disabled": false, "current": "2.11.0", "latest": null, "newer": null, "releases_url": "https://example.invalid/r"}}"""));
+        Assert.NotNull(s);
+        Assert.Null(s!.Consent);
+        Assert.False(s.HardDisabled);
+        Assert.Equal("2.11.0", s.Current);
+        Assert.Null(s.Latest);
+        Assert.Null(s.Newer);
+        Assert.Equal("https://example.invalid/r", s.ReleasesUrl);
+    }
+
+    [Fact]
+    public void Parse_reads_a_newer_version()
+    {
+        var s = UpdateCheck.Parse(Summary(
+            """{"update_check": {"consent": true, "hard_disabled": false, "current": "2.11.0", "latest": "2.12.0", "newer": true, "releases_url": "u"}}"""));
+        Assert.Equal((true, "2.12.0", true), (s!.Consent, s.Latest, s.Newer));
+    }
+
+    [Fact]
+    public void Parse_returns_null_without_the_block()
+    {
+        // An older CLI's doctor summary, a missing summary, a non-object:
+        // nothing to act on, never a throw.
+        Assert.Null(UpdateCheck.Parse(Summary("""{"tools": {}}""")));
+        Assert.Null(UpdateCheck.Parse(null));
+        Assert.Null(UpdateCheck.Parse(Summary("""{"update_check": 42}""")));
+    }
+}

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceScreenTests.cs
@@ -139,6 +139,42 @@ public class WorkspaceScreenTests
     }
 
     [AvaloniaFact]
+    public void Update_question_and_note_live_in_the_footer_and_hide_by_default()
+    {
+        // #319: nothing shows until the view model says so; the question
+        // brings its Yes/No, the note brings its release-page link, and
+        // neither disturbs the CLI escape-hatch link beside them.
+        var vm = NewWorkspaceViewModel();
+        var window = ShowWorkspace(vm);
+        var panels = window.GetVisualDescendants().OfType<StackPanel>().ToList();
+        var question = panels.Single(n => n.Name == "UpdateQuestion");
+        var note = panels.Single(n => n.Name == "UpdateNotePanel");
+        Assert.False(question.IsVisible);
+        Assert.False(note.IsVisible);
+
+        vm.ShowUpdateQuestion = true;
+        Assert.True(question.IsVisible);
+        var labels = window.GetVisualDescendants().OfType<Button>()
+            .Where(b => b.Name is "UpdateYes" or "UpdateNo")
+            .Select(b => b.Command).ToList();
+        Assert.Equal(2, labels.Count);
+        Assert.All(labels, Assert.NotNull);
+
+        vm.UpdateNote = "Version 99.0.0 is available";
+        Assert.True(note.IsVisible);
+        var text = string.Join(" ", note.GetVisualDescendants()
+            .OfType<TextBlock>().Select(t => t.Text ?? ""));
+        Assert.Contains("99.0.0", text);
+        // The link's content is declared in XAML; its template only
+        // realises on the next layout pass, so read the Content directly.
+        var link = window.GetVisualDescendants().OfType<Button>()
+            .Single(b => b.Name == "UpdateReleaseLink");
+        Assert.Contains("download page", ((TextBlock)link.Content!).Text);
+        Assert.Single(window.GetVisualDescendants().OfType<Button>(),
+            b => b.Classes.Contains("footerLink"));
+    }
+
+    [AvaloniaFact]
     public void Idle_pane_keeps_the_photo_identity()
     {
         var window = ShowWorkspace();

--- a/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/WorkspaceViewModelTests.cs
@@ -436,6 +436,144 @@ public class WorkspaceViewModelTests : IDisposable
         """{"v": 1, "event": "result", "ok": true, "outputs": [], "summary": {"tools": {"ffmpeg": {"present": true, "version": "7.1"}}}}""",
     ];
 
+    // ----- launch update note (#319) -----------------------------------
+
+    private static string DoctorWithUpdate(string updateBlock) =>
+        """{"v": 1, "event": "result", "ok": true, "outputs": [], "summary": {"tools": {"ffmpeg": {"present": true}}, "update_check": """
+        + updateBlock + "}}";
+
+    private const string Rel = "https://example.invalid/releases";
+
+    private static readonly DateTimeOffset Noon =
+        new(2026, 8, 22, 12, 0, 0, TimeSpan.Zero);
+
+    private (string Cli, string ArgsFile) UpdateCli(string updateBlock)
+    {
+        var argsFile = Path.Combine(_dir, "argv-" + Guid.NewGuid().ToString("N")[..6] + ".txt");
+        var cli = FakeCli.WriteArgvLinesRecorder(_dir, argsFile,
+        [
+            """{"v": 1, "event": "start", "command": "doctor"}""",
+            DoctorWithUpdate(updateBlock),
+        ]);
+        return (cli, argsFile);
+    }
+
+    private static string[] Argv(string argsFile) =>
+        File.Exists(argsFile) ? File.ReadAllLines(argsFile) : [];
+
+    [Fact]
+    public async Task Update_check_asks_doctors_question_once_when_consent_is_unknown()
+    {
+        var (cli, argsFile) = UpdateCli(
+            $$$"""{"consent": null, "hard_disabled": false, "current": "2.11.0", "releases_url": "{{{Rel}}}"}""");
+        var store = new GuiStateStore(Path.Combine(_dir, "state.json"));
+        var vm = Vm(cli, stateStore: store);
+        await vm.CheckForUpdatesAsync(Noon);
+        Assert.True(vm.ShowUpdateQuestion);
+        Assert.Null(vm.UpdateNote);
+        // The probe was plain doctor — no flag, no network — and nothing
+        // was stamped: an unanswered question is not a check.
+        Assert.Equal(["doctor", "--progress", "jsonl"], Argv(argsFile));
+        Assert.Null(store.State.LastUpdateCheck);
+    }
+
+    [Fact]
+    public async Task Answering_yes_runs_the_online_check_and_notes_a_newer_version()
+    {
+        var (cli, argsFile) = UpdateCli(
+            $$$"""{"consent": null, "hard_disabled": false, "current": "2.11.0", "latest": "99.0.0", "newer": true, "releases_url": "{{{Rel}}}"}""");
+        var store = new GuiStateStore(Path.Combine(_dir, "state.json"));
+        var vm = Vm(cli, stateStore: store);
+        await vm.CheckForUpdatesAsync(Noon);
+        await vm.AllowUpdateChecksCommand.ExecuteAsync(null);
+        Assert.False(vm.ShowUpdateQuestion);
+        Assert.Equal("Version 99.0.0 is available", vm.UpdateNote);
+        Assert.Contains("--online", Argv(argsFile));
+        Assert.NotNull(store.State.LastUpdateCheck);
+        string? opened = null;
+        vm.UrlLauncher = u => opened = u;
+        vm.OpenReleasePageCommand.Execute(null);
+        Assert.Equal(Rel, opened);
+    }
+
+    [Fact]
+    public async Task Answering_no_persists_through_doctor_offline_and_stamps_the_day()
+    {
+        var (cli, argsFile) = UpdateCli(
+            $$$"""{"consent": null, "hard_disabled": false, "current": "2.11.0", "releases_url": "{{{Rel}}}"}""");
+        var store = new GuiStateStore(Path.Combine(_dir, "state.json"));
+        var vm = Vm(cli, stateStore: store);
+        await vm.CheckForUpdatesAsync(Noon);
+        await vm.DeclineUpdateChecksCommand.ExecuteAsync(null);
+        Assert.False(vm.ShowUpdateQuestion);
+        Assert.Null(vm.UpdateNote);
+        Assert.Contains("--offline", Argv(argsFile));
+        Assert.DoesNotContain("--online", Argv(argsFile));
+        Assert.NotNull(store.State.LastUpdateCheck);
+    }
+
+    [Fact]
+    public async Task Remembered_consent_checks_online_once_a_day_and_links_the_release_page()
+    {
+        var (cli, argsFile) = UpdateCli(
+            $$$"""{"consent": true, "hard_disabled": false, "current": "2.11.0", "latest": "99.0.0", "newer": true, "releases_url": "{{{Rel}}}"}""");
+        var store = new GuiStateStore(Path.Combine(_dir, "state.json"));
+        var vm = Vm(cli, stateStore: store);
+        await vm.CheckForUpdatesAsync(Noon);
+        Assert.False(vm.ShowUpdateQuestion);
+        Assert.Equal("Version 99.0.0 is available", vm.UpdateNote);
+        // Offline probe first, then the explicit flag — the flag is the consent.
+        Assert.Equal(
+            ["doctor", "--progress", "jsonl", "doctor", "--online", "--progress", "jsonl"],
+            Argv(argsFile));
+        Assert.Equal(Noon, store.State.LastUpdateCheck);
+
+        // Same day: nothing spawns. Next day: the probe runs again.
+        var before = Argv(argsFile).Length;
+        await vm.CheckForUpdatesAsync(Noon.AddHours(6));
+        Assert.Equal(before, Argv(argsFile).Length);
+        await vm.CheckForUpdatesAsync(Noon.AddHours(25));
+        Assert.True(Argv(argsFile).Length > before);
+    }
+
+    [Fact]
+    public async Task Remembered_refusal_and_the_kill_switch_stay_offline_and_silent()
+    {
+        foreach (var block in new[]
+        {
+            $$$"""{"consent": false, "hard_disabled": false, "current": "2.11.0", "releases_url": "{{{Rel}}}"}""",
+            $$$"""{"consent": true, "hard_disabled": true, "current": "2.11.0", "releases_url": "{{{Rel}}}"}""",
+        })
+        {
+            var (cli, argsFile) = UpdateCli(block);
+            var store = new GuiStateStore(Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".json"));
+            var vm = Vm(cli, stateStore: store);
+            await vm.CheckForUpdatesAsync(Noon);
+            Assert.False(vm.ShowUpdateQuestion);
+            Assert.Null(vm.UpdateNote);
+            Assert.Equal(["doctor", "--progress", "jsonl"], Argv(argsFile));
+            Assert.Equal(Noon, store.State.LastUpdateCheck);
+        }
+    }
+
+    [Fact]
+    public async Task Update_check_is_silent_without_a_cli_or_without_the_block()
+    {
+        var store = new GuiStateStore(Path.Combine(_dir, "state.json"));
+        await Vm(null, stateStore: store).CheckForUpdatesAsync(Noon);
+        Assert.Null(store.State.LastUpdateCheck);
+        // An older CLI whose doctor summary predates the block: nothing to
+        // act on, and no stamp either — the newer CLI gets asked next time.
+        var cli = FakeCli.WritePerCommand(_dir, new Dictionary<string, (string[], int)>
+        {
+            ["doctor"] = (DoctorStream, 0),
+        });
+        var vm = Vm(cli, stateStore: store);
+        await vm.CheckForUpdatesAsync(Noon);
+        Assert.False(vm.ShowUpdateQuestion);
+        Assert.Null(vm.UpdateNote);
+    }
+
     [Fact]
     public async Task Missing_cli_fails_with_novice_wording()
     {

--- a/gui/DjiEmbed.Gui/App.axaml.cs
+++ b/gui/DjiEmbed.Gui/App.axaml.cs
@@ -23,10 +23,14 @@ public partial class App : Application
             // app-data folder — %APPDATA% on Windows, ~/Library/Application
             // Support on macOS (the .NET 8+ GetFolderPath mapping).
             var store = new GuiStateStore(GuiState.DefaultPath);
+            var main = new MainViewModel(store);
             desktop.MainWindow = new MainWindow(store)
             {
-                DataContext = new MainViewModel(store),
+                DataContext = main,
             };
+            // Launch update note (#319): opt-in, once a day at most, never
+            // blocking — fire-and-forget; it swallows its own failures.
+            _ = main.StartUpdateCheckAsync();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/gui/DjiEmbed.Gui/Services/GuiState.cs
+++ b/gui/DjiEmbed.Gui/Services/GuiState.cs
@@ -12,13 +12,16 @@ public sealed record WindowBounds(
     int X, int Y, int Width, int Height, bool Maximized);
 
 /// <summary>
-/// The one persisted GUI state (workspace spec 2026-07-18): MRU folders and
-/// window bounds, nothing else, ever, without a spec amendment. Pure data
-/// plus static I/O helpers; the runtime lifecycle lives in
+/// The one persisted GUI state (workspace spec 2026-07-18): MRU folders,
+/// window bounds and — the one amendment, granted by #319 — when the app
+/// last looked for a newer version, so the opt-in check does not ping on
+/// every launch. Nothing else, ever, without a further amendment. Pure
+/// data plus static I/O helpers; the runtime lifecycle lives in
 /// <see cref="GuiStateStore"/>.
 /// </summary>
 public sealed record GuiState(
-    WindowBounds? Window, IReadOnlyList<string> RecentFolders)
+    WindowBounds? Window, IReadOnlyList<string> RecentFolders,
+    DateTimeOffset? LastUpdateCheck = null)
 {
     /// <summary>Shared no-saved-state instance: record equality over
     /// IReadOnlyList is reference equality, so "no state" must be one
@@ -54,6 +57,9 @@ public sealed record GuiState(
     {
         public WindowDto? Window { get; set; }
         public List<string>? RecentFolders { get; set; }
+        // ISO-8601 round-trip text, not a DateTimeOffset: a hand-edited or
+        // garbled value must degrade to "never checked", not fail the load.
+        public string? LastUpdateCheck { get; set; }
     }
 
     /// <summary>Missing, corrupt, or unreadable → <see cref="Empty"/>.
@@ -76,9 +82,13 @@ public sealed record GuiState(
                 .Where(static f => !string.IsNullOrWhiteSpace(f))
                 .Take(MaxRecent)
                 .ToList();
-            return window is null && recents.Count == 0
+            DateTimeOffset? lastCheck = DateTimeOffset.TryParse(
+                dto.LastUpdateCheck, null,
+                System.Globalization.DateTimeStyles.RoundtripKind, out var t)
+                ? t : null;
+            return window is null && recents.Count == 0 && lastCheck is null
                 ? Empty
-                : new GuiState(window, recents);
+                : new GuiState(window, recents, lastCheck);
         }
         catch (Exception)
         {
@@ -112,6 +122,7 @@ public sealed record GuiState(
                     }
                     : null,
                 RecentFolders = state.RecentFolders.ToList(),
+                LastUpdateCheck = state.LastUpdateCheck?.ToString("o"),
             };
             File.WriteAllText(temp, JsonSerializer.Serialize(dto, Json));
             File.Move(temp, path, overwrite: true);

--- a/gui/DjiEmbed.Gui/Services/GuiStateStore.cs
+++ b/gui/DjiEmbed.Gui/Services/GuiStateStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -39,6 +40,15 @@ public sealed class GuiStateStore
     public void SaveWindow(WindowBounds bounds)
     {
         State = State with { Window = bounds };
+        SaveNow();
+    }
+
+    /// <summary>The app looked for a newer version (or learned it must
+    /// not) at <paramref name="when"/> — remember it so the next launch
+    /// inside <see cref="UpdateCheck.MinInterval"/> stays offline (#319).</summary>
+    public void MarkUpdateCheck(DateTimeOffset when)
+    {
+        State = State with { LastUpdateCheck = when };
         SaveNow();
     }
 

--- a/gui/DjiEmbed.Gui/Services/UpdateCheck.cs
+++ b/gui/DjiEmbed.Gui/Services/UpdateCheck.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Text.Json;
+
+namespace DjiEmbed.Gui.Services;
+
+/// <summary>
+/// The <c>summary.update_check</c> block of <c>doctor --progress jsonl</c>
+/// (docs/PROGRESS_JSONL.md, #319). <see cref="Consent"/> is doctor's own
+/// remembered <c>--online/--offline</c> choice (null = never answered);
+/// <see cref="Latest"/>/<see cref="Newer"/> are present only after an
+/// explicit <c>--online</c> run and are null when the network was
+/// unreachable — that is a non-event, never an error.
+/// </summary>
+public sealed record UpdateStatus(
+    bool? Consent, bool HardDisabled, string? Current, string? Latest,
+    bool? Newer, string? ReleasesUrl);
+
+/// <summary>
+/// The launch update note's pure parts (#319). The policy: the app may
+/// look for a newer version at most once per <see cref="MinInterval"/>,
+/// only with doctor's remembered consent, and it never downloads anything
+/// — the note links to the release page, nothing more.
+/// </summary>
+public static class UpdateCheck
+{
+    public static readonly TimeSpan MinInterval = TimeSpan.FromHours(24);
+
+    /// <summary>True when the app should run the probe now: never checked,
+    /// checked at least <see cref="MinInterval"/> ago, or a last-check
+    /// stamp from the future (clock jump) — a stale stamp must not silence
+    /// the check forever.</summary>
+    public static bool IsDue(DateTimeOffset? last, DateTimeOffset now) =>
+        last is not { } l || now - l >= MinInterval || l - now > MinInterval;
+
+    /// <summary>Null when the summary carries no block (an older CLI, a
+    /// failed run): nothing to act on.</summary>
+    public static UpdateStatus? Parse(JsonElement? summary)
+    {
+        if (summary is not { ValueKind: JsonValueKind.Object } s
+            || !s.TryGetProperty("update_check", out var u)
+            || u.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        return new UpdateStatus(
+            Bool(u, "consent"),
+            Bool(u, "hard_disabled") == true,
+            Str(u, "current"),
+            Str(u, "latest"),
+            Bool(u, "newer"),
+            Str(u, "releases_url"));
+    }
+
+    private static bool? Bool(JsonElement o, string name) =>
+        o.TryGetProperty(name, out var v) ? v.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null,
+        } : null;
+
+    private static string? Str(JsonElement o, string name) =>
+        o.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString() : null;
+}

--- a/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlowViewModel.cs
@@ -110,6 +110,10 @@ public abstract partial class FlowViewModel(
     /// Settable so a long-lived flow can re-probe a missing CLI.</summary>
     protected string? CliPath { get; set; } = cliPath;
 
+    /// <summary>The CLI bridge, for subclass work that runs outside the
+    /// flow's busy state (the launch update check, #319).</summary>
+    protected DjiEmbedRunner Runner => runner;
+
     /// <summary>Fails fast when the bundled CLI is missing.</summary>
     protected bool EnsureCli()
     {

--- a/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/MainViewModel.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DjiEmbed.Gui.Services;
 
@@ -26,6 +27,11 @@ public partial class MainViewModel : ViewModelBase
             OpenCliDiscovery, CliLocator.Find, stateStore: store);
         CurrentPage = _workspace;
     }
+
+    /// <summary>The launch update note (#319): started by the app shell
+    /// once the window exists, never by construction — tests build this
+    /// view model freely and must not spawn the CLI as a side effect.</summary>
+    public Task StartUpdateCheckAsync() => _workspace.CheckForUpdatesAsync();
 
     private void OpenCliDiscovery() => CurrentPage =
         new CliDiscoveryViewModel(CliLocator.Find(),

--- a/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/WorkspaceViewModel.cs
@@ -599,6 +599,122 @@ public partial class WorkspaceViewModel : FlowViewModel
     [RelayCommand]
     private void OpenCliDiscovery() => _openCliDiscovery();
 
+    // ----- launch update note (#319) ------------------------------------
+    //
+    // Doctor's opt-in online check, reused: the app never has a consent of
+    // its own. At most once per UpdateCheck.MinInterval it runs a plain
+    // (offline) doctor to read the remembered choice; unknown → doctor's
+    // one-time question appears in the footer, and the answer goes back as
+    // `doctor --online` / `--offline` (the flag persists it, CLI and app
+    // agree from then on); yes → `doctor --online` and, if PyPI knows a
+    // newer version, a one-line note linking to the release page. Nothing
+    // is downloaded, nothing blocks, and every failure is silence.
+
+    /// <summary>Doctor's one-time question, shown only while the remembered
+    /// choice is unknown and this launch was due to ask.</summary>
+    [ObservableProperty]
+    public partial bool ShowUpdateQuestion { get; set; }
+
+    /// <summary>"Version X.Y.Z is available", or null when there is nothing
+    /// to say (current, offline, declined, not due).</summary>
+    [ObservableProperty]
+    public partial string? UpdateNote { get; set; }
+
+    private string _releasesUrl =
+        "https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/latest";
+
+    /// <summary>The launch-time entry point; fire-and-forget from the app
+    /// shell, awaited by tests. <paramref name="now"/> is injectable so the
+    /// once-a-day gate is assertable.</summary>
+    internal async Task CheckForUpdatesAsync(DateTimeOffset? now = null)
+    {
+        var at = now ?? DateTimeOffset.UtcNow;
+        if (!UpdateCheck.IsDue(_stateStore.State.LastUpdateCheck, at))
+        {
+            return;
+        }
+        var status = await DoctorUpdateStatusAsync(online: null);
+        if (status is null)
+        {
+            return;
+        }
+        if (status.HardDisabled)
+        {
+            // DJIEMBED_NO_UPDATE_CHECK=1: settled for today, no question.
+            _stateStore.MarkUpdateCheck(at);
+            return;
+        }
+        switch (status.Consent)
+        {
+            case null:
+                ShowUpdateQuestion = true;
+                break;
+            case false:
+                _stateStore.MarkUpdateCheck(at);
+                break;
+            case true:
+                await RunOnlineCheckAsync(at);
+                break;
+        }
+    }
+
+    [RelayCommand]
+    private async Task AllowUpdateChecks()
+    {
+        ShowUpdateQuestion = false;
+        await RunOnlineCheckAsync(DateTimeOffset.UtcNow);
+    }
+
+    [RelayCommand]
+    private async Task DeclineUpdateChecks()
+    {
+        ShowUpdateQuestion = false;
+        await DoctorUpdateStatusAsync(online: false);
+        _stateStore.MarkUpdateCheck(DateTimeOffset.UtcNow);
+    }
+
+    [RelayCommand]
+    private void OpenReleasePage() => UrlLauncher(_releasesUrl);
+
+    private async Task RunOnlineCheckAsync(DateTimeOffset at)
+    {
+        var status = await DoctorUpdateStatusAsync(online: true);
+        _stateStore.MarkUpdateCheck(at);
+        if (status is { Newer: true, Latest: { } latest })
+        {
+            _releasesUrl = status.ReleasesUrl ?? _releasesUrl;
+            UpdateNote = $"Version {latest} is available";
+        }
+    }
+
+    /// <summary>One doctor run outside the flow's busy state: the UI keeps
+    /// working while it spawns. A missing CLI, a crash, or an older CLI
+    /// without the block all come back null — the note simply stays off.</summary>
+    private async Task<UpdateStatus?> DoctorUpdateStatusAsync(bool? online)
+    {
+        CliPath ??= _cliResolver?.Invoke();
+        if (CliPath is not { } cli)
+        {
+            return null;
+        }
+        string[] args = online switch
+        {
+            true => ["doctor", "--online"],
+            false => ["doctor", "--offline"],
+            null => ["doctor"],
+        };
+        try
+        {
+            var result = await Runner.RunAsync(cli, args);
+            return UpdateCheck.Parse(result.Terminal?.Summary);
+        }
+        catch (Exception e) when (e is System.ComponentModel.Win32Exception
+            or InvalidOperationException or IOException)
+        {
+            return null;
+        }
+    }
+
     [RelayCommand]
     private void ShowInFolder()
     {

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -23,12 +23,12 @@
         <Style Selector="Border#DropZone.dragover Rectangle.dropOutline">
             <Setter Property="Stroke" Value="#6366f1" />
         </Style>
-        <Style Selector="Button.footerLink, Button.copyLink">
+        <Style Selector="Button.footerLink, Button.copyLink, Button.quietLink">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="Padding" Value="0" />
             <Setter Property="Cursor" Value="Hand" />
         </Style>
-        <Style Selector="Button.footerLink:pointerover /template/ ContentPresenter#PART_ContentPresenter, Button.copyLink:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Style Selector="Button.footerLink:pointerover /template/ ContentPresenter#PART_ContentPresenter, Button.copyLink:pointerover /template/ ContentPresenter#PART_ContentPresenter, Button.quietLink:pointerover /template/ ContentPresenter#PART_ContentPresenter">
             <Setter Property="Background" Value="Transparent" />
         </Style>
 
@@ -86,6 +86,39 @@
                                Opacity="0.7" FontSize="12"
                                TextWrapping="Wrap" TextDecorations="Underline" />
                 </Button>
+                <!-- Launch update note (#319): doctor's one-time question
+                     while the remembered choice is unknown, otherwise at
+                     most one quiet line with a link. Never a download. -->
+                <StackPanel DockPanel.Dock="Bottom" Name="UpdateQuestion"
+                            Margin="2,18,0,0" Spacing="6"
+                            IsVisible="{Binding ShowUpdateQuestion}">
+                    <TextBlock Text="Look for new versions when the app starts? One request to pypi.org for the latest version number; nothing about you or your files is sent."
+                               Opacity="0.7" FontSize="12" TextWrapping="Wrap" />
+                    <StackPanel Orientation="Horizontal" Spacing="14">
+                        <Button Classes="quietLink" Name="UpdateYes"
+                                AutomationProperties.Name="Yes, look for new versions"
+                                Command="{Binding AllowUpdateChecksCommand}">
+                            <TextBlock Text="Yes" FontSize="12" TextDecorations="Underline" />
+                        </Button>
+                        <Button Classes="quietLink" Name="UpdateNo"
+                                AutomationProperties.Name="No, stay offline"
+                                Command="{Binding DeclineUpdateChecksCommand}">
+                            <TextBlock Text="No" FontSize="12" TextDecorations="Underline" />
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+                <StackPanel DockPanel.Dock="Bottom" Name="UpdateNotePanel"
+                            Orientation="Horizontal" Spacing="8" Margin="2,18,0,0"
+                            IsVisible="{Binding UpdateNote, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    <TextBlock Text="{Binding UpdateNote}" FontSize="12"
+                               VerticalAlignment="Center" />
+                    <Button Classes="quietLink" Name="UpdateReleaseLink"
+                            AutomationProperties.Name="Open the download page"
+                            Command="{Binding OpenReleasePageCommand}">
+                        <TextBlock Text="open the download page →" FontSize="12"
+                                   Opacity="0.8" TextDecorations="Underline" />
+                    </Button>
+                </StackPanel>
 
                 <StackPanel>
                     <TextBlock Classes="zone" Text="SOURCE" Margin="2,0,0,6" />

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -1777,8 +1777,12 @@ def doctor(
 
     if progress.active:
         # Machine consumers get a structured report. The online update
-        # check never runs here: consent is interactive-only, and a GUI or
-        # script must not trigger the network path as a side effect.
+        # check never runs here as a side effect and nobody is prompted:
+        # only the explicit --online flag goes online (the flag is the
+        # consent, #319), and the remembered choice is reported so a GUI
+        # can ask doctor's one-time question itself.
+        from .utils import update_check
+
         with _jsonl_terminal(progress, "doctor"):
             if install_tool == "exiftool":
                 exe = provision_exiftool(force=force)
@@ -1786,6 +1790,7 @@ def doctor(
                     f"ExifTool {EXIFTOOL_VERSION} installed: {exe}", err=True
                 )
             summary = _doctor_summary()
+            summary["update_check"] = update_check.machine_report(online)
             for tool, info in summary["tools"].items():
                 if not info["present"]:
                     progress.warning("Not found", item=tool)

--- a/src/dji_metadata_embedder/utils/update_check.py
+++ b/src/dji_metadata_embedder/utils/update_check.py
@@ -278,6 +278,38 @@ def exiftool_pin_lines() -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+def machine_report(cli_choice: bool | None = None) -> dict:
+    """Structured update-check block for ``doctor --progress jsonl`` (#319).
+
+    Never prompts, and goes online only on an explicit ``--online`` flag —
+    the flag is the consent, persisted exactly as on the interactive path —
+    never as a side effect of a plain machine run. The remembered choice is
+    reported either way so a GUI can put doctor's one-time question to the
+    user itself and pass the answer back as the flag. The kill-switch env
+    var blocks both the network and the persisting, as everywhere else.
+    """
+    from .. import __version__
+
+    disabled = hard_disabled()
+    report: dict = {
+        "consent": load_consent(),
+        "hard_disabled": disabled,
+        "current": __version__,
+        "releases_url": RELEASES_URL,
+    }
+    if disabled or cli_choice is None:
+        return report
+    save_consent(cli_choice)
+    report["consent"] = cli_choice
+    if cli_choice:
+        latest = latest_pypi_version()
+        report["latest"] = latest
+        report["newer"] = is_newer(latest, __version__) if latest else None
+        if report["newer"]:
+            report["hint"] = upgrade_hint()
+    return report
+
+
 def update_report(cli_choice: bool | None = None) -> list[str]:
     """All update-check lines for doctor output (may prompt interactively)."""
     online, status = resolve_online(cli_choice)

--- a/tests/test_progress_jsonl.py
+++ b/tests/test_progress_jsonl.py
@@ -802,16 +802,88 @@ def test_fetch_log_jsonl_one_failure_ends_in_error(monkeypatch, tmp_path):
     assert events[-1]["event"] == "error"
 
 
-def test_doctor_jsonl_never_runs_the_online_update_check(monkeypatch):
-    # Consent for going online is interactive-only; a machine consumer of
-    # the event stream must never trigger the network path.
+def test_doctor_jsonl_never_goes_online_without_the_explicit_flag(
+        monkeypatch, tmp_path):
+    # A machine consumer of the event stream must never trigger the
+    # network path as a side effect, and must never be prompted. It is
+    # told the remembered choice so it can put doctor's one-time question
+    # to the user itself (#319).
     _patch_doctor_env(monkeypatch)
+    monkeypatch.setenv("DJIEMBED_TOOLS_DIR", str(tmp_path / "dji-embed" / "tools"))
+    monkeypatch.delenv("DJIEMBED_NO_UPDATE_CHECK", raising=False)
+    from dji_metadata_embedder import __version__
     from dji_metadata_embedder.utils import update_check
 
     def _boom(*a, **k):
-        raise AssertionError("update check must not run under --progress jsonl")
+        raise AssertionError("network touched without an explicit flag")
 
-    monkeypatch.setattr(update_check, "update_report", _boom)
+    monkeypatch.setattr(update_check, "urlopen", _boom)
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: (_ for _ in ()).throw(AssertionError("prompted"))
+    )
+    res = CliRunner().invoke(main, ["doctor", "--progress", "jsonl"])
+    assert res.exit_code == 0, res.output
+    summary = _events(res.stdout)[-1]["summary"]
+    assert summary["update_check"] == {
+        "consent": None, "hard_disabled": False, "current": __version__,
+        "releases_url": update_check.RELEASES_URL,
+    }
+    assert update_check.load_consent() is None
+
+
+def test_doctor_jsonl_online_flag_is_the_consent_and_reports_the_check(
+        monkeypatch, tmp_path):
+    # #319: the GUI reuses doctor's check by passing the explicit flag —
+    # the flag IS the consent (persisted like the interactive path) and
+    # the result comes back structured: current, latest, newer, hint.
+    _patch_doctor_env(monkeypatch)
+    monkeypatch.setenv("DJIEMBED_TOOLS_DIR", str(tmp_path / "dji-embed" / "tools"))
+    monkeypatch.delenv("DJIEMBED_NO_UPDATE_CHECK", raising=False)
+    from dji_metadata_embedder import __version__
+    from dji_metadata_embedder.utils import update_check
+
+    monkeypatch.setattr(update_check, "latest_pypi_version", lambda **k: "99.0.0")
     res = CliRunner().invoke(main, ["doctor", "--progress", "jsonl", "--online"])
     assert res.exit_code == 0, res.output
-    assert _events(res.stdout)[-1]["event"] == "result"
+    uc = _events(res.stdout)[-1]["summary"]["update_check"]
+    assert uc["consent"] is True and uc["hard_disabled"] is False
+    assert uc["current"] == __version__ and uc["latest"] == "99.0.0"
+    assert uc["newer"] is True and "hint" in uc
+    assert uc["releases_url"] == update_check.RELEASES_URL
+    assert update_check.load_consent() is True
+
+    # --offline persists the refusal and never touches the network.
+    monkeypatch.setattr(update_check, "latest_pypi_version",
+                        lambda **k: (_ for _ in ()).throw(AssertionError("net")))
+    res = CliRunner().invoke(main, ["doctor", "--progress", "jsonl", "--offline"])
+    uc = _events(res.stdout)[-1]["summary"]["update_check"]
+    assert uc["consent"] is False and "latest" not in uc
+    assert update_check.load_consent() is False
+
+
+def test_doctor_jsonl_online_flag_degrades_silently_and_obeys_the_kill_switch(
+        monkeypatch, tmp_path):
+    _patch_doctor_env(monkeypatch)
+    monkeypatch.setenv("DJIEMBED_TOOLS_DIR", str(tmp_path / "dji-embed" / "tools"))
+    monkeypatch.delenv("DJIEMBED_NO_UPDATE_CHECK", raising=False)
+    from dji_metadata_embedder.utils import update_check
+
+    # Offline / PyPI down: latest is null, newer is null, no hint, no error.
+    monkeypatch.setattr(update_check, "latest_pypi_version", lambda **k: None)
+    res = CliRunner().invoke(main, ["doctor", "--progress", "jsonl", "--online"])
+    uc = _events(res.stdout)[-1]["summary"]["update_check"]
+    assert uc["latest"] is None and uc["newer"] is None and "hint" not in uc
+
+    # DJIEMBED_NO_UPDATE_CHECK=1 blocks the network AND the persisting.
+    def _boom(**k):
+        raise AssertionError("network touched despite kill switch")
+    monkeypatch.setattr(update_check, "latest_pypi_version", _boom)
+    (tmp_path / "dji-embed").mkdir(exist_ok=True)
+    update_check.consent_path().unlink(missing_ok=True)
+    res = CliRunner().invoke(
+        main, ["doctor", "--progress", "jsonl", "--online"],
+        env={"DJIEMBED_NO_UPDATE_CHECK": "1"},
+    )
+    uc = _events(res.stdout)[-1]["summary"]["update_check"]
+    assert uc["hard_disabled"] is True and "latest" not in uc
+    assert update_check.load_consent() is None


### PR DESCRIPTION
## Summary
The live half of #319 (the last-used-folder half shipped as MRU in GUI 2.0). The design decision: **the app never grows a consent of its own** — doctor's remembered `--online/--offline` choice is the one switch, shared by CLI and app, and there is no settings screen.

**CLI** — `doctor --progress jsonl` gains `summary.update_check`: `{consent: true|false|null, hard_disabled, current, releases_url}`. A plain run still never prompts and never goes online. The explicit `--online` flag *is* the consent (persisted exactly as on the interactive path) and runs the PyPI check, adding `latest`, `newer` (null when offline — never an error) and `hint`; `--offline` persists the refusal; `DJIEMBED_NO_UPDATE_CHECK=1` blocks network and persisting. This amends the PROGRESS_JSONL.md line that said the check "never runs under jsonl" — it now says "never as a side effect, only on the explicit flag".

**GUI** — at most once per 24 h (a `lastUpdateCheck` stamp in `state.json`, the one spec amendment the issue grants) the app runs a plain doctor to read the choice:
- unknown → doctor's one-time question in the footer: *Look for new versions when the app starts? One request to pypi.org for the latest version number; nothing about you or your files is sent.* Yes/No go back as `doctor --online` / `--offline`.
- yes → `doctor --online`; if newer, one quiet line *Version X.Y.Z is available* + *open the download page →* (the GitHub releases page). Nothing is downloaded.
- no / kill switch → stamp the day, silence.
- no CLI, crash, older CLI without the block → silence, no stamp.

Started by the app shell after the window exists, never by construction — tests build view models freely and must not spawn the CLI.

## Tests
- Python: three jsonl-contract tests (plain run offline + no prompt; `--online` consent + structured report + `--offline` refusal; degrade-to-null + kill switch). `ruff`, `mypy`, full non-browser suite 1327 passed.
- C#: GuiState stamp round-trip and garbled-stamp degrade; `UpdateCheck` policy (24 h, future stamps) and parse; six `WorkspaceViewModel` scenarios via an argv-recording fake CLI (question once, yes→online+note+link, no→offline+stamp, remembered yes→probe then `--online` then once-a-day gate, remembered no + kill switch, no CLI/no block); footer screen test. GUI suite 594 passed.

## Docs
`docs/desktop-app.md` privacy section now lists three stored things and gains "Looking for new versions" (plain language, honest about the one request); `docs/PROGRESS_JSONL.md` doctor section documents the block.

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t