### PR TITLE
feat(mavic4pro): confirm the format, parse ct/tint, and unlock the gimbal block via a bundled ExifTool config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mavic 4 Pro**: format confirmed on sample footage from DJI Stockholm; `samples/mavic4pro/clip.SRT` fixture, docs rows, and the `[ct: N, tint: N]` token parsed as `ct` + a new CSV `tint` column
+- **flightmap**: `--gimbal-from-video` now works on Mavic 4 Pro footage via a bundled ExifTool user config that maps the stream's undecoded gimbal block (`dvtm_Mavic4_3-4-3`) to `GimbalInfo`; passed with `-config` on every ExifTool call
+
+### Fixed
+
+- **SRT/CSV**: `ct` no longer swallows the trailing `tint` on Mavic 4 Pro files (`"5574, tint: 8"` → `5574`)
+- **flightmap --3d**: the `--gimbal-from-video` hint only appears when the video's djmd schema actually carries gimbal attitude (Mini 5 Pro streams hold position only)
+
 ## [2.13.0] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ end-to-end examples in [docs/recipes.md](docs/recipes.md).
 - **DJI Mini 5 Pro** - HTML-style bracket format with decimal aperture (`[fnum: 1.8]`)
 - **DJI Air 3** - HTML-style format with extended telemetry data
 - **DJI Air 3S** - HTML-style bracket format with decimal `focal_len` and HLG color mode (`[color_md: hlg]`); MP4 also carries embedded `djmd`/`dbgi` data streams
+- **DJI Mavic 4 Pro** - HTML-style bracket format with a tint on the colour-temperature token (`[ct: 5562, tint: 0]`); MP4 and `.LRF` carry embedded `djmd`/`dbgi` data streams incl. gimbal angles
 - **DJI Avata 360** - HTML-style bracket format with stabilization (`pp_*`) fields; footage ships as `.OSV` (360 video) + `.LRF` proxy
 - **DJI Neo 2** - HTML-style bracket format with stabilization (`pp_*`) fields; MP4 also carries embedded `djmd`/`dbgi` data streams
 - **DJI Avata 2** - Legacy GPS format `GPS(lat,lon,alt)` with BAROMETER data
@@ -270,7 +271,8 @@ end-to-end examples in [docs/recipes.md](docs/recipes.md).
 **Sidecar-less models (Air 3S, Mini 5 Pro, …):** telemetry is read straight from
 the MP4's embedded `djmd`/`dbgi` track via ExifTool — no `.SRT` needed —
 for `dji-embed convert <fmt> FILE.MP4` and `dji-embed verify-sun FILE.MP4`.
-Requires a recent ExifTool (Air 3S ≥ 13.39, Mini 5 Pro ≥ 13.52); see
+Requires a recent ExifTool (Air 3S ≥ 13.39, Mini 5 Pro ≥ 13.52, Mavic 4 Pro
+≥ 13.59); see
 [docs/MP4_TIMED_METADATA.md](docs/MP4_TIMED_METADATA.md).
 
 ## Intended use & scope
@@ -525,7 +527,8 @@ Notes:
   lists the joined files; tune or disable with `--join-gap`.
 - The 3D map's camera footprints are estimates unless the SRT logs gimbal
   angles. `--gimbal-from-video` reads them from the MP4's own telemetry (Air
-  3S and newer; needs ExifTool, opens every video), and `--flight-log CSV`
+  3/3S, Mavic 3/4 Pro, Mini 4 Pro; needs ExifTool, opens every video), and
+  `--flight-log CSV`
   merges them from a decoded flight record for drones that log none.
 - Tracks are thinned to ~1 GPS point per second for the map (DJI logs ~30
   per second) — visually identical but far smaller files; use
@@ -874,6 +877,8 @@ MIT License - see LICENSE file for details
 ## Acknowledgments
 
 - Thanks to the DJI drone community for format documentation
+- DJI Stockholm (Grev Turegatan) for flying and sharing the Mavic 4 Pro sample
+  footage that confirmed the format and located its gimbal telemetry
 - FFmpeg and ExifTool teams for their excellent tools
 
 ## Related Projects

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -5,7 +5,7 @@ a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],
     binaries=[],
-    datas=[],
+    datas=[('src/dji_metadata_embedder/data/exiftool.config', 'dji_metadata_embedder/data')],
     hiddenimports=['dji_metadata_embedder', 'dji_metadata_embedder.cli', 'dji_metadata_embedder.core', 'dji_metadata_embedder.telemetry_converter', 'dji_metadata_embedder.metadata_check', 'click', 'rich'],
     hookspath=[],
     hooksconfig={},

--- a/docs/MODEL_SURVEY.md
+++ b/docs/MODEL_SURVEY.md
@@ -24,7 +24,7 @@ samples below).
 |---|---|---|---|---|---|
 | DJI Mini 5 Pro | Shipping | Yes (reported) | Square-bracket (likely) | Moderate | Sample request |
 | DJI Air 3S | Shipping | Yes (official) | HTML-style extended (likely) | Moderate | Sample request |
-| DJI Mavic 4 Pro | Shipping | Yes (first-hand) | Possibly novel extended | Large | Sample request |
+| DJI Mavic 4 Pro | Shipping | Yes (confirmed) | Format 3b (`html_extended`) | Done | Fixture `samples/mavic4pro/`, 2026-08-26 |
 | DJI Neo | Shipping | Unconfirmed | Unknown | Large | Sample request |
 | DJI Flip | Shipping (2025) | Yes (official) | Square-bracket (likely) | Trivial | Sample request |
 | DJI Avata 360 | Shipping | Yes (official) | Legacy / Avata 2 (likely) | Trivial | Sample request |
@@ -143,9 +143,11 @@ prerequisite.
   successor). Best consumer candidate.
 - **DJI Air 3S** — officially confirmed SRT support; expected HTML-style
   extended (Air 3 successor).
-- **DJI Mavic 4 Pro** — first-hand confirmation of `.SRT` + `.LRF` files on
-  internal storage (MavicPilots thread 155866). Tri-camera + new gimbal may
-  add novel tokens; treat as possibly novel until a file proves otherwise.
+- **DJI Mavic 4 Pro** — **confirmed 2026-08-26** on sample clips from DJI
+  Stockholm (firmware V01.00.0800): plain Format 3b, the only new token being
+  `[ct: N, tint: N]`. The MP4 and `.LRF` carry `djmd`/`dbgi`
+  (`dvtm_Mavic4.proto`); ExifTool 13.59 decodes GPS, altitude and aircraft
+  attitude, and dji-embed's bundled ExifTool config adds the gimbal block.
 - **DJI Neo** — indirect tooling support; unconfirmed format; lower priority
   than the three above.
 - **DJI Flip** — officially confirmed SRT; square-bracket family expected;

--- a/docs/MP4_TIMED_METADATA.md
+++ b/docs/MP4_TIMED_METADATA.md
@@ -23,6 +23,7 @@ ExifTool decodes each model's protobuf schema in a specific release:
 | DJI Neo | 13.35 |
 | Air 3S | 13.39 |
 | Mini 5 Pro | 13.52 |
+| Mavic 4 Pro | 13.59 (verified; may work earlier) |
 
 Newer models land in later releases — check the ExifTool change history. If your
 ExifTool is too old, the stream is recognised but no GPS is decoded, and
@@ -48,5 +49,16 @@ supported model. To use a specific binary instead, set
 Field coverage varies by model (e.g. Air 3S includes gimbal angles; Mini 5 Pro
 is GPS + altitude only). CSV from an MP4 fills geo/altitude/`datetime_utc`/solar
 columns; SRT-only camera columns (iso, shutter, …) stay blank.
+
+## Bundled ExifTool config
+
+`dji-embed` passes its own ExifTool user config (`data/exiftool.config` inside
+the package) on every call. It adds tag mappings ExifTool does not have yet;
+today that is the Mavic 4 Pro gimbal block (protobuf field `3-4-3`, the same
+layout ExifTool names `GimbalInfo` on the Air 3/Air 3S), so
+`flightmap --3d --gimbal-from-video` works on Mavic 4 Pro footage. Plain
+`exiftool` on the command line will not show those tags unless you pass
+`-config <that file>` yourself. An ExifTool too old to know the table being
+extended ignores the config.
 
 > UTC note: an MP4's time is intrinsic, so `--tz-offset` is ignored for video.

--- a/docs/SRT_FORMATS.md
+++ b/docs/SRT_FORMATS.md
@@ -98,7 +98,7 @@ Used by: DJI Mavic 3, DJI Air 2S
 
 ### Format 3b: Modern HTML Bracket (FrameCnt + decimal units)
 
-Used by: DJI Mini 5 Pro, DJI Avata 360, DJI Neo 2, DJI Air 3S
+Used by: DJI Mini 5 Pro, DJI Avata 360, DJI Neo 2, DJI Air 3S, DJI Mavic 4 Pro
 
 Current models keep the HTML-wrapped bracket structure of Format 3 but change
 two things: the counter is `FrameCnt` (not `SrtCnt`), and the aperture and
@@ -125,6 +125,12 @@ focal length are written as **literal decimals** rather than the legacy
   observed fixture to report `color_md: hlg` (HLG color mode, alongside the
   usual `default`/`dlog_m`). Its MP4 also carries DJI's proprietary
   `djmd`/`dbgi` data streams, dropped on MP4 mux and round-tripped on MKV.
+- The Mavic 4 Pro variant appends a tint to the colour-temperature token,
+  `[ct: 5562, tint: 0]`, parsed as `ct` and `tint` (CSV gets a `tint` column
+  next to `ct`). It logs at 60 fps with no gimbal fields; the MP4 and the
+  `.LRF` proxy both carry the `djmd`/`dbgi` streams, and the gimbal angles
+  in them are readable via `--gimbal-from-video` (see
+  [MP4_TIMED_METADATA.md](MP4_TIMED_METADATA.md)).
 - Detected as the `html_extended` format family.
 
 ## Camera Settings Interpretation
@@ -224,6 +230,7 @@ if new_format_match:
 | DJI Avata 360 | Format 3b | FrameCnt + decimal units; `.OSV`/`.LRF` video, `pp_*` stabilization fields |
 | DJI Neo 2 | Format 3b | FrameCnt + decimal units; `pp_*` stabilization fields; MP4 carries `djmd`/`dbgi` streams; audio recorded to a **separate same-basename `.m4a`** (see `--audio-sidecar`) |
 | DJI Air 3S | Format 3b | FrameCnt + decimal units; `color_md: hlg`; MP4 carries `djmd`/`dbgi` streams |
+| DJI Mavic 4 Pro | Format 3b | FrameCnt + decimal units; `[ct: N, tint: N]`; MP4 and `.LRF` carry `djmd`/`dbgi` streams (gimbal via bundled ExifTool config) |
 | DJI Mavic Pro | Format 2 | GPS function format |
 | DJI Phantom 4 | Format 2 | GPS function format |
 | DJI Avata 2 | Format 2 | GPS function format with BAROMETER data |

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -193,8 +193,9 @@ Most DJI SRTs carry no gimbal attitude, so the 3D map draws the camera
 footprint as a labelled estimate. Two routes upgrade it to a measurement,
 and neither ever overwrites a value the SRT itself recorded:
 
-- Drones whose MP4 carries a timed-metadata track with gimbal angles (Air 3S
-  and newer): `--gimbal-from-video` reads pitch/yaw from the video beside
+- Drones whose MP4 carries a timed-metadata track with gimbal angles (Air 3,
+  Air 3S, Mavic 3 and 4 Pro, Mini 4 Pro, Matrice): `--gimbal-from-video`
+  reads pitch/yaw from the video beside
   each SRT and joins it frame by frame. It needs ExifTool (`dji-embed doctor
   --install exiftool`) and opens every video, roughly 15 seconds per
   gigabyte, which is why it is opt-in; the 3D map says so once when it

--- a/docs/how-to/flight-log-gimbal.md
+++ b/docs/how-to/flight-log-gimbal.md
@@ -5,7 +5,8 @@ track, and similar) record **no gimbal attitude anywhere on the SD card**.
 Their SRT sidecars carry position but not where the camera pointed, so the
 3D map draws the camera footprint as a labelled *estimate*.
 
-(Air 3S and newer write gimbal angles into the MP4 itself; for those,
+(Air 3, Air 3S, Mavic 3 and 4 Pro and Mini 4 Pro write gimbal angles into
+the MP4 itself; for those,
 `flightmap --3d --gimbal-from-video` reads them straight from the video and
 no flight log is needed.)
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -36,6 +36,11 @@ Each directory contains a complete set of test files:
 - **Format**: HTML-style SRT with stabilization (`pp_*`) fields
 - **Features**: GPS, altitude, camera metadata; MP4 also carries embedded `djmd`/`dbgi` data streams. Includes a `clip_nogps.SRT` variant for no-GPS handling.
 
+### `mavic4pro/` - DJI Mavic 4 Pro Format
+- **Format**: HTML-style SRT (`FrameCnt`/`DiffTime`, 60 fps) with a tint on the colour-temperature token (`[ct: 5574, tint: 8]`)
+- **Features**: GPS, altitude, camera settings; the MP4 and `.LRF` carry embedded `djmd`/`dbgi` streams incl. gimbal angles
+- **GPS**: Stockholm, Sweden area (redacted coordinates); footage courtesy of DJI Stockholm
+
 ### `Avata360/` - DJI Avata 360 Format
 - **Format**: HTML-style SRT (`FrameCnt`/`FrameId`) with stabilization (`pp_*`) fields
 - **Features**: Footage ships as `.OSV` (360 video) + `.LRF` proxy alongside the SRT

--- a/samples/mavic4pro/clip.SRT
+++ b/samples/mavic4pro/clip.SRT
@@ -1,0 +1,30 @@
+1
+00:00:00,000 --> 00:00:00,016
+<font size="28">FrameCnt: 1, DiffTime: 16ms
+2026-08-23 17:22:01.253
+[iso: 160] [shutter: 1/1000.0] [fnum: 2.8] [ev: -0.3] [color_md: default] [focal_len: 28.00] [latitude: 59.329400] [longitude: 18.068600] [rel_alt: 59.764 abs_alt: 92.670] [ct: 5574, tint: 8] </font>
+
+2
+00:00:00,016 --> 00:00:00,032
+<font size="28">FrameCnt: 2, DiffTime: 16ms
+2026-08-23 17:22:01.270
+[iso: 160] [shutter: 1/1000.0] [fnum: 2.8] [ev: -0.3] [color_md: default] [focal_len: 28.00] [latitude: 59.329400] [longitude: 18.068600] [rel_alt: 59.764 abs_alt: 92.670] [ct: 5574, tint: 8] </font>
+
+3
+00:00:00,032 --> 00:00:00,049
+<font size="28">FrameCnt: 3, DiffTime: 17ms
+2026-08-23 17:22:01.287
+[iso: 160] [shutter: 1/1000.0] [fnum: 2.8] [ev: -0.3] [color_md: default] [focal_len: 28.00] [latitude: 59.329400] [longitude: 18.068600] [rel_alt: 59.764 abs_alt: 92.670] [ct: 5574, tint: 8] </font>
+
+4
+00:00:00,049 --> 00:00:00,066
+<font size="28">FrameCnt: 4, DiffTime: 17ms
+2026-08-23 17:22:01.304
+[iso: 160] [shutter: 1/1000.0] [fnum: 2.8] [ev: -0.3] [color_md: default] [focal_len: 28.00] [latitude: 59.329400] [longitude: 18.068600] [rel_alt: 59.764 abs_alt: 92.670] [ct: 5574, tint: 8] </font>
+
+5
+00:00:00,066 --> 00:00:00,082
+<font size="28">FrameCnt: 5, DiffTime: 16ms
+2026-08-23 17:22:01.320
+[iso: 160] [shutter: 1/1000.0] [fnum: 2.8] [ev: -0.3] [color_md: default] [focal_len: 28.00] [latitude: 59.329400] [longitude: 18.068600] [rel_alt: 59.764 abs_alt: 92.670] [ct: 5575, tint: 8] </font>
+

--- a/src/dji_metadata_embedder/cli.py
+++ b/src/dji_metadata_embedder/cli.py
@@ -56,7 +56,11 @@ from .geo.airspace.overlay import zones_to_overlay_json
 from .geo.flightlog import FlightLogError, merge_into_flights, parse_flight_log
 from .geo.logfetch import LogFetchError, cache_path, fetch_log
 from .geo.media import find_video_path, resolve_media
-from .geo.videogimbal import VideoGimbalReport, VideoGimbalUnavailable
+from .geo.videogimbal import (
+    VideoGimbalReport,
+    VideoGimbalUnavailable,
+    schema_carries_gimbal,
+)
 from .geo.record import build_records
 from .geo.record_html import write_flight_record
 from .mp4_telemetry import _EXIFTOOL_INSTALL_HINT, Mp4TelemetryError, probe
@@ -851,7 +855,9 @@ def _hint_gimbal_from_video(tracks: list, src: Path) -> None:
     Only when ExifTool is present: without it there is nothing to probe and
     no honest way to know what the videos hold. The probe reads the moov
     atom alone (0.14 s on a 4 GB Air 3S clip), so it is cheap enough to run
-    per gimbal-less flight (#546).
+    per gimbal-less flight (#546). A djmd track alone does not qualify: the
+    schema it names must be one that carries gimbal attitude (Mini 5 Pro
+    streams, say, hold position only).
     """
     if not exiftool_available():
         return
@@ -867,7 +873,7 @@ def _hint_gimbal_from_video(tracks: list, src: Path) -> None:
             if video is None:
                 continue
             try:
-                if probe(video) is not None:
+                if schema_carries_gimbal(probe(video)):
                     carrying += 1
                     break
             except Mp4TelemetryError:

--- a/src/dji_metadata_embedder/data/exiftool.config
+++ b/src/dji_metadata_embedder/data/exiftool.config
@@ -1,0 +1,24 @@
+# ExifTool user configuration bundled with dji-embed.
+#
+# Passed as ``exiftool -config <this file> ...`` by dji_metadata_embedder.mp4_telemetry
+# so every ExifTool call (probe and extraction) sees the same tag tables.
+#
+# Mavic 4 Pro (dvtm_Mavic4.proto): ExifTool 13.59 decodes GPS, altitude and the
+# aircraft attitude from the djmd stream but leaves protobuf field 3-4-3
+# undecoded. That block has the same layout ExifTool already names GimbalInfo
+# on the Air 3 / Air 3S (field 1 = pitch, 2 = roll, 3 = yaw, tenths of a
+# degree; roll is omitted when 0), verified on DJI Stockholm's sample clips
+# (2026-08-26): the neighbouring 3-4-4 quaternion reproduces these angles
+# exactly. Mapping it here makes ``flightmap --3d --gimbal-from-video`` work on
+# Mavic 4 Pro footage. Remove once upstream ExifTool decodes it natively (a
+# duplicate definition is harmless in the meantime).
+%Image::ExifTool::UserDefined = (
+    'Image::ExifTool::DJI::Protobuf' => {
+        'dvtm_Mavic4_3-4-3' => {
+            Name => 'GimbalInfo',
+            SubDirectory => { TagTable => 'Image::ExifTool::DJI::GimbalInfo' },
+        },
+    },
+);
+
+1; # end

--- a/src/dji_metadata_embedder/embedder.py
+++ b/src/dji_metadata_embedder/embedder.py
@@ -371,7 +371,12 @@ class DJIMetadataEmbedder:
                         ev_match = re.search(
                             r"(?<![A-Za-z])EV\s+([+-]?\d+\.?\d*)", telemetry_line
                         )
-                    ct_match = re.search(r"\[ct\s*:\s*([^\]]+)\]", telemetry_line)
+                    # ``[ct: 5562]`` on most models; the Mavic 4 Pro appends a
+                    # tint inside the same bracket: ``[ct: 5562, tint: 0]``.
+                    ct_match = re.search(r"\[ct\s*:\s*([+-]?\d+\.?\d*)", telemetry_line)
+                    tint_match = re.search(
+                        r"\btint\s*:\s*([+-]?\d+\.?\d*)", telemetry_line
+                    )
                     color_md_match = re.search(
                         r"\[color_md\s*:\s*([^\]]+)\]", telemetry_line
                     )
@@ -385,6 +390,7 @@ class DJIMetadataEmbedder:
                         or fnum_match
                         or ev_match
                         or ct_match
+                        or tint_match
                         or color_md_match
                         or focal_len_match
                     ):
@@ -399,6 +405,8 @@ class DJIMetadataEmbedder:
                             camera_data["ev"] = ev_match.group(1)
                         if ct_match:
                             camera_data["ct"] = ct_match.group(1)
+                        if tint_match:
+                            camera_data["tint"] = tint_match.group(1)
                         if color_md_match:
                             camera_data["color_md"] = color_md_match.group(1)
                         if focal_len_match:

--- a/src/dji_metadata_embedder/geo/videogimbal.py
+++ b/src/dji_metadata_embedder/geo/videogimbal.py
@@ -60,6 +60,31 @@ class VideoGimbalReport:
     reason: str | None = None
 
 
+# djmd schemas whose protobuf carries a GimbalInfo block (pitch/roll/yaw).
+# From ExifTool 13.59's DJI.pm (every ``dvtm_*_3-4-3 => GimbalInfo`` entry)
+# plus the Mavic 4 Pro, which dji-embed's bundled ExifTool config maps at the
+# same path. Mini 5 Pro, Neo, Avata 2 and the action cams stream position
+# only, so their videos cannot supply what the SRT lacks.
+GIMBAL_SCHEMAS: frozenset[str] = frozenset({
+    "dvtm_Air3.proto",
+    "dvtm_Air3s.proto",
+    "dvtm_Mavic4.proto",
+    "dvtm_Mini4_Pro.proto",
+    "dvtm_pm320.proto",    # Matrice 30
+    "dvtm_wa345e.proto",   # Matrice 4E
+    "dvtm_wm261.proto",    # Mavic 3 family
+    "dvtm_wm265e.proto",   # Mavic 3 Enterprise
+})
+
+
+def schema_carries_gimbal(schema: str | None) -> bool:
+    """True when a :func:`~dji_metadata_embedder.mp4_telemetry.probe` result
+    names a djmd schema that includes gimbal attitude."""
+    if not schema:
+        return False
+    return any(key in schema for key in GIMBAL_SCHEMAS)
+
+
 def needs_gimbal(samples: list[TelemetrySample]) -> bool:
     """True when any sample lacks gimbal yaw or pitch."""
     return any(s.gimbal_yaw is None or s.gimbal_pitch is None for s in samples)

--- a/src/dji_metadata_embedder/mp4_telemetry.py
+++ b/src/dji_metadata_embedder/mp4_telemetry.py
@@ -11,6 +11,7 @@ import json
 import re
 import subprocess
 from datetime import datetime
+from importlib.resources import files
 from pathlib import Path
 
 from .utilities import TelemetrySample, is_gps_fix
@@ -148,10 +149,29 @@ _EXIFTOOL_INSTALL_HINT = (
 )
 
 
+def exiftool_config_path() -> Path | None:
+    """The ExifTool user config bundled with dji-embed, or ``None`` if absent.
+
+    ``data/exiftool.config`` adds tag mappings ExifTool lacks (today: the
+    Mavic 4 Pro gimbal block). It is passed with ``-config`` on every call so
+    probe and extraction agree; an ExifTool too old to know the table it
+    extends simply ignores it.
+    """
+    try:
+        path = Path(str(files(__package__) / "data" / "exiftool.config"))
+    except (ModuleNotFoundError, TypeError, ValueError):
+        return None
+    return path if path.is_file() else None
+
+
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    config = exiftool_config_path()
+    # ``-config`` must be the very first argument (ExifTool reads it before
+    # anything else).
+    prefix = ["-config", str(config)] if config is not None else []
     try:
         return subprocess.run(
-            [exiftool_exe(), *args], capture_output=True, text=True
+            [exiftool_exe(), *prefix, *args], capture_output=True, text=True
         )
     except FileNotFoundError:
         raise Mp4TelemetryError(_EXIFTOOL_INSTALL_HINT) from None

--- a/src/dji_metadata_embedder/telemetry_converter.py
+++ b/src/dji_metadata_embedder/telemetry_converter.py
@@ -310,7 +310,7 @@ def batch_convert_to_csv(directory: Path | str) -> None:
 # is identical regardless of source.
 _CSV_COLUMNS = (
     "timestamp", "latitude", "longitude", "rel_altitude", "abs_altitude",
-    "iso", "shutter", "fnum", "ev", "ct", "color_md", "focal_len",
+    "iso", "shutter", "fnum", "ev", "ct", "tint", "color_md", "focal_len",
     "datetime_utc", "sun_azimuth", "sun_elevation",
 )
 
@@ -321,8 +321,8 @@ def _csv_from_samples(
     """Write CSV rows from video-sourced samples (UTC is intrinsic).
 
     Fills geo, altitude, ``datetime_utc`` and solar columns; camera columns that
-    only the SRT text carries (iso/shutter/fnum/ev/ct/color_md/focal_len) stay
-    blank.
+    only the SRT text carries (iso/shutter/fnum/ev/ct/tint/color_md/focal_len)
+    stay blank.
     """
     import csv
 
@@ -452,7 +452,9 @@ def extract_telemetry_to_csv(
             shutter_match = re.search(r"\[shutter\s*:\s*([^\]]+)\]", telemetry_line)
             fnum_match = re.search(r"\[fnum\s*:\s*(\d+)\]", telemetry_line)
             ev_match = re.search(r"\[ev\s*:\s*([^\]]+)\]", telemetry_line)
-            ct_match = re.search(r"\[ct\s*:\s*([^\]]+)\]", telemetry_line)
+            # ``[ct: 5562]``, or ``[ct: 5562, tint: 0]`` on the Mavic 4 Pro.
+            ct_match = re.search(r"\[ct\s*:\s*([+-]?\d+\.?\d*)", telemetry_line)
+            tint_match = re.search(r"\btint\s*:\s*([+-]?\d+\.?\d*)", telemetry_line)
             color_md_match = re.search(r"\[color_md\s*:\s*([^\]]+)\]", telemetry_line)
             focal_len_match = re.search(r"\[focal_len\s*:\s*([^\]]+)\]", telemetry_line)
 
@@ -466,6 +468,8 @@ def extract_telemetry_to_csv(
                 row["ev"] = ev_match.group(1)
             if ct_match:
                 row["ct"] = ct_match.group(1)
+            if tint_match:
+                row["tint"] = tint_match.group(1)
             if color_md_match:
                 row["color_md"] = color_md_match.group(1)
             if focal_len_match:

--- a/src/dji_metadata_embedder/utils/exiftool.py
+++ b/src/dji_metadata_embedder/utils/exiftool.py
@@ -74,6 +74,9 @@ EXIFTOOL_FLOORS: dict[str, tuple[str, str]] = {
     "dvtm_NEO.proto": ("Neo", "13.35"),
     "dvtm_Air3s.proto": ("Air 3S", "13.39"),
     "dvtm_Mini5Pro.proto": ("Mini 5 Pro", "13.52"),
+    # Verified on real footage at the 13.59 pin (2026-08-26); the gimbal block
+    # comes from dji-embed's bundled ExifTool config, not ExifTool itself.
+    "dvtm_Mavic4.proto": ("Mavic 4 Pro", "13.59"),
 }
 
 _INSTALL_HINT = "run: dji-embed doctor --install exiftool"

--- a/tests/test_cli_flightmap.py
+++ b/tests/test_cli_flightmap.py
@@ -533,3 +533,27 @@ def test_flightmap_flat_map_never_probes_videos(tmp_path, monkeypatch):
     res = CliRunner().invoke(main, ["flightmap", str(folder)])
     assert res.exit_code == 0, res.output
     assert "--gimbal-from-video" not in res.output
+
+
+def test_flightmap_3d_no_hint_when_schema_carries_no_gimbal(tmp_path, monkeypatch):
+    """A djmd track alone is not enough: Mini 5 Pro streams have no gimbal
+    block, so promising ``--gimbal-from-video`` there would be a false hope."""
+    folder = _video_folder(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "dji_metadata_embedder.cli.probe",
+        lambda p: "dvtm_Mini5Pro.proto;model_name:FC9999;pb_version:02.00.03;",
+    )
+    res = CliRunner().invoke(main, ["flightmap", str(folder), "--3d"])
+    assert res.exit_code == 0, res.output
+    assert "--gimbal-from-video" not in res.output
+
+
+def test_flightmap_3d_hints_for_mavic4pro_schema(tmp_path, monkeypatch):
+    folder = _video_folder(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        "dji_metadata_embedder.cli.probe",
+        lambda p: "dvtm_Mavic4.proto;model_name:L3D-100c;pb_version:02.00.03;",
+    )
+    res = CliRunner().invoke(main, ["flightmap", str(folder), "--3d"])
+    assert res.exit_code == 0, res.output
+    assert res.output.count("--gimbal-from-video") == 1

--- a/tests/test_csv_camera_columns.py
+++ b/tests/test_csv_camera_columns.py
@@ -1,0 +1,46 @@
+"""CSV camera columns from the SRT text, incl. the Mavic 4 Pro ``tint`` token."""
+
+import csv
+
+from dji_metadata_embedder.telemetry_converter import extract_telemetry_to_csv
+
+_M4P_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,016\n"
+    '<font size="28">FrameCnt: 1, DiffTime: 16ms\n'
+    "2026-08-23 17:22:01.253\n"
+    "[iso: 160] [shutter: 1/1000.0] [fnum: 2.8] [ev: -0.3] [color_md: default] "
+    "[focal_len: 28.00] [latitude: 59.329400] [longitude: 18.068600] "
+    "[rel_alt: 59.764 abs_alt: 92.670] [ct: 5574, tint: 8] </font>\n"
+)
+
+_AIR3S_SRT = (
+    "1\n00:00:00,000 --> 00:00:00,016\n"
+    '<font size="28">FrameCnt: 1, DiffTime: 16ms\n'
+    "2026-05-17 08:28:30.219\n"
+    "[iso: 180] [shutter: 1/640.0] [fnum: 1.8] [ev: 0] [color_md: hlg] "
+    "[focal_len: 24.00] [latitude: 34.270373] [longitude: -84.176160] "
+    "[rel_alt: 0.000 abs_alt: 302.208] [ct: 5419] </font>\n"
+)
+
+
+def _rows(tmp_path, text):
+    srt = tmp_path / "clip.SRT"
+    srt.write_text(text, encoding="utf-8")
+    out = tmp_path / "clip.csv"
+    extract_telemetry_to_csv(srt, out)
+    lines = out.read_text(encoding="utf-8").splitlines()
+    return lines[0].split(","), list(csv.DictReader(lines))
+
+
+def test_csv_ct_numeric_and_tint_column(tmp_path):
+    header, rows = _rows(tmp_path, _M4P_SRT)
+    assert rows[0]["ct"] == "5574"
+    assert rows[0]["tint"] == "8"
+    # tint sits right after ct so existing column order is preserved.
+    assert header.index("tint") == header.index("ct") + 1
+
+
+def test_csv_tint_blank_when_absent(tmp_path):
+    _header, rows = _rows(tmp_path, _AIR3S_SRT)
+    assert rows[0]["ct"] == "5419"
+    assert rows[0]["tint"] == ""

--- a/tests/test_geo_videogimbal.py
+++ b/tests/test_geo_videogimbal.py
@@ -161,3 +161,24 @@ def test_enrich_merges_and_reports(tmp_path, monkeypatch):
     assert report.reason is None
     assert report.seconds >= 0.0
     assert samples[2].gimbal_yaw is None
+
+
+# --- schema_carries_gimbal: which djmd schemas hold a GimbalInfo block ---
+
+
+@pytest.mark.parametrize(
+    "schema, expected",
+    [
+        ("dvtm_Air3s.proto;model_name:FC9113;pb_version:02.00.02;", True),
+        ("dvtm_Air3.proto", True),
+        ("dvtm_Mavic4.proto;model_name:L3D-100c;pb_version:02.00.03;", True),
+        ("dvtm_Mini5Pro.proto;model_name:FC9999;", False),
+        ("dvtm_NEO2.proto;model_name:FC9470", False),
+        ("djmd", False),
+        (None, False),
+    ],
+)
+def test_schema_carries_gimbal(schema, expected):
+    from dji_metadata_embedder.geo.videogimbal import schema_carries_gimbal
+
+    assert schema_carries_gimbal(schema) is expected

--- a/tests/test_mp4_telemetry.py
+++ b/tests/test_mp4_telemetry.py
@@ -208,3 +208,42 @@ def test_undecodable_stream_error_names_model_floor(monkeypatch, tmp_path):
     assert ">= 13.39" in text
     assert "12.76" in text
     assert "dji-embed doctor --install exiftool" in text
+
+
+# --- bundled ExifTool user config (Mavic 4 Pro gimbal block) ---
+
+
+def test_bundled_config_exists_and_maps_mavic4_gimbal():
+    cfg = mt.exiftool_config_path()
+    assert cfg is not None and cfg.is_file()
+    text = cfg.read_text(encoding="utf-8")
+    assert "dvtm_Mavic4_3-4-3" in text
+    assert "Image::ExifTool::DJI::GimbalInfo" in text
+
+
+def test_run_prepends_config_before_every_other_argument(monkeypatch):
+    seen = []
+
+    def fake_run(argv, **kwargs):
+        seen.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(mt.subprocess, "run", fake_run)
+    mt._run(["-ver"])
+    argv = seen[0]
+    assert argv[1] == "-config"
+    assert argv[2] == str(mt.exiftool_config_path())
+    assert argv[3:] == ["-ver"]
+
+
+def test_run_without_config_file_falls_back_to_plain_argv(monkeypatch):
+    seen = []
+
+    def fake_run(argv, **kwargs):
+        seen.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(mt.subprocess, "run", fake_run)
+    monkeypatch.setattr(mt, "exiftool_config_path", lambda: None)
+    mt._run(["-ver"])
+    assert seen[0][1:] == ["-ver"]

--- a/tests/test_new_model_samples.py
+++ b/tests/test_new_model_samples.py
@@ -6,7 +6,8 @@ tests pin the parser, telemetry-point extraction, and format detection against
 the trimmed ``clip.SRT`` fixtures shipped under ``samples/``. They also lock the
 decimal-aperture and FrameCnt fixes on real data — see ``test_parsing`` for the
 focused regressions. Air 3S additionally pins ``color_md: hlg``, the first
-fixture to exercise the HLG color mode.
+fixture to exercise the HLG color mode. Mavic 4 Pro pins the ``tint``
+suffix on the colour-temperature token.
 """
 
 from pathlib import Path
@@ -20,7 +21,7 @@ from dji_metadata_embedder.utilities import parse_telemetry_points
 SAMPLES = Path(__file__).resolve().parents[1] / "samples"
 
 # Models with on-disk golden clip.SRT fixtures.
-MODELS = ["Avata360", "Mini5PRO", "neo2", "air3S"]
+MODELS = ["Avata360", "Mini5PRO", "neo2", "air3S", "mavic4pro"]
 
 
 @pytest.mark.parametrize(
@@ -32,6 +33,8 @@ MODELS = ["Avata360", "Mini5PRO", "neo2", "air3S"]
         ("neo2", (45.607181, 13.753860), 114.0, "2.2", None, "default"),
         # Air 3S: first fixture exercising the HLG color mode.
         ("air3S", (34.270373, -84.176160), 302.208, "1.8", "24.00", "hlg"),
+        # Mavic 4 Pro (DJI Stockholm samples, 2026-08-26): ``[ct: N, tint: N]``.
+        ("mavic4pro", (59.329400, 18.068600), 92.670, "2.8", "28.00", "default"),
     ],
 )
 def test_new_model_clip_parses(
@@ -70,3 +73,9 @@ def test_new_model_format_detected_html_extended(model):
     assert validation["valid"]
     assert validation["format_detected"] == "html_extended"
     assert validation["telemetry_points"] == 5
+
+
+def test_mavic4pro_clip_ct_and_tint(tmp_path):
+    t = DJIMetadataEmbedder(tmp_path).parse_dji_srt(SAMPLES / "mavic4pro" / "clip.SRT")
+    assert t["camera_settings"]["ct"] == "5574"
+    assert t["camera_settings"]["tint"] == "8"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -252,3 +252,29 @@ def test_embed_metadata_ffmpeg_mkv_preserves_data_streams(tmp_path, monkeypatch)
     assert cmd[cmd.index("-map") + 1] == "0"
     # Matroska-native subtitle codec.
     assert cmd[cmd.index("-c:s") + 1] == "srt"
+
+
+def test_parse_ct_with_tint(tmp_path):
+    """Mavic 4 Pro appends a tint to the colour-temperature token:
+    ``[ct: 5562, tint: 0]``. ``ct`` must stay numeric and ``tint`` is kept."""
+    srt = """1
+00:00:00,000 --> 00:00:00,016
+<font size="28">FrameCnt: 1, DiffTime: 16ms
+2026-08-23 17:20:57.804
+[iso: 160] [shutter: 1/640.0] [fnum: 2.8] [ev: -0.3] [color_md: default] [focal_len: 28.00] [latitude: 59.329400] [longitude: 18.068600] [rel_alt: -0.000 abs_alt: 32.938] [ct: 5562, tint: 0] </font>
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["camera_settings"]["ct"] == "5562"
+    assert t["camera_settings"]["tint"] == "0"
+
+
+def test_parse_ct_without_tint_unchanged(tmp_path):
+    srt = """1
+00:00:00,000 --> 00:00:00,016
+<font size="28">FrameCnt: 1, DiffTime: 16ms
+2026-05-17 08:28:30.219
+[iso: 180] [latitude: 34.270373] [longitude: -84.176160] [rel_alt: 0.000 abs_alt: 302.208] [ct: 5419] </font>
+"""
+    t = _parse_from_string(tmp_path, srt)
+    assert t["camera_settings"]["ct"] == "5419"
+    assert "tint" not in t["camera_settings"]

--- a/tests/test_utils_exiftool.py
+++ b/tests/test_utils_exiftool.py
@@ -55,6 +55,9 @@ def test_decode_floor_matches_known_schemas():
     assert decode_floor("dvtm_Air3s.proto;model_name:FC9113") == "13.39"
     assert decode_floor("dvtm_Mini5Pro.proto") == "13.52"
     assert decode_floor("dvtm_NEO.proto") == "13.35"
+    # Mavic 4 Pro: verified on real footage at 13.59 (the pin); earlier
+    # releases that may already decode it are untested.
+    assert decode_floor("dvtm_Mavic4.proto;model_name:L3D-100c") == "13.59"
 
 
 def test_describe_decode_capability_unavailable_below_baseline():


### PR DESCRIPTION
## Summary

DJI Stockholm sent two Mavic 4 Pro clips (MP4 + SRT + LRF, firmware V01.00.0800). Triage on the real files turned up three things, all fixed here:

- **`[ct: 5562, tint: 0]`**: the Mavic 4 Pro appends a tint to the colour-temperature token, and the `ct` regex captured `"5562, tint: 0"` as the value (visible in CSV). `ct` is now numeric-only; `tint` is parsed as its own camera field and gets a CSV column right after `ct` (blank for other models).
- **Gimbal from video**: the MP4/LRF `dvtm_Mavic4.proto` stream leaves protobuf field `3-4-3` undecoded in ExifTool 13.59. It is the same block ExifTool names `GimbalInfo` on the Air 3/Air 3S (pitch/roll/yaw in tenths; the neighbouring `3-4-4` quaternion reproduces the angles exactly). dji-embed now ships `src/dji_metadata_embedder/data/exiftool.config` mapping it and passes `-config <file>` as the first argument on every ExifTool call (probe and extraction). On the sample set `flightmap --3d --gimbal-from-video` goes from "0 of 2 enriched" to 4563 of 4563 samples. An old ExifTool (apt 12.76) ignores the config silently; the wheel carries the file, and the PyInstaller spec bundles it.
- **Hint false positive**: `--3d` suggested `--gimbal-from-video` for any djmd track. It now checks the schema against the set that carries `GimbalInfo` (from DJI.pm plus Mavic 4 via the config), so position-only streams such as the Mini 5 Pro get no hint.

Also: `samples/mavic4pro/clip.SRT` (5 blocks, coordinates replaced), rows in SRT_FORMATS / MODEL_SURVEY / MP4_TIMED_METADATA / README / samples README, Mavic 4 Pro ExifTool floor (13.59, verified), CHANGELOG, and the DJI Stockholm acknowledgement they asked for.

## Verification

- `uv run pytest --ignore=tests/browser`: 1370 passed; `ruff`, `mypy`, `sync_version --check` clean.
- Real footage (local only): hint fires on plain `--3d`; `--gimbal-from-video` enriches 2 of 2 flights; the 3D page carries `gpitch_deg`/`gyaw_deg` with no nulls and the last values match ExifTool's per-frame output; CSV shows `ct=5574, tint=8`.
- `tests/test_mp4_telemetry_integration.py` passes against a real Air 3S clip and the Mavic 4 Pro clip with the `-config` prefix in place.
- Wheel built and inspected: `dji_metadata_embedder/data/exiftool.config` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162eGe1nJT7jQjEAvfqu48t
