### PR TITLE
feat(airspace): state the ED-318 file's own edition date for Ireland and Sweden (#563)

### DIFF
--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -470,8 +470,9 @@ Zones draw in one neutral
 style; clicking one shows the published facts: restriction class, vertical
 limits (or "not stated"), applicability windows, and the feed, license and
 fetch time. Where the dataset is published per edition (the UK's 28-day
-AIRAC cycle, dated in the filename), the popup and the corner note also
-state the edition's effective date, so a cached copy that has outlived its
+AIRAC cycle, dated in the filename; the Irish and Swedish ED-318 files,
+which state their valid-from date inside the document), the popup and the
+corner note also state the edition's effective date, so a cached copy that has outlived its
 cycle is visible as such: "fetched" is when the copy was downloaded,
 "effective" is which cycle it reflects. Zones the
 flight entered get a slightly stronger outline plus the entry/exit times and

--- a/src/dji_metadata_embedder/geo/airspace/ed318.py
+++ b/src/dji_metadata_embedder/geo/airspace/ed318.py
@@ -220,6 +220,35 @@ def _point_circle(
     return _circle_ring(lon, lat, float(radius))
 
 
+def ed318_effective(raw: bytes) -> str | None:
+    """The ISO date of the edition the document says it is, or None.
+
+    #563: the IAA's reuse conditions ask that a reader can see WHICH
+    version is shown, not only when we fetched it. Ireland states the
+    edition in ``datasetMetadata`` and Sweden in ``metadata``;
+    ``validFrom`` is the edition (``issued`` as fallback), reduced to its
+    UTC date to match the UK's AIRAC-cycle line. A stated stamp that is
+    not a datetime fails loudly; an unstated one is honestly None. A
+    document that is not JSON is left to :func:`parse_ed318` to report."""
+    try:
+        data = json.loads(raw.decode("utf-8-sig"))
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    meta = data.get("datasetMetadata")
+    if not isinstance(meta, dict):
+        meta = data.get("metadata")
+    if not isinstance(meta, dict):
+        return None
+    stamp = meta.get("validFrom") or meta.get("issued")
+    if stamp is None:
+        return None
+    if not isinstance(stamp, str):
+        raise AirspaceError(f"ED-318 edition date {stamp!r} is not a string")
+    return _utc(stamp, "ED-318 edition date").date().isoformat()
+
+
 def parse_ed318(raw: bytes, source: SourceInfo) -> list[Zone]:
     """Every zone of an ED-318 GeoJSON document as normalized :class:`Zone`s."""
     try:

--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -31,7 +31,7 @@ from .dronezoner import (
 )
 from .eans import EANS_FEEDS, parse_eans
 from .ed269 import ED269_FEEDS, parse_ed269
-from .ed318 import ED318_FEEDS, discover_feed_url, parse_ed318
+from .ed318 import ED318_FEEDS, discover_feed_url, ed318_effective, parse_ed318
 from .jurisdiction import resolve_jurisdiction
 from .model import AirspaceError, SourceInfo, Zone
 
@@ -226,6 +226,9 @@ def fetch_zones(
                 else:
                     page = _fetch_url(url, transport)
                     body = _fetch_url(discover_feed_url(page, url), transport)
+                # The file states its own edition (#563); it rides in the
+                # record and the cache sidecar like the UK's cycle date.
+                effective = ed318_effective(body)
             elif code in DRONEZONER_FEEDS:
                 page = _fetch_url(url, transport)
                 body = _fetch_url(

--- a/tests/test_airspace_ed318.py
+++ b/tests/test_airspace_ed318.py
@@ -16,6 +16,7 @@ from dji_metadata_embedder.geo.airspace import AirspaceError, SourceInfo
 from dji_metadata_embedder.geo.airspace.ed318 import (
     ED318_FEEDS,
     discover_feed_url,
+    ed318_effective,
     parse_ed318,
 )
 
@@ -244,3 +245,35 @@ def test_se_feed_registry_states_the_lfv_terms():
     assert "schedule" in (feed.note or "")
     # Ireland keeps the discovery path: no direct URL.
     assert ED318_FEEDS["IE"].file_url is None
+
+
+def _se() -> bytes:
+    return (FIXTURES / "ed318-se.json").read_bytes()
+
+
+def test_edition_date_is_the_irish_datasetmetadata_valid_from():
+    # #563: the IAA's condition is that a reader sees WHICH edition is
+    # shown, not only when we fetched it. Ireland states the edition in
+    # datasetMetadata.validFrom; the record carries the UTC date.
+    assert ed318_effective(_ie()) == "2026-08-04"
+
+
+def test_edition_date_is_the_swedish_metadata_valid_from():
+    # Sweden's file uses a top-level ``metadata`` block instead.
+    assert ed318_effective(_se()) == "2026-08-13"
+
+
+def test_edition_date_falls_back_to_issued_and_is_absent_when_unstated():
+    doc = json.loads(_ie())
+    doc["datasetMetadata"] = {"issued": "2026-08-01T22:00:00+00:00"}
+    assert ed318_effective(json.dumps(doc).encode("utf-8")) == "2026-08-01"
+    del doc["datasetMetadata"]
+    # No stated edition: the record omits the line rather than guessing.
+    assert ed318_effective(json.dumps(doc).encode("utf-8")) is None
+
+
+def test_edition_date_that_is_not_a_datetime_fails_loudly():
+    doc = json.loads(_ie())
+    doc["datasetMetadata"]["validFrom"] = "August 2026"
+    with pytest.raises(AirspaceError):
+        ed318_effective(json.dumps(doc).encode("utf-8"))

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -214,6 +214,13 @@ def test_an_irish_flight_discovers_the_dated_file_then_fetches_it(tmp_path):
     assert data.source is not None and "Irish Aviation Authority" in data.source.license
     assert (tmp_path / "ed318-IE.json").exists()
     assert any("Fetching" in ln and "iaa.ie" in ln for ln in lines)
+    # #563: the file's own edition (datasetMetadata.validFrom) is what the
+    # IAA asked the reader to see; it reaches the record and the sidecar.
+    assert data.source.effective == "2026-08-04"
+    meta = json.loads(
+        (tmp_path / "ed318-IE.json.meta.json").read_text(encoding="utf-8")
+    )
+    assert meta["effective"] == "2026-08-04"
 
 
 def test_a_cached_irish_body_skips_discovery_entirely(tmp_path):
@@ -228,6 +235,8 @@ def test_a_cached_irish_body_skips_discovery_entirely(tmp_path):
         raise AssertionError("cached run must not touch the network")
     data = fetch_zones(_track(53.35, -6.26), tmp_path, transport=no_network)
     assert data.from_cache and len(data.zones) == 4
+    # The cached copy still states which edition it is (#563).
+    assert data.source is not None and data.source.effective == "2026-08-04"
 
 
 def _gb_zip() -> bytes:
@@ -387,6 +396,7 @@ def test_a_swedish_flight_fetches_the_lfv_file_directly(tmp_path):
     assert data.source.url.endswith("uas_zones_ED318.json")
     assert (tmp_path / "ed318-SE.json").exists()
     assert any("Fetching" in ln and "dronechart.lfv.se" in ln for ln in lines)
+    assert data.source.effective == "2026-08-13"  # metadata.validFrom (#563)
     circle = next(z for z in data.zones if z.identifier == "ESU902")
     assert len(circle.polygons[0]) >= 32
 


### PR DESCRIPTION
Closes #563. Follow-up to #452 (Ireland) and #510 (Sweden); the UK precedent is #502.

## Why

The IAA's reply of 2026-09-01 on the Irish reuse thread set three conditions for using the published ED-318 file: it must be obvious where the data comes from, **which version is shown**, and that it cannot be used for operation. The source line printed *our* fetch date, not the *file's* edition, so the second condition was only half met. Marcus's reply to the IAA on 2026-09-05 promised the edition date for the next release.

## What

- `ed318.py`: new `ed318_effective(raw) -> str | None`. Reads the document-level block (`datasetMetadata` for Ireland, `metadata` for Sweden), takes `validFrom` with `issued` as fallback, and returns the UTC date in ISO form. No stated edition → `None` (the line is omitted, no guessing). A stated stamp that is not a datetime → `AirspaceError`, consistent with the parser's all-or-nothing stance.
- `fetch.py`: the ED-318 branch stores that value in the existing `effective` slot, so the record, the popup and the cache sidecar carry it with no further plumbing (`overlay.py` already renders `effective …` when set, from #502).
- `docs/geospatial.md`: the edition-date sentence now names the Irish and Swedish files alongside the UK cycle.

## Tests (written first, watched fail)

- `test_airspace_ed318.py`: IE fixture → `2026-08-04`; SE fixture → `2026-08-13`; `issued` fallback and absent-block → `None`; non-datetime stamp raises.
- `test_airspace_fetch.py`: the Irish fetch carries `effective` in the record and in the `.meta.json` sidecar; the cached Irish run still states it; the Swedish fetch carries `2026-08-13`.

Gates: ruff clean, mypy clean, 1374 passed / 4 skipped.

## Not in scope

Comparing the cached edition with the live one or warning that a newer edition exists (the CH/UK cadence question). Estonia's EANS file was not checked for an equivalent block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLhdpoWs2CXoiX3zrrWi74
