### PR TITLE
feat(flightmap --3d): playback marker at the drone's true altitude, ground dot kept as its shadow (#553)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -345,8 +345,10 @@ you and the flight blocks it from view.
 The 3D map has a playback control at the bottom left: play/pause, a speed
 button cycling 1×, 5×, 20×, 60×, a scrubber, a time readout, and — with more
 than one playable flight on the map — a picker for which one is playing. As
-the clock runs, the camera's ground footprint for that second is drawn on the
-terrain, with four rays connecting the camera to its corners.
+the clock runs, a small block marks the aircraft at its recorded altitude
+with a dot on the ground beneath it as its shadow, and the camera's ground
+footprint for that second is drawn on the terrain, with four rays connecting
+the camera to its corners.
 
 Press play while you are in the ghost view and the camera rides the recorded
 flight in real time instead of stepping sample by sample. An arrow key still

--- a/src/dji_metadata_embedder/geo/flightmap3d_gaze_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap3d_gaze_js.py
@@ -271,6 +271,62 @@ function beamFor(fl, i, ring) {
   return feats;
 }
 
+// --- Altitude marker (#553): the aircraft itself, not just its shadow ---
+// The cursor dot is a circle layer, and circles can only be draped, so it
+// reads as the drone's shadow on the ground. This is the body at height: a
+// small fill-extrusion block centred on the interpolated position at the
+// drone's true altitude, converted through the same ground reference as the
+// sculpture (#548) so the two agree to the metre. Screen-size-aware like the
+// ribbon, so it neither vanishes zoomed out nor becomes a hangar up close.
+const MARKER_SCALE = 2.5;   // block side, in sculpture plank widths
+
+function aglAt(fl, t) {
+  // Linear between the two samples the clock sits between, like positionAt;
+  // null if either end is unknown, because a marker at an invented height is
+  // a claim the data never made.
+  if (!fl.agl) return null;
+  const i = sampleIndexAt(fl, t);
+  if (i >= fl.pts.length - 1) return fl.agl[i];
+  const a = fl.agl[i], b = fl.agl[i + 1];
+  if (a == null || b == null) return null;
+  const t0 = fl.times[i], t1 = fl.times[i + 1];
+  const f = t1 > t0 ? (t - t0) / (t1 - t0) : 1;
+  return a + (b - a) * f;
+}
+
+function markerFor(fl, t) {
+  const agl = aglAt(fl, t);
+  if (agl == null) return [];
+  const c = positionAt(fl, t);
+  const tElev = takeoffElev(fl);
+  const lElev = tElev == null ? null : terrainElevAt(c);
+  // Same conversion as planksFor: AGL is above the launch site, the
+  // extrusion measures from the local surface (or sea level, terrain off).
+  const top = (tElev != null && lElev != null) ? (tElev + agl) - lElev : agl;
+  const side = sculptWidthM() * MARKER_SCALE, half = side / 2;
+  const hgt = top + half;
+  // Wholly below the rendered surface: fill-extrusion cannot draw there.
+  if (hgt <= 0) return [];
+  const mLat = GAZE_M_PER_DEG_LAT;
+  const mLon = mLat * Math.cos(c[1] * Math.PI / 180);
+  const dx = half / mLon, dy = half / mLat;
+  return [{ type: 'Feature',
+    // base clamped in JS: the style spec forbids a negative one.
+    properties: { base: Math.max(0, top - half), hgt: hgt },
+    geometry: { type: 'Polygon', coordinates: [[
+      [c[0] - dx, c[1] - dy], [c[0] + dx, c[1] - dy],
+      [c[0] + dx, c[1] + dy], [c[0] - dx, c[1] + dy],
+      [c[0] - dx, c[1] - dy],
+    ]] } }];
+}
+
+function renderMarker() {
+  const src = map.getSource('gaze-marker');
+  if (!src || !pb.run) return;
+  src.setData({ type: 'FeatureCollection',
+                features: markerFor(pb.run, pb.t) });
+}
+
 // --- Playback (#378): the flat map's animator (#267/#327), MapLibre-side ---
 // Semantics are deliberately identical to geo/flightmap_html.py so a user who
 // learns one map's playback knows the other's: same eligibility rule, same
@@ -314,6 +370,10 @@ function pbRecolour() {
   if (map.getLayer('gaze-cursor-dot')) {
     map.setPaintProperty('gaze-cursor-dot', 'circle-color', pb.run.color);
   }
+  if (map.getLayer('gaze-marker-body')) {
+    map.setPaintProperty('gaze-marker-body', 'fill-extrusion-color',
+                         pb.run.color);
+  }
   if (map.getLayer('gaze-fill')) {
     map.setPaintProperty('gaze-fill', 'fill-color', pb.run.color);
     map.setPaintProperty('gaze-edge', 'line-color', pb.run.color);
@@ -337,6 +397,7 @@ function pbRender(skipGhost) {
   const src = map.getSource('gaze-cursor');
   if (src) src.setData({ type: 'Feature', properties: {},
     geometry: { type: 'Point', coordinates: positionAt(pb.run, pb.t) } });
+  renderMarker();
   const slider = document.getElementById('pb-slider');
   if (slider) slider.value = String(pb.t);
   const time = document.getElementById('pb-time');
@@ -399,8 +460,10 @@ function applyGazeVisibility() {
   // 'visible' always; its own source data (emptied by gazeHighlight([]) on
   // panel toggle -- see buildPanel -- and on popup close) is what controls
   // whether anything is actually drawn (#378 whole-branch review, M1).
+  // The altitude marker (#553) follows the beam rule: a block at your own
+  // eye would fill the cockpit frame, exactly as the ribbon would.
   [['gaze-fill', v], ['gaze-edge', v], ['gaze-cursor-dot', v],
-   ['beam-ray', beam]].forEach(pair => {
+   ['beam-ray', beam], ['gaze-marker-body', beam]].forEach(pair => {
     if (map.getLayer(pair[0])) {
       map.setLayoutProperty(pair[0], 'visibility', pair[1]);
     }
@@ -509,6 +572,18 @@ function mountPlayback() {
   map.addLayer({ id: 'gaze-cursor-dot', type: 'circle', source: 'gaze-cursor',
     paint: { 'circle-radius': 7, 'circle-color': pb.run.color,
              'circle-stroke-color': '#fff', 'circle-stroke-width': 2 } });
+  // The body at height (#553). Mounted with the dot, not with the gaze:
+  // it claims no more than the dot does, so it survives fuzz. Zoom changes
+  // its metre size (sculptWidthM), so rebuild on zoomend like the ribbon.
+  map.addSource('gaze-marker', { type: 'geojson', data: emptyFC() });
+  map.addLayer({ id: 'gaze-marker-body', type: 'fill-extrusion',
+    source: 'gaze-marker',
+    paint: { 'fill-extrusion-color': pb.run.color,
+             'fill-extrusion-base': ['get', 'base'],
+             'fill-extrusion-height': ['get', 'hgt'],
+             'fill-extrusion-opacity': 0.9,
+             'fill-extrusion-vertical-gradient': false } });
+  map.on('zoomend', renderMarker);
   if (REDACTED === 'none') {
     // Fuzzed coordinates would make every footprint a confident claim about
     // ground the camera never saw. The clock still works.

--- a/tests/browser/test_flightmap_3d_marker.py
+++ b/tests/browser/test_flightmap_3d_marker.py
@@ -1,0 +1,164 @@
+"""Playback marker at the drone's true altitude (#553).
+
+The draped cursor dot is the aircraft's SHADOW; nothing marked the aircraft
+itself at height, so the beams looked like they hung down from the ribbon
+with no body at the top. The marker is a small fill-extrusion prism centred
+on the current position at the drone's true altitude, converted through the
+#548 ground reference exactly as the sculpture is.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+
+from dji_metadata_embedder.geo.flightmap3d_html import flights_to_3d_html  # noqa: E402
+from dji_metadata_embedder.geo.track import Track, TrackPoint  # noqa: E402
+
+pytestmark = pytest.mark.browser
+
+TILE_DEG = 360 / 2 ** 15   # z15 tile width; the DEM cliff sits at each midpoint
+
+
+def _flight(name: str, lat: float, lon: float, agls: list[float | None], *,
+            step: float = 0.0006) -> Track:
+    """Synthetic playable flight: ``agls[i]`` is point i's rel_alt, one
+    sample a second, attitude fixed so the gaze layers have something."""
+    t0 = datetime(2026, 6, 15, 12, 0, 0)
+    return Track(name=name, points=[
+        TrackPoint(lat=lat, lon=lon + i * step, alt=100.0 + (a or 0),
+                   timestamp=f"00:00:{i:02d},000",
+                   utc=t0 + timedelta(seconds=i), rel_alt=a,
+                   focal_len=24.0, gimbal_yaw=90.0, gimbal_pitch=-45.0)
+        for i, a in enumerate(agls)
+    ])
+
+
+def _ready(page):
+    page.wait_for_selector("#flights-panel", timeout=15000)
+
+
+_MARKER_JS = ("() => map.getSource('gaze-marker').serialize().data.features"
+              ".map(f => ({base: f.properties.base, hgt: f.properties.hgt,"
+              " ring: f.geometry.coordinates[0]}))")
+
+_VIS = "(id) => map.getLayoutProperty(id, 'visibility') || 'visible'"
+
+
+def _centre(ring):
+    xs = [p[0] for p in ring[:-1]]
+    ys = [p[1] for p in ring[:-1]]
+    return sum(xs) / len(xs), sum(ys) / len(ys)
+
+
+def test_marker_layer_mounts_with_the_cursor_dot(serve_map, page):
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, [50.0] * 6)],
+                                 "trip"))
+    _ready(page)
+    assert page.evaluate("() => !!map.getLayer('gaze-cursor-dot')")
+    assert page.evaluate("() => map.getLayer('gaze-marker-body').type") \
+        == "fill-extrusion"
+
+
+def test_marker_follows_the_slider_at_the_drones_height(serve_map, page):
+    """Terrain off: the extrusion measures from sea level, so the prism must
+    be centred on raw AGL, and its footprint on the interpolated position."""
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, [50.0] * 6)],
+                                 "trip"))
+    _ready(page)
+    page.evaluate("() => { pb.t = 2.5; pbRender(); }")
+    feats = page.evaluate(_MARKER_JS)
+    assert len(feats) == 1, feats
+    f = feats[0]
+    assert f["hgt"] > f["base"] >= 0
+    assert abs((f["base"] + f["hgt"]) / 2 - 50.0) < 0.01, f
+    want = page.evaluate("() => positionAt(pb.run, 2.5)")
+    cx, cy = _centre(f["ring"])
+    assert abs(cx - want[0]) < 1e-6 and abs(cy - want[1]) < 1e-6
+    page.evaluate("() => { pb.t = 4; pbRender(); }")
+    moved = _centre(page.evaluate(_MARKER_JS)[0]["ring"])
+    assert moved[0] > cx, "marker did not move with the slider"
+
+
+def test_marker_sits_at_true_altitude_over_the_terrain(serve_map, page):
+    """Recording started airborne over a 600 m plateau, rel_alt 700 (the
+    launch site is the valley floor, where the clip lands). The prism must
+    be 100 m above the plateau: through the #548 ground reference, not the
+    600 m under sample 0, which would put it 700 m up."""
+    lat = 10.0
+    tile_lon = TILE_DEG * 1660
+    start_lon = tile_lon + TILE_DEG * 1.75          # high (600 m) side
+    step = TILE_DEG * 0.12                          # walks east into the valley
+    html = flights_to_3d_html(
+        [_flight("DJI_0001", lat, start_lon,
+                 [700.0, 700.0, 700.0, 3.0, 0.0, 0.0], step=step)], "trip")
+    serve_map(html, terrain_steps=(0.0, 600.0))
+    _ready(page)
+    page.wait_for_function(
+        "() => map.getTerrain() && map.areTilesLoaded()", timeout=20000)
+    page.wait_for_function(
+        "() => terrainElevAt(flights[0].pts[0]) > 599"
+        " && Math.abs(groundRef(flights[0]).elev) < 1", timeout=20000)
+    page.evaluate("() => { pb.t = 0; pbRender(); }")
+    feats = page.evaluate(_MARKER_JS)
+    assert len(feats) == 1, feats
+    f = feats[0]
+    assert abs((f["base"] + f["hgt"]) / 2 - 100.0) < 1.0, f
+
+
+def test_marker_hides_in_the_cockpit(serve_map, page):
+    """A block at your own eye would fill the frame, like the ribbon and the
+    beam; it comes back on exit."""
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, [50.0] * 6)],
+                                 "trip"))
+    _ready(page)
+    assert page.evaluate(_VIS, "gaze-marker-body") == "visible"
+    page.evaluate("() => ghostEnter(0, 2)")
+    assert page.evaluate(_VIS, "gaze-marker-body") == "none"
+    assert page.evaluate(_VIS, "gaze-cursor-dot") == "visible"
+    page.evaluate("() => ghostExit()")
+    page.wait_for_function("() => !map.isMoving()", timeout=15000)
+    assert page.evaluate(_VIS, "gaze-marker-body") == "visible"
+
+
+def test_marker_stays_up_when_riding_a_different_flight(serve_map, page):
+    serve_map(flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [50.0] * 6),
+         _flight("DJI_0002", 10.05, 20.05, [50.0] * 6)], "trip"))
+    _ready(page)
+    assert page.evaluate("() => pb.run === flights[0]") is True
+    page.evaluate("() => ghostEnter(1, 0)")
+    assert page.evaluate(_VIS, "gaze-marker-body") == "visible"
+
+
+def test_marker_recolours_with_the_picked_flight(serve_map, page):
+    serve_map(flights_to_3d_html(
+        [_flight("DJI_0001", 10.0, 20.0, [50.0] * 6),
+         _flight("DJI_0002", 10.05, 20.05, [50.0] * 6)], "trip"))
+    _ready(page)
+    page.select_option("#pb-flight", "1")
+    colour = page.evaluate(
+        "() => map.getPaintProperty('gaze-marker-body', 'fill-extrusion-color')")
+    assert colour == page.evaluate("() => flights[1].color")
+
+
+def test_no_marker_without_altitude(serve_map, page):
+    """No AGL, no height claim: the shadow dot alone carries the position."""
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, [None] * 6)],
+                                 "trip"))
+    _ready(page)
+    page.evaluate("() => { pb.t = 2; pbRender(); }")
+    assert page.evaluate(_MARKER_JS) == []
+    assert page.evaluate(
+        "() => map.getSource('gaze-cursor').serialize().data.geometry.type"
+    ) == "Point"
+
+
+def test_marker_follows_the_dot_under_fuzz(serve_map, page):
+    """Fuzzed coordinates gate the gaze (a claim about filmed ground) but not
+    the dot, and the marker claims no more than the dot does."""
+    serve_map(flights_to_3d_html([_flight("DJI_0001", 10.0, 20.0, [50.0] * 6)],
+                                 "trip", redact="fuzz"))
+    _ready(page)
+    assert page.evaluate("() => !map.getLayer('beam-ray')")
+    assert page.evaluate("() => !!map.getLayer('gaze-marker-body')")
+    page.evaluate("() => { pb.t = 2; pbRender(); }")
+    assert len(page.evaluate(_MARKER_JS)) == 1

--- a/tests/test_geo_flightmap3d_html.py
+++ b/tests/test_geo_flightmap3d_html.py
@@ -122,6 +122,7 @@ def test_template_carries_the_gaze_and_playback_app():
     for needle in ("function gazeRing(", "function beamFor(",
                    "function gazeLookup(", "'gaze-fill'", "'beam-ray'",
                    "'gaze-hits-line'", "id: 'gaze-cursor-dot'",
+                   "id: 'gaze-marker-body'", "function markerFor(",
                    "pb-play", "pb-slider", "GAZE_FALLBACK_HFOV"):
         assert needle in html, needle
 


### PR DESCRIPTION
Closes #553.

## What

During 3D playback the position marker (`gaze-cursor-dot`, a `circle` layer) is draped on the terrain, so it reads as the aircraft's shadow and nothing marks the aircraft itself at height; the gaze beams appeared to hang down from the ribbon with no body at the top.

This adds `gaze-marker-body`: a small `fill-extrusion` block centred on the interpolated playback position at the drone's true altitude. The shadow dot is unchanged.

## How

- Height converts through the #548 ground reference exactly as the sculpture does (`takeoffElev(fl) + agl - terrainElevAt(pos)`), so marker and ribbon agree; with terrain off it is raw AGL from sea level, like the beams.
- Side length is screen-size-aware (2.5 × `sculptWidthM()`), rebuilt on `zoomend` like the ribbon; updated every `pbRender()`.
- AGL is interpolated between samples like the position (`aglAt`); a null at either end gives no marker rather than an invented height.
- Visibility follows the beam rule in `applyGazeVisibility` (hidden while the cockpit rides the same flight, shown when riding another); colour follows the picker via `pbRecolour`.
- Mounted with the dot rather than with the gaze layers, so it survives `--redact fuzz`: it claims no more than the dot already does.
- Not done: the optional plumb prism from the dot up to the block. Easy to add if the pair doesn't read as one object on real footage.

## Tests

- New `tests/browser/test_flightmap_3d_marker.py` (8 tests, written first and watched fail): layer mounts; follows the slider at raw AGL with terrain off; sits 100 m over a 600 m plateau on the stepped DEM when the clip started airborne and landed in the valley (the naive sample-0 reference would put it at 700 m); hides in the cockpit and returns on exit; stays up when riding a different flight; recolours with the picker; no marker without AGL; survives fuzz.
- 3D browser regression (playback, gaze, sculpture, ghost, 3d, crossfade): 113 passed, all untouched.
- Unit suite 1370 passed; ruff and mypy clean.
- Docs: one sentence in `docs/geospatial.md`.

Not yet E2E'd on the local test-flights pair (Marcus's Air 3S climbing clip); that's the remaining acceptance item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DoinGDPqC12SLpZu2jqGf
