### PR TITLE
feat(airspace): Slovenia UAS geographical zones from the CAA's published KMZ (#565)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ it's a handful of copy-paste commands. For a guided tour see
   logbook with airspace facts (FAA / ED-269) and honestly-labelled heights,
   and `--airspace` overlays the same zones on the interactive maps — as
   translucent ceiling-height volumes in the 3D view. Covered so far: the
-  US, UK, Ireland, Switzerland, Luxembourg, Denmark, Sweden, Finland and
-  Estonia; everywhere else the record states the gap honestly.
+  US, UK, Ireland, Switzerland, Luxembourg, Denmark, Sweden, Finland,
+  Estonia and Slovenia; everywhere else the record states the gap honestly.
 - **See where every photo was taken** — `dji-embed photomap` pins a whole
   folder of stills on one clustered map, thumbnails included; 360° panoramas
   get their own marker color and toggle, and open in an interactive viewer.

--- a/docs/geospatial.md
+++ b/docs/geospatial.md
@@ -462,10 +462,14 @@ Trafikstyrelsen's drone-zone dataset, which likewise leaves NOTAM-driven
 temporaries to the AIP, Sweden via LFV's ED-318 file, where a few
 zones apply only during scheduled hours within their published windows —
 the schedule stays in the zone's published data and is not evaluated,
-and Estonia via EANS's published zones file, which reflects the rules
+Estonia via EANS's published zones file, which reflects the rules
 at the time of download rather than the time of the flight — that
 caveat rides along, and NOTAM activation hours stay as text in the
-zone's published message).
+zone's published message, and Slovenia via the CAA's published UAS
+geo-zones file, which the CAA itself notes does not contain the
+populated-area limits for the Open category and whose restricted and
+danger areas defer to NOTAM; its published exceptions, contacts and
+reasons appear in the popup as text, not evaluated).
 Zones draw in one neutral
 style; clicking one shows the published facts: restriction class, vertical
 limits (or "not stated"), applicability windows, and the feed, license and

--- a/samples/airspace/README.md
+++ b/samples/airspace/README.md
@@ -34,6 +34,14 @@ verified on issue #413 (2026-07-29). Public data, no privacy concern.
   pins the skip contract instead of just the happy path. Attribution:
   "Estonian Air Navigation Services", public data confirmed in writing by
   EANS UTM development.
+- `caa-si.kml` — Slovenia: the `doc.kml` inside the CAA's "UAS Geo zones -
+  May 2026" KMZ (caa.si, file dated 2026-05-25; issue #565, live shape
+  verified 2026-09-05), trimmed to one placemark per representative folder
+  (9 of 137) with each ring reduced to a few of its real vertices. Every
+  placemark's popup HTML is kept whole: that table IS the attribute schema,
+  and its field names differ per folder. Tests wrap the KML into the live
+  zip→kmz nesting in memory. Reproduced under the CAA site's terms of use
+  (source marked, data content unchanged).
 
 The manual E2E step before merge re-fetches each live endpoint and confirms
 these shapes still match; `ed318-se.json` and `eans-ee.json` are synthetic,

--- a/samples/airspace/caa-si.kml
+++ b/samples/airspace/caa-si.kml
@@ -1,0 +1,1367 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Trimmed from the CAA Slovenia "UAS Geo zones - May 2026" KMZ (caa.si, 2026-05-25):
+     one placemark per representative folder, rings reduced to a few real vertices.
+     Official public zones; reproduced with the CAA named as source, content unchanged. -->
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <name>UAS Geo zones - May 2026</name>
+    <Folder>
+      <name>Polygons</name>
+      <Placemark>
+        <name>Heliport UKC Ljubljana</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;Heliport UKC Ljubljana&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Name&lt;/td&gt;
+
+&lt;td&gt;Heliport UKC Ljubljana&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;FolderPath&lt;/td&gt;
+
+&lt;td&gt;Heli_airfield/Heli_airfield&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;SymbolID&lt;/td&gt;
+
+&lt;td&gt;0&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;AltMode&lt;/td&gt;
+
+&lt;td&gt;0&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Base&lt;/td&gt;
+
+&lt;td&gt;0&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Clamped&lt;/td&gt;
+
+&lt;td&gt;-1&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Extruded&lt;/td&gt;
+
+&lt;td&gt;0&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Snippet&lt;/td&gt;
+
+&lt;td&gt;&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;PopupInfo&lt;/td&gt;
+
+&lt;td&gt;&amp;lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&amp;gt;
+
+&amp;lt;head&amp;gt;
+
+&amp;lt;META http-equiv="Content-Type" content="text/html"&amp;gt;
+
+&amp;lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&amp;gt;
+
+&amp;lt;/head&amp;gt;
+
+&amp;lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&amp;gt;
+
+&amp;lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&amp;gt;
+
+&amp;lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&amp;gt;
+
+&amp;lt;td&amp;gt;Heliport UKC Ljubljana&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;
+
+&amp;lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;FID&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;0&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;Obmocje&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;Heliport UKC Ljubljana&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;Contact_ap&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;Heliport UKC Ljubljana (hospital)&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;UAS_omejit&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;Prepovedano&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;UAS_restri&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;Forbidden&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;Izjeme&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;Dovoljenje upravljalca heliporta +  veljaven certifikat podkategorije A2&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;Exceptions&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;Approval from heliport + valid certificate for subcategory A2&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;Kontakt&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;heliport@kclj.si&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;Naziv&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;Subject&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;UAS_omej_1&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;UAS_rest_1&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;Izjeme_za&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;lat&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;lon&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;Ime&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr&amp;gt;
+
+&amp;lt;td&amp;gt;lat_dec&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;0&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;tr bgcolor="#D4E4F3"&amp;gt;
+
+&amp;lt;td&amp;gt;lon_dec&amp;lt;/td&amp;gt;
+
+&amp;lt;td&amp;gt;0&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;/table&amp;gt;
+
+&amp;lt;/td&amp;gt;
+
+&amp;lt;/tr&amp;gt;
+
+&amp;lt;/table&amp;gt;
+
+&amp;lt;/body&amp;gt;&amp;lt;script type="text/javascript"&amp;gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&amp;lt;/script&amp;gt;&amp;lt;/html&amp;gt;&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>14.52056,46.07173 14.50002,46.06346 14.49980,46.04695 14.52010,46.03841 14.54099,46.04623 14.54196,46.06273 14.52056,46.07173</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+    <Folder>
+      <name>UAS_URSIKS</name>
+      <Placemark>
+        <name>GO.08 URSIKS</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;GO.08 URSIKS&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;FID&lt;/td&gt;
+
+&lt;td&gt;0&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;naziv&lt;/td&gt;
+
+&lt;td&gt;GO.08 URSIKS&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;subject&lt;/td&gt;
+
+&lt;td&gt;GO.08 URSIKS&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;omejitev&lt;/td&gt;
+
+&lt;td&gt;Prepovedano&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Restrict&lt;/td&gt;
+
+&lt;td&gt;Prohibited&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Izjema&lt;/td&gt;
+
+&lt;td&gt;Lastne potrebe ali predhodna odobritev.&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Exception&lt;/td&gt;
+
+&lt;td&gt;For operational needs with prior approval.&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Kontakt&lt;/td&gt;
+
+&lt;td&gt;gp.ursiks@gov.si&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Contact&lt;/td&gt;
+
+&lt;td&gt;gp.ursiks@gov.si&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Razlog&lt;/td&gt;
+
+&lt;td&gt;Varovanje&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Reason&lt;/td&gt;
+
+&lt;td&gt;Security&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Zakonodaja&lt;/td&gt;
+
+&lt;td&gt;Zakon o izvrševanju kazenskih sankcij (ZIKS-1)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Regulation&lt;/td&gt;
+
+&lt;td&gt;Act on the Execution of Criminal Sanctions (ZIKS-1)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Višina nad tlemi v m&lt;/td&gt;
+
+&lt;td&gt;150&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Height AGL in meters&lt;/td&gt;
+
+&lt;td&gt;150&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>15.09066,45.95944 15.08415,45.95807 15.08788,45.95145 15.10379,45.94967 15.09980,45.95364 15.09513,45.95727 15.09066,45.95944</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+    <Folder>
+      <name>CTR_WGS</name>
+      <Placemark>
+        <name>Kontrolirana cona (CTR Ljubljana)</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;Kontrolirana cona (CTR Ljubljana)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Območje&lt;/td&gt;
+
+&lt;td&gt;Kontrolirana cona (CTR Ljubljana)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Omejitev&lt;/td&gt;
+
+&lt;td&gt;dovoljeno do višine 50 m AGL (nad terenom)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Subject&lt;/td&gt;
+
+&lt;td&gt;Control zone (CTR Ljubljana)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Kontakt/Contact&lt;/td&gt;
+
+&lt;td&gt;info@sloveniacontrol.si&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Restriction&lt;/td&gt;
+
+&lt;td&gt;allowed up to a height of 50 m AGL (above ground level)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Exceptions during operational hours of aerodrome&lt;/td&gt;
+
+&lt;td&gt;specific category only: approval SloveniaControl&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Izjeme med obratovalnim časom letališča&lt;/td&gt;
+
+&lt;td&gt;posebna kategorija: soglasje KZPS&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Izjeme izven obratovalnega časa letališča&lt;/td&gt;
+
+&lt;td&gt;odprto 24/7&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Exceptions outside operational hours of aerodrome&lt;/td&gt;
+
+&lt;td&gt;open 24/7&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>14.37000000000591,46.32027777913824,-2.349999999751162e-05 14.25972222283931,46.20888888935855,-2.349999999751162e-05 14.69472222198524,46.00000000152041,-2.349999999751162e-05 14.80527777710231,46.11083333343596,-2.349999999751162e-05 14.37000000000591,46.32027777913824,-2.349999999751162e-05</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+    <Folder>
+      <name>ModelarskeCone</name>
+      <Placemark>
+        <name>MK Krško, Žadovinek</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;MK Krško, Žadovinek&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;FID&lt;/td&gt;
+
+&lt;td&gt;0&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Id&lt;/td&gt;
+
+&lt;td&gt;1&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Obmocje&lt;/td&gt;
+
+&lt;td&gt;MK Krško, Žadovinek&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Subject&lt;/td&gt;
+
+&lt;td&gt;MK Krško, Žadovinek&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Omejitve&lt;/td&gt;
+
+&lt;td&gt;dovoljenje za modelarske aktivnosti za člane modelskega kluba&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Restrict&lt;/td&gt;
+
+&lt;td&gt;permit for modeling activities for members of the modeling club&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Kontakt&lt;/td&gt;
+
+&lt;td&gt;Sašo Cerovšek, Modelarski klub Krško, CKŽ 137, 8270 Krško, saso.cerovsek@gmail.com&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Contact&lt;/td&gt;
+
+&lt;td&gt;Sašo Cerovšek, Modelarski klub Krško, CKŽ 137, 8270 Krško, saso.cerovsek@gmail.com&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>15.49746,45.93188 15.48467,45.93120 15.48585,45.92851 15.48909,45.92684 15.49313,45.92684 15.49637,45.92851 15.49746,45.93188</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+    <Folder>
+      <name>restricted_area</name>
+      <Placemark>
+        <name>LJ R6A restricted</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;LJ R6A restricted&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;FID&lt;/td&gt;
+
+&lt;td&gt;1&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;IME&lt;/td&gt;
+
+&lt;td&gt;LJ R6A restricted&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Pred letom glej NOTAM&lt;/td&gt;
+
+&lt;td&gt;&lt;a target="_blank" href="https://www.sloveniacontrol.si/Strani/Zapore.aspx"&gt;https://www.sloveniacontrol.si/Strani/Zapore.aspx&lt;/a&gt;&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Check NOTAM before fly&lt;/td&gt;
+
+&lt;td&gt;&lt;a target="_blank" href="https://www.sloveniacontrol.si/en"&gt;https://www.sloveniacontrol.si/en&lt;/a&gt;&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Obratovalni čas letališča (glej AD 2.3)&lt;/td&gt;
+
+&lt;td&gt;&amp;lt;Null&amp;gt;&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>14.06866335661168,45.83942496567288,2.399999902991112e-05 13.92923466546879,45.83942077323233,2.399999902991112e-05 13.92924298476665,45.70360071159748,2.399999902991112e-05 14.02090608551644,45.59305870559164,2.399999902991112e-05 14.06867849052928,45.59306014444792,2.399999902991112e-05 14.06866335661168,45.83942496567288,2.399999902991112e-05</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+    <Folder>
+      <name>JEK_PROHIBITED</name>
+      <Placemark>
+        <name>Prohibited areas - Nuclear power plant</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;Prohibited areas - Nuclear power plant&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;FID&lt;/td&gt;
+
+&lt;td&gt;1&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Zone&lt;/td&gt;
+
+&lt;td&gt;Prohibited areas - Nuclear power plant&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Naziv&lt;/td&gt;
+
+&lt;td&gt;Prepovedana cona - Nuklearna elektrarna Krsko&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;UAS omejitve&lt;/td&gt;
+
+&lt;td&gt;Prepovedano&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;UAS restrictions&lt;/td&gt;
+
+&lt;td&gt;Forbidden&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Izjeme samo za posebno UAS kategorijo&lt;/td&gt;
+
+&lt;td&gt;ocena tveganja+dovoljenje uprave za jedrsko var.&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Exceptions specific UAS category only&lt;/td&gt;
+
+&lt;td&gt;Risk Assesment+Nuclear Safety Adm. approval&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>15.51536,45.94733 15.50418,45.94292 15.50401,45.93396 15.51501,45.92933 15.52628,45.93364 15.52664,45.94260 15.51536,45.94733</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+    <Folder>
+      <name>TNP_WGS</name>
+      <Placemark>
+        <name>Triglavski narodni park (TNP)</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;Triglavski narodni park (TNP)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;FID&lt;/td&gt;
+
+&lt;td&gt;1&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;IME_ZNAMEN&lt;/td&gt;
+
+&lt;td&gt;Triglavski narodni park (TNP)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Subject&lt;/td&gt;
+
+&lt;td&gt;Triglav National Park (TNP)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;UAS omejitve&lt;/td&gt;
+
+&lt;td&gt;prepovedano&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;UAS restriction&lt;/td&gt;
+
+&lt;td&gt;forbidden&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Izjeme za odprto in posebno UAS kategorijo&lt;/td&gt;
+
+&lt;td&gt;dovoljenje TNP  (glej info)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Exceptions for open and specific UAS category&lt;/td&gt;
+
+&lt;td&gt;approval from TNP (see information)&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Informacije&lt;/td&gt;
+
+&lt;td&gt;&lt;a target="_blank" href="https://www.tnp.si/sl/spoznajte/"&gt;https://www.tnp.si/sl/spoznajte/&lt;/a&gt;&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Information&lt;/td&gt;
+
+&lt;td&gt;&lt;a target="_blank" href="https://www.tnp.si/en/learn/"&gt;https://www.tnp.si/en/learn/&lt;/a&gt;&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>13.84109,46.48113 13.68865,46.44006 13.54021,46.38880 13.74636,46.19500 13.92046,46.29326 14.06005,46.38069 13.84109,46.48113</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+    <Folder>
+      <name>danger</name>
+      <Placemark>
+        <name>33297.328000487156</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;LJD1 - Danger area&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;FID&lt;/td&gt;
+
+&lt;td&gt;1&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Naziv&lt;/td&gt;
+
+&lt;td&gt;LJD1 - Danger area&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Check NOTAM before fly&lt;/td&gt;
+
+&lt;td&gt;&lt;a target="_blank" href="https://www.sloveniacontrol.si/Strani/Zapore.aspx"&gt;https://www.sloveniacontrol.si/Strani/Zapore.aspx&lt;/a&gt;&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>14.30514,45.67500 14.26429,45.65822 14.26438,45.62502 14.30527,45.60833 14.34644,45.62468 14.34710,45.65787 14.30514,45.67500</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+    <Folder>
+      <name>Luka_Koper_25</name>
+      <Placemark>
+        <name>22</name>
+        <description>&lt;html xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:msxsl="urn:schemas-microsoft-com:xslt"&gt;
+
+&lt;head&gt;
+
+&lt;META http-equiv="Content-Type" content="text/html"&gt;
+
+&lt;meta http-equiv="content-type" content="text/html; charset=UTF-8"&gt;
+
+&lt;/head&gt;
+
+&lt;body style="margin:0px 0px 0px 0px;overflow:auto;background:#FFFFFF;"&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-collapse:collapse;padding:3px 3px 3px 3px"&gt;
+
+&lt;tr style="text-align:center;font-weight:bold;background:#9CBCE2"&gt;
+
+&lt;td&gt;22&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;
+
+&lt;table style="font-family:Arial,Verdana,Times;font-size:12px;text-align:left;width:100%;border-spacing:0px; padding:3px 3px 3px 3px"&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;FID&lt;/td&gt;
+
+&lt;td&gt;0&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;id&lt;/td&gt;
+
+&lt;td&gt;22&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Naziv&lt;/td&gt;
+
+&lt;td&gt;Luka Koper&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Subject&lt;/td&gt;
+
+&lt;td&gt;Port of Koper&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;UAS omejitev&lt;/td&gt;
+
+&lt;td&gt;Prepovedano&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Restriction&lt;/td&gt;
+
+&lt;td&gt;Forbidden&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Izjema&lt;/td&gt;
+
+&lt;td&gt;predhodna odobritev ali operacije Luke Koper&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Exemptions&lt;/td&gt;
+
+&lt;td&gt;authorisation of operations by Port of Koper&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Kontakt za izjeme&lt;/td&gt;
+
+&lt;td&gt;00 386 31 738 883; matevz.bregar@luka-kp.si&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Contact for exemptions&lt;/td&gt;
+
+&lt;td&gt;00 386 31 738 883; matevz.bregar@luka-kp.si&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Razlog&lt;/td&gt;
+
+&lt;td&gt;Varovanje&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Reason&lt;/td&gt;
+
+&lt;td&gt;Security&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr&gt;
+
+&lt;td&gt;Zakonodaja&lt;/td&gt;
+
+&lt;td&gt;Uradni list RS, št. 195/20 in 31/21&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;tr bgcolor="#D4E4F3"&gt;
+
+&lt;td&gt;Regulation&lt;/td&gt;
+
+&lt;td&gt;Official Gazette RS, Nos. 195/20 and 31/21&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/td&gt;
+
+&lt;/tr&gt;
+
+&lt;/table&gt;
+
+&lt;/body&gt;&lt;script type="text/javascript"&gt;
+
+				function changeImage(attElement, nameElement) {
+
+				document.getElementById('imageAttachment').src = attElement;
+
+				document.getElementById('imageName').innerHTML = nameElement;}
+
+			&lt;/script&gt;&lt;/html&gt;
+
+</description>
+        <MultiGeometry>
+          <Polygon>
+            <outerBoundaryIs>
+              <LinearRing>
+                <coordinates>13.76137,45.55985 13.76028,45.55801 13.76851,45.56317 13.76524,45.56834 13.75960,45.56717 13.75836,45.56240 13.76137,45.55985</coordinates>
+              </LinearRing>
+            </outerBoundaryIs>
+          </Polygon>
+        </MultiGeometry>
+      </Placemark>
+    </Folder>
+  </Document>
+</kml>

--- a/src/dji_metadata_embedder/geo/airspace/caa_si.py
+++ b/src/dji_metadata_embedder/geo/airspace/caa_si.py
@@ -88,7 +88,7 @@ _TAG_RE = re.compile(r"<[^>]+>")
 _FURNITURE = {
     "folderpath", "symbolid", "altmode", "base", "clamped", "extruded",
     "snippet", "popupinfo", "fid", "objectid", "id", "field",
-    "shape length", "shape area", "lat", "lon",
+    "shape length", "shape area", "lat", "lon", "lat dec", "lon dec",
 }
 # Name rows, in preference order, for placemarks whose own <name> is junk.
 _NAME_KEYS = ("naziv", "name", "ime", "obmocje", "letalisce", "zone", "subject")
@@ -224,7 +224,10 @@ def _height_agl_m(rows: list[tuple[str, str]], where: str) -> VerticalLimit | No
 
 
 def _is_restriction_key(norm: str) -> bool:
-    return "omejit" in norm or "restrict" in norm
+    # Live spellings (2026-09-05): Omejitev, Omejitve, UAS omejitev, UAS
+    # omejitve, UAS_omejit, UAS_omej_1 / Restrict, Restriction(s), UAS
+    # restriction(s), UAS_restri, UAS_rest_1 — ArcGIS truncates field names.
+    return "omej" in norm or "restri" in norm or norm.startswith("uas rest")
 
 
 def _is_height_key(norm: str) -> bool:
@@ -238,8 +241,10 @@ def _name(placemark_name: str | None, rows: list[tuple[str, str]],
         return own
     by_key = {_norm(k): v for k, v in rows}
     for key in _NAME_KEYS:
-        if by_key.get(key):
-            return by_key[key]
+        candidate = by_key.get(key, "").strip()
+        # The export repeats the junk <name> as a "Name: Placemark" row.
+        if candidate and not _JUNK_NAME_RE.match(candidate):
+            return candidate
     return f"{folder} {index}"
 
 
@@ -299,8 +304,13 @@ def parse_caa_si(raw_zip: bytes, source: SourceInfo) -> list[Zone]:
                 restriction, upper = _restriction(restriction_values, where)
             else:
                 # The restricted/danger areas publish only a name and a
-                # "check NOTAM" pointer: no class is stated, so none is invented.
-                restriction, upper = "Restriction not stated (check NOTAM)", None
+                # "check NOTAM" pointer: no class is stated, so none is
+                # invented; the pointer is named only when it is there.
+                has_notam = any("notam" in _norm(k) for k, _ in rows)
+                restriction = "Restriction not stated" + (
+                    " (check NOTAM)" if has_notam else ""
+                )
+                upper = None
             height = _height_agl_m(rows, where)
             if height is not None:
                 upper = height
@@ -309,7 +319,8 @@ def parse_caa_si(raw_zip: bytes, source: SourceInfo) -> list[Zone]:
                 if _norm(k) not in _FURNITURE
                 and not _is_restriction_key(_norm(k))
                 and not _is_height_key(_norm(k))
-                and not (_norm(k) in _NAME_KEYS and v == name)
+                and not (_norm(k) in _NAME_KEYS
+                         and (v == name or _JUNK_NAME_RE.match(v)))
             ]
             polygons, holes = _polygons(placemark, ns, where)
             zones.append(

--- a/src/dji_metadata_embedder/geo/airspace/caa_si.py
+++ b/src/dji_metadata_embedder/geo/airspace/caa_si.py
@@ -1,0 +1,334 @@
+"""Slovenia UAS geographical-zone parser (CAA Slovenia KMZ, #565).
+
+The Javna agencija za civilno letalstvo RS publishes its UAS geographical
+zones as a Google Earth export linked from its geographic-limits page: a
+zip holding one ``.kmz``, itself a zip holding ``doc.kml``. Every zone is
+a Placemark whose attributes live only in the popup HTML table of its
+``description`` — and the table's field names differ per folder because
+each folder is a different ArcGIS layer export ("UAS_omejit", "Omejitev",
+"UAS omejitve" … all mean restriction). The parser is therefore a
+tolerant mapper: keys are matched after diacritics and punctuation are
+stripped, restriction wording is classified at the provider boundary, and
+any wording this parser has never seen live fails loudly rather than being
+guessed. The prose the CAA publishes alongside (exceptions, contacts,
+reasons, regulations) rides verbatim in ``Zone.notes``.
+
+Permission record: the CAA site's terms of use ("Avtorske pravice",
+caa.si/pogoji-uporabe) permit storing, reproducing and distributing files
+obtained from the site provided the source is visibly marked and the data
+remain unchanged, with every reproduction accurate and the CAA named as
+source. The zone content is carried unchanged; only the presentation is
+ours.
+
+Two limits the page itself states, both carried in the feed note: the
+file does not contain the populated-area restrictions for the Open
+category, and the CAA's 3D application is for flight notification only.
+"""
+
+from __future__ import annotations
+
+import html
+import io
+import re
+import unicodedata
+import zipfile
+from dataclasses import dataclass
+from datetime import date
+from urllib.parse import urljoin
+from xml.etree import ElementTree
+
+from .model import AirspaceError, SourceInfo, VerticalLimit, Zone
+
+
+@dataclass(frozen=True)
+class CaaSiFeed:
+    code: str
+    page_url: str
+    feed_name: str
+    license: str
+    caveat: str
+    note: str | None = None
+
+
+_CAVEAT = (
+    "UAS geographical-zone data is informational and is not an "
+    "authorization to fly."
+)
+
+CAA_SI_FEEDS: dict[str, CaaSiFeed] = {
+    "SI": CaaSiFeed(
+        code="SI",
+        page_url="https://www.caa.si/geografske-omejitve-za-uas.html",
+        feed_name="Slovenia UAS geographical zones (CAA)",
+        license=(
+            "© Javna agencija za civilno letalstvo RS (caa.si) — "
+            "reproduction and distribution permitted with the source marked "
+            "and the data unchanged (site terms of use)"
+        ),
+        caveat=_CAVEAT,
+        note=(
+            "The published file does not contain the populated-area (Open "
+            "category) restrictions; the CAA's 3D application is for flight "
+            "notification only. Restricted and danger areas refer to NOTAM "
+            "(sloveniacontrol.si)."
+        ),
+    ),
+}
+
+# The page links exactly one zip (an opaque upload filename that churns
+# between editions), so the page is what the registry pins and the zip
+# href is discovered per fetch.
+_ZIP_HREF_RE = re.compile(
+    r"""href=["']([^"']*/upload/editor/file/[^"']+\.zip)["']""", re.IGNORECASE
+)
+
+_ROW_RE = re.compile(r"<td[^>]*>(.*?)</td>\s*<td[^>]*>(.*?)</td>", re.S | re.I)
+_TAG_RE = re.compile(r"<[^>]+>")
+# ArcGIS/Google Earth export furniture, never a published fact.
+_FURNITURE = {
+    "folderpath", "symbolid", "altmode", "base", "clamped", "extruded",
+    "snippet", "popupinfo", "fid", "objectid", "id", "field",
+    "shape length", "shape area", "lat", "lon",
+}
+# Name rows, in preference order, for placemarks whose own <name> is junk.
+_NAME_KEYS = ("naziv", "name", "ime", "obmocje", "letalisce", "zone", "subject")
+_JUNK_NAME_RE = re.compile(r"^(?:placemark|[0-9.\s]*)$", re.IGNORECASE)
+_CEILING_RE = re.compile(
+    r"(?:dovoljeno do|allowed up to)\D{0,40}?(\d+(?:[.,]\d+)?)\s*m\s*agl"
+)
+
+
+def discover_feed_url(page: bytes, page_url: str) -> str:
+    """The current zones-zip URL from the CAA page's HTML."""
+    hrefs = _ZIP_HREF_RE.findall(page.decode("utf-8", errors="replace"))
+    if len(hrefs) != 1:
+        raise AirspaceError(
+            "expected exactly one UAS geo-zones zip on the caa.si page "
+            f"({page_url}), found {len(hrefs)} — the page layout may have "
+            "changed"
+        )
+    return urljoin(page_url, hrefs[0].replace("&amp;", "&"))
+
+
+def _kmz_member(raw_zip: bytes, feed: str) -> tuple[zipfile.ZipInfo, bytes]:
+    try:
+        outer = zipfile.ZipFile(io.BytesIO(raw_zip))
+    except zipfile.BadZipFile as exc:
+        raise AirspaceError(f"{feed}: download is not a zip archive ({exc})") from exc
+    members = [i for i in outer.infolist() if i.filename.lower().endswith(".kmz")]
+    if len(members) != 1:
+        raise AirspaceError(
+            f"{feed}: expected one .kmz inside the zip, found {len(members)}"
+        )
+    return members[0], outer.read(members[0])
+
+
+def _kml_bytes(raw_zip: bytes, feed: str) -> bytes:
+    _, kmz = _kmz_member(raw_zip, feed)
+    try:
+        inner = zipfile.ZipFile(io.BytesIO(kmz))
+    except zipfile.BadZipFile as exc:
+        raise AirspaceError(f"{feed}: the .kmz is not a zip archive ({exc})") from exc
+    names = [n for n in inner.namelist() if n.lower().endswith(".kml")]
+    if len(names) != 1:
+        raise AirspaceError(
+            f"{feed}: expected one .kml inside the kmz, found {len(names)}"
+        )
+    return inner.read(names[0])
+
+
+def caa_si_effective(raw_zip: bytes) -> str | None:
+    """The edition the download says it is: the kmz member's own timestamp.
+
+    The page names the edition only as a month ("maj 2026"); the kmz entry
+    carries the day. A zip without a real timestamp (the 1980 epoch
+    default) claims nothing."""
+    try:
+        info, _ = _kmz_member(raw_zip, "caa.si")
+    except AirspaceError:
+        return None
+    year, month, day = info.date_time[:3]
+    if year < 1990:
+        return None
+    return date(year, month, day).isoformat()
+
+
+def _norm(key: str) -> str:
+    folded = unicodedata.normalize("NFKD", key)
+    ascii_only = "".join(c for c in folded if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]+", " ", ascii_only.lower()).strip()
+
+
+def _slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", _norm(name)).strip("-") or "folder"
+
+
+def _rows(description: str | None) -> list[tuple[str, str]]:
+    """The popup's attribute table as (key, value) pairs, tags stripped.
+
+    The export wraps a title table around the attribute table; only the
+    innermost table carries attributes, so parsing starts at the last
+    ``<table``."""
+    text = description or ""
+    start = text.lower().rfind("<table")
+    if start >= 0:
+        text = text[start:]
+    rows: list[tuple[str, str]] = []
+    for raw_key, raw_value in _ROW_RE.findall(text):
+        key = re.sub(r"\s+", " ", html.unescape(_TAG_RE.sub("", raw_key))).strip()
+        value = re.sub(r"\s+", " ", html.unescape(_TAG_RE.sub("", raw_value))).strip()
+        if not key or not value:
+            continue
+        if _norm(key) == "popupinfo" and "<table" in value.lower():
+            # The Polygons-folder export (heliports, airfields) nests the
+            # real attribute table one level down, as escaped HTML inside a
+            # PopupInfo cell; unescaped above, it parses like any other.
+            rows.extend(_rows(value))
+            continue
+        rows.append((key, value))
+    return rows
+
+
+def _restriction(values: list[str], where: str) -> tuple[str, VerticalLimit | None]:
+    """The zone's restriction class from its published wording (any language).
+
+    "dovoljeno do 50 m AGL" / "allowed up to 50 m AGL" is a conditional
+    zone with that ceiling; "prepovedano / prohibited / forbidden" is
+    PROHIBITED; a permit/approval regime (model-flying clubs) is
+    CONDITIONAL. Anything else has never been seen live and fails loudly."""
+    text = " | ".join(values)
+    low = text.lower()
+    ceiling = _CEILING_RE.search(low)
+    if ceiling:
+        metres = float(ceiling.group(1).replace(",", "."))
+        return "CONDITIONAL", VerticalLimit(metres, "m", "AGL")
+    if re.search(r"prepovedan|prohibit|forbidden", low):
+        return "PROHIBITED", None
+    if re.search(r"dovoljenje|permit|approval", low):
+        return "CONDITIONAL", None
+    raise AirspaceError(
+        f"{where}: restriction wording {text!r} has not been seen live — "
+        "refusing to guess a class"
+    )
+
+
+def _height_agl_m(rows: list[tuple[str, str]], where: str) -> VerticalLimit | None:
+    for key, value in rows:
+        norm = _norm(key)
+        if "visina nad tlemi" in norm or "height agl" in norm:
+            match = re.search(r"\d+(?:[.,]\d+)?", value)
+            if not match:
+                raise AirspaceError(f"{where}: height {value!r} is not a number")
+            return VerticalLimit(float(match.group(0).replace(",", ".")), "m", "AGL")
+    return None
+
+
+def _is_restriction_key(norm: str) -> bool:
+    return "omejit" in norm or "restrict" in norm
+
+
+def _is_height_key(norm: str) -> bool:
+    return "visina nad tlemi" in norm or "height agl" in norm
+
+
+def _name(placemark_name: str | None, rows: list[tuple[str, str]],
+          folder: str, index: int) -> str:
+    own = (placemark_name or "").strip()
+    if own and not _JUNK_NAME_RE.match(own):
+        return own
+    by_key = {_norm(k): v for k, v in rows}
+    for key in _NAME_KEYS:
+        if by_key.get(key):
+            return by_key[key]
+    return f"{folder} {index}"
+
+
+def _coords(element: ElementTree.Element | None, ns: str, where: str
+            ) -> list[tuple[float, float]]:
+    text = element.findtext(f"{ns}LinearRing/{ns}coordinates") if element is not None else None
+    if not text or not text.strip():
+        raise AirspaceError(f"{where}: ring without coordinates")
+    ring: list[tuple[float, float]] = []
+    for token in text.split():
+        parts = token.split(",")
+        try:
+            ring.append((float(parts[0]), float(parts[1])))
+        except (IndexError, ValueError) as exc:
+            raise AirspaceError(f"{where}: malformed coordinate {token!r}") from exc
+    if ring[0] != ring[-1]:
+        ring.append(ring[0])
+    return ring
+
+
+def _polygons(placemark: ElementTree.Element, ns: str, where: str
+              ) -> tuple[list[list[tuple[float, float]]], list[list[tuple[float, float]]]]:
+    polygons: list[list[tuple[float, float]]] = []
+    holes: list[list[tuple[float, float]]] = []
+    for polygon in placemark.iter(f"{ns}Polygon"):
+        polygons.append(_coords(polygon.find(f"{ns}outerBoundaryIs"), ns, where))
+        for inner in polygon.findall(f"{ns}innerBoundaryIs"):
+            holes.append(_coords(inner, ns, where))
+    if not polygons:
+        raise AirspaceError(f"{where}: no polygon geometry")
+    return polygons, holes
+
+
+def parse_caa_si(raw_zip: bytes, source: SourceInfo) -> list[Zone]:
+    """Every zone of the CAA's zones download as normalized :class:`Zone`s."""
+    kml = _kml_bytes(raw_zip, source.feed)
+    try:
+        root = ElementTree.fromstring(kml)
+    except ElementTree.ParseError as exc:
+        raise AirspaceError(f"{source.feed}: doc.kml is not well-formed XML ({exc})") from exc
+    ns = root.tag[: root.tag.index("}") + 1] if root.tag.startswith("{") else ""
+    zones: list[Zone] = []
+    containers = list(root.iter(f"{ns}Folder"))
+    document = root.find(f"{ns}Document")
+    if document is not None:
+        containers.insert(0, document)
+    for container in containers:
+        folder = (container.findtext(f"{ns}name") or "").strip() or "document"
+        slug = _slug(folder)
+        for index, placemark in enumerate(container.findall(f"{ns}Placemark"), 1):
+            raw_name = placemark.findtext(f"{ns}name")
+            rows = _rows(placemark.findtext(f"{ns}description"))
+            name = _name(raw_name, rows, folder, index)
+            where = f"{source.feed}: {folder} / {name}"
+            restriction_values = [v for k, v in rows if _is_restriction_key(_norm(k))]
+            if restriction_values:
+                restriction, upper = _restriction(restriction_values, where)
+            else:
+                # The restricted/danger areas publish only a name and a
+                # "check NOTAM" pointer: no class is stated, so none is invented.
+                restriction, upper = "Restriction not stated (check NOTAM)", None
+            height = _height_agl_m(rows, where)
+            if height is not None:
+                upper = height
+            notes = [
+                f"{k}: {v}" for k, v in rows
+                if _norm(k) not in _FURNITURE
+                and not _is_restriction_key(_norm(k))
+                and not _is_height_key(_norm(k))
+                and not (_norm(k) in _NAME_KEYS and v == name)
+            ]
+            polygons, holes = _polygons(placemark, ns, where)
+            zones.append(
+                Zone(
+                    identifier=f"SI-{slug}-{index}",
+                    name=name,
+                    restriction=restriction,
+                    lower=None,
+                    upper=upper,
+                    applicability=[],
+                    polygons=polygons,
+                    holes=holes,
+                    source=source,
+                    native={
+                        "folder": folder,
+                        "placemark_name": raw_name,
+                        "rows": [list(r) for r in rows],
+                    },
+                    notes=notes,
+                )
+            )
+    return zones

--- a/src/dji_metadata_embedder/geo/airspace/fetch.py
+++ b/src/dji_metadata_embedder/geo/airspace/fetch.py
@@ -24,6 +24,12 @@ from .aixm51 import (
     parse_aixm51,
 )
 from .arcgis_faa import FAA_FEED, FAA_QUERY_URL, fetch_faa_pages, parse_faa, snap_bbox
+from .caa_si import (
+    CAA_SI_FEEDS,
+    caa_si_effective,
+    discover_feed_url as discover_caa_si_url,
+    parse_caa_si,
+)
 from .dronezoner import (
     DRONEZONER_FEEDS,
     discover_feed_url as discover_dronezoner_url,
@@ -179,6 +185,16 @@ def fetch_zones(
         # fetched and cited directly, like Sweden's ED-318 file.
         url = feed_ee.url
         note = feed_ee.note
+    elif code in CAA_SI_FEEDS:
+        feed_si = CAA_SI_FEEDS[code]
+        # The download is a zip around a kmz around doc.kml; the cache
+        # keeps the zip as downloaded so cached and fresh bodies parse
+        # identically (and the kmz timestamp, the edition, survives).
+        body_path = cache_dir / f"caa-si-{code}.zip"
+        feed_name = feed_si.feed_name
+        license_line, caveat = feed_si.license, feed_si.caveat
+        url = feed_si.page_url
+        note = feed_si.note
     else:
         feed_aixm = AIXM_FEEDS[code]
         body_path = cache_dir / f"aixm-{code}.xml"
@@ -202,6 +218,8 @@ def fetch_zones(
             return parse_dronezoner(body, source)
         if code in EANS_FEEDS:
             return parse_eans(body, source)
+        if code in CAA_SI_FEEDS:
+            return parse_caa_si(body, source)
         return parse_aixm51(body, source)
 
     cached = None if refresh else _read_cache(body_path)
@@ -236,6 +254,12 @@ def fetch_zones(
                 )
             elif code in EANS_FEEDS:
                 body = _fetch_url(url, transport)
+            elif code in CAA_SI_FEEDS:
+                page = _fetch_url(url, transport)
+                body = _fetch_url(discover_caa_si_url(page, url), transport)
+                # The kmz member's timestamp is the edition (#565); it rides
+                # in the record and the cache sidecar like the UK cycle date.
+                effective = caa_si_effective(body)
             else:
                 page = _fetch_url(url, transport)
                 zip_url, effective = discover_aixm_url(

--- a/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
+++ b/src/dji_metadata_embedder/geo/airspace/jurisdiction.py
@@ -183,6 +183,26 @@ _CORE: dict[str, list[Box]] = {
         (21.9, 57.9, 23.45, 58.65),   # Saaremaa + Muhu (Kolka LV >=17 km S)
         (22.0, 58.68, 23.1, 59.1),    # Hiiumaa incl. Kõpu/Ristna
     ],
+    # Land borders on every side (IT, AT, HU, HR) and a 47 km coast, so the
+    # cores are the interior only. All 51 edge probes Nominatim-verified
+    # 2026-09-05: Slovenian markers (Tržič, Idrija, Žužemberk, Majšperk,
+    # Markovci, Ilirska Bistrica, Divača, Tišina, Moravske Toplice,
+    # Beltinci, Slovenj Gradec) resolve SI inside the cores; foreign
+    # markers (Trieste, Gorizia, Tarvisio, Villach, Klagenfurt, Bleiburg,
+    # Leibnitz, Bad Radkersburg, Lenti, Čakovec, Varaždin, Krapina, Zagreb,
+    # Karlovac, Buje, Umag) sit outside them. Deliberate gaps, each an
+    # honest border band: Koper and the whole coast (Italy <=5 km), Nova
+    # Gorica (Gorizia adjoins), Jesenice/Kranjska Gora, the Drava valley
+    # (Dravograd), Šentilj, Gornja Radgona and the Mura, Lendava, Brežice,
+    # Metlika and the Kolpa, Kočevje.
+    "SI": [
+        (14.00, 45.85, 14.95, 46.38),  # Ljubljana basin, Kranj, Kamnik, Bled (Austria >=8 km N, Italy >=30 km W)
+        (14.95, 46.05, 15.45, 46.45),  # Celje, Velenje, Zasavje (Austria >=15 km N)
+        (15.50, 46.35, 15.95, 46.58),  # Maribor, Ptuj (Šentilj 46.68 N, Rogatec 46.23 S)
+        (14.95, 45.75, 15.25, 45.95),  # Novo Mesto (Metlika 45.65 S)
+        (14.00, 45.62, 14.40, 45.85),  # Postojna, Notranjska (Italy >=20 km W, Croatia >=15 km S)
+        (16.08, 46.58, 16.28, 46.70),  # Murska Sobota (Mura/Austria >=8 km NW, Hungary >=13 km E)
+    ],
 }
 _HULL: dict[str, list[Box]] = {
     "US": [
@@ -230,13 +250,17 @@ _HULL: dict[str, list[Box]] = {
     # outside. Overlaps the FI hull over the Gulf of Finland on purpose:
     # cores break the tie (#499).
     "EE": [(21.5, 57.45, 28.45, 59.9)],
+    # The national bounding box: Trieste, Gorizia, Villach, Klagenfurt,
+    # Bad Radkersburg, Zagreb and Istria sit inside it deliberately, so a
+    # flight there gaps as a border band (cores decide), never as SI.
+    "SI": [(13.35, 45.40, 16.62, 46.88)],
 }
 # CH takes the EU measure: Regulation (EU) 2019/947 applies in Switzerland
 # since 2023-01-01 under the CH-EU air transport agreement.
 _MEASURE = {
     "US": MEASURE_US, "LU": MEASURE_EU, "FI": MEASURE_EU, "CH": MEASURE_EU,
     "IE": MEASURE_EU, "GB": MEASURE_UK, "DK": MEASURE_EU, "SE": MEASURE_EU,
-    "EE": MEASURE_EU,
+    "EE": MEASURE_EU, "SI": MEASURE_EU,
 }
 
 
@@ -268,7 +292,7 @@ def resolve_jurisdiction(track: Track) -> Resolution:
             None,
             "no supported airspace data source for this location "
             "(covered: the US, Luxembourg, Finland, Switzerland, "
-            "Ireland, the UK, Denmark, Sweden and Estonia)",
+            "Ireland, the UK, Denmark, Sweden, Estonia and Slovenia)",
         )
     cores = [code for code in hulls if _all_inside(track, _CORE[code])]
     if len(cores) != 1:

--- a/src/dji_metadata_embedder/geo/airspace/model.py
+++ b/src/dji_metadata_embedder/geo/airspace/model.py
@@ -98,3 +98,9 @@ class Zone:
     # activation — Mon-Sat SR to SS."). Never an applicability window:
     # the evaluator must keep treating such zones as applicable.
     activation: list[str] = field(default_factory=list)
+    # Published free text about the zone, one line per fact, rendered
+    # verbatim and labelled as not evaluated (#565). Slovenia's CAA file
+    # carries its exceptions, contacts, reasons and regulations only as
+    # popup prose; this is where such prose rides so the reader sees what
+    # the publisher said. Never feeds the evaluator.
+    notes: list[str] = field(default_factory=list)

--- a/src/dji_metadata_embedder/geo/airspace/overlay.py
+++ b/src/dji_metadata_embedder/geo/airspace/overlay.py
@@ -109,6 +109,7 @@ def zones_to_overlay_json(
                     # zone carries any, so undated/plain feeds keep shape.
                     **({"activation": list(zone.activation)}
                        if zone.activation else {}),
+                    **({"notes": list(zone.notes)} if zone.notes else {}),
                     "source": {
                         "feed": zone.source.feed,
                         "license": zone.source.license,

--- a/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
+++ b/src/dji_metadata_embedder/geo/flightmap_airspace_js.py
@@ -36,6 +36,11 @@ function zonePopupHtml(z) {
   if (z.activation && z.activation.length)
     html += `<br><i>activation (published, not evaluated): ` +
             `${z.activation.map(esc).join('; ')}</i>`;
+  // #565: the publisher's own free text (exceptions, contacts, reasons),
+  // verbatim; the evaluator never read it and the label says so.
+  if (z.notes && z.notes.length)
+    html += `<br><i>published, not evaluated: ` +
+            `${z.notes.map(esc).join('; ')}</i>`;
   for (const e of z.entered) {
     html += `<hr><b>${esc(e.flight)}</b> was inside this zone`;
     html += e.entry_utc

--- a/src/dji_metadata_embedder/geo/record_html.py
+++ b/src/dji_metadata_embedder/geo/record_html.py
@@ -161,6 +161,13 @@ def _zone_row(f: ZoneFinding) -> str:
             "<br><small>activation (published, not evaluated): "
             f"{_esc('; '.join(z.activation))}</small>"
         )
+    if z.notes:
+        # #565: the publisher's free text (exceptions, contacts, reasons),
+        # verbatim and labelled; the record never evaluated it.
+        name_cell += (
+            "<br><small>published, not evaluated: "
+            f"{_esc('; '.join(z.notes))}</small>"
+        )
     return (
         f"<tr><td>{name_cell}</td>"
         f"<td>{_esc(z.restriction)}</td><td>{_esc(limit)}</td>"

--- a/tests/test_airspace_caa_si.py
+++ b/tests/test_airspace_caa_si.py
@@ -1,0 +1,248 @@
+"""Slovenia CAA KMZ provider tests (#565) against the trimmed real fixture.
+
+The CAA publishes a Google Earth export: one zip → one kmz → ``doc.kml``.
+Every zone attribute lives in the placemark's popup HTML table and the
+field names differ per folder, so the parser is a tolerant mapper and the
+tests pin each mapping case the live file exhibits.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from dji_metadata_embedder.geo.airspace.caa_si import (
+    CAA_SI_FEEDS,
+    caa_si_effective,
+    discover_feed_url,
+    parse_caa_si,
+)
+from dji_metadata_embedder.geo.airspace.model import AirspaceError, SourceInfo
+
+FIXTURE = Path(__file__).parent.parent / "samples" / "airspace" / "caa-si.kml"
+PAGE_URL = "https://www.caa.si/geografske-omejitve-za-uas.html"
+SOURCE = SourceInfo(
+    feed="Slovenia UAS geographical zones (CAA)",
+    url=PAGE_URL,
+    fetched="2026-09-05T12:00:00Z",
+    license="test",
+    caveat="test",
+)
+
+
+def wrap(kml: bytes, kmz_name: str = "UAS Geo zones - May_2026.kmz",
+         stamp: tuple = (2026, 5, 25, 13, 39, 0),
+         inner_name: str = "doc.kml") -> bytes:
+    """The live nesting: zip → kmz (itself a zip) → doc.kml, with the kmz
+    member carrying the publication timestamp."""
+    kmz = io.BytesIO()
+    with zipfile.ZipFile(kmz, "w") as z:
+        z.writestr(inner_name, kml)
+    outer = io.BytesIO()
+    with zipfile.ZipFile(outer, "w") as z:
+        info = zipfile.ZipInfo(kmz_name, date_time=stamp)
+        z.writestr(info, kmz.getvalue())
+    return outer.getvalue()
+
+
+def fixture_zones():
+    return parse_caa_si(wrap(FIXTURE.read_bytes()), SOURCE)
+
+
+def zone(zones, ident):
+    return next(z for z in zones if z.identifier == ident)
+
+
+KML_HEAD = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<kml xmlns="http://www.opengis.net/kml/2.2"><Document><name>t</name>'
+)
+KML_TAIL = b"</Document></kml>"
+
+
+def placemark(name: str, rows: str, coords: str,
+              inner: str | None = None, folder: str = "Test") -> bytes:
+    hole = (
+        f"<innerBoundaryIs><LinearRing><coordinates>{inner}</coordinates>"
+        f"</LinearRing></innerBoundaryIs>" if inner else ""
+    )
+    desc = (
+        "&lt;html&gt;&lt;body&gt;&lt;table&gt;"
+        + rows.replace("<", "&lt;").replace(">", "&gt;")
+        + "&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;"
+    )
+    return (
+        f"<Folder><name>{folder}</name><Placemark><name>{name}</name>"
+        f"<description>{desc}</description><MultiGeometry><Polygon>"
+        f"<outerBoundaryIs><LinearRing><coordinates>{coords}</coordinates>"
+        f"</LinearRing></outerBoundaryIs>{hole}</Polygon></MultiGeometry>"
+        f"</Placemark></Folder>"
+    ).encode("utf-8")
+
+
+SQUARE = "14.5,46.0,0 14.6,46.0,0 14.6,46.1,0 14.5,46.1,0 14.5,46.0,0"
+SQUARE_HOLE = "14.52,46.02,0 14.58,46.02,0 14.58,46.08,0 14.52,46.08,0 14.52,46.02,0"
+
+
+# --- registry, discovery, unpacking, edition ---------------------------------
+
+def test_registry_states_the_caa_terms_and_the_populated_area_gap():
+    feed = CAA_SI_FEEDS["SI"]
+    assert feed.page_url == PAGE_URL
+    assert "caa.si" in feed.license and "unchanged" in feed.license
+    assert feed.note is not None and "populated-area" in feed.note
+    assert "NOTAM" in feed.note
+
+
+def test_discovery_finds_the_single_zip_href_and_resolves_it():
+    page = (
+        b'<p>Omejitve ...: <a href="https://caa-slovenia.maps.arcgis.com/x">'
+        b'3D aplikacija</a>, <a href="/upload/editor/file/filef72ffaa1afe7b46.zip">'
+        b'ezyZip_maj 2026.zip</a></p>'
+    )
+    assert discover_feed_url(page, PAGE_URL) == (
+        "https://www.caa.si/upload/editor/file/filef72ffaa1afe7b46.zip"
+    )
+
+
+def test_discovery_fails_loudly_on_zero_or_several_zip_hrefs():
+    with pytest.raises(AirspaceError, match="caa.si"):
+        discover_feed_url(b"<a href='/upload/editor/file/x.pdf'>x</a>", PAGE_URL)
+    two = (b'<a href="/upload/editor/file/a.zip">a</a>'
+           b'<a href="/upload/editor/file/b.zip">b</a>')
+    with pytest.raises(AirspaceError, match="2"):
+        discover_feed_url(two, PAGE_URL)
+
+
+def test_edition_date_is_the_kmz_members_timestamp():
+    assert caa_si_effective(wrap(FIXTURE.read_bytes())) == "2026-05-25"
+
+
+def test_edition_date_is_absent_when_the_body_is_not_a_zip():
+    assert caa_si_effective(b"not a zip") is None
+
+
+def test_unpacking_errors_name_the_missing_layer():
+    with pytest.raises(AirspaceError, match="zip"):
+        parse_caa_si(b"not a zip", SOURCE)
+    no_kmz = io.BytesIO()
+    with zipfile.ZipFile(no_kmz, "w") as z:
+        z.writestr("readme.txt", b"x")
+    with pytest.raises(AirspaceError, match="kmz"):
+        parse_caa_si(no_kmz.getvalue(), SOURCE)
+    with pytest.raises(AirspaceError, match="kml"):
+        parse_caa_si(wrap(b"<kml/>", inner_name="styles.xsl"), SOURCE)
+
+
+# --- the fixture: one placemark per representative folder --------------------
+
+def test_parses_the_nine_fixture_placemarks_with_folder_based_identifiers():
+    zones = fixture_zones()
+    assert [z.identifier for z in zones] == [
+        "SI-polygons-1", "SI-uas-ursiks-1", "SI-ctr-wgs-1", "SI-modelarskecone-1",
+        "SI-restricted-area-1", "SI-jek-prohibited-1", "SI-tnp-wgs-1",
+        "SI-danger-1", "SI-luka-koper-25-1",
+    ]
+    for z in zones:
+        assert z.lower is None and z.applicability == []
+        assert z.native["folder"]
+        for ring in z.polygons:
+            assert ring[0] == ring[-1] and len(ring) >= 4
+            assert all(len(pt) == 2 for pt in ring)
+            assert all(13.0 < lon < 17.0 and 45.0 < lat < 47.0 for lon, lat in ring)
+
+
+def test_prohibited_heliport_keeps_its_exceptions_and_contact_as_notes():
+    z = zone(fixture_zones(), "SI-polygons-1")
+    assert z.name == "Heliport UKC Ljubljana"
+    assert z.restriction == "PROHIBITED"
+    assert z.upper is None
+    assert ("Exceptions: Approval from heliport + valid certificate for "
+            "subcategory A2") in z.notes
+    assert "Kontakt: heliport@kclj.si" in z.notes
+    # ArcGIS export furniture never reaches the reader
+    assert not any(n.startswith(("FolderPath", "SymbolID", "PopupInfo", "FID"))
+                   for n in z.notes)
+    assert z.polygons[0][0] == pytest.approx((14.52056, 46.07173), abs=1e-5)
+
+
+def test_prison_zone_states_its_published_height_as_the_upper_limit():
+    z = zone(fixture_zones(), "SI-uas-ursiks-1")
+    assert z.restriction == "PROHIBITED"
+    assert z.upper is not None and z.upper.label() == "150 m AGL"
+    assert any(n.startswith("Regulation: Act on the Execution") for n in z.notes)
+
+
+def test_ctr_allowed_up_to_50_m_is_conditional_with_that_ceiling():
+    z = zone(fixture_zones(), "SI-ctr-wgs-1")
+    assert z.name == "Kontrolirana cona (CTR Ljubljana)"
+    assert z.restriction == "CONDITIONAL"
+    assert z.upper is not None and z.upper.label() == "50 m AGL"
+
+
+def test_model_flying_permit_zone_is_conditional():
+    z = zone(fixture_zones(), "SI-modelarskecone-1")
+    assert z.restriction == "CONDITIONAL"
+    assert z.upper is None
+
+
+def test_restricted_area_without_a_statement_says_so_and_points_at_notam():
+    z = zone(fixture_zones(), "SI-restricted-area-1")
+    assert z.name == "LJ R6A restricted"
+    assert z.restriction == "Restriction not stated (check NOTAM)"
+    assert any("sloveniacontrol.si" in n for n in z.notes)
+
+
+def test_nuclear_plant_and_national_park_are_prohibited_in_either_case():
+    zones = fixture_zones()
+    assert zone(zones, "SI-jek-prohibited-1").restriction == "PROHIBITED"
+    assert zone(zones, "SI-tnp-wgs-1").restriction == "PROHIBITED"   # "prepovedano"
+
+
+def test_junk_placemark_names_fall_back_to_the_popup_name_row():
+    zones = fixture_zones()
+    assert zone(zones, "SI-danger-1").name == "LJD1 - Danger area"      # was "33297.328…"
+    assert zone(zones, "SI-luka-koper-25-1").name == "Luka Koper"      # was "22"
+    assert zone(zones, "SI-luka-koper-25-1").restriction == "PROHIBITED"
+
+
+# --- synthetic edge cases ----------------------------------------------------
+
+def test_inner_rings_become_holes():
+    kml = KML_HEAD + placemark(
+        "Hole zone", "<tr><td>Omejitev</td><td>Prepovedano</td></tr>",
+        SQUARE, inner=SQUARE_HOLE,
+    ) + KML_TAIL
+    z = parse_caa_si(wrap(kml), SOURCE)[0]
+    assert len(z.polygons) == 1 and len(z.holes) == 1
+    assert z.holes[0][0] == (14.52, 46.02)
+
+
+def test_an_unseen_restriction_wording_fails_loudly_naming_the_zone():
+    kml = KML_HEAD + placemark(
+        "Odd zone", "<tr><td>Omejitev</td><td>Dovoljeno s pogoji</td></tr>", SQUARE,
+    ) + KML_TAIL
+    with pytest.raises(AirspaceError, match="Odd zone"):
+        parse_caa_si(wrap(kml), SOURCE)
+
+
+def test_a_placemark_without_polygon_geometry_fails_loudly():
+    kml = KML_HEAD + (
+        b"<Folder><name>F</name><Placemark><name>Pt</name>"
+        b"<description>x</description><Point><coordinates>14.5,46.0,0"
+        b"</coordinates></Point></Placemark></Folder>"
+    ) + KML_TAIL
+    with pytest.raises(AirspaceError, match="Pt"):
+        parse_caa_si(wrap(kml), SOURCE)
+
+
+def test_nested_folders_are_walked_and_indexed_per_folder():
+    inner_a = placemark("A1", "<tr><td>Omejitev</td><td>Prepovedano</td></tr>", SQUARE, folder="Inner")
+    kml = KML_HEAD + b"<Folder><name>Outer</name>" + inner_a + placemark(
+        "O1", "<tr><td>Omejitev</td><td>Prepovedano</td></tr>", SQUARE, folder="Outer"
+    ) + b"</Folder>" + KML_TAIL
+    ids = [z.identifier for z in parse_caa_si(wrap(kml), SOURCE)]
+    assert sorted(ids) == ["SI-inner-1", "SI-outer-1"]

--- a/tests/test_airspace_caa_si.py
+++ b/tests/test_airspace_caa_si.py
@@ -164,7 +164,8 @@ def test_prohibited_heliport_keeps_its_exceptions_and_contact_as_notes():
             "subcategory A2") in z.notes
     assert "Kontakt: heliport@kclj.si" in z.notes
     # ArcGIS export furniture never reaches the reader
-    assert not any(n.startswith(("FolderPath", "SymbolID", "PopupInfo", "FID"))
+    assert not any(n.startswith(("FolderPath", "SymbolID", "PopupInfo", "FID",
+                                 "UAS_restri", "lat_dec", "lon_dec"))
                    for n in z.notes)
     assert z.polygons[0][0] == pytest.approx((14.52056, 46.07173), abs=1e-5)
 
@@ -246,3 +247,34 @@ def test_nested_folders_are_walked_and_indexed_per_folder():
     ) + b"</Folder>" + KML_TAIL
     ids = [z.identifier for z in parse_caa_si(wrap(kml), SOURCE)]
     assert sorted(ids) == ["SI-inner-1", "SI-outer-1"]
+
+
+def test_truncated_arcgis_keys_still_classify_the_restriction():
+    # Live file, 2026-09-05: 30 heliport/airfield polygons carry the
+    # restriction under the truncated export keys UAS_omej_1 / UAS_rest_1,
+    # a "Name: Placemark" row and lat_dec/lon_dec furniture; the real name
+    # sits under "Ime".
+    rows = ("<tr><td>Name</td><td>Placemark</td></tr>"
+            "<tr><td>FID</td><td>12</td></tr>"
+            "<tr><td>Izjeme</td><td>dovoljenje upravljalca vzletisca</td></tr>"
+            "<tr><td>Exceptions</td><td>approval from airfield operator</td></tr>"
+            "<tr><td>UAS_omej_1</td><td>Prepovedano</td></tr>"
+            "<tr><td>UAS_rest_1</td><td>Forbidden</td></tr>"
+            "<tr><td>Ime</td><td>Kamnik-Duplica</td></tr>"
+            "<tr><td>lat_dec</td><td>46,1972</td></tr>"
+            "<tr><td>lon_dec</td><td>14,5808</td></tr>")
+    kml = KML_HEAD + placemark("Placemark", rows, SQUARE, folder="Polygons") + KML_TAIL
+    z = parse_caa_si(wrap(kml), SOURCE)[0]
+    assert z.restriction == "PROHIBITED"
+    assert z.name == "Kamnik-Duplica"
+    assert z.notes == ["Izjeme: dovoljenje upravljalca vzletisca",
+                       "Exceptions: approval from airfield operator"]
+
+
+def test_no_restriction_row_and_no_notam_row_is_plainly_not_stated():
+    rows = "<tr><td>Naziv</td><td>Some site</td></tr><tr><td>Kontakt</td><td>a@b.si</td></tr>"
+    kml = KML_HEAD + placemark("Some site", rows, SQUARE) + KML_TAIL
+    z = parse_caa_si(wrap(kml), SOURCE)[0]
+    assert z.restriction == "Restriction not stated"
+    assert z.notes == ["Kontakt: a@b.si"]
+

--- a/tests/test_airspace_fetch.py
+++ b/tests/test_airspace_fetch.py
@@ -411,6 +411,60 @@ def test_a_cached_swedish_body_never_touches_the_network(tmp_path):
     assert data.from_cache and len(data.zones) == 3
 
 
+SI_PAGE = (
+    b'<p><a href="https://caa-slovenia.maps.arcgis.com/apps/x">3D aplikacija</a>, '
+    b'<a href="/upload/editor/file/filef72ffaa1afe7b46.zip">ezyZip_maj 2026.zip</a></p>'
+)
+
+
+def _si_zip() -> bytes:
+    # The live nesting: zip -> kmz (a zip) -> doc.kml, kmz member dated.
+    kmz = io.BytesIO()
+    with zipfile.ZipFile(kmz, "w") as zf:
+        zf.writestr("doc.kml", (FIXTURES / "caa-si.kml").read_bytes())
+    outer = io.BytesIO()
+    with zipfile.ZipFile(outer, "w") as zf:
+        info = zipfile.ZipInfo("UAS Geo zones - May_2026.kmz",
+                               date_time=(2026, 5, 25, 13, 39, 0))
+        zf.writestr(info, kmz.getvalue())
+    return outer.getvalue()
+
+
+def test_a_slovenian_flight_discovers_the_zip_then_fetches_it(tmp_path):
+    # #565: the CAA page is the stable address; the zip href is an opaque
+    # upload name, discovered per fetch. The kmz member's timestamp is the
+    # edition and reaches the record and the cache sidecar.
+    fake = FakeTransport([SI_PAGE, _si_zip()])
+    lines = []
+    data = fetch_zones(_track(46.05, 14.51), tmp_path, transport=fake,
+                       announce=lines.append)
+    assert data.gap_reason is None and len(data.zones) == 9
+    assert fake.urls[0].startswith("https://www.caa.si/geografske-omejitve-za-uas.html")
+    assert fake.urls[1].endswith("/upload/editor/file/filef72ffaa1afe7b46.zip")
+    assert data.source is not None and "caa.si" in data.source.license
+    assert "populated-area" in (data.source.note or "")
+    assert data.source.effective == "2026-05-25"
+    assert (tmp_path / "caa-si-SI.zip").exists()
+    meta = json.loads(
+        (tmp_path / "caa-si-SI.zip.meta.json").read_text(encoding="utf-8")
+    )
+    assert meta["effective"] == "2026-05-25"
+    assert any("Fetching" in ln and "www.caa.si" in ln for ln in lines)
+    heliport = next(z for z in data.zones if z.identifier == "SI-polygons-1")
+    assert heliport.restriction == "PROHIBITED" and heliport.notes
+
+
+def test_a_cached_slovenian_body_skips_discovery_and_the_network(tmp_path):
+    fetch_zones(_track(46.05, 14.51), tmp_path,
+                transport=FakeTransport([SI_PAGE, _si_zip()]))
+
+    def no_network(req, timeout=None):
+        raise AssertionError("cached run must not touch the network")
+    data = fetch_zones(_track(46.05, 14.51), tmp_path, transport=no_network)
+    assert data.from_cache and len(data.zones) == 9
+    assert data.source is not None and data.source.effective == "2026-05-25"
+
+
 def test_an_estonian_flight_fetches_the_eans_file_directly(tmp_path):
     # #511: EANS's URL is stable — one fetch, no discovery, the record
     # cites the file URL itself.

--- a/tests/test_airspace_jurisdiction.py
+++ b/tests/test_airspace_jurisdiction.py
@@ -509,3 +509,51 @@ def test_the_gulf_coast_overlap_band_resolves_ee_via_its_core():
     # the EE hull; only the EE core contains it (#499 tie-break).
     r = resolve_jurisdiction(_track((59.50, 26.50)))
     assert r.jurisdiction is not None and r.jurisdiction.code == "EE"
+
+
+# --- Slovenia (#565): land borders on every side, 51/51 Nominatim probes
+# 2026-09-05 (scratch script si_nominatim.py) -------------------------------
+
+def test_a_ljubljana_flight_resolves_to_si_with_the_eu_measure():
+    r = resolve_jurisdiction(_track((46.05, 14.51)))
+    assert r.jurisdiction is not None and r.jurisdiction.code == "SI"
+    assert "2019/947" in r.jurisdiction.measure_note
+
+
+def test_slovenian_cities_resolve_through_their_cores():
+    # Kranj, Bled, Celje, Velenje, Maribor, Ptuj, Novo Mesto, Postojna,
+    # Murska Sobota: one core each, all >=8 km from the nearest border.
+    for lat, lon in ((46.24, 14.36), (46.37, 14.11), (46.23, 15.26), (46.36, 15.11),
+                     (46.55, 15.65), (46.42, 15.87), (45.80, 15.17), (45.77, 14.21),
+                     (46.66, 16.16)):
+        r = resolve_jurisdiction(_track((lat, lon)))
+        assert r.jurisdiction is not None and r.jurisdiction.code == "SI", (lat, lon)
+
+
+def test_slovenian_border_towns_gap_as_a_border_band():
+    # Koper (Italy 5 km), Nova Gorica (Gorizia adjoins), Jesenice (Austria),
+    # Brežice (Croatia), Lendava (Hungary/Croatia), Metlika (Croatia),
+    # Dravograd (Austria), Gornja Radgona (Austria, Mura bridge): inside the
+    # hull, outside every core, so honestly a band rather than a verdict.
+    for lat, lon in ((45.55, 13.73), (45.96, 13.65), (46.43, 14.07), (45.90, 15.59),
+                     (46.56, 16.45), (45.65, 15.32), (46.59, 15.02), (46.68, 15.99)):
+        r = resolve_jurisdiction(_track((lat, lon)))
+        assert r.jurisdiction is None, (lat, lon)
+        assert r.gap_reason is not None and "boundary" in r.gap_reason, (lat, lon)
+
+
+def test_neighbouring_cities_never_resolve_to_si():
+    # Trieste, Gorizia, Villach, Klagenfurt, Bad Radkersburg, Čakovec,
+    # Varaždin, Krapina, Zagreb, Umag: foreign, some inside the SI hull.
+    for lat, lon in ((45.65, 13.77), (45.94, 13.62), (46.61, 13.85), (46.62, 14.31),
+                     (46.69, 15.99), (46.39, 16.43), (46.31, 16.34), (46.16, 15.87),
+                     (45.81, 15.98), (45.43, 13.52)):
+        r = resolve_jurisdiction(_track((lat, lon)))
+        assert r.jurisdiction is None or r.jurisdiction.code != "SI", (lat, lon)
+
+
+def test_the_no_provider_message_lists_slovenia():
+    r = resolve_jurisdiction(_track((48.85, 2.35)))  # Paris
+    assert r.jurisdiction is None
+    assert r.gap_reason is not None and "Slovenia" in r.gap_reason
+

--- a/tests/test_airspace_overlay.py
+++ b/tests/test_airspace_overlay.py
@@ -92,6 +92,26 @@ def test_published_activation_text_reaches_the_popup_data_only_when_present():
     assert all("activation" not in by_id[z.identifier] for z in zones[1:])
 
 
+def test_published_notes_reach_the_popup_data_only_when_present():
+    # #565: zones carrying published free text (Slovenia's exceptions,
+    # contacts, reasons) get a "notes" list in their popup data; every
+    # other zone keeps the pinned shape (no key invented).
+    zones, source = _lu_zones()
+    zones[0].notes = [
+        "Exceptions: Approval from heliport + valid certificate for subcategory A2",
+        "Contact: heliport@kclj.si",
+    ]
+    out = zones_to_overlay_json(
+        [_track_far()], [AirspaceData(zones=zones, source=source)]
+    )
+    by_id = {z["id"]: z for z in out["zones"]}
+    assert by_id[zones[0].identifier]["notes"] == [
+        "Exceptions: Approval from heliport + valid certificate for subcategory A2",
+        "Contact: heliport@kclj.si",
+    ]
+    assert all("notes" not in by_id[z.identifier] for z in zones[1:])
+
+
 def test_zone_dict_shape_and_source_footer():
     zones, source = _lu_zones()
     out = zones_to_overlay_json(

--- a/tests/test_geo_flightmap_html.py
+++ b/tests/test_geo_flightmap_html.py
@@ -242,6 +242,17 @@ def test_airspace_popup_renders_activation_text_as_published_not_evaluated():
     assert "z.activation.map(esc).join('; ')" in html
 
 
+def test_airspace_popup_renders_published_notes_not_evaluated():
+    # #565: the popup shows a zone's published free text (exceptions,
+    # contacts, reasons) verbatim, labelled as published information the
+    # record did not evaluate, and nothing at all for zones without it.
+    from dji_metadata_embedder.geo.flightmap_html import flights_to_html
+    html = flights_to_html([_mini_track()], "t", airspace_json=_OVERLAY)
+    assert "if (z.notes && z.notes.length)" in html
+    assert "published, not evaluated: " in html
+    assert "z.notes.map(esc).join('; ')" in html
+
+
 def test_airspace_json_embeds_block_layer_and_note():
     from dji_metadata_embedder.geo.flightmap_html import flights_to_html
     html = flights_to_html([_mini_track()], "t", airspace_json=_OVERLAY)

--- a/tests/test_geo_record_html.py
+++ b/tests/test_geo_record_html.py
@@ -108,6 +108,24 @@ def test_zone_row_carries_published_activation_text_when_present():
     assert "activation (published" not in plain
 
 
+def test_zone_row_carries_published_notes_when_present():
+    # #565: a zone's published free text (exceptions, contact, reason) shows
+    # under its name in the zone table, framed as published and not
+    # evaluated; zones without it render exactly as before.
+    from dataclasses import replace
+
+    noted = replace(
+        ZONE, notes=["Exceptions: approval from heliport", "Contact: heliport@kclj.si"]
+    )
+    rec = _record()
+    rec.airspace.findings[0].zone = noted
+    html = record_to_html([rec], "t", "2.4.0")
+    assert ("<small>published, not evaluated: Exceptions: approval from "
+            "heliport; Contact: heliport@kclj.si</small>") in html
+    plain = record_to_html([_record()], "t", "2.4.0")
+    assert "published, not evaluated:" not in plain
+
+
 def test_no_verdict_vocabulary_ever():
     html = record_to_html([_record()], "t", "2.4.0").lower()
     for word in ("legal", "illegal", "compliant", "violation"):


### PR DESCRIPTION
Closes #565. Tenth country, first one whose publication is a Google Earth export rather than a GeoJSON/ED-269/AIXM document.

## Rights

The CAA Slovenia site terms of use ("Avtorske pravice", caa.si/pogoji-uporabe) permit storing, reproducing and distributing files obtained directly from the site provided the source is visibly marked and the data remain unchanged, with every reproduction accurate and the CAA named as source. That is the permission record; the licence line quotes the condition. No enquiry was needed.

## What the feed is

The geographic-limits page links one zip (opaque upload filename, discovered per fetch) holding one KMZ holding `doc.kml`: 137 placemarks in 17 folders (heliports and airfields, ELES power lines, prisons, hospitals, Port of Koper, Petrol sites, the Krško nuclear plant, Velenje mine, TEŠ, Triglav national park, CTRs, restricted and danger areas, model-flying zones). The page itself states the file does **not** contain the populated-area restrictions for the Open category, and that the 3D application is for flight notification only. Both ride in the feed note.

Every attribute lives in the popup HTML table of the placemark description and the field names differ per folder (they are separate ArcGIS layer exports). The parser is therefore a tolerant mapper:

- keys matched after diacritics and punctuation are stripped; restriction under any of `Omejitev`, `Omejitve`, `UAS omejitev/omejitve`, `UAS_omejit`, `UAS_omej_1`, `Restrict`, `Restriction(s)`, `UAS restriction(s)`, `UAS_restri`, `UAS_rest_1` (ArcGIS truncates);
- restriction wording classified at the provider boundary: prepovedano / prohibited / forbidden → `PROHIBITED`; "dovoljeno do 50 m AGL" / "allowed up to 50 m AGL" (the CTRs) → `CONDITIONAL` with that ceiling; permit regimes (model-flying clubs) → `CONDITIONAL`; the restricted and danger areas, which publish only a name and a "check NOTAM" pointer → `Restriction not stated (check NOTAM)`. Wording never seen live raises, like every other provider;
- published heights (`Višina nad tlemi v m`, the prisons' 150 m) become the upper limit; everything else renders "not stated";
- the Polygons-folder export nests its real table inside a `PopupInfo` cell as escaped HTML; the row parser recurses into it;
- placemarks literally named "Placemark" or "22" take their name from the popup's name row (`Naziv`, `Ime`, …);
- exceptions, contacts, reasons, regulations and NOTAM pointers ride verbatim as `Zone.notes`.

## `Zone.notes` (new, small)

A `notes` list on `Zone`, sibling of the UK `activation` text (#503): emitted in the overlay data only when present, rendered in the flat-map popup and the record's zone table under "published, not evaluated". Slovenia is the first user; Belgium's descriptions (#562) and Spain's messages (#451) will want the same slot.

## Fetch, edition, jurisdiction, docs

- Fetch: page → discovered zip → cached as downloaded (`caa-si-SI.zip`); the kmz member's timestamp (2026-05-25 today) is the edition and reaches the source line and the cache sidecar via the #563 slot.
- Jurisdiction: six interior cores and the national bbox as hull, **51/51 Nominatim edge probes** (2026-09-05). Koper, Nova Gorica, Jesenice, Brežice, Lendava, Metlika, Dravograd and Gornja Radgona gap as border bands; Trieste, Klagenfurt, Zagreb, Čakovec never resolve SI. The no-provider message lists Slovenia.
- Docs: `docs/geospatial.md` airspace paragraph, README country list, `samples/airspace/README.md`.

## Tests (written first, watched fail) and gates

`tests/test_airspace_caa_si.py` (20: registry, discovery one/zero/two, unpacking errors, edition date, each fixture placemark's mapping, holes, unseen wording raises, no-polygon raises, nested folders, truncated keys + junk Name rows, plain "not stated" without a NOTAM row), fetch (discover + cache + edition), jurisdiction (cores, bands, neighbours, message), overlay/record/flightmap rendering of notes. Fixture `samples/airspace/caa-si.kml`: 9 real placemarks, rings reduced to a few real vertices, popup HTML kept whole.

**Live E2E 2026-09-05** through the shipped code against caa.si: 137 zones, edition 2026-05-25, restriction PROHIBITED 124 / CONDITIONAL 7 / not stated (check NOTAM) 6 (exactly the 5 restricted areas + LJD1), 18 zones with a ceiling (4 CTRs + 14 prisons), 3 holes, no junk names, no furniture in notes; a track on the UKC Ljubljana heliport is reported entered with its exceptions and contact in the notes.

Gates: ruff clean, mypy clean, 1404 passed / 4 skipped.

## Out of scope

Populated-area (Open category) limits (not published); NOTAM evaluation; the stale ArcGIS services (March 2022); Czechia (gated on the AIM reply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLhdpoWs2CXoiX3zrrWi74
