### PR TITLE
fix(geo): cap the 3D flight map's layer panel and let it fold to one button (#542)

### DIFF
--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -65,8 +65,19 @@ _TEMPLATE = """<!DOCTYPE html>
                    background: #fff; border-radius: 4px; padding: 8px 12px;
                    box-shadow: 0 1px 5px rgba(0,0,0,.4);
                    font: 13px/1.8 sans-serif; max-height: 60%;
-                   overflow-y: auto; }}
+                   overflow-y: auto; max-width: min(360px, 70vw);
+                   box-sizing: border-box; }}
   .flights-panel label {{ display: block; cursor: pointer; }}
+  .flights-panel .panel-head {{ display: flex; justify-content: flex-end;
+                               margin: -4px -6px 0 0; line-height: 1.4; }}
+  .flights-panel .panel-head button {{ border: none; background: none;
+                                      cursor: pointer; font: inherit;
+                                      font-size: 12px; opacity: .7;
+                                      padding: 2px 4px; }}
+  .flights-panel.collapsed {{ padding: 4px 8px; }}
+  .flights-panel.collapsed .panel-head {{ margin: 0; }}
+  .flights-panel.collapsed .panel-head button {{ opacity: 1; }}
+  .flights-panel.collapsed > :not(.panel-head) {{ display: none; }}
   .flights-panel hr {{ border: none; border-top: 1px solid #ddd;
                       margin: 6px 0; }}
   .panel-note {{ opacity: .7; font-size: 11px; }}
@@ -287,6 +298,27 @@ function buildPanel() {
   const panel = document.createElement('div');
   panel.id = 'flights-panel';
   panel.className = 'flights-panel';
+  // Collapse toggle (#542): the panel is hand-built (MapLibre has no
+  // layer control), and once airspace notes ride in it it is the largest
+  // thing on the page -- so, like the layer control on the 2D map, it
+  // can fold down to a single button. A <button>, not a checkbox: the
+  // checkboxes in this panel are the flight rows, and are counted as such.
+  const head = document.createElement('div');
+  head.className = 'panel-head';
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.id = 'panel-toggle';
+  const setCollapsed = (c) => {
+    panel.classList.toggle('collapsed', c);
+    toggle.setAttribute('aria-expanded', String(!c));
+    toggle.textContent = c ? 'Layers \\u25be' : 'hide \\u25b4';
+    toggle.title = c ? 'Show the layer list' : 'Hide the layer list';
+  };
+  toggle.addEventListener('click', () =>
+    setCollapsed(!panel.classList.contains('collapsed')));
+  head.appendChild(toggle);
+  panel.appendChild(head);
+  setCollapsed(false);
   flights.forEach(f => {
     const label = document.createElement('label');
     const box = document.createElement('input');

--- a/tests/browser/test_flightmap_3d.py
+++ b/tests/browser/test_flightmap_3d.py
@@ -43,6 +43,36 @@ def test_3d_map_boots_and_lists_flights(serve_map, page):
     assert page.locator("#map canvas").count() >= 1
 
 
+def test_layer_panel_folds_to_one_button_and_reopens(serve_map, page):
+    # #542: the hand-built panel is the largest thing on the page once
+    # airspace notes ride in it; like Leaflet's control on the 2D map it
+    # must be able to fold down to a single button, and come back.
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, 5), _flight("DJI_0002", 11.0, 21.0, 5)],
+        "trip",
+    )
+    serve_map(html)
+    panel = page.locator("#flights-panel")
+    toggle = page.locator("#panel-toggle")
+    rows = page.locator("#flights-panel input[type=checkbox]")
+    expect(panel).to_be_visible(timeout=15000)
+    expect(toggle).to_have_attribute("aria-expanded", "true")
+    expect(rows.first).to_be_visible()
+    open_width = panel.bounding_box()["width"]
+
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-expanded", "false")
+    expect(toggle).to_have_text("Layers \u25be")
+    expect(rows.first).to_be_hidden()
+    assert rows.count() == 2                       # hidden, never removed
+    assert panel.bounding_box()["width"] < open_width
+
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-expanded", "true")
+    expect(rows.first).to_be_visible()
+    expect(rows.nth(1)).to_be_visible()
+
+
 def test_3d_terrain_failure_shows_flat_view_banner(serve_map, page):
     html = flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, 5)], "trip")
     serve_map(html)

--- a/tests/browser/test_flightmap_3d_airspace.py
+++ b/tests/browser/test_flightmap_3d_airspace.py
@@ -150,6 +150,30 @@ def test_entered_zone_lands_in_the_entered_layer(serve_map, page):
     ) == ["!", ["get", "entered"]]
 
 
+def test_long_airspace_notes_wrap_inside_a_capped_panel(serve_map, page):
+    # #542: each note is one long sentence; uncapped, the panel grew to
+    # the width of the longest one (nearly the whole browser on a real
+    # Swedish folder). The cap makes the notes wrap instead.
+    long_note = ("Airspace note: Published by LFV with Transportstyrelsen "
+                 "as data provider. Some zones apply only during scheduled "
+                 "hours within their validity window; the schedule is in "
+                 "the zone's published data and is not evaluated here.")
+    html = flights_to_3d_html(
+        [_flight()], "t",
+        airspace_json=_overlay([_zone()], notes=[
+            "Airspace: Sweden UAS geographical zones (ED-318, LFV), "
+            "fetched 2026-08-22T12:44:39Z", long_note]))
+    page.set_viewport_size({"width": 1600, "height": 900})
+    serve_map(html, terrain_stub=100.0)
+    _wait_layers(page)
+    panel = page.locator("#flights-panel")
+    expect(panel).to_contain_text("not evaluated here")
+    width = panel.bounding_box()["width"]
+    assert width <= 360 + 2, width               # the cap, not the note
+    note = page.locator("#airspace-notes div").nth(1)
+    assert note.bounding_box()["height"] > 30       # wrapped onto lines
+
+
 def test_airspace_toggle_hides_all_layers(serve_map, page):
     html = flights_to_3d_html(
         [_flight()], "t", airspace_json=_overlay([_zone()]))

--- a/tests/test_geo_flightmap3d_html.py
+++ b/tests/test_geo_flightmap3d_html.py
@@ -82,6 +82,18 @@ def test_3d_html_has_flight_toggle_panel():
     assert "flights-panel" in html
 
 
+def test_3d_html_caps_the_panel_width_and_offers_a_collapse_toggle():
+    # #542: the panel has no natural width limit, and airspace notes are
+    # long single sentences, so without a cap it stretched to the width
+    # of the longest note. The toggle is a <button>, never a checkbox --
+    # the checkboxes in this panel are the flight rows.
+    html = flights_to_3d_html([_track()], "t")
+    assert "max-width: min(360px, 70vw)" in html
+    assert "toggle.id = 'panel-toggle'" in html
+    assert "toggle.type = 'button'" in html
+    assert ".flights-panel.collapsed > :not(.panel-head) { display: none; }" in html
+
+
 def test_3d_html_does_not_render_at_altitude():
     # Spec amendment: draped tracks only — line geometry never anchors at
     # elevation. Ghost Camera (#372) legitimately calls


### PR DESCRIPTION
## What

On the 3D flight map with `--airspace`, the top-left layer panel stretched to nearly the full browser width and could not be hidden (Marcus, real Air 3S folder, v2.12.0 via the desktop app's new `--airspace --3d` pair).

## Why

`.flights-panel` had `max-height: 60%` but no `max-width`; `mountAirspacePanel` appends each airspace note as a single-line div, so the panel grew to the longest sentence. And unlike the 2D map's Leaflet layer control, the hand-built 3D panel had no collapse affordance at all.

## Changes

- `max-width: min(360px, 70vw)` + `box-sizing: border-box` on the panel, so notes wrap and the cap is the rendered width.
- A `.panel-head` row with `#panel-toggle`, a `<button>` (never a checkbox: `#flights-panel input[type=checkbox]` is how the browser suites count flight rows). `aria-expanded` + title track the state; collapsed shows just "Layers ▾", expanded shows a quiet "hide ▴". `.flights-panel.collapsed > :not(.panel-head)` hides the rest, so `mountAirspacePanel` and the sculpture/gaze/crossfade notes keep appending to the panel unchanged. Glyphs are `\uXXXX` escapes per the emitted-JS ASCII pin.
- Expanded by default: three flights plus one airspace row is small once the width is capped.

## Testing

- Static: `test_3d_html_caps_the_panel_width_and_offers_a_collapse_toggle`.
- Browser: `test_layer_panel_folds_to_one_button_and_reopens` (toggle hides rows without removing them, panel narrows, reopens) and `test_long_airspace_notes_wrap_inside_a_capped_panel` (the real Swedish note text at 1600 px: panel ≤ 360 px, note wraps).
- Non-browser suite 1339 passed; all 3D browser suites (3d, airspace, playback, crossfade, gaze, ghost, sculpture) 123 passed with one load flake (`test_amsl_ceiling_settles_to_terrain_relative_height`, passes 3/3 in isolation incl. on clean master); ruff + mypy clean.
- Eyeballed both states in headless Chromium (open: wrapped notes under the cap; collapsed: single button).

Closes #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t