### PR TITLE
feat(flightmap): read gimbal attitude from the MP4 djmd stream when the SRT has none (#546)

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,10 @@ Notes:
   position) where the previous one ended — measured on the SRT's own
   timestamps, so it survives copied files with rewritten mtimes. The popup
   lists the joined files; tune or disable with `--join-gap`.
+- The 3D map's camera footprints are estimates unless the SRT logs gimbal
+  angles. `--gimbal-from-video` reads them from the MP4's own telemetry (Air
+  3S and newer; needs ExifTool, opens every video), and `--flight-log CSV`
+  merges them from a decoded flight record for drones that log none.
 - Tracks are thinned to ~1 GPS point per second for the map (DJI logs ~30
   per second) — visually identical but far smaller files; use
   `dji-embed convert` on a single flight when you need every sample.

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -189,12 +189,21 @@ reuse DJI's restarting file numbering stay distinct. Sidecar-less models whose
 telemetry lives inside the MP4 (Air 3S, Mini 5 Pro, …) are not scanned — map
 those per clip with `dji-embed convert html VIDEO.MP4`.
 
-Drones whose SRT carries no gimbal attitude (the Mini series) can borrow it
-from a decoded flight log: `--flight-log my-flight.csv` merges per-sample
-gimbal pitch/yaw into the matching flight by timestamp, upgrading the 3D
-map's estimated camera footprints to measurements. See
-[Gimbal from a flight log](how-to/flight-log-gimbal.md) for the export
-settings that make the join exact.
+Most DJI SRTs carry no gimbal attitude, so the 3D map draws the camera
+footprint as a labelled estimate. Two routes upgrade it to a measurement,
+and neither ever overwrites a value the SRT itself recorded:
+
+- Drones whose MP4 carries a timed-metadata track with gimbal angles (Air 3S
+  and newer): `--gimbal-from-video` reads pitch/yaw from the video beside
+  each SRT and joins it frame by frame. It needs ExifTool (`dji-embed doctor
+  --install exiftool`) and opens every video, roughly 15 seconds per
+  gigabyte, which is why it is opt-in; the 3D map says so once when it
+  notices videos that carry angles the SRTs lack.
+- Drones that log no gimbal attitude anywhere on the SD card (the Mini
+  series): `--flight-log my-flight.csv` merges per-sample gimbal pitch/yaw
+  from a decoded flight record into the matching flight by timestamp. See
+  [Gimbal from a flight log](how-to/flight-log-gimbal.md) for the export
+  settings that make the join exact.
 
 Popup start times are converted to UTC by auto-detecting the recording
 timezone from each file's mtime. On archives whose mtimes were rewritten by

--- a/docs/how-to/flight-log-gimbal.md
+++ b/docs/how-to/flight-log-gimbal.md
@@ -5,6 +5,10 @@ track, and similar) record **no gimbal attitude anywhere on the SD card**.
 Their SRT sidecars carry position but not where the camera pointed, so the
 3D map draws the camera footprint as a labelled *estimate*.
 
+(Air 3S and newer write gimbal angles into the MP4 itself; for those,
+`flightmap --3d --gimbal-from-video` reads them straight from the video and
+no flight log is needed.)
+
 The attitude does exist — inside the flight record your DJI app or RC
 keeps. `--flight-log` merges it into the map:
 

--- a/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/CommandBuilderTests.cs
@@ -311,6 +311,29 @@ public class CommandBuilderTests
     }
 
     [Fact]
+    public void Gimbal_from_video_with_three_d_follows_the_3d_flags()
+    {
+        var opts = FlightMapOptions.Defaults with
+        {
+            ThreeD = true,
+            LinkOriginals = true,
+            GimbalFromVideo = true,
+        };
+        Assert.Equal(
+            ["flightmap", "/x", "-r", "--3d", "--link-originals",
+             "--gimbal-from-video"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
+    public void Gimbal_from_video_without_three_d_is_suppressed()
+    {
+        var opts = FlightMapOptions.Defaults with { GimbalFromVideo = true };
+        Assert.Equal(["flightmap", "/x", "-r"],
+            CommandBuilder.FlightMap("/x", opts));
+    }
+
+    [Fact]
     public void Link_originals_rides_along_with_fuzz_like_the_cli_permits()
     {
         var opts = FlightMapOptions.Defaults with

--- a/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
+++ b/gui/DjiEmbed.Gui.Tests/FlightMapOptionsViewModelTests.cs
@@ -22,6 +22,7 @@ public class FlightMapOptionsViewModelTests
         Assert.False(vm.Airspace);
         Assert.Equal(15, vm.JoinGap);
         Assert.False(vm.LinkOriginals);
+        Assert.False(vm.GimbalFromVideo);
         Assert.False(vm.ExportAll);
         Assert.Equal("auto", vm.TzOffset);
         Assert.Equal("", vm.Title);
@@ -48,6 +49,7 @@ public class FlightMapOptionsViewModelTests
             Airspace = true,
             JoinGap = 0,
             LinkOriginals = true,
+            GimbalFromVideo = true,
             ExportAll = true,
             TzOffset = "-8",
             Title = "Trip",
@@ -58,7 +60,7 @@ public class FlightMapOptionsViewModelTests
 
         Assert.Equal(
             new FlightMapOptions(false, true, "cyclosm", MapPrivacy.Fuzz, true,
-                0, true, true, "-8", "Trip", "/out/map.html"),
+                0, true, true, "-8", "Trip", "/out/map.html", GimbalFromVideo: true),
             vm.ToOptions());
     }
 

--- a/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
+++ b/gui/DjiEmbed.Gui/Services/CommandBuilder.cs
@@ -62,6 +62,13 @@ public static class CommandBuilder
             // the same media data is embedded with nothing that reads it.
             args.Add("--link-originals");
         }
+        if (opts.ThreeD && opts.GimbalFromVideo)
+        {
+            // Same reasoning as --link-originals: only the 3D map's camera
+            // footprints read gimbal attitude, and the flag costs minutes of
+            // ExifTool time, so it never rides on a flat map (#546).
+            args.Add("--gimbal-from-video");
+        }
         if (!opts.ThreeD && opts.TileStyle != FlightMapOptions.Defaults.TileStyle)
         {
             args.Add("--tile-style");

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptions.cs
@@ -33,6 +33,12 @@ public enum MapPrivacy
 /// Only useful with <paramref name="ThreeD"/> — on the flat map the CLI
 /// warns it embeds dead weight — so the builder emits it only alongside
 /// <c>--3d</c> (#392).</param>
+/// <param name="GimbalFromVideo">Read gimbal pitch/yaw from each flight's
+/// MP4 timed metadata when the SRT carries none (<c>--gimbal-from-video</c>,
+/// #546: Air 3S and newer). Opens every video through ExifTool, roughly 15 s
+/// per GB, and only the 3D map's camera footprints consume it, so like
+/// <paramref name="LinkOriginals"/> the builder emits it only alongside
+/// <c>--3d</c>.</param>
 /// <param name="ExportAll">Also write KML + GeoJSON and the printable flight
 /// record (<c>--format all</c>, record since v2.3.0); the CLI format is
 /// single-valued, so this is one honest toggle, not per-format. The record
@@ -50,7 +56,8 @@ public sealed record FlightMapOptions(
     bool ExportAll,
     string TzOffset,
     string Title,
-    string Output)
+    string Output,
+    bool GimbalFromVideo = false)
 {
     public static readonly FlightMapOptions Defaults = new(
         Recursive: true,
@@ -63,5 +70,6 @@ public sealed record FlightMapOptions(
         ExportAll: false,
         TzOffset: "auto",
         Title: "",
-        Output: "");
+        Output: "",
+        GimbalFromVideo: false);
 }

--- a/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
+++ b/gui/DjiEmbed.Gui/ViewModels/FlightMapOptionsViewModel.cs
@@ -45,6 +45,9 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
     public partial bool LinkOriginals { get; set; }
 
     [ObservableProperty]
+    public partial bool GimbalFromVideo { get; set; }
+
+    [ObservableProperty]
     public partial bool ExportAll { get; set; }
 
     [ObservableProperty]
@@ -157,7 +160,8 @@ public partial class FlightMapOptionsViewModel : ViewModelBase
         ExportAll: ExportAll,
         TzOffset: TzOffset,
         Title: Title,
-        Output: Output);
+        Output: Output,
+        GimbalFromVideo: GimbalFromVideo);
 
     /// <summary>Reset the output override back to the default (write the map
     /// into the source folder).</summary>

--- a/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
+++ b/gui/DjiEmbed.Gui/Views/WorkspaceView.axaml
@@ -317,6 +317,11 @@
                                                   IsChecked="{Binding FlightOptions.LinkOriginals}"
                                                   Content="Link the original videos"
                                                   ToolTip.Tip="Lets the cockpit view blend into the real footage. Needs the videos next to the map, in a format the browser can play (DJI 4K H.265 needs Edge or Chrome)." />
+                                        <CheckBox Name="FlightGimbalFromVideoCheck"
+                                                  IsVisible="{Binding FlightOptions.ThreeD}"
+                                                  IsChecked="{Binding FlightOptions.GimbalFromVideo}"
+                                                  Content="Read gimbal angles from the videos"
+                                                  ToolTip.Tip="For drones whose SRT carries no gimbal data (Air 3S and newer): the camera direction comes from the video's own telemetry instead of an estimate. Needs ExifTool (Doctor installs it) and opens every video, about 15 seconds per gigabyte." />
                                         <TextBlock Name="FlightFuzzCaveatNote"
                                                    Text="With fuzzed locations the video blend stays off — coarsened coordinates can't honestly be compared against real footage. The links still open the originals, which keep exact GPS in their own metadata."
                                                    IsVisible="{Binding FlightOptions.ShowsFuzzCaveat}"

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -55,10 +55,12 @@ from .geo.panoedit import (
 from .geo.airspace.overlay import zones_to_overlay_json
 from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
 from .geo.logfetch import LogFetchError, cache_path, fetch_log
-from .geo.media import resolve_media
+from .geo.media import find_video_path, resolve_media
+from .geo.videogimbal import VideoGimbalReport, VideoGimbalUnavailable
 from .geo.record import build_records
 from .geo.record_html import write_flight_record
-from .mp4_telemetry import Mp4TelemetryError
+from .mp4_telemetry import _EXIFTOOL_INSTALL_HINT, Mp4TelemetryError, probe
+from .utils.exiftool import exiftool_available
 from .progress import NullProgress, make_progress
 from .utilities import (
     check_dependencies,
@@ -843,6 +845,42 @@ def photomap(
         )
 
 
+def _hint_gimbal_from_video(tracks: list, src: Path) -> None:
+    """Say once when 3D flights lack gimbal attitude their videos could supply.
+
+    Only when ExifTool is present: without it there is nothing to probe and
+    no honest way to know what the videos hold. The probe reads the moov
+    atom alone (0.14 s on a 4 GB Air 3S clip), so it is cheap enough to run
+    per gimbal-less flight (#546).
+    """
+    if not exiftool_available():
+        return
+    carrying = 0
+    for track in tracks:
+        if any(
+            p.gimbal_yaw is not None or p.gimbal_pitch is not None
+            for p in track.points
+        ):
+            continue
+        for name in track.segments or [track.name]:
+            video = find_video_path(src, name)
+            if video is None:
+                continue
+            try:
+                if probe(video) is not None:
+                    carrying += 1
+                    break
+            except Mp4TelemetryError:
+                continue
+    if carrying:
+        click.echo(
+            f"Note: {carrying} flight{'s' if carrying != 1 else ''} "
+            f"{'have' if carrying != 1 else 'has'} no gimbal attitude in the "
+            "SRT but the video carries it; add --gimbal-from-video to read "
+            "it (opens every video, roughly 15 seconds per gigabyte)",
+            err=True,
+        )
+
 @main.command()
 @click.argument("directory", type=click.Path(exists=True, file_okay=False))
 @click.option(
@@ -930,6 +968,14 @@ def photomap(
          "several flights. Enable the UTC timestamp and the gimbal "
          "pitch/yaw fields in the decoder's export settings.",
 )
+@click.option(
+    "--gimbal-from-video", is_flag=True,
+    help="Read gimbal pitch/yaw from each flight's MP4 timed metadata when "
+         "the SRT carries none (Air 3S and newer), upgrading the 3D map's "
+         "estimated camera footprints to measurements. Needs ExifTool "
+         "(dji-embed doctor --install exiftool) and opens every video, "
+         "roughly 15 seconds per gigabyte. SRT values are never overwritten.",
+)
 @_tile_style_option
 @_progress_option
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
@@ -949,6 +995,7 @@ def flightmap(
     link_originals: bool,
     link_base: str | None,
     flight_logs: tuple[str, ...],
+    gimbal_from_video: bool,
     tile_style: str,
     progress_mode: str | None,
     verbose: bool,
@@ -1033,14 +1080,24 @@ def flightmap(
                 err=True,
             )
         src = Path(directory)
-        tracks, skipped = scan_flights(
-            src,
-            recursive=recursive,
-            redact=redact.lower(),
-            join_gap=join_gap,
-            tz_offset=offset,
-            on_file=progress.advance if progress.active else None,
-        )
+        if gimbal_from_video and not exiftool_available():
+            raise click.ClickException(
+                "--gimbal-from-video needs ExifTool. " + _EXIFTOOL_INSTALL_HINT
+            )
+        video_reports: list[VideoGimbalReport] = []
+        try:
+            tracks, skipped = scan_flights(
+                src,
+                recursive=recursive,
+                redact=redact.lower(),
+                join_gap=join_gap,
+                tz_offset=offset,
+                on_file=progress.advance if progress.active else None,
+                gimbal_from_video=gimbal_from_video,
+                on_video_gimbal=video_reports.append,
+            )
+        except VideoGimbalUnavailable as e:
+            raise click.ClickException(str(e))
         total = len(tracks) + len(skipped)
         if total == 0:
             raise click.ClickException(
@@ -1089,6 +1146,30 @@ def flightmap(
                     f"flight: {reason}",
                     err=True,
                 )
+        if gimbal_from_video:
+            enriched = [r for r in video_reports if r.matched]
+            for r in enriched:
+                if not quiet:
+                    click.echo(
+                        f"Gimbal from video: {r.matched} of {r.total} samples "
+                        f"on {r.name} ({r.seconds:.1f} s)"
+                    )
+            if verbose:
+                for r in video_reports:
+                    if not r.matched:
+                        click.echo(
+                            f"Gimbal from video skipped for {r.name}: "
+                            f"{r.reason}",
+                            err=True,
+                        )
+            if not quiet:
+                click.echo(
+                    f"Gimbal from video: {len(enriched)} flight"
+                    f"{'s' if len(enriched) != 1 else ''} of "
+                    f"{len(video_reports)} enriched"
+                )
+        elif three_d:
+            _hint_gimbal_from_video(tracks, src)
         joined = [t for t in tracks if t.segments]
         files_joined = sum(len(t.segments or []) for t in joined)
         if not quiet:

--- a/src/dji_metadata_embedder/geo/__init__.py
+++ b/src/dji_metadata_embedder/geo/__init__.py
@@ -40,6 +40,12 @@ from .tiles import DEFAULT_TILE_STYLE, TILE_STYLES, TileStyle
 from .solar import sun_position
 from .track import Track, TrackPoint, build_track
 
+from .videogimbal import (
+    VideoGimbalReport,
+    VideoGimbalUnavailable,
+    enrich_from_video,
+)
+
 __all__ = [
     "Track",
     "TrackPoint",
@@ -76,6 +82,9 @@ __all__ = [
     "FlightLogError",
     "MergeReport",
     "parse_flight_log",
+    "VideoGimbalReport",
+    "VideoGimbalUnavailable",
+    "enrich_from_video",
     "merge_gimbal",
     "merge_into_flights",
     "scan_flights",

--- a/src/dji_metadata_embedder/geo/flightmap.py
+++ b/src/dji_metadata_embedder/geo/flightmap.py
@@ -20,10 +20,12 @@ from statistics import median
 from xml.sax.saxutils import escape
 
 from .. import utilities
-from ..utilities import load_samples, redact_coords
+from ..utilities import TelemetrySample, load_samples, redact_coords
+from . import videogimbal
 from .footprint import DEFAULT_LENS, fov_degrees
 from .geometry import haversine_m
 from .track import Track, TrackPoint, _cue_seconds, build_track_from_samples
+from .videogimbal import VideoGimbalReport
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +199,9 @@ def scan_flights(
     join_gap: float = 15.0,
     tz_offset: timedelta | None = None,
     on_file: Callable[[int, int, str], None] | None = None,
+    gimbal_from_video: bool = False,
+    on_video_gimbal: Callable[[VideoGimbalReport], None] | None = None,
+    extract: Callable[[Path], list[TelemetrySample]] | None = None,
 ) -> tuple[list[Track], list[str]]:
     """Scan *directory* for ``.SRT`` files and return ``(tracks, skipped)``.
 
@@ -212,7 +217,13 @@ def scan_flights(
     per file from the mtime, falling back to mtime-based start times (with one
     aggregated warning) when the mtimes were rewritten by a transfer.
     ``on_file(index, total, name)`` is called (1-based) as each SRT file is
-    picked up, for progress reporting.
+    picked up, for progress reporting. ``gimbal_from_video`` fills each
+    SRT's missing gimbal attitude from the sibling video's djmd stream
+    before the track is built (#546, opt-in: ExifTool walks every video);
+    ``on_video_gimbal(report)`` hears what happened per file, and
+    ``extract`` overrides the video sample extractor for tests.
+    :class:`~.videogimbal.VideoGimbalUnavailable` propagates when ExifTool
+    is missing, so the caller can say so once.
     """
     root = Path(directory)
     files: set[Path] = set()
@@ -234,6 +245,13 @@ def scan_flights(
                 if not samples:
                     skipped.append(name)
                     continue
+                if gimbal_from_video:
+                    report = videogimbal.enrich_from_video(
+                        path, samples, name=name,
+                        extract=extract or videogimbal.extract_samples,
+                    )
+                    if on_video_gimbal is not None:
+                        on_video_gimbal(report)
                 mtime_utc = datetime.fromtimestamp(
                     path.stat().st_mtime, tz=timezone.utc
                 ).replace(tzinfo=None)

--- a/src/dji_metadata_embedder/geo/media.py
+++ b/src/dji_metadata_embedder/geo/media.py
@@ -20,8 +20,9 @@ from .track import Track
 _VIDEO_SUFFIXES = (".MP4", ".mp4", ".MOV", ".mov")
 
 
-def _find_video(root: Path, name: str) -> str | None:
-    """Relative POSIX path of the video for segment *name*, or ``None``.
+def find_video_path(root: Path, name: str) -> Path | None:
+    """The video for segment *name* (an SRT stem, path-qualified on
+    recursive scans) as a path under *root*, or ``None``.
 
     Scans the real directory entries rather than probing guessed filenames.
     Probing (``(root / f"{name}{suffix}").is_file()``) is wrong on a
@@ -42,7 +43,13 @@ def _find_video(root: Path, name: str) -> str | None:
             r = rank.get(entry.suffix.lower())
             if r is not None and (best is None or r < best[0]):
                 best = (r, entry)
-    return best[1].relative_to(root).as_posix() if best else None
+    return best[1] if best else None
+
+
+def _find_video(root: Path, name: str) -> str | None:
+    """Relative POSIX path of the video for segment *name*, or ``None``."""
+    found = find_video_path(root, name)
+    return found.relative_to(root).as_posix() if found else None
 
 
 def resolve_media(

--- a/src/dji_metadata_embedder/geo/videogimbal.py
+++ b/src/dji_metadata_embedder/geo/videogimbal.py
@@ -1,0 +1,148 @@
+"""Gimbal attitude from the sibling video's timed metadata (#546).
+
+Air 3S and later write no gimbal fields to the SRT, yet the MP4's ``djmd``
+stream carries ``GimbalYaw``/``GimbalPitch`` on every frame. This module
+fills the SRT samples' missing attitude from that stream so the 3D map's
+camera footprints become measurements instead of the estimated 30-degree
+down-tilt. It is opt-in (``flightmap --gimbal-from-video``): ExifTool must
+walk every sample of the video, which costs roughly 15 seconds per gigabyte.
+
+The join is on elapsed cue, not UTC: the SRT and the djmd stream are the
+same recording, so both clocks start at zero, whereas their wall-clock
+stamps disagree by a few hundred milliseconds on real Air 3S footage.
+"""
+
+from __future__ import annotations
+
+import time
+from bisect import bisect_left
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..mp4_telemetry import (
+    _EXIFTOOL_INSTALL_HINT,
+    Mp4TelemetryError,
+    extract_samples,
+)
+from ..utilities import TelemetrySample
+from ..utils.exiftool import exiftool_available
+from .media import find_video_path
+from .track import _cue_seconds
+
+__all__ = [
+    "VideoGimbalReport",
+    "VideoGimbalUnavailable",
+    "enrich_from_video",
+    "merge_video_gimbal",
+    "needs_gimbal",
+]
+
+# SRT and djmd samples are frame-aligned on every model seen so far; the
+# slack only has to survive a djmd stream that is a few frames shorter than
+# the SRT. Half a second never reaches the neighbouring second of a 1 Hz SRT.
+_CUE_TOLERANCE_S = 0.5
+
+
+class VideoGimbalUnavailable(Mp4TelemetryError):
+    """ExifTool is missing, so no video can be read: stop, don't report per file."""
+
+
+@dataclass
+class VideoGimbalReport:
+    """What :func:`enrich_from_video` did for one SRT, for the CLI to say."""
+
+    name: str
+    video: str | None = None
+    matched: int = 0
+    total: int = 0
+    seconds: float = 0.0
+    reason: str | None = None
+
+
+def needs_gimbal(samples: list[TelemetrySample]) -> bool:
+    """True when any sample lacks gimbal yaw or pitch."""
+    return any(s.gimbal_yaw is None or s.gimbal_pitch is None for s in samples)
+
+
+def merge_video_gimbal(
+    samples: list[TelemetrySample], video_samples: list[TelemetrySample]
+) -> int:
+    """Fill missing gimbal yaw/pitch in *samples* from the nearest-cue video
+    sample within :data:`_CUE_TOLERANCE_S`. SRT-borne values always win.
+
+    Returns the number of samples that received at least one value.
+    """
+    stamped = sorted(
+        (t, v) for v in video_samples if (t := _cue_seconds(v.cue)) is not None
+    )
+    if not stamped:
+        return 0
+    times = [t for t, _ in stamped]
+    matched = 0
+    for s in samples:
+        if s.gimbal_yaw is not None and s.gimbal_pitch is not None:
+            continue
+        cue = _cue_seconds(s.cue)
+        if cue is None:
+            continue
+        k = bisect_left(times, cue)
+        best: tuple[float, TelemetrySample] | None = None
+        for j in (k - 1, k):
+            if 0 <= j < len(times):
+                dt = abs(times[j] - cue)
+                if best is None or dt < best[0]:
+                    best = (dt, stamped[j][1])
+        if best is None or best[0] > _CUE_TOLERANCE_S:
+            continue
+        v = best[1]
+        gained = False
+        if s.gimbal_yaw is None and v.gimbal_yaw is not None:
+            s.gimbal_yaw = v.gimbal_yaw
+            gained = True
+        if s.gimbal_pitch is None and v.gimbal_pitch is not None:
+            s.gimbal_pitch = v.gimbal_pitch
+            gained = True
+        matched += gained
+    return matched
+
+
+def enrich_from_video(
+    srt_path: Path,
+    samples: list[TelemetrySample],
+    *,
+    name: str | None = None,
+    extract: Callable[[Path], list[TelemetrySample]] = extract_samples,
+) -> VideoGimbalReport:
+    """Fill *samples*' missing gimbal attitude from the video beside *srt_path*.
+
+    Skips (with a reason) when every sample is already complete, when no
+    sibling video exists, or when the video yields no usable telemetry
+    (:class:`Mp4TelemetryError`: no djmd track, decoder too old, ...).
+    Raises :class:`VideoGimbalUnavailable` when ExifTool itself is missing,
+    since that affects every file and deserves one loud message.
+    """
+    srt_path = Path(srt_path)
+    report = VideoGimbalReport(name=name or srt_path.stem, total=len(samples))
+    if not needs_gimbal(samples):
+        report.reason = "the SRT already carries gimbal attitude"
+        return report
+    video = find_video_path(srt_path.parent, srt_path.stem)
+    if video is None:
+        report.reason = "no video with the same name beside the SRT"
+        return report
+    report.video = video.name
+    if not exiftool_available():
+        raise VideoGimbalUnavailable(_EXIFTOOL_INSTALL_HINT)
+    started = time.perf_counter()
+    try:
+        video_samples = extract(video)
+    except Mp4TelemetryError as exc:
+        report.reason = str(exc)
+        report.seconds = time.perf_counter() - started
+        return report
+    report.matched = merge_video_gimbal(samples, video_samples)
+    report.seconds = time.perf_counter() - started
+    if report.matched == 0:
+        report.reason = "the video's telemetry carries no gimbal attitude"
+    return report

--- a/src/dji_metadata_embedder/mp4_telemetry.py
+++ b/src/dji_metadata_embedder/mp4_telemetry.py
@@ -76,6 +76,11 @@ _TELEMETRY_KEYS = (
 _DOC_KEY_RE = re.compile(r"^Doc(\d+)$")
 
 
+# Optional scalar fields protobuf drops at their default (see the defaults
+# comment inside :func:`_samples_from_exiftool`).
+_DEFAULTED_KEYS = ("GimbalYaw", "GimbalPitch", "RelativeAltitude")
+
+
 def _samples_from_exiftool(data: list) -> tuple[list[TelemetrySample], bool]:
     """Map ExifTool ``-g3 -j`` JSON to samples and whether telemetry was decoded.
 
@@ -91,6 +96,18 @@ def _samples_from_exiftool(data: list) -> tuple[list[TelemetrySample], bool]:
         ((m.group(1), v) for k, v in root.items() if (m := _DOC_KEY_RE.match(k))),
         key=lambda kv: int(kv[0]),
     )
+    # Protobuf omits fields at their default value, so ExifTool emits no tag
+    # for a level gimbal (pitch 0), one pointing true north (yaw 0), or an
+    # aircraft still on the ground (relative altitude 0). A field the stream
+    # carries anywhere is therefore 0.0 where a sample lacks it, not unknown;
+    # a field the stream never carries stays None (#546: Air 3S clips run
+    # 3 minutes without GimbalPitch and then report 0.2, a minute without
+    # RelativeAltitude and then 0.1; GimbalRoll never appears because it is
+    # always 0).
+    defaults: dict[str, float | None] = {
+        key: 0.0 if any(key in doc for _, doc in docs) else None
+        for key in _DEFAULTED_KEYS
+    }
     samples: list[TelemetrySample] = []
     saw_telemetry = False
     for _, doc in docs:
@@ -104,9 +121,9 @@ def _samples_from_exiftool(data: list) -> tuple[list[TelemetrySample], bool]:
         if not is_gps_fix(lat, lon):
             continue
         alt = float(doc.get("AbsoluteAltitude", 0.0))
-        rel = doc.get("RelativeAltitude")
-        gy = doc.get("GimbalYaw")
-        gp = doc.get("GimbalPitch")
+        rel = doc.get("RelativeAltitude", defaults["RelativeAltitude"])
+        gy = doc.get("GimbalYaw", defaults["GimbalYaw"])
+        gp = doc.get("GimbalPitch", defaults["GimbalPitch"])
         samples.append(
             TelemetrySample(
                 lat,

--- a/src/dji_metadata_embedder/utils/exiftool.py
+++ b/src/dji_metadata_embedder/utils/exiftool.py
@@ -10,6 +10,7 @@ on ``PATH``.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -25,6 +26,19 @@ def exiftool_exe() -> str:
     if provisioned is not None:
         return str(provisioned)
     return "exiftool"
+
+
+def exiftool_available() -> bool:
+    """True when :func:`exiftool_exe` resolves to something that exists.
+
+    The resolver falls back to the bare name ``exiftool``, which only works
+    when it is on PATH; callers that want to fail fast with the install hint
+    (rather than once per file) check this first.
+    """
+    exe = exiftool_exe()
+    if os.sep in exe or (os.altsep and os.altsep in exe):
+        return Path(exe).exists()
+    return shutil.which(exe) is not None
 
 
 def exiftool_source() -> str:

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -427,3 +427,109 @@ def test_flightmap_flight_log_bad_export_fails_loudly(tmp_path):
     ])
     assert res.exit_code != 0
     assert "gimbal" in res.output.lower()
+
+
+# --- #546: --gimbal-from-video reads attitude from the sibling MP4 ---
+
+
+def _djmd(cue, yaw, pitch):
+    from dji_metadata_embedder.utilities import TelemetrySample
+
+    return TelemetrySample(lat=10.0, lon=20.0, alt=5.0, cue=cue, dt=None,
+                           gimbal_yaw=yaw, gimbal_pitch=pitch)
+
+
+def _video_folder(tmp_path, monkeypatch, available=True):
+    folder = _folder(tmp_path, {"DJI_0001.SRT": FLIGHT_A})
+    (folder / "DJI_0001.MP4").write_bytes(b"")
+    monkeypatch.setattr(
+        "dji_metadata_embedder.geo.videogimbal.exiftool_available",
+        lambda: available,
+    )
+    monkeypatch.setattr(
+        "dji_metadata_embedder.cli.exiftool_available", lambda: available
+    )
+    monkeypatch.setattr(
+        "dji_metadata_embedder.geo.videogimbal.extract_samples",
+        lambda p: [_djmd("00:00:00,000", 90.0, -30.0),
+                   _djmd("00:00:01,000", 91.0, -31.0)],
+    )
+    return folder
+
+
+def test_flightmap_gimbal_from_video_fills_attitude(tmp_path, monkeypatch):
+    folder = _video_folder(tmp_path, monkeypatch)
+    out = folder / "out.geojson"
+    res = CliRunner().invoke(main, [
+        "flightmap", str(folder), "-f", "geojson", "-o", str(out),
+        "--gimbal-from-video",
+    ])
+    assert res.exit_code == 0, res.output
+    assert "Gimbal from video: 2 of 2 samples on DJI_0001" in res.output
+    props = json.loads(out.read_text(encoding="utf-8"))[
+        "features"][0]["properties"]
+    assert props["gyaw_deg"] == [90.0, 91.0]
+    assert props["gpitch_deg"] == [-30.0, -31.0]
+
+
+def test_flightmap_gimbal_from_video_without_exiftool_fails_with_hint(
+    tmp_path, monkeypatch
+):
+    folder = _video_folder(tmp_path, monkeypatch, available=False)
+    res = CliRunner().invoke(main, [
+        "flightmap", str(folder), "--gimbal-from-video",
+    ])
+    assert res.exit_code != 0
+    assert "doctor --install exiftool" in res.output
+    assert not (folder / "flightmap.html").exists()
+
+
+def test_flightmap_gimbal_from_video_skip_reason_only_verbose(
+    tmp_path, monkeypatch
+):
+    folder = _video_folder(tmp_path, monkeypatch)
+    (folder / "DJI_0001.MP4").unlink()
+    quiet = CliRunner().invoke(
+        main, ["flightmap", str(folder), "--gimbal-from-video"])
+    assert quiet.exit_code == 0, quiet.output
+    assert "no video" not in quiet.output
+    assert "Gimbal from video: 0 flights" in quiet.output
+    loud = CliRunner().invoke(
+        main, ["flightmap", str(folder), "--gimbal-from-video", "-v"])
+    assert "skipped for DJI_0001: no video" in loud.output
+
+
+def test_flightmap_3d_hints_when_videos_carry_gimbal(tmp_path, monkeypatch):
+    folder = _video_folder(tmp_path, monkeypatch)
+    probed = []
+
+    def probe(path):
+        probed.append(path.name)
+        return "dvtm_Air3s.proto"
+
+    monkeypatch.setattr("dji_metadata_embedder.cli.probe", probe)
+    res = CliRunner().invoke(main, ["flightmap", str(folder), "--3d"])
+    assert res.exit_code == 0, res.output
+    assert res.output.count("--gimbal-from-video") == 1
+    assert "1 flight" in res.output
+    assert probed == ["DJI_0001.MP4"]
+
+
+def test_flightmap_3d_no_hint_when_video_has_no_djmd(tmp_path, monkeypatch):
+    folder = _video_folder(tmp_path, monkeypatch)
+    monkeypatch.setattr("dji_metadata_embedder.cli.probe", lambda p: None)
+    res = CliRunner().invoke(main, ["flightmap", str(folder), "--3d"])
+    assert res.exit_code == 0, res.output
+    assert "--gimbal-from-video" not in res.output
+
+
+def test_flightmap_flat_map_never_probes_videos(tmp_path, monkeypatch):
+    folder = _video_folder(tmp_path, monkeypatch)
+
+    def boom(path):
+        raise AssertionError("probe must not run for the flat map")
+
+    monkeypatch.setattr("dji_metadata_embedder.cli.probe", boom)
+    res = CliRunner().invoke(main, ["flightmap", str(folder)])
+    assert res.exit_code == 0, res.output
+    assert "--gimbal-from-video" not in res.output

--- a/tests/test_geo_flightmap.py
+++ b/tests/test_geo_flightmap.py
@@ -704,3 +704,52 @@ def test_cue_s_restarts_at_a_segment_boundary(tmp_path):
     last_seg0 = max(i for i, s in enumerate(seg_i) if s == 0)
     first_seg1 = min(i for i, s in enumerate(seg_i) if s == 1)
     assert props["cue_s"][first_seg1] < props["cue_s"][last_seg0]
+
+
+# --- #546: gimbal attitude from the sibling video ---
+
+
+def _djmd_sample(cue: str, yaw: float, pitch: float):
+    from dji_metadata_embedder.utilities import TelemetrySample
+
+    return TelemetrySample(
+        lat=10.0, lon=20.0, alt=5.0, cue=cue, dt=None,
+        gimbal_yaw=yaw, gimbal_pitch=pitch,
+    )
+
+
+def test_scan_flights_gimbal_from_video_fills_points_and_reports(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "dji_metadata_embedder.geo.videogimbal.exiftool_available", lambda: True
+    )
+    _write(tmp_path, "DJI_0001.SRT", _bracket_srt((10.0, 20.0, 5.0), (10.001, 20.001, 6.0)))
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"")
+    reports = []
+    fake = lambda p: [  # noqa: E731
+        _djmd_sample("00:00:00,000", 90.0, -30.0),
+        _djmd_sample("00:00:01,000", 91.0, -31.0),
+    ]
+    tracks, skipped = scan_flights(
+        tmp_path, gimbal_from_video=True, on_video_gimbal=reports.append, extract=fake
+    )
+    assert skipped == []
+    assert [(p.gimbal_yaw, p.gimbal_pitch) for p in tracks[0].points] == [
+        (90.0, -30.0), (91.0, -31.0)
+    ]
+    assert len(reports) == 1
+    assert (reports[0].name, reports[0].video, reports[0].matched) == (
+        "DJI_0001", "DJI_0001.MP4", 2
+    )
+
+
+def test_scan_flights_without_the_flag_never_touches_videos(tmp_path):
+    _write(tmp_path, "DJI_0001.SRT", _bracket_srt((10.0, 20.0, 5.0)))
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"")
+
+    def boom(p):
+        raise AssertionError("extractor must not run")
+
+    reports = []
+    tracks, _ = scan_flights(tmp_path, on_video_gimbal=reports.append, extract=boom)
+    assert tracks[0].points[0].gimbal_yaw is None
+    assert reports == []

--- a/tests/test_geo_videogimbal.py
+++ b/tests/test_geo_videogimbal.py
@@ -1,0 +1,163 @@
+"""#546: gimbal attitude from the sibling video's djmd stream."""
+
+from datetime import datetime
+
+import pytest
+
+from dji_metadata_embedder.geo.media import find_video_path
+from dji_metadata_embedder.geo.videogimbal import (
+    VideoGimbalUnavailable,
+    enrich_from_video,
+    merge_video_gimbal,
+    needs_gimbal,
+)
+from dji_metadata_embedder.mp4_telemetry import Mp4TelemetryError
+from dji_metadata_embedder.utilities import TelemetrySample
+
+
+def _srt(cue: str, yaw=None, pitch=None) -> TelemetrySample:
+    return TelemetrySample(
+        lat=10.0, lon=20.0, alt=5.0, cue=cue,
+        dt=datetime(2026, 8, 15, 14, 23, 33),
+        gimbal_yaw=yaw, gimbal_pitch=pitch,
+    )
+
+
+def _djmd(cue: str, yaw: float, pitch: float) -> TelemetrySample:
+    return TelemetrySample(
+        lat=10.0, lon=20.0, alt=5.0, cue=cue,
+        dt=datetime(2026, 8, 15, 12, 23, 33),
+        gimbal_yaw=yaw, gimbal_pitch=pitch,
+    )
+
+
+# --- merge_video_gimbal: pure cue join ---
+
+
+def test_merge_fills_missing_attitude_from_nearest_cue():
+    srt = [_srt("00:00:00,000"), _srt("00:00:01,000")]
+    video = [
+        _djmd("00:00:00,017", 90.0, -30.0),
+        _djmd("00:00:00,983", 95.0, -35.0),
+        _djmd("00:00:01,017", 100.0, -40.0),
+    ]
+    assert merge_video_gimbal(srt, video) == 2
+    assert (srt[0].gimbal_yaw, srt[0].gimbal_pitch) == (90.0, -30.0)
+    # 1.000 is 17 ms from both neighbours; the earlier one wins ties.
+    assert srt[1].gimbal_yaw in (95.0, 100.0)
+
+
+def test_merge_never_overwrites_srt_values():
+    srt = [_srt("00:00:00,000", yaw=12.0, pitch=None)]
+    video = [_djmd("00:00:00,000", 90.0, -30.0)]
+    assert merge_video_gimbal(srt, video) == 1
+    assert srt[0].gimbal_yaw == 12.0
+    assert srt[0].gimbal_pitch == -30.0
+
+
+def test_merge_skips_cues_beyond_tolerance_and_unparseable():
+    srt = [_srt("00:00:05,000"), _srt("garbage")]
+    video = [_djmd("00:00:00,000", 90.0, -30.0)]
+    assert merge_video_gimbal(srt, video) == 0
+    assert srt[0].gimbal_yaw is None and srt[1].gimbal_yaw is None
+
+
+def test_merge_counts_only_samples_that_gained_something():
+    srt = [_srt("00:00:00,000", yaw=1.0, pitch=2.0), _srt("00:00:01,000")]
+    video = [_djmd("00:00:00,000", 90.0, -30.0), _djmd("00:00:01,000", 91.0, -31.0)]
+    assert merge_video_gimbal(srt, video) == 1
+
+
+def test_needs_gimbal_is_false_only_when_every_sample_is_complete():
+    assert needs_gimbal([_srt("00:00:00,000")])
+    assert needs_gimbal([_srt("00:00:00,000", yaw=1.0)])
+    assert not needs_gimbal([_srt("00:00:00,000", yaw=1.0, pitch=2.0)])
+    assert not needs_gimbal([])
+
+
+# --- find_video_path ---
+
+
+def test_find_video_path_prefers_mp4_over_mov_and_is_none_when_absent(tmp_path):
+    (tmp_path / "DJI_0001.SRT").write_text("", encoding="utf-8")
+    assert find_video_path(tmp_path, "DJI_0001") is None
+    (tmp_path / "DJI_0001.mov").write_bytes(b"")
+    assert find_video_path(tmp_path, "DJI_0001") == tmp_path / "DJI_0001.mov"
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"")
+    assert find_video_path(tmp_path, "DJI_0001") == tmp_path / "DJI_0001.MP4"
+
+
+# --- enrich_from_video ---
+
+
+def test_enrich_without_sibling_video_reports_reason(tmp_path):
+    srt = tmp_path / "DJI_0001.SRT"
+    srt.write_text("", encoding="utf-8")
+    calls = []
+    report = enrich_from_video(srt, [_srt("00:00:00,000")], extract=calls.append)
+    assert report.matched == 0 and calls == []
+    assert report.video is None
+    assert "no video" in (report.reason or "")
+
+
+def test_enrich_skips_when_srt_already_carries_attitude(tmp_path):
+    srt = tmp_path / "DJI_0001.SRT"
+    srt.write_text("", encoding="utf-8")
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"")
+    calls = []
+    report = enrich_from_video(
+        srt, [_srt("00:00:00,000", yaw=1.0, pitch=2.0)], extract=calls.append
+    )
+    assert calls == []
+    assert "already" in (report.reason or "")
+
+
+def test_enrich_reports_extractor_errors_as_reason(tmp_path, monkeypatch):
+    srt = tmp_path / "DJI_0001.SRT"
+    srt.write_text("", encoding="utf-8")
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"")
+    monkeypatch.setattr(
+        "dji_metadata_embedder.geo.videogimbal.exiftool_available", lambda: True
+    )
+
+    def boom(path):
+        raise Mp4TelemetryError("No embedded telemetry found in DJI_0001.MP4")
+
+    report = enrich_from_video(srt, [_srt("00:00:00,000")], extract=boom)
+    assert report.matched == 0
+    assert report.video == "DJI_0001.MP4"
+    assert "No embedded telemetry" in (report.reason or "")
+
+
+def test_enrich_raises_when_exiftool_is_missing(tmp_path, monkeypatch):
+    srt = tmp_path / "DJI_0001.SRT"
+    srt.write_text("", encoding="utf-8")
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"")
+    monkeypatch.setattr(
+        "dji_metadata_embedder.geo.videogimbal.exiftool_available", lambda: False
+    )
+    with pytest.raises(VideoGimbalUnavailable, match="doctor --install exiftool"):
+        enrich_from_video(srt, [_srt("00:00:00,000")], extract=lambda p: [])
+
+
+def test_enrich_merges_and_reports(tmp_path, monkeypatch):
+    srt = tmp_path / "DJI_0001.SRT"
+    srt.write_text("", encoding="utf-8")
+    (tmp_path / "DJI_0001.MP4").write_bytes(b"")
+    monkeypatch.setattr(
+        "dji_metadata_embedder.geo.videogimbal.exiftool_available", lambda: True
+    )
+    samples = [_srt("00:00:00,000"), _srt("00:00:01,000"), _srt("00:00:09,000")]
+    seen = []
+
+    def fake(path):
+        seen.append(path)
+        return [_djmd("00:00:00,000", 90.0, -30.0), _djmd("00:00:01,000", 91.0, -31.0)]
+
+    report = enrich_from_video(srt, samples, name="DJI_0001", extract=fake)
+    assert seen == [tmp_path / "DJI_0001.MP4"]
+    assert (report.name, report.video) == ("DJI_0001", "DJI_0001.MP4")
+    assert (report.matched, report.total) == (2, 3)
+    assert report.reason is None
+    assert report.seconds >= 0.0
+    assert samples[2].gimbal_yaw is None

--- a/tests/test_mp4_telemetry.py
+++ b/tests/test_mp4_telemetry.py
@@ -49,12 +49,39 @@ def test_samples_from_exiftool_maps_air3s():
     assert first.cue == "00:00:00,000"
     assert first.dt == datetime(2026, 5, 16, 23, 55, 53, 0)
     assert first.gimbal_yaw == -7.1
-    # sparse early sample: optional fields absent
-    assert first.rel_alt is None and first.gimbal_pitch is None
+    # Early sample lacks RelativeAltitude and GimbalPitch, but later samples
+    # carry both, so these are protobuf default omissions: the aircraft sits
+    # at 0 m with a level gimbal (#546, verified on Air 3S: 182 s without a
+    # pitch tag, then 0.2 appears; GimbalRoll never does because it is 0).
+    assert first.rel_alt == 0.0 and first.gimbal_pitch == 0.0
     # rich mid-flight sample: optional fields present
     assert last.rel_alt == 5.4
     assert last.gimbal_pitch == -90
     assert last.focal_len is None  # stream carries no focal length
+
+
+def _docs(*per_sample):
+    root = {}
+    for i, fields in enumerate(per_sample, start=1):
+        root[f"Doc{i}"] = {"GPSLatitude": 51.0, "GPSLongitude": -0.1, **fields}
+    return [root]
+
+
+def test_default_omission_fills_a_field_the_stream_carries_elsewhere():
+    samples, _ = mt._samples_from_exiftool(_docs(
+        {"GimbalYaw": 12.5},
+        {"GimbalYaw": 13.0, "GimbalPitch": -30.0, "RelativeAltitude": 0.1},
+    ))
+    first = samples[0]
+    assert (first.gimbal_yaw, first.gimbal_pitch, first.rel_alt) == (12.5, 0.0, 0.0)
+
+
+def test_fields_the_stream_never_carries_stay_unknown():
+    samples, _ = mt._samples_from_exiftool(_docs(
+        {"AbsoluteAltitude": 10.0}, {"AbsoluteAltitude": 11.0},
+    ))
+    for s in samples:
+        assert (s.gimbal_yaw, s.gimbal_pitch, s.rel_alt) == (None, None, None)
 
 
 def test_samples_from_exiftool_undecoded_sets_saw_false():


### PR DESCRIPTION
Closes #546.

Air 3S (and newer) SRTs carry no gimbal fields, so the 3D map drew every gaze pass as "estimated". The MP4's djmd stream has GimbalYaw/GimbalPitch on every frame and `mp4_telemetry` already decodes it; this wires the two together.

**What changes**

- New `geo/videogimbal.py`: joins djmd samples onto SRT samples by elapsed cue (both clocks start at 0 in the same recording; their wall-clock stamps disagree by ~0.4 s on real Air 3S footage, so a UTC join would lag by up to 13 frames). Fills only `None` fields; SRT values are never overwritten.
- `scan_flights(gimbal_from_video=, on_video_gimbal=, extract=)`: per-file enrichment before track building, so joining/decimation/3D need no changes. Return signature unchanged.
- `flightmap --gimbal-from-video`: opt-in because ExifTool walks every sample (measured 55 s on a 4 GB clip, ~2 min for a 9-clip batch against a sub-second scan today). Prints one line per enriched flight plus a summary; skip reasons under `-v`; fails fast with the `doctor --install exiftool` hint when ExifTool is missing. Without the flag, `--3d` probes gimbal-less flights' videos (moov only, 0.14 s each) and hints once when they carry angles.
- GUI: "Read gimbal angles from the videos" checkbox in the 3D block, emitted only with `--3d` like `--link-originals`.
- `media.find_video_path` extracted from `_find_video` so both callers share the case-safe lookup; `utils.exiftool.exiftool_available()` added.
- `mp4_telemetry` fix found during E2E: protobuf omits fields at their default value, so ExifTool emits no GimbalPitch tag while the gimbal is level (182 s on clip 0001, then 0.2 appears), no RelativeAltitude while the aircraft is on the ground (59 s, then 0.1), and never a GimbalRoll. The sample builder now treats a field the stream carries anywhere as 0.0 where a sample lacks it; a field never carried stays None. Before this, the enriched 3D map still showed 23 to 47 s runs of "estimated" pitch per flight.
- Docs: geospatial.md now lists the two routes (djmd models vs `--flight-log` for the Mini series), how-to pointer, README note.

**Verification**

- pytest 1493 passed, ruff clean, mypy clean, GUI xunit 596 passed.
- E2E on a local Air 3S batch (real GPS, not committed): see PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t