### PR TITLE
fix(flightmap --3d): ground reference from a sample on the ground, not sample 0 (#548)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -315,6 +315,13 @@ which keeps it consistent with the landscape you are looking at instead of
 trusting an absolute altitude whose datum may not match. Fly level toward
 rising ground and the curtain visibly shortens as the clearance closes.
 
+The takeoff point is a sample where the aircraft was on the ground, not
+simply the first sample: if you pressed record after launching, the clip
+starts airborne, often over terrain quite unlike the launch site, and the
+landing at the end of the clip gives the reference instead. A clip with no
+ground contact at all falls back to its first sample, and the cockpit view
+badges it *ground reference estimated* so you know the heights are a guess.
+
 Where the terrain model is unavailable the curtain falls back to plain height
 above takeoff. Segments where the drone works out to be at or below the
 rendered ground — a rooftop launch, a datum artefact near a cliff, or a low

--- a/src/dji_metadata_embedder/geo/flightmap3d_html.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_html.py
@@ -475,9 +475,38 @@ function terrainElevAt(lngLat) {
   return typeof e === 'number' ? e : null;
 }
 
+// A sample this close to takeoff height counts as "on the ground": DJI's
+// rel_alt reads -0.1..0.3 m at rest, so half a metre never catches a hover.
+const GROUND_AGL_M = 0.5;
+
+function groundRef(fl) {
+  // The DEM elevation the flight's rel_alt is measured from (#548).
+  // rel_alt is relative to the real takeoff point, NOT to wherever the
+  // recording happened to start: a clip whose first sample is airborne
+  // (record pressed after launch) would otherwise borrow the terrain under
+  // that sample, lifting or sinking every consumer of this reference --
+  // the sculpture, the ghost camera and the gaze. So prefer a sample that
+  // is on the ground: the start when it qualifies, else the landing, else
+  // the first ground contact anywhere; and only then fall back to sample 0,
+  // flagged so the HUD can say the reference is a guess.
+  const n = fl.pts.length;
+  let idx = 0, estimated = true;
+  if (fl.agl && n) {
+    const onGround = i => fl.agl[i] != null && Math.abs(fl.agl[i]) <= GROUND_AGL_M;
+    if (onGround(0)) { idx = 0; estimated = false; }
+    else if (onGround(n - 1)) { idx = n - 1; estimated = false; }
+    else {
+      for (let i = 1; i < n - 1; i++) {
+        if (onGround(i)) { idx = i; estimated = false; break; }
+      }
+    }
+  }
+  const p = fl.pts[idx];
+  return { elev: terrainElevAt([p[0], p[1]]), idx: idx, estimated: estimated };
+}
+
 function takeoffElev(fl) {
-  const p0 = fl.pts[0];
-  return terrainElevAt([p0[0], p0[1]]);
+  return groundRef(fl).elev;
 }
 
 function ghostEnter(flightIdx, sampleIdx) {
@@ -669,6 +698,9 @@ function updateHud() {
   };
   if (pose.clamped) badge('pitch clamped to ' + GHOST_MAX_PITCH + '\\u00b0');
   if (pose.estimated) badge('estimated view \\u2014 no gimbal data');
+  if (fl.agl && groundRef(fl).estimated) {
+    badge('ground reference estimated \\u2014 clip started airborne');
+  }
   if (REDACTED === 'fuzz') badge('position fuzzed ~100 m');
 }
 

--- a/tests/browser/test_flightmap_sculpture.py
+++ b/tests/browser/test_flightmap_sculpture.py
@@ -693,3 +693,63 @@ def test_rapid_ghost_cycle_restores_correctly(serve_map, page):
         " 'doubleClickZoom', 'touchZoomRotate']"
         ".every(h => map[h].isEnabled())"), (
         "camera interaction handlers were not re-enabled after settling")
+
+
+# --- #548: the ground reference is a sample on the ground, not sample 0 ---
+
+
+def _serve_steps(serve_map, page, agls):
+    lat = 10.0
+    tile_lon = TILE_DEG * 1660
+    start_lon = tile_lon + TILE_DEG * 1.75          # high (600 m) side
+    step = TILE_DEG * 0.12                          # walks east into the valley
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", lat, start_lon, agls, step=step)], "trip")
+    serve_map(html, terrain_steps=(0.0, 600.0))
+    page.wait_for_function(
+        "() => typeof map !== 'undefined' && map && map.getLayer("
+        "'sculpt-0-curtain')", timeout=20000)
+    page.wait_for_function(
+        "() => map.getTerrain() && map.areTilesLoaded()", timeout=20000)
+    page.evaluate("() => setSculptData()")
+
+
+def test_airborne_start_takes_the_ground_reference_from_the_landing(
+    serve_map, page
+):
+    """Recording started airborne over the plateau; landed in the valley.
+
+    rel_alt is relative to the real launch site (the valley floor, where
+    the clip ends on the ground), so the ribbon over the plateau must NOT
+    be lifted by the 600 m the DEM under sample 0 would imply.
+    """
+    _serve_steps(serve_map, page, [6.0, 6.0, 6.0, 6.0, 3.0, 0.0])
+    ref = page.evaluate("() => groundRef(flights[0])")
+    assert ref["idx"] == 5 and ref["estimated"] is False
+    assert abs(ref["elev"]) < 1.0, ref
+    hs = page.evaluate(
+        "() => planksFor(flights[0], 10).map(f => f.properties.hgt)")
+    assert hs, "no planks built"
+    assert max(hs) < 20, f"plateau planks lifted by the wrong reference: {hs}"
+
+
+def test_ground_start_still_wins_over_a_later_landing(serve_map, page):
+    """Sample 0 on the ground stays the reference even when the clip also
+    lands somewhere else (a one-way flight down into the valley)."""
+    _serve_steps(serve_map, page, [0.0, 6.0, 6.0, 6.0, 3.0, 0.0])
+    ref = page.evaluate("() => groundRef(flights[0])")
+    assert ref["idx"] == 0 and ref["estimated"] is False
+    assert ref["elev"] > 500, ref
+
+
+def test_no_ground_contact_falls_back_to_sample_zero_with_a_badge(
+    serve_map, page
+):
+    from playwright.sync_api import expect
+
+    _serve_steps(serve_map, page, [6.0, 6.0, 6.0, 6.0, 6.0, 6.0])
+    ref = page.evaluate("() => groundRef(flights[0])")
+    assert ref["idx"] == 0 and ref["estimated"] is True
+    page.evaluate("() => ghostEnter(0, 1)")
+    expect(page.locator("#ghost-badges")).to_contain_text(
+        "ground reference estimated", timeout=10000)


### PR DESCRIPTION
Closes #548.

A recording that starts airborne (record pressed after launch) took its terrain ground reference from the DEM under sample 0. DJI's rel_alt is relative to the real takeoff point, so whenever the terrain under sample 0 differs from the launch site, the sculpture ribbon sat at the wrong altitude and planks whose clearance went negative were dropped; the ghost camera and gaze read the same reference.

**Change**

`groundRef(fl)` in `flightmap3d_html.py` replaces the sample-0 assumption: the start when it is on the ground (|rel_alt| <= 0.5 m), else the landing, else the first ground contact anywhere; with none, sample 0 flagged `estimated`, and the cockpit HUD shows "ground reference estimated — clip started airborne". `takeoffElev()` is kept as a wrapper so the three consumers are unchanged. Docs paragraph in geospatial.md.

**Verification**

- New browser tests: airborne start over a 600 m plateau landing in the valley picks the landing (max plank 12 m, not 600); a ground start still wins over a later landing; no ground contact -> fallback + badge.
- Browser suites sculpture/ghost/gaze/3d/playback green locally; ruff, mypy, non-browser 3D tests green.
- E2E on a local Air 3S pair (not committed): the level clip that started 250 m out over water now takes its reference from its landing (6.1 m, matching the other clip's takeoff), keeps 115 of 133 planks instead of 76, and its ribbon reaches the landing point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t