### PR TITLE
release: prepare version 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **airspace**: Slovenia is the tenth covered country — `-f record` and `--airspace` fetch the CAA's published UAS geo-zones KMZ (137 zones), with the CAA's own caveats (no Open-category populated-area limits; restricted and danger areas defer to NOTAM) and each zone's published exceptions, contacts and reasons carried as text, labelled published, not evaluated (#565) (#566) (4a03952)
+- **airspace**: the Irish and Swedish ED-318 files' own edition date (`validFrom`) now appears in the record's source line, the map popup and the cache sidecar, alongside the fetch time — the version shown is stated, as promised to the IAA (#563) (#564) (3c627c5)
+
+### Changed
+
+- Dependency refresh: click 8.5, ruff 0.16 (lint rule set pinned to `E4/E7/E9/F`, wider adoption tracked in #561), mypy 2.3, PyInstaller 6.22, hatchling 1.32 and friends (#559) (#560)
+- Model survey marks the Mini 5 Pro, Air 3S and Avata 360 as shipped with fixtures (#558)
+
 ## [2.14.0] - 2026-08-28
 
 ### Added

--- a/HOUSEKEEPING.md
+++ b/HOUSEKEEPING.md
@@ -1,7 +1,7 @@
 # Repository Housekeeping Recommendations
 
 **Last refreshed:** 2026-06-21
-**Current state:** v2.14.0, production-ready, root directory already slim
+**Current state:** v2.15.0, production-ready, root directory already slim
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DJI Drone Metadata Embedder
 
 [![GitHub Release](https://img.shields.io/github/v/release/CallMarcus/dji-drone-metadata-embedder?logo=github)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
-[![Version](https://img.shields.io/badge/version-2.14.0-blue)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
+[![Version](https://img.shields.io/badge/version-2.15.0-blue)](https://github.com/CallMarcus/dji-drone-metadata-embedder/releases)
 [![PyPI](https://img.shields.io/pypi/v/dji-drone-metadata-embedder?logo=pypi)](https://pypi.org/project/dji-drone-metadata-embedder/)
 [![Winget](https://img.shields.io/winget/v/CallMarcus.DJIMetadataEmbedder?logo=windows&label=winget)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/c/CallMarcus/DJIMetadataEmbedder)
 

--- a/dji-embed.spec
+++ b/dji-embed.spec
@@ -1,6 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-__version__ = "2.14.0"
+__version__ = "2.15.0"
 a = Analysis(
     ['_pyinstaller_entry.py'],
     pathex=['src'],

--- a/docs/decision-table.md
+++ b/docs/decision-table.md
@@ -17,7 +17,7 @@ This guide helps you choose the right command and approach for your specific use
 | **Map a whole folder of flights** | `dji-embed flightmap` | You want every flight's track on one combined map |
 | **Map your still photos** | `dji-embed photomap` | You shot geotagged photos and want them on a map |
 | **Map a mixed folder of photos and videos** | `dji-embed map` | You want photos, panoramas, and flight tracks together on one map |
-| **See official drone zones along your flights** | `dji-embed flightmap --airspace` | Overlays published airspace zones on the flight map — nine countries covered, see [Flight records](how-to/flight-record.md) |
+| **See official drone zones along your flights** | `dji-embed flightmap --airspace` | Overlays published airspace zones on the flight map — ten countries covered, see [Flight records](how-to/flight-record.md) |
 | **A printable flight record / logbook** | `dji-embed flightmap -f record` | One page per flight with airspace facts and honestly-labelled heights |
 | **Set a 360° panorama's opening view** | `dji-embed panoedit` | Drag-and-save editor for the view a panorama opens with (also the app's *360° views* mode) |
 | **No terminal at all** | drag the folder onto `dji-embed.exe` | Maps the folder's flight logs and photos, then opens the result in your browser (same as `dji-embed <folder>`) |

--- a/docs/development_roadmap.md
+++ b/docs/development_roadmap.md
@@ -1,6 +1,6 @@
 # Development Roadmap
 
-_Last updated: 2026-07-30 · Current version: **v2.14.0** · Status: **Production Ready**_
+_Last updated: 2026-07-30 · Current version: **v2.15.0** · Status: **Production Ready**_
 
 This roadmap tracks the evolution of **DJI Drone Metadata Embedder**. The
 original Phase 1–6 plan (standalone Windows GUI, dependency bootstrap,

--- a/docs/external-tool-versions.md
+++ b/docs/external-tool-versions.md
@@ -81,10 +81,10 @@ The image installs ExifTool from apt with no version pin (`apt-get install ffmpe
 
 | dji-embed | FFmpeg | ExifTool | Status |
 |-----------|---------|----------|--------|
-| 2.14.0    | 6.1.1   | 13.59    | ✅ Recommended |
-| 2.14.0    | 6.0.x   | 12.70+   | ✅ Supported |
-| 2.14.0    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
-| 2.14.0    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
+| 2.15.0    | 6.1.1   | 13.59    | ✅ Recommended |
+| 2.15.0    | 6.0.x   | 12.70+   | ✅ Supported |
+| 2.15.0    | 5.1.x   | 12.50+   | ⚠️ Limited testing |
+| 2.15.0    | 4.4.x   | 11.00+   | ⚠️ Minimum support |
 
 ## Known Issues
 
@@ -101,7 +101,7 @@ The image installs ExifTool from apt with no version pin (`apt-get install ffmpe
 The `dji-embed --version` command now shows detected tool versions:
 
 ```
-dji-embed 2.14.0
+dji-embed 2.15.0
   python: python
   ffmpeg: 6.1.1
   exiftool: 13.59

--- a/docs/how-to/flight-record.md
+++ b/docs/how-to/flight-record.md
@@ -62,6 +62,12 @@ Six feeds are used:
   NOTAM activation hours live only as text in the zone's published
   message, not a machine-readable field; the record says so on both
   counts.
+- **Slovenia** flights fetch the CAA's whole published UAS geo-zones
+  file (a KMZ export), again with no location sent. The CAA's own page
+  says the file does not contain the populated-area limits for the Open
+  category, and its restricted and danger areas defer to NOTAM; both
+  caveats ride along. The zones' published exceptions, contacts and
+  reasons appear as text, labelled published, not evaluated.
 - **Every flight**, regardless of jurisdiction, fetches surface-height
   tiles from Mapterhorn (`tiles.mapterhorn.com`) for the surface-referenced
   height estimate, when the `[terrain]` extra is installed.
@@ -76,11 +82,12 @@ nothing without `-f record`; terrain tiles are unaffected by this flag).
 dji-embed flightmap ./flights -f record --airspace-refresh
 ```
 
-## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark, Sweden, Estonia — and an honest gap everywhere else
+## Coverage: US, Luxembourg, Finland, Switzerland, Ireland, the UK, Denmark, Sweden, Estonia, Slovenia — and an honest gap everywhere else
 
 Airspace lookup only resolves for flights that sit clearly inside the
 United States, Luxembourg, Finland, Switzerland, Ireland, the UK,
-Denmark, Sweden, or Estonia. Everywhere else the record states the gap
+Denmark, Sweden, Estonia, or Slovenia. Everywhere else the record states
+the gap
 instead of guessing: *"no supported airspace data source for this
 location."*
 A flight near a jurisdiction boundary gaps the same way, deliberately,

--- a/src/dji_metadata_embedder/__init__.py
+++ b/src/dji_metadata_embedder/__init__.py
@@ -1,6 +1,6 @@
 """DJI Drone Metadata Embedder."""
 
-__version__ = "2.14.0"
+__version__ = "2.15.0"
 
 # Import check to ensure files were moved correctly
 try:

--- a/tools/bootstrap.ps1
+++ b/tools/bootstrap.ps1
@@ -196,7 +196,7 @@ function Ensure-Python {
 # IMPROVED: Get latest version with robust fallback handling
 if(-not $Version){
     # Default fallback version that we know works
-    $fallbackVersion = "2.14.0"
+    $fallbackVersion = "2.15.0"
     
     try{
         LogInfo "Checking for latest version..."

--- a/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.14.0
+PackageVersion: 2.15.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -16,7 +16,7 @@ FileExtensions:
 - dat
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.14.0/dji-embed.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.15.0/dji-embed.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.14.0
+PackageVersion: 2.15.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus
@@ -37,7 +37,7 @@ Tags:
 - srt
 - ffmpeg
 - cli
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.14.0
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.15.0
 PurchaseUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder
 InstallationNotes: |
   After installation, run 'dji-embed doctor' to verify dependencies are installed.

--- a/winget/CallMarcus.DJIMetadataEmbedder.yaml
+++ b/winget/CallMarcus.DJIMetadataEmbedder.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder
-PackageVersion: 2.14.0
+PackageVersion: 2.15.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.14.0
+PackageVersion: 2.15.0
 Platform:
 - Windows.Desktop
 MinimumOSVersion: 10.0.0.0
@@ -14,7 +14,7 @@ AppsAndFeaturesEntries:
 - ProductCode: '{A0F2FECD-3BEB-4832-9BC6-4A57B20ED947}_is1'
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.14.0/dji-metadata-embedder-setup-2.14.0.exe
+  InstallerUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/download/v2.15.0/dji-metadata-embedder-setup-2.15.0.exe
   InstallerSha256: PLACEHOLDER_HASH_WILL_BE_UPDATED_BY_WINGET_CREATE
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.14.0
+PackageVersion: 2.15.0
 PackageLocale: en-US
 Publisher: CallMarcus
 PublisherUrl: https://github.com/CallMarcus
@@ -37,7 +37,7 @@ Tags:
 - map
 - panorama
 - gui
-ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.14.0
+ReleaseNotesUrl: https://github.com/CallMarcus/dji-drone-metadata-embedder/releases/tag/v2.15.0
 InstallationNotes: |
   Start the app from the Start menu ("DJI Metadata Embedder"). The
   dji-embed command is also available in new terminals.

--- a/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
+++ b/winget/desktop/CallMarcus.DJIMetadataEmbedder.Desktop.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: CallMarcus.DJIMetadataEmbedder.Desktop
-PackageVersion: 2.14.0
+PackageVersion: 2.15.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Release prep for v2.15.0: Slovenia (#565/#566, tenth airspace country), the ED-318 edition date for Ireland and Sweden (#563/#564, promised to the IAA), the dependency refresh (#559/#560) and the model-survey doc fix (#558).

- Version bump via `tools/sync_version.py 2.15.0` (`--check` clean), same file set as the 2.14.0 prep.
- CHANGELOG `[Unreleased]` curated with the four items above.
- Docs drift fixed: `docs/how-to/flight-record.md` (Slovenia bullet, coverage heading and paragraph) and `docs/decision-table.md` (nine → ten countries).

Gates locally: ruff clean, mypy clean, 1404 passed / 4 skipped.

Tag `v2.15.0` follows the squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166sj5VMJ1DDFMVkAbNDBxW
